### PR TITLE
Update sidekick.lua with improved OpenCode integration

### DIFF
--- a/nvim/.config/nvim/lua/plugins/sidekick.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick.lua
@@ -6,18 +6,38 @@ local tool_urls = {
 local claude_bin = vim.fn.executable(vim.fn.expand("~/.local/bin/claude")) == 1 and vim.fn.expand("~/.local/bin/claude")
   or "claude"
 
+local opencode_bin = vim.fn.executable(vim.fn.expand("~/.opencode/bin/opencode")) == 1
+    and vim.fn.expand("~/.opencode/bin/opencode")
+  or "opencode"
+
 local tool_commands = {
   claude = { claude_bin, "--ide" },
-  opencode = { "opencode" },
+  opencode = { opencode_bin, "--port" },
 }
 
-local function command_to_shell(cmd)
-  if type(cmd) ~= "table" then
-    return tostring(cmd)
+local toggle_tool_session
+
+local function command_to_list(cmd)
+  if type(cmd) == "table" then
+    local command = vim.deepcopy(cmd)
+    if command[1] then
+      command[1] = vim.fn.expand(command[1])
+    end
+    return command
   end
 
+  local command = vim.split(tostring(cmd), "%s+", { trimempty = true })
+  if #command == 0 then
+    return { tostring(cmd) }
+  end
+
+  command[1] = vim.fn.expand(command[1])
+  return command
+end
+
+local function command_to_shell(cmd)
   local escaped = {}
-  for _, part in ipairs(cmd) do
+  for _, part in ipairs(command_to_list(cmd)) do
     escaped[#escaped + 1] = vim.fn.shellescape(part)
   end
   return table.concat(escaped, " ")
@@ -27,15 +47,27 @@ local function is_claude_tool(name)
   return type(name) == "string" and name:match("^claude") ~= nil
 end
 
-local function ensure_claude_bridge()
-  local ok, claudecode = pcall(require, "claudecode")
-  if not ok then
-    local lazy_ok, lazy = pcall(require, "lazy")
-    if lazy_ok and type(lazy.load) == "function" then
-      lazy.load({ plugins = { "claudecode.nvim" } })
-      ok, claudecode = pcall(require, "claudecode")
-    end
+local function is_opencode_tool(name)
+  return name == "opencode"
+end
+
+local function ensure_plugin_module(module_name, plugin_name)
+  local ok, module = pcall(require, module_name)
+  if ok then
+    return true, module
   end
+
+  local lazy_ok, lazy = pcall(require, "lazy")
+  if lazy_ok and type(lazy.load) == "function" then
+    lazy.load({ plugins = { plugin_name } })
+    return pcall(require, module_name)
+  end
+
+  return false, nil
+end
+
+local function ensure_claude_bridge()
+  local ok, claudecode = ensure_plugin_module("claudecode", "claudecode.nvim")
 
   if not ok then
     vim.notify("Sidekick: failed to load claudecode.nvim", vim.log.levels.ERROR)
@@ -55,27 +87,18 @@ local function ensure_claude_bridge()
   return false
 end
 
-local function toggle_tool_session(name, focus)
-  if is_claude_tool(name) and not ensure_claude_bridge() then
-    return
-  end
-  require("sidekick.cli").toggle({ name = name, focus = focus ~= false })
-end
-
 -- Helper to create a tool with a specific working directory
 local function make_tool(cmd, cwd, url)
+  local command = command_to_list(cmd)
+
   if cwd and cwd ~= "" then
     return {
-      cmd = { "sh", "-c", string.format("cd %s && exec %s", vim.fn.shellescape(cwd), command_to_shell(cmd)) },
+      cmd = { "sh", "-c", string.format("cd %s && exec %s", vim.fn.shellescape(cwd), command_to_shell(command)) },
       url = url,
     }
   end
 
-  if type(cmd) == "table" then
-    return { cmd = vim.deepcopy(cmd), url = url }
-  end
-
-  return { cmd = { cmd }, url = url }
+  return { cmd = command, url = url }
 end
 
 local function normalize_label(label)
@@ -101,6 +124,122 @@ local function normalize_cwd(cwd)
   return expanded
 end
 
+local function opencode_has_port_flag(command)
+  for _, part in ipairs(command) do
+    if part == "--port" or part:match("^%-%-port=.*") then
+      return true
+    end
+  end
+  return false
+end
+
+local function opencode_with_port(command, port)
+  local resolved = {}
+  local i = 1
+  while i <= #command do
+    local part = command[i]
+    if part == "--port" then
+      local next_part = command[i + 1]
+      if next_part and next_part:match("^%d+$") then
+        i = i + 2
+      else
+        i = i + 1
+      end
+    elseif part:match("^%-%-port=.*") then
+      i = i + 1
+    else
+      resolved[#resolved + 1] = part
+      i = i + 1
+    end
+  end
+
+  resolved[#resolved + 1] = "--port"
+  resolved[#resolved + 1] = tostring(port)
+  return resolved
+end
+
+local function resolve_opencode_command(port)
+  local command = vim.deepcopy(tool_commands.opencode)
+
+  local ok, opencode_config = pcall(require, "opencode.config")
+  if ok then
+    local provider_cmd = opencode_config.provider and opencode_config.provider.cmd
+    if not provider_cmd and opencode_config.opts and opencode_config.opts.provider then
+      provider_cmd = opencode_config.opts.provider.cmd
+    end
+
+    if provider_cmd and provider_cmd ~= "" then
+      command = command_to_list(provider_cmd)
+    end
+  end
+
+  if port then
+    command = opencode_with_port(command, port)
+  elseif not opencode_has_port_flag(command) then
+    command[#command + 1] = "--port"
+  end
+
+  return command
+end
+
+local function with_opencode_command(opts, cb)
+  opts = opts or {}
+
+  local ok = ensure_plugin_module("opencode", "opencode.nvim")
+  if not ok then
+    vim.notify("Sidekick: failed to load opencode.nvim", vim.log.levels.ERROR)
+    cb(vim.deepcopy(tool_commands.opencode))
+    return
+  end
+
+  if not opts.resolve_port then
+    cb(resolve_opencode_command())
+    return
+  end
+
+  local ok_server, server = pcall(require, "opencode.cli.server")
+  if not ok_server or type(server.get_port) ~= "function" then
+    cb(resolve_opencode_command())
+    return
+  end
+
+  local ok_promise, promise = pcall(server.get_port, false)
+  if not ok_promise or type(promise) ~= "table" or type(promise.next) ~= "function" then
+    cb(resolve_opencode_command())
+    return
+  end
+
+  promise
+    :next(function(port)
+      cb(resolve_opencode_command(port))
+    end)
+    :catch(function()
+      cb(resolve_opencode_command())
+    end)
+end
+
+local function set_opencode_tool_command(name, command, cwd)
+  local config = require("sidekick.config")
+  local current = config.cli.tools[name] or {}
+  config.cli.tools[name] = vim.tbl_deep_extend("force", current, make_tool(command, cwd, tool_urls.opencode))
+end
+
+toggle_tool_session = function(name, focus)
+  if is_claude_tool(name) and not ensure_claude_bridge() then
+    return
+  end
+
+  if is_opencode_tool(name) then
+    with_opencode_command({ resolve_port = true }, function(command)
+      set_opencode_tool_command(name, command)
+      require("sidekick.cli").toggle({ name = name, focus = focus ~= false })
+    end)
+    return
+  end
+
+  require("sidekick.cli").toggle({ name = name, focus = focus ~= false })
+end
+
 local function start_named_session(tool, label, cwd)
   local slug = normalize_label(label)
   if slug == "" then
@@ -110,8 +249,18 @@ local function start_named_session(tool, label, cwd)
 
   local name = tool .. "-" .. slug
   local config = require("sidekick.config")
+  local normalized_cwd = normalize_cwd(cwd)
+
+  if tool == "opencode" then
+    with_opencode_command({ resolve_port = false }, function(command)
+      config.cli.tools[name] = make_tool(command, normalized_cwd, tool_urls[tool])
+      toggle_tool_session(name, true)
+    end)
+    return
+  end
+
   local command = tool_commands[tool] or { tool }
-  config.cli.tools[name] = make_tool(command, normalize_cwd(cwd), tool_urls[tool])
+  config.cli.tools[name] = make_tool(command, normalized_cwd, tool_urls[tool])
   toggle_tool_session(name, true)
 end
 
@@ -135,6 +284,7 @@ return {
   "folke/sidekick.nvim",
   dependencies = {
     "coder/claudecode.nvim",
+    "NickvanDyke/opencode.nvim",
   },
   opts = {
     cli = {
@@ -203,6 +353,14 @@ return {
               return
             end
 
+            if is_opencode_tool(tool_name) then
+              with_opencode_command({ resolve_port = true }, function(command)
+                set_opencode_tool_command(tool_name, command)
+                require("sidekick.cli.state").attach(state, { show = true, focus = true })
+              end)
+              return
+            end
+
             require("sidekick.cli.state").attach(state, { show = true, focus = true })
           end,
         })
@@ -261,7 +419,7 @@ return {
     {
       "<leader>ao",
       function()
-        require("sidekick.cli").toggle({ name = "opencode", focus = true })
+        toggle_tool_session("opencode", true)
       end,
       desc = "Sidekick Toggle OpenCode",
     },


### PR DESCRIPTION
## Summary
- Add dynamic port resolution for opencode CLI to support the new opencode.nvim plugin
- Refactor command handling with `command_to_list` helper for consistent command processing
- Add `ensure_plugin_module` helper for lazy loading both claudecode and opencode plugins
- Support opencode.nvim configuration for provider commands
- Add opencode.nvim as a dependency alongside claudecode.nvim

## Test plan
- [ ] Verify Claude CLI toggle works with `:Sidekick claude`
- [ ] Verify OpenCode CLI toggle works with `:Sidekick opencode`
- [ ] Test named sessions with custom working directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)