### PR TITLE
Add Packer AMI build and EC2 devbox infrastructure

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -1,0 +1,123 @@
+name: Packer
+
+on:
+  push:
+    branches: [main]
+    paths: [ops/packer/**]
+  pull_request:
+    branches: [main]
+    paths: [ops/packer/**]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build AMI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ops/packer
+    outputs:
+      ami_id: ${{ steps.build.outputs.ami_id }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@main
+
+      - name: Packer Init
+        run: packer init .
+
+      - name: Packer Validate
+        run: packer validate .
+
+      - name: Packer Build
+        id: build
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: |
+          packer build -machine-readable . | tee build.log
+          AMI_ID=$(grep 'artifact,0,id' build.log | cut -d: -f2)
+          echo "ami_id=$AMI_ID" >> "$GITHUB_OUTPUT"
+
+  validate:
+    name: Validate AMI
+    needs: build
+    if: needs.build.outputs.ami_id != ''
+    runs-on: ubuntu-latest
+
+    env:
+      TF_VAR_hostinger_api_token: ${{ secrets.HOSTINGER_API_TOKEN }}
+      TF_VAR_github_token: ${{ secrets.GH_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f /tmp/devbox-key -N ""
+          echo "SSH_PUBLIC_KEY=$(cat /tmp/devbox-key.pub)" >> "$GITHUB_ENV"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Launch EC2 instance
+        working-directory: ops/terraform
+        run: |
+          terraform init
+          terraform apply -auto-approve \
+            -var="devbox_enabled=true" \
+            -var="ssh_public_key=$SSH_PUBLIC_KEY"
+          echo "INSTANCE_IP=$(terraform output -raw devbox_public_ip)" >> "$GITHUB_ENV"
+
+      - name: Wait for instance to be ready
+        run: |
+          echo "Waiting for SSH on $INSTANCE_IP..."
+          for i in $(seq 1 30); do
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -i /tmp/devbox-key "ubuntu@$INSTANCE_IP" true 2>/dev/null; then
+              echo "SSH is ready"
+              exit 0
+            fi
+            echo "Attempt $i/30 - waiting 10s..."
+            sleep 10
+          done
+          echo "Timed out waiting for SSH"
+          exit 1
+
+      - name: Run validation
+        run: |
+          scp -o StrictHostKeyChecking=no -i /tmp/devbox-key \
+            ops/packer/scripts/validate_tools.sh "ubuntu@$INSTANCE_IP:/tmp/validate_tools.sh"
+          ssh -o StrictHostKeyChecking=no -i /tmp/devbox-key "ubuntu@$INSTANCE_IP" \
+            "chmod +x /tmp/validate_tools.sh && /tmp/validate_tools.sh"
+
+      - name: Tear down EC2 instance
+        if: always()
+        working-directory: ops/terraform
+        run: |
+          terraform apply -auto-approve \
+            -var="devbox_enabled=false" \
+            -var="ssh_public_key=$SSH_PUBLIC_KEY"
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f /tmp/devbox-key /tmp/devbox-key.pub

--- a/ops/packer/devbox.pkr.hcl
+++ b/ops/packer/devbox.pkr.hcl
@@ -1,0 +1,83 @@
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
+  }
+}
+
+source "amazon-ebs" "devbox" {
+  ami_name      = "${var.ami_name_prefix}-{{timestamp}}"
+  instance_type = var.instance_type
+  region        = var.aws_region
+  profile       = var.aws_profile
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/*ubuntu-noble-24.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"] # Canonical
+  }
+
+  ssh_username            = "ubuntu"
+  temporary_key_pair_type = "ed25519"
+
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = 30
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name     = "dotfiles-devbox"
+    built-by = "packer"
+  }
+
+  run_tags = {
+    Name = "packer-build-dotfiles-devbox"
+  }
+
+  ami_description = "Development environment with dotfiles, zsh, tmux, neovim, and dev tools"
+}
+
+build {
+  sources = ["source.amazon-ebs.devbox"]
+
+  # Phase 1: System packages
+  provisioner "shell" {
+    script      = "${path.root}/scripts/install_system_packages.sh"
+    max_retries = 3
+  }
+
+  # Phase 2: Rust toolchain + cargo-installed tools (eza, bob-nvim)
+  provisioner "shell" {
+    script = "${path.root}/scripts/install_rust.sh"
+  }
+
+  # Phase 3: CLI tools installed via curl/binary downloads
+  provisioner "shell" {
+    script      = "${path.root}/scripts/install_cli_tools.sh"
+    max_retries = 2
+  }
+
+  # Phase 4: Clone and deploy dotfiles via stow
+  provisioner "shell" {
+    script = "${path.root}/scripts/deploy_dotfiles.sh"
+  }
+
+  # Phase 5: Shell plugins (Oh My Zsh, zsh plugins, TPM)
+  provisioner "shell" {
+    script      = "${path.root}/scripts/install_shell_plugins.sh"
+    max_retries = 2
+  }
+
+  # Phase 6: Cleanup and finalize
+  provisioner "shell" {
+    script = "${path.root}/scripts/cleanup.sh"
+  }
+}

--- a/ops/packer/scripts/cleanup.sh
+++ b/ops/packer/scripts/cleanup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "==> Deploying git config (deferred to avoid SSH URL rewrite during installs)"
+stow -d "$HOME/dotfiles" -t "$HOME" git
+
+echo "==> Setting zsh as default shell"
+sudo chsh -s "$(which zsh)" ubuntu
+
+echo "==> Cleaning up apt cache"
+sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/*
+
+echo "==> Cleaning up temp files"
+sudo rm -rf /tmp/* /var/tmp/*
+
+echo "==> Provisioning complete"

--- a/ops/packer/scripts/deploy_dotfiles.sh
+++ b/ops/packer/scripts/deploy_dotfiles.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+DOTFILES_DIR="$HOME/dotfiles"
+
+echo "==> Cloning dotfiles"
+git clone https://github.com/aviralmansingka/dotfiles.git "$DOTFILES_DIR"
+
+echo "==> Removing conflicting files"
+rm -f "$HOME/.zshenv" "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_logout" "$HOME/.profile"
+
+echo "==> Deploying dotfiles via stow"
+stow -d "$DOTFILES_DIR" -t "$HOME" zsh
+stow -d "$DOTFILES_DIR" -t "$HOME" tmux
+stow -d "$DOTFILES_DIR" -t "$HOME" nvim
+stow -d "$DOTFILES_DIR" -t "$HOME" starship
+
+# NOTE: git config is stowed in cleanup.sh (after shell plugin installs)
+# because it contains url.insteadOf that rewrites HTTPS to SSH

--- a/ops/packer/scripts/install_cli_tools.sh
+++ b/ops/packer/scripts/install_cli_tools.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+ARCH=$(dpkg --print-architecture)
+
+mkdir -p "$HOME/.local/bin"
+
+echo "==> Installing starship"
+curl -sS https://starship.rs/install.sh | sh -s -- -y -b "$HOME/.local/bin"
+
+echo "==> Installing zoxide"
+curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
+
+echo "==> Installing lazygit"
+LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | jq -r '.tag_name' | sed 's/^v//')
+if [ "$ARCH" = "amd64" ]; then
+  curl -Lo /tmp/lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
+else
+  curl -Lo /tmp/lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_arm64.tar.gz"
+fi
+tar xzf /tmp/lazygit.tar.gz -C /tmp lazygit
+sudo install /tmp/lazygit /usr/local/bin/lazygit
+
+echo "==> Installing yq"
+if [ "$ARCH" = "amd64" ]; then
+  sudo curl -Lo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"
+else
+  sudo curl -Lo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_arm64"
+fi
+sudo chmod +x /usr/local/bin/yq
+
+echo "==> Installing kubectl"
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl"
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+rm kubectl
+
+echo "==> Installing kubectx + kubens"
+if [ ! -d /opt/kubectx ]; then
+  sudo git clone https://github.com/ahmetb/kubectx /opt/kubectx
+  sudo ln -sf /opt/kubectx/kubectx /usr/local/bin/kubectx
+  sudo ln -sf /opt/kubectx/kubens /usr/local/bin/kubens
+fi
+
+echo "==> Installing k9s"
+K9S_VERSION=$(curl -s "https://api.github.com/repos/derailed/k9s/releases/latest" | jq -r '.tag_name')
+if [ "$ARCH" = "amd64" ]; then
+  curl -Lo /tmp/k9s.tar.gz "https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_amd64.tar.gz"
+else
+  curl -Lo /tmp/k9s.tar.gz "https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_arm64.tar.gz"
+fi
+tar xzf /tmp/k9s.tar.gz -C /tmp k9s
+sudo install /tmp/k9s /usr/local/bin/k9s
+
+echo "==> Installing AWS CLI v2"
+curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+sudo /tmp/aws/install
+rm -rf /tmp/awscliv2.zip /tmp/aws
+
+echo "==> Installing uv"
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+echo "==> Installing direnv"
+export bin_path="$HOME/.local/bin"
+curl -sfL https://direnv.net/install.sh | bash

--- a/ops/packer/scripts/install_rust.sh
+++ b/ops/packer/scripts/install_rust.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "==> Installing Rust via rustup"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+
+echo "==> Installing eza"
+cargo install eza
+
+echo "==> Installing bob-nvim"
+cargo install bob-nvim
+
+echo "==> Installing neovim nightly via bob"
+"$HOME/.cargo/bin/bob" use nightly

--- a/ops/packer/scripts/install_shell_plugins.sh
+++ b/ops/packer/scripts/install_shell_plugins.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "==> Installing Oh My Zsh"
+sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+echo "==> Removing Oh My Zsh generated .zshrc and restoring stowed version"
+rm -f "$HOME/.zshrc"
+cd "$HOME/dotfiles"
+stow -R -t "$HOME" zsh
+
+echo "==> Installing zsh plugins"
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
+
+echo "==> Installing TPM (Tmux Plugin Manager)"
+git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm"

--- a/ops/packer/scripts/install_system_packages.sh
+++ b/ops/packer/scripts/install_system_packages.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "==> Updating apt and installing system packages"
+sudo apt-get update -y
+sudo apt-get install -y \
+  git curl wget zsh tmux stow \
+  gcc make build-essential \
+  golang-go python3 python3-pip python3-venv nodejs npm \
+  fd-find ripgrep fzf tree \
+  luarocks unzip jq \
+  software-properties-common

--- a/ops/packer/variables.pkr.hcl
+++ b/ops/packer/variables.pkr.hcl
@@ -1,0 +1,19 @@
+variable "aws_region" {
+  type    = string
+  default = "${env("AWS_REGION")}"
+}
+
+variable "aws_profile" {
+  type    = string
+  default = "${env("AWS_PROFILE")}"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.medium"
+}
+
+variable "ami_name_prefix" {
+  type    = string
+  default = "dotfiles-devbox"
+}

--- a/ops/terraform/ec2.tf
+++ b/ops/terraform/ec2.tf
@@ -1,0 +1,83 @@
+data "aws_ami" "devbox" {
+  count = var.devbox_enabled ? 1 : 0
+
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["dotfiles-devbox-*"]
+  }
+
+  filter {
+    name   = "tag:built-by"
+    values = ["packer"]
+  }
+
+  owners = ["self"]
+}
+
+resource "aws_key_pair" "devbox" {
+  count = var.devbox_enabled ? 1 : 0
+
+  key_name   = "devbox-key"
+  public_key = var.ssh_public_key
+}
+
+resource "aws_security_group" "devbox" {
+  count = var.devbox_enabled ? 1 : 0
+
+  name        = "devbox-sg"
+  description = "Security group for devbox EC2 instance"
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "devbox-sg"
+  }
+}
+
+resource "aws_instance" "devbox" {
+  count = var.devbox_enabled ? 1 : 0
+
+  ami                    = data.aws_ami.devbox[0].id
+  instance_type          = "t3.medium"
+  key_name               = aws_key_pair.devbox[0].key_name
+  vpc_security_group_ids = [aws_security_group.devbox[0].id]
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+  }
+
+  tags = {
+    Name = "dotfiles-devbox"
+  }
+}
+
+output "devbox_public_ip" {
+  value       = var.devbox_enabled ? aws_instance.devbox[0].public_ip : null
+  description = "Public IP of the devbox instance"
+}
+
+output "devbox_instance_id" {
+  value       = var.devbox_enabled ? aws_instance.devbox[0].id : null
+  description = "Instance ID of the devbox"
+}
+
+output "devbox_ami_id" {
+  value       = var.devbox_enabled ? data.aws_ami.devbox[0].id : null
+  description = "AMI ID used for the devbox"
+}

--- a/ops/terraform/variables.tf
+++ b/ops/terraform/variables.tf
@@ -16,3 +16,16 @@ variable "github_token" {
   sensitive   = true
 }
 
+variable "devbox_enabled" {
+  type        = bool
+  description = "Whether to create the devbox EC2 instance"
+  default     = false
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key for devbox EC2 access"
+  default     = ""
+  sensitive   = true
+}
+


### PR DESCRIPTION
## Summary
- Packer template builds Ubuntu 24.04 AMI with full dotfiles dev environment (zsh, tmux, neovim, Rust, Go, kubectl, cloud tools)
- Terraform resources for EC2 instance (t3.medium) gated by `devbox_enabled` variable
- CI workflow that builds AMI on packer changes, spins up EC2, validates all tools via SSH, then tears down

## Test plan
- [x] `packer validate` passes
- [x] `terraform validate` passes
- [x] Packer build completes successfully on c5.2xlarge
- [ ] Manual trigger of workflow via `workflow_dispatch`
- [ ] EC2 instance launches and passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)