### PR TITLE
Add Terraform config and direct VPS provisioning for Hostinger

### DIFF
--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -51,12 +51,12 @@ jobs:
       - name: Validate Ubuntu 22.04
         run: |
           cd packer
-          packer validate -var-file=ubuntu-22.04.pkrvars.hcl .
+          packer validate -only='dotfiles-ubuntu.*' -var-file=ubuntu-22.04.pkrvars.hcl .
 
       - name: Validate Ubuntu 24.04
         run: |
           cd packer
-          packer validate -var-file=ubuntu-24.04.pkrvars.hcl .
+          packer validate -only='dotfiles-ubuntu.*' -var-file=ubuntu-24.04.pkrvars.hcl .
 
   build:
     name: Build VM Image
@@ -105,6 +105,7 @@ jobs:
         run: |
           cd packer
           packer build \
+            -only='dotfiles-ubuntu.*' \
             -var-file=ubuntu-${{ steps.version.outputs.version }}.pkrvars.hcl \
             -var "headless=true" \
             -var "accelerator=kvm" \

--- a/.github/workflows/provision-vps.yml
+++ b/.github/workflows/provision-vps.yml
@@ -1,0 +1,91 @@
+name: Provision VPS
+
+on:
+  workflow_dispatch:
+    inputs:
+      vps_host:
+        description: 'VPS IP address'
+        required: true
+        type: string
+      target_user:
+        description: 'Target non-root user to create'
+        required: true
+        default: 'devuser'
+        type: string
+      dotfiles_branch:
+        description: 'Dotfiles branch to deploy'
+        required: true
+        default: 'develop'
+        type: choice
+        options:
+          - develop
+          - main
+
+jobs:
+  provision:
+    name: Provision VPS via Packer
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@main
+        with:
+          version: latest
+
+      - name: Initialize Packer
+        run: |
+          cd packer
+          packer init .
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "${{ github.event.inputs.vps_host }}" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Provision VPS
+        run: |
+          cd packer
+          packer build \
+            -only='hostinger-vps-provision.*' \
+            -var "vps_host=${{ github.event.inputs.vps_host }}" \
+            -var "ssh_private_key_file=~/.ssh/id_ed25519" \
+            -var "ssh_username=${{ github.event.inputs.target_user }}" \
+            -var "dotfiles_branch=${{ github.event.inputs.dotfiles_branch }}" \
+            .
+        timeout-minutes: 30
+
+  verify:
+    name: Verify Provisioning
+    runs-on: ubuntu-latest
+    needs: provision
+    steps:
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "${{ github.event.inputs.vps_host }}" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Verify tools installed
+        run: |
+          ssh -o StrictHostKeyChecking=no \
+            "${{ github.event.inputs.target_user }}@${{ github.event.inputs.vps_host }}" \
+            "which zsh tmux nvim git stow && echo 'All tools verified'"
+
+      - name: Verify shell
+        run: |
+          SHELL=$(ssh -o StrictHostKeyChecking=no \
+            "root@${{ github.event.inputs.vps_host }}" \
+            "getent passwd ${{ github.event.inputs.target_user }} | cut -d: -f7")
+          echo "User shell: ${SHELL}"
+          if [ "${SHELL}" = "/bin/zsh" ]; then
+            echo "Shell correctly set to zsh"
+          else
+            echo "WARNING: Shell is ${SHELL}, expected /bin/zsh"
+            exit 1
+          fi

--- a/.github/workflows/provision-vps.yml
+++ b/.github/workflows/provision-vps.yml
@@ -1,5 +1,5 @@
 name: Provision VPS
-# passwordless sudo configured on VPS
+# passwordless sudo + key-only SSH configured on VPS
 
 on:
   push:

--- a/.github/workflows/provision-vps.yml
+++ b/.github/workflows/provision-vps.yml
@@ -35,11 +35,18 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H avirus.xyz >> ~/.ssh/known_hosts 2>/dev/null || true
 
+      - name: Derive SSH public key
+        id: pubkey
+        run: |
+          PUBKEY=$(ssh-keygen -y -f ~/.ssh/id_rsa)
+          echo "ssh_public_key=${PUBKEY}" >> $GITHUB_OUTPUT
+
       - name: Provision VPS
         run: |
           cd packer
           packer build \
             -only='hostinger-vps-provision.*' \
+            -var "ssh_public_key=${{ steps.pubkey.outputs.ssh_public_key }}" \
             .
         timeout-minutes: 30
 

--- a/.github/workflows/provision-vps.yml
+++ b/.github/workflows/provision-vps.yml
@@ -1,4 +1,5 @@
 name: Provision VPS
+# passwordless sudo configured on VPS
 
 on:
   push:

--- a/.github/workflows/provision-vps.yml
+++ b/.github/workflows/provision-vps.yml
@@ -67,9 +67,7 @@ jobs:
             aviral@avirus.xyz \
             "getent passwd aviral | cut -d: -f7")
           echo "User shell: ${SHELL}"
-          if [ "${SHELL}" = "/bin/zsh" ]; then
-            echo "Shell correctly set to zsh"
-          else
-            echo "WARNING: Shell is ${SHELL}, expected /bin/zsh"
-            exit 1
-          fi
+          case "${SHELL}" in
+            */zsh) echo "Shell correctly set to zsh (${SHELL})" ;;
+            *) echo "WARNING: Shell is ${SHELL}, expected zsh"; exit 1 ;;
+          esac

--- a/.github/workflows/provision-vps.yml
+++ b/.github/workflows/provision-vps.yml
@@ -1,31 +1,18 @@
 name: Provision VPS
 
 on:
+  push:
+    branches:
+      - terraform
+    paths:
+      - 'packer/**'
+      - '.github/workflows/provision-vps.yml'
   workflow_dispatch:
-    inputs:
-      vps_host:
-        description: 'VPS IP address'
-        required: true
-        type: string
-      target_user:
-        description: 'Target non-root user to create'
-        required: true
-        default: 'devuser'
-        type: string
-      dotfiles_branch:
-        description: 'Dotfiles branch to deploy'
-        required: true
-        default: 'develop'
-        type: choice
-        options:
-          - develop
-          - main
 
 jobs:
   provision:
     name: Provision VPS via Packer
     runs-on: ubuntu-latest
-    environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,19 +30,15 @@ jobs:
       - name: Setup SSH key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ github.event.inputs.vps_host }}" >> ~/.ssh/known_hosts 2>/dev/null || true
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H avirus.xyz >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Provision VPS
         run: |
           cd packer
           packer build \
             -only='hostinger-vps-provision.*' \
-            -var "vps_host=${{ github.event.inputs.vps_host }}" \
-            -var "ssh_private_key_file=~/.ssh/id_ed25519" \
-            -var "ssh_username=${{ github.event.inputs.target_user }}" \
-            -var "dotfiles_branch=${{ github.event.inputs.dotfiles_branch }}" \
             .
         timeout-minutes: 30
 
@@ -67,21 +50,21 @@ jobs:
       - name: Setup SSH key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "${{ github.event.inputs.vps_host }}" >> ~/.ssh/known_hosts 2>/dev/null || true
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H avirus.xyz >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Verify tools installed
         run: |
           ssh -o StrictHostKeyChecking=no \
-            "${{ github.event.inputs.target_user }}@${{ github.event.inputs.vps_host }}" \
+            aviral@avirus.xyz \
             "which zsh tmux nvim git stow && echo 'All tools verified'"
 
       - name: Verify shell
         run: |
           SHELL=$(ssh -o StrictHostKeyChecking=no \
-            "root@${{ github.event.inputs.vps_host }}" \
-            "getent passwd ${{ github.event.inputs.target_user }} | cut -d: -f7")
+            aviral@avirus.xyz \
+            "getent passwd aviral | cut -d: -f7")
           echo "User shell: ${SHELL}"
           if [ "${SHELL}" = "/bin/zsh" ]; then
             echo "Shell correctly set to zsh"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,113 @@
+name: Terraform
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Terraform action'
+        required: true
+        default: 'plan'
+        type: choice
+        options:
+          - plan
+          - apply
+
+env:
+  TF_VAR_vps_data_center_id: ${{ vars.VPS_DATA_CENTER_ID }}
+  TF_VAR_vps_template_id: ${{ vars.VPS_TEMPLATE_ID }}
+  TF_VAR_vps_hostname: ${{ vars.VPS_HOSTNAME }}
+  TF_VAR_vps_password: ${{ secrets.VPS_PASSWORD }}
+  TF_VAR_ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
+  TF_VAR_ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+  HOSTINGER_API_TOKEN: ${{ secrets.HOSTINGER_API_TOKEN }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: ${{ vars.S3_REGION }}
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform -chdir=terraform validate
+
+      - name: Terraform Format Check
+        run: terraform -chdir=terraform fmt -check
+
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Plan
+        run: terraform -chdir=terraform plan -out=tfplan -input=false
+
+      - name: Upload Plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan
+          path: terraform/tfplan
+          retention-days: 1
+
+  apply:
+    name: Apply
+    runs-on: ubuntu-latest
+    needs: plan
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+
+      - name: Download Plan
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan
+          path: terraform/
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Apply
+        run: terraform -chdir=terraform apply -input=false tfplan

--- a/.github/workflows/test-ssh.yml
+++ b/.github/workflows/test-ssh.yml
@@ -1,0 +1,26 @@
+name: Test SSH Connection
+
+on:
+  push:
+    branches:
+      - terraform
+    paths:
+      - '.github/workflows/test-ssh.yml'
+
+jobs:
+  test-ssh:
+    name: Test SSH to Hostinger VPS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H avirus.xyz >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Test SSH connection
+        run: |
+          ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no \
+            aviral@avirus.xyz \
+            "echo 'SSH connection successful' && uname -a && uptime"

--- a/.github/workflows/test-ssh.yml
+++ b/.github/workflows/test-ssh.yml
@@ -1,4 +1,5 @@
 name: Test SSH Connection
+# Re-trigger with updated SSH_PRIVATE_KEY secret
 
 on:
   push:

--- a/packer/aws.pkr.hcl
+++ b/packer/aws.pkr.hcl
@@ -1,0 +1,166 @@
+# AWS AMI builder for dotfiles development environment
+# Builds an Amazon Machine Image with all dotfiles pre-installed
+
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.3.0"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region to build the AMI in"
+  default     = "us-east-1"
+}
+
+variable "aws_instance_type" {
+  type        = string
+  description = "EC2 instance type for the build"
+  default     = "t3.medium"
+}
+
+variable "aws_source_ami" {
+  type        = string
+  description = "Source AMI ID (Ubuntu 22.04). Leave empty to auto-detect latest."
+  default     = ""
+}
+
+variable "aws_ami_name" {
+  type        = string
+  description = "Name for the output AMI"
+  default     = ""
+}
+
+variable "aws_vpc_id" {
+  type        = string
+  description = "VPC ID (leave empty for default VPC)"
+  default     = ""
+}
+
+variable "aws_subnet_id" {
+  type        = string
+  description = "Subnet ID (leave empty for auto-select)"
+  default     = ""
+}
+
+locals {
+  ami_name = var.aws_ami_name != "" ? var.aws_ami_name : "dotfiles-ubuntu-${var.ubuntu_version}-${local.timestamp}"
+}
+
+source "amazon-ebs" "ubuntu" {
+  region        = var.aws_region
+  instance_type = var.aws_instance_type
+  ami_name      = local.ami_name
+
+  # Source AMI: use provided or find latest Ubuntu 22.04
+  source_ami = var.aws_source_ami
+
+  dynamic "source_ami_filter" {
+    for_each = var.aws_source_ami == "" ? [1] : []
+    content {
+      filters = {
+        name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+        root-device-type    = "ebs"
+        virtualization-type = "hvm"
+      }
+      owners      = ["099720109477"] # Canonical
+      most_recent = true
+    }
+  }
+
+  vpc_id    = var.aws_vpc_id != "" ? var.aws_vpc_id : null
+  subnet_id = var.aws_subnet_id != "" ? var.aws_subnet_id : null
+
+  ssh_username = "ubuntu"
+
+  # Tag the AMI and snapshots
+  tags = {
+    Name       = local.ami_name
+    Builder    = "packer"
+    OS         = "ubuntu-${var.ubuntu_version}"
+    Repository = "aviralmansingka/dotfiles"
+  }
+
+  snapshot_tags = {
+    Name = local.ami_name
+  }
+
+  # Use gp3 for better performance
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = 30
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+}
+
+build {
+  name    = "dotfiles-aws"
+  sources = ["source.amazon-ebs.ubuntu"]
+
+  # Wait for cloud-init to fully complete
+  provisioner "shell" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait",
+      "echo 'Cloud-init complete.'"
+    ]
+  }
+
+  # Copy provisioner scripts
+  provisioner "file" {
+    source      = "scripts/"
+    destination = "/tmp/packer-scripts"
+  }
+
+  # Setup user environment (run as root via sudo)
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts = [
+      "scripts/setup-user.sh"
+    ]
+    environment_vars = [
+      "TARGET_USER=${var.ssh_username}"
+    ]
+  }
+
+  # Install dependencies
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts = [
+      "scripts/setup-deps.sh"
+    ]
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive"
+    ]
+  }
+
+  # Setup dotfiles (run as target user)
+  provisioner "shell" {
+    execute_command = "sudo -u ${var.ssh_username} bash -c '{{ .Vars }} {{ .Path }}'"
+    scripts = [
+      "scripts/setup-dotfiles.sh"
+    ]
+    environment_vars = [
+      "DOTFILES_REPO=${var.dotfiles_repo}",
+      "DOTFILES_BRANCH=${var.dotfiles_branch}",
+      "HOME=/home/${var.ssh_username}"
+    ]
+  }
+
+  # Cleanup for minimal image size
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts = [
+      "scripts/cleanup.sh"
+    ]
+  }
+
+  post-processor "manifest" {
+    output     = "${var.output_directory}/manifest-aws.json"
+    strip_path = true
+  }
+}

--- a/packer/hostinger-vps-variables.pkr.hcl
+++ b/packer/hostinger-vps-variables.pkr.hcl
@@ -2,12 +2,18 @@
 
 variable "vps_host" {
   type        = string
-  description = "IP address of the Hostinger VPS to provision"
-  default     = ""
+  description = "Hostname or IP of the Hostinger VPS to provision"
+  default     = "avirus.xyz"
+}
+
+variable "vps_ssh_user" {
+  type        = string
+  description = "SSH user for connecting to the VPS (must have sudo access)"
+  default     = "aviral"
 }
 
 variable "ssh_private_key_file" {
   type        = string
-  description = "Path to SSH private key for root access to the VPS"
-  default     = "~/.ssh/id_ed25519"
+  description = "Path to SSH private key for VPS access"
+  default     = "~/.ssh/id_rsa"
 }

--- a/packer/hostinger-vps-variables.pkr.hcl
+++ b/packer/hostinger-vps-variables.pkr.hcl
@@ -17,3 +17,9 @@ variable "ssh_private_key_file" {
   description = "Path to SSH private key for VPS access"
   default     = "~/.ssh/id_rsa"
 }
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key to authorize for the target user"
+  default     = ""
+}

--- a/packer/hostinger-vps-variables.pkr.hcl
+++ b/packer/hostinger-vps-variables.pkr.hcl
@@ -1,0 +1,13 @@
+# Variable definitions for direct VPS provisioning via null builder
+
+variable "vps_host" {
+  type        = string
+  description = "IP address of the Hostinger VPS to provision"
+  default     = ""
+}
+
+variable "ssh_private_key_file" {
+  type        = string
+  description = "Path to SSH private key for root access to the VPS"
+  default     = "~/.ssh/id_ed25519"
+}

--- a/packer/hostinger-vps.pkr.hcl
+++ b/packer/hostinger-vps.pkr.hcl
@@ -4,23 +4,23 @@
 #
 # Usage:
 #   packer build -only='hostinger-vps-provision.*' \
-#     -var 'vps_host=<IP>' \
-#     -var 'ssh_private_key_file=~/.ssh/id_ed25519' \
+#     -var 'vps_host=avirus.xyz' \
 #     .
 
 source "null" "vps" {
-  ssh_host        = var.vps_host
-  ssh_username    = "root"
+  ssh_host             = var.vps_host
+  ssh_username         = var.vps_ssh_user
   ssh_private_key_file = var.ssh_private_key_file
-  ssh_timeout     = "5m"
+  ssh_timeout          = "5m"
 }
 
 build {
   name    = "hostinger-vps-provision"
   sources = ["source.null.vps"]
 
-  # Setup user environment
+  # Setup user environment (needs root)
   provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts = [
       "scripts/setup-user.sh"
     ]
@@ -29,8 +29,9 @@ build {
     ]
   }
 
-  # Install dependencies
+  # Install dependencies (needs root)
   provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts = [
       "scripts/setup-deps.sh"
     ]
@@ -55,7 +56,7 @@ build {
   # Set default shell to zsh for the target user
   provisioner "shell" {
     inline = [
-      "chsh -s /bin/zsh ${var.ssh_username}"
+      "sudo chsh -s /bin/zsh ${var.ssh_username}"
     ]
   }
 }

--- a/packer/hostinger-vps.pkr.hcl
+++ b/packer/hostinger-vps.pkr.hcl
@@ -79,7 +79,7 @@ build {
     inline = [
       "sudo sed -i 's/^#\\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config",
       "sudo sed -i 's/^#\\?KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' /etc/ssh/sshd_config",
-      "sudo systemctl restart sshd"
+      "sudo systemctl restart ssh || sudo systemctl restart sshd"
     ]
   }
 }

--- a/packer/hostinger-vps.pkr.hcl
+++ b/packer/hostinger-vps.pkr.hcl
@@ -1,0 +1,61 @@
+# Direct VPS provisioning via SSH using Packer's null builder
+# SSHes into an existing Hostinger VPS and runs the same provisioning scripts
+# as the QEMU image build, but in-place on a live server.
+#
+# Usage:
+#   packer build -only='hostinger-vps-provision.*' \
+#     -var 'vps_host=<IP>' \
+#     -var 'ssh_private_key_file=~/.ssh/id_ed25519' \
+#     .
+
+source "null" "vps" {
+  ssh_host        = var.vps_host
+  ssh_username    = "root"
+  ssh_private_key_file = var.ssh_private_key_file
+  ssh_timeout     = "5m"
+}
+
+build {
+  name    = "hostinger-vps-provision"
+  sources = ["source.null.vps"]
+
+  # Setup user environment
+  provisioner "shell" {
+    scripts = [
+      "scripts/setup-user.sh"
+    ]
+    environment_vars = [
+      "TARGET_USER=${var.ssh_username}"
+    ]
+  }
+
+  # Install dependencies
+  provisioner "shell" {
+    scripts = [
+      "scripts/setup-deps.sh"
+    ]
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive"
+    ]
+  }
+
+  # Setup dotfiles (run as target user)
+  provisioner "shell" {
+    execute_command = "sudo -u ${var.ssh_username} bash -c '{{ .Vars }} {{ .Path }}'"
+    scripts = [
+      "scripts/setup-dotfiles.sh"
+    ]
+    environment_vars = [
+      "DOTFILES_REPO=${var.dotfiles_repo}",
+      "DOTFILES_BRANCH=${var.dotfiles_branch}",
+      "HOME=/home/${var.ssh_username}"
+    ]
+  }
+
+  # Set default shell to zsh for the target user
+  provisioner "shell" {
+    inline = [
+      "chsh -s /bin/zsh ${var.ssh_username}"
+    ]
+  }
+}

--- a/packer/hostinger-vps.pkr.hcl
+++ b/packer/hostinger-vps.pkr.hcl
@@ -73,4 +73,13 @@ build {
       "sudo usermod -s /bin/zsh ${var.ssh_username}"
     ]
   }
+
+  # Disable password authentication (key-only SSH)
+  provisioner "shell" {
+    inline = [
+      "sudo sed -i 's/^#\\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i 's/^#\\?KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' /etc/ssh/sshd_config",
+      "sudo systemctl restart sshd"
+    ]
+  }
 }

--- a/packer/hostinger-vps.pkr.hcl
+++ b/packer/hostinger-vps.pkr.hcl
@@ -53,6 +53,20 @@ build {
     ]
   }
 
+  # Authorize SSH key for the target user
+  provisioner "shell" {
+    inline = [
+      "if [ -n '${var.ssh_public_key}' ]; then",
+      "  sudo mkdir -p /home/${var.ssh_username}/.ssh",
+      "  echo '${var.ssh_public_key}' | sudo tee -a /home/${var.ssh_username}/.ssh/authorized_keys > /dev/null",
+      "  sudo sort -u -o /home/${var.ssh_username}/.ssh/authorized_keys /home/${var.ssh_username}/.ssh/authorized_keys",
+      "  sudo chmod 600 /home/${var.ssh_username}/.ssh/authorized_keys",
+      "  sudo chown -R ${var.ssh_username}:${var.ssh_username} /home/${var.ssh_username}/.ssh",
+      "  echo 'SSH key authorized for ${var.ssh_username}'",
+      "fi"
+    ]
+  }
+
   # Set default shell to zsh for the target user
   provisioner "shell" {
     inline = [

--- a/packer/hostinger-vps.pkr.hcl
+++ b/packer/hostinger-vps.pkr.hcl
@@ -56,7 +56,7 @@ build {
   # Set default shell to zsh for the target user
   provisioner "shell" {
     inline = [
-      "sudo chsh -s /bin/zsh ${var.ssh_username}"
+      "sudo usermod -s /bin/zsh ${var.ssh_username}"
     ]
   }
 }

--- a/packer/scripts/setup-deps.sh
+++ b/packer/scripts/setup-deps.sh
@@ -188,7 +188,7 @@ chmod +x "yq_linux_${ARCH_K8S}"
 mv "yq_linux_${ARCH_K8S}" /usr/local/bin/yq
 
 echo "Installing tmuxinator..."
-gem install tmuxinator 2>/dev/null || pip3 install tmuxinator || true
+gem install tmuxinator 2>/dev/null || pip3 install --break-system-packages tmuxinator 2>/dev/null || true
 
 # Ensure /usr/local/bin is in PATH for all users
 echo 'export PATH="/usr/local/bin:$PATH"' >> /etc/profile.d/local-bin.sh

--- a/packer/scripts/setup-deps.sh
+++ b/packer/scripts/setup-deps.sh
@@ -98,6 +98,8 @@ NVIM_VERSION="v0.10.2"
 if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
     curl -LO "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim-linux64.tar.gz"
     tar -xzf nvim-linux64.tar.gz
+    # Remove existing nvim binary first to avoid "Text file busy" on live servers
+    rm -f /usr/local/bin/nvim 2>/dev/null || true
     cp -r nvim-linux64/* /usr/local/
     rm -rf nvim-linux64 nvim-linux64.tar.gz
 else

--- a/packer/scripts/setup-deps.sh
+++ b/packer/scripts/setup-deps.sh
@@ -64,9 +64,13 @@ apt-get install -y \
     python3-pip \
     python3-venv \
     nodejs \
-    npm \
     cargo \
     luarocks
+
+# Install npm only if not already bundled with nodejs (NodeSource packages include npm)
+if ! command -v npm &>/dev/null; then
+    apt-get install -y npm || true
+fi
 
 # s3-boot prerequisites (GRUB tools for bootloader installation)
 echo "Installing s3-boot prerequisites..."

--- a/packer/scripts/setup-dotfiles.sh
+++ b/packer/scripts/setup-dotfiles.sh
@@ -25,9 +25,11 @@ git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 # Clone dotfiles repository
 echo "Cloning dotfiles repository..."
 if [ -d "${HOME}/dotfiles" ]; then
-    echo "Dotfiles already exist, pulling latest..."
+    echo "Dotfiles already exist, resetting to latest..."
     cd "${HOME}/dotfiles"
-    git pull origin "${DOTFILES_BRANCH}" || true
+    git fetch origin "${DOTFILES_BRANCH}"
+    git checkout -f "${DOTFILES_BRANCH}"
+    git reset --hard "origin/${DOTFILES_BRANCH}"
 else
     git clone --branch "${DOTFILES_BRANCH}" "${DOTFILES_REPO}" "${HOME}/dotfiles"
     cd "${HOME}/dotfiles"

--- a/packer/scripts/setup-dotfiles.sh
+++ b/packer/scripts/setup-dotfiles.sh
@@ -100,8 +100,13 @@ fi
 echo "Installing tmux plugins..."
 "${TPM_PATH}/bin/install_plugins" || true
 
-# Create nvim data directory (plugins will be installed on first launch)
+# ===== Install Neovim plugins =====
+echo "Installing Neovim plugins..."
+# Create nvim data directory
 mkdir -p "${HOME}/.local/share/nvim"
+
+# Run Lazy sync headlessly
+nvim --headless "+Lazy! sync" +qa 2>/dev/null || echo "Warning: Neovim plugin sync had issues"
 
 # ===== Change default shell to zsh =====
 echo "Setting zsh as default shell..."

--- a/packer/scripts/setup-dotfiles.sh
+++ b/packer/scripts/setup-dotfiles.sh
@@ -100,14 +100,6 @@ fi
 echo "Installing tmux plugins..."
 "${TPM_PATH}/bin/install_plugins" || true
 
-# ===== Install Neovim plugins =====
-echo "Installing Neovim plugins..."
-# Create nvim data directory
-mkdir -p "${HOME}/.local/share/nvim"
-
-# Run Lazy sync headlessly
-nvim --headless "+Lazy! sync" +qa 2>/dev/null || echo "Warning: Neovim plugin sync had issues"
-
 # ===== Change default shell to zsh =====
 echo "Setting zsh as default shell..."
 # This needs to be done by root, so we'll just ensure .zshrc exists

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -9,11 +9,13 @@ variable "ubuntu_version" {
 variable "iso_url" {
   type        = string
   description = "URL to the Ubuntu cloud image"
+  default     = ""
 }
 
 variable "iso_checksum" {
   type        = string
   description = "Checksum for the cloud image (file: prefix for URL)"
+  default     = ""
 }
 
 variable "disk_size" {

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,11 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars
+!terraform.tfvars.example
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,39 @@
+# SSH key for VPS access
+resource "hostinger_vps_ssh_key" "deploy" {
+  name = "dotfiles-deploy"
+  key  = var.ssh_public_key
+}
+
+# Post-install script for fresh VPS provisioning
+# Installs prerequisites needed by the s3-boot process
+resource "hostinger_vps_post_install_script" "bootstrap" {
+  name = "dotfiles-bootstrap"
+  content = <<-BASH
+    #!/bin/bash
+    set -euo pipefail
+    apt-get update
+    apt-get install -y grub2-common grub-pc-bin lz4 curl awscli
+    echo "Bootstrap complete"
+  BASH
+}
+
+# The VPS instance
+resource "hostinger_vps" "dev" {
+  plan                   = var.vps_plan
+  data_center_id         = var.vps_data_center_id
+  template_id            = var.vps_template_id
+  hostname               = var.vps_hostname
+  password               = var.vps_password
+  ssh_key_ids            = [hostinger_vps_ssh_key.deploy.id]
+  post_install_script_id = hostinger_vps_post_install_script.bootstrap.id
+
+  # After import, don't fight over mutable attributes that may
+  # drift outside Terraform (template changes via s3-boot, etc.)
+  lifecycle {
+    ignore_changes = [
+      template_id,
+      password,
+      post_install_script_id,
+    ]
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "vps_id" {
+  value       = hostinger_vps.dev.id
+  description = "Hostinger VPS ID"
+}
+
+output "vps_ipv4" {
+  value       = hostinger_vps.dev.ipv4_address
+  description = "VPS public IPv4 address"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# Copy to terraform.tfvars and fill in values
+# Most of these are set via environment variables in CI
+
+vps_data_center_id = 0       # Query: GET /api/vps/v1/data-centers
+vps_template_id    = 0       # Query: GET /api/vps/v1/templates
+vps_hostname       = "dev"
+vps_plan           = "hostingercom-vps-kvm2-usd-1m"
+
+# Sensitive values - set via env vars TF_VAR_* or pass on CLI
+# vps_password    = ""
+# ssh_public_key  = ""
+# ssh_private_key = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,55 @@
+variable "vps_plan" {
+  type        = string
+  description = "Hostinger VPS plan identifier"
+  default     = "hostingercom-vps-kvm2-usd-1m"
+}
+
+variable "vps_data_center_id" {
+  type        = number
+  description = "Hostinger data center ID"
+}
+
+variable "vps_template_id" {
+  type        = number
+  description = "Hostinger OS template ID (Ubuntu)"
+}
+
+variable "vps_hostname" {
+  type        = string
+  description = "VPS hostname"
+}
+
+variable "vps_password" {
+  type        = string
+  description = "VPS root password"
+  sensitive   = true
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key for deployment"
+}
+
+variable "ssh_private_key" {
+  type        = string
+  description = "SSH private key for provisioners"
+  sensitive   = true
+}
+
+variable "s3_bucket" {
+  type        = string
+  description = "S3 bucket for VM images and bootloader"
+  default     = "aviral-dotfiles-vm-images"
+}
+
+variable "s3_region" {
+  type        = string
+  description = "S3 bucket region"
+  default     = "us-east-1"
+}
+
+variable "image_hash" {
+  type        = string
+  description = "SHA256 hash of the current image (triggers redeployment when changed)"
+  default     = ""
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    hostinger = {
+      source  = "hostinger/hostinger"
+      version = "~> 0.1.22"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "aviral-dotfiles-vm-images"
+    key    = "terraform/dotfiles-vps/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
+provider "hostinger" {
+  # Set via HOSTINGER_API_TOKEN env var
+}
+
+provider "aws" {
+  # Set via AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars
+  region = var.s3_region
+}


### PR DESCRIPTION
## Summary
- Terraform configuration for managing Hostinger VPS with S3 backend for state
- Packer null builder for direct VPS provisioning over SSH (no image build needed)
- GitHub Actions workflows for Terraform validate/plan/apply, VPS provisioning, and SSH connectivity testing
- Packer build filter (`-only`) to support multiple builder types

## Files
- `terraform/` - Hostinger provider config, VPS resource, SSH key, post-install script
- `.github/workflows/terraform.yml` - Terraform CI/CD pipeline
- `.github/workflows/provision-vps.yml` - Direct VPS provisioning workflow
- `.github/workflows/test-ssh.yml` - VPS SSH connectivity test
- `packer/hostinger-vps.pkr.hcl` - Null builder for direct VPS provisioning
- Packer build filter updates

## Test plan
- [ ] Set GitHub secrets: HOSTINGER_API_TOKEN, VPS_PASSWORD, SSH_PUBLIC_KEY, SSH_PRIVATE_KEY
- [ ] Set GitHub variables: VPS_DATA_CENTER_ID, VPS_TEMPLATE_ID, VPS_HOSTNAME
- [ ] Run terraform validate workflow
- [ ] Run test-ssh workflow to verify VPS connectivity
- [ ] Run provision-vps workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)