### PR TITLE
Migrate GitHub Actions AWS auth to OIDC

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export AWS_PROFILE=aviral

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   terraform:
@@ -21,16 +22,18 @@ jobs:
         working-directory: ops/terraform
 
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       TF_VAR_hostinger_api_token: ${{ secrets.HOSTINGER_API_TOKEN }}
       TF_VAR_github_token: ${{ secrets.GH_TOKEN }}
-      TF_VAR_aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      TF_VAR_aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/ops/terraform/github.tf
+++ b/ops/terraform/github.tf
@@ -2,18 +2,6 @@ data "github_repository" "dotfiles" {
   full_name = "aviralmansingka/dotfiles"
 }
 
-resource "github_actions_secret" "aws_access_key_id" {
-  repository      = data.github_repository.dotfiles.name
-  secret_name     = "AWS_ACCESS_KEY_ID"
-  plaintext_value = var.aws_access_key_id
-}
-
-resource "github_actions_secret" "aws_secret_access_key" {
-  repository      = data.github_repository.dotfiles.name
-  secret_name     = "AWS_SECRET_ACCESS_KEY"
-  plaintext_value = var.aws_secret_access_key
-}
-
 resource "github_actions_secret" "hostinger_api_token" {
   repository      = data.github_repository.dotfiles.name
   secret_name     = "HOSTINGER_API_TOKEN"

--- a/ops/terraform/iam.tf
+++ b/ops/terraform/iam.tf
@@ -8,14 +8,6 @@ resource "aws_iam_user" "aviral" {
   }
 }
 
-resource "aws_iam_user" "dotfiles_ci" {
-  name = "dotfiles-ci"
-
-  tags = {
-    AKIAXQDYCVWIBCYUSFU5 = "dotfiles-ci"
-  }
-}
-
 # ─── IAM Group ────────────────────────────────────────────────────────────────
 
 resource "aws_iam_group" "admin" {
@@ -30,7 +22,6 @@ resource "aws_iam_group_membership" "admin" {
 
   users = [
     aws_iam_user.aviral.name,
-    aws_iam_user.dotfiles_ci.name,
   ]
 }
 

--- a/ops/terraform/oidc.tf
+++ b/ops/terraform/oidc.tf
@@ -1,0 +1,43 @@
+# ─── GitHub Actions OIDC Federation ──────────────────────────────────────────
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
+}
+
+resource "aws_iam_role" "github_actions" {
+  name = "github-actions-terraform"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = aws_iam_openid_connect_provider.github_actions.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:aviralmansingka/dotfiles:*"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_admin" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "github_actions_secret" "aws_role_arn" {
+  repository      = data.github_repository.dotfiles.name
+  secret_name     = "AWS_ROLE_ARN"
+  plaintext_value = aws_iam_role.github_actions.arn
+}

--- a/ops/terraform/variables.tf
+++ b/ops/terraform/variables.tf
@@ -16,14 +16,3 @@ variable "github_token" {
   sensitive   = true
 }
 
-variable "aws_access_key_id" {
-  type        = string
-  description = "AWS access key ID for GitHub Actions"
-  sensitive   = true
-}
-
-variable "aws_secret_access_key" {
-  type        = string
-  description = "AWS secret access key for GitHub Actions"
-  sensitive   = true
-}


### PR DESCRIPTION
## Summary
- Replace static IAM credentials with OIDC federation for GitHub Actions AWS authentication
- Remove `dotfiles-ci` IAM user and associated secrets
- Add OIDC provider, IAM role, and trust policy scoped to this repo
- Update workflow to use `aws-actions/configure-aws-credentials@v4` with role assumption

## Test plan
- [ ] Verify this PR's terraform plan step authenticates via OIDC
- [ ] Merge and verify terraform apply runs successfully via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)