### PR TITLE
Update docs, install script, and packer build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Dotfiles
 
-This repository includes the local setup that is shared across development machines. It includes:
+This repository manages development environment configuration across macOS and Linux systems using [GNU Stow](https://www.gnu.org/software/stow/) for symlink management. It includes:
 
-- `kitty` (Terminal application that uses GPU to render text)
-- `zsh` (`bash` replacement with a good plugin system)
-- `tmux` (Terminal multiplexer that makes it easier to persistently work on remote machines)
-- `neovim` ("blazingly fast" text editor written in Lua)
+- **ghostty** - GPU-accelerated terminal emulator
+- **zsh** - Shell with Oh My Zsh, Powerlevel10k, and plugins
+- **tmux** - Terminal multiplexer with Catppuccin theme and TPM
+- **neovim** - LazyVim distribution with AI coding assistance
+- **aerospace** - Tiling window manager for macOS
+- **starship** - Cross-shell prompt
 
-## Easy Installation
+## Quick Start
 
 ```sh
 git clone https://github.com/aviralmansingka/dotfiles ${HOME}/dotfiles
@@ -15,81 +17,83 @@ cd ${HOME}/dotfiles/
 ./install.sh
 ```
 
-The script does the following:
-
-1. Install `homebrew` (works on Linux as well!)
-2. Install dependencies mentioned in `Brewfile`
-3. Move configuration files using `stow` to `~/`
+The script installs dependencies via Homebrew, deploys configurations with `stow`, sets up shell plugins, and installs Neovim via `bob`.
 
 ## Manual Installation
 
-### Dependencies
-
-#### MacOS
+### macOS
 
 ```sh
 brew bundle
+stow nvim tmux zsh ghostty git starship
 ```
 
-#### RHEL/CentOS
+### Ubuntu
 
 ```sh
-sudo yum install -y git gcc gcc-c++ make fd stow fzf ripgrep wget tree zsh tmux go
+sudo apt-get install -y git build-essential tmux stow fzf ripgrep wget tree zsh fd-find curl python3-pip
 ```
 
-#### Ubuntu
+### RHEL/CentOS
 
 ```sh
-sudo apt-get install -y git build-essential tmux stow fzf ripgrep wget tree zsh fd-find curl python3-pip go
+sudo yum install -y git gcc gcc-c++ make fd stow fzf ripgrep wget tree zsh tmux
 ```
 
-### Clone repository
+### Deploy Configurations
 
 ```sh
 git clone https://github.com/aviralmansingka/dotfiles ${HOME}/dotfiles
 cd ${HOME}/dotfiles
-stow lazyvim tmux zsh
+stow nvim tmux zsh ghostty git
 ```
 
-### Install Neovim
+### Shell Setup
 
 ```sh
-cd ${HOME}
-curl -LO https://github.com/neovim/neovim/releases/download/stable/nvim-linux-arm64.tar.gz
-tar xvf ./nvim-linux-arm64.tar.gz
-ln -s ./nvim-linux-arm64/bin/nvim /usr/local/bin/
-export PATH=$PATH:${HOME}/nvim-linux-arm64/bin
+# Oh My Zsh
+sh -c "RUNZSH='no' KEEP_ZSHRC='yes' $(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# Plugins
+git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 ```
 
-### Install tmux
+### Tmux Setup
 
 ```sh
 git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+~/.tmux/plugins/tpm/bin/install_plugins
 ```
 
-### Install zsh
+## Stow Packages
 
-```sh
-sh -c "RUNZSH='no' KEEP_ZSHRC='yes' $(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+| Package | Description |
+|---------|-------------|
+| `aerospace` | AeroSpace tiling window manager |
+| `blinksh` | Blink Shell (iOS terminal) config |
+| `claude` | Claude AI context files |
+| `code` | Code snippets (Golang, Lua) |
+| `ghostty` | Ghostty terminal emulator |
+| `git` | Git configuration |
+| `kube` | Kubernetes configuration |
+| `neovide` | Neovide (Neovim GUI) config |
+| `nvim` | Neovim with LazyVim |
+| `ssh` | SSH configuration |
+| `starship` | Starship prompt |
+| `terminfo` | Custom terminfo entries |
+| `tmux` | Tmux configuration |
+| `tmuxinator` | Tmuxinator session templates |
+| `zsh` | Zsh shell configuration |
 
-# Install plugins
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
-git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
-git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
-git clone https://github.com/ptavares/zsh-exa.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-exa
+## Infrastructure
 
-rm -rf ${HOME}/.zshrc
-echo 'export PATH=$PATH:${HOME}/nvim-linux-arm64/bin' >> .zshrc
-```
+Development environment AMIs and cloud infrastructure are managed in `ops/`:
 
-### Setup all tools
+- **Packer** (`ops/packer/`) - Builds Ubuntu 24.04 AMIs with full development toolchain
+- **Terraform** (`ops/terraform/`) - Manages AWS infrastructure (EC2, IAM, DNS, GitHub OIDC)
 
-**note**: This introduces a lot of additional packages and configuration
-required for `tmux` and `zsh`
-
-```sh
-./install.sh
-```
+CI/CD workflows automatically build AMIs and apply infrastructure changes on push to `main`.
 
 ## LICENSE
 

--- a/install.sh
+++ b/install.sh
@@ -1,79 +1,112 @@
 #!/bin/bash
+set -euo pipefail
 
-# Dotfiles installation script
-# Dependencies are managed centrally in dependencies.yml
-# Brewfile is automatically generated from dependencies.yml via scripts/generate-brewfile.sh
+# Dotfiles installation script for macOS
+# Mirrors the provisioning pipeline in ops/packer/scripts/ adapted for macOS+Homebrew:
+#   1. System packages (Homebrew)
+#   2. Rust toolchain + cargo tools
+#   3. Dotfiles deployment via stow
+#   4. Shell plugins (Oh My Zsh, zsh plugins, TPM)
+#   5. Git config (deferred to avoid SSH URL rewrite during installs)
 
-####################
-#      Brew        #
-####################
-
-# Install all dependencies from Brewfile (generated from dependencies.yml)
-brew bundle
-
-# Get developer essentials
-stow git
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 ####################
-#      Kitty       #
+#  1. Homebrew     #
 ####################
 
-# Move configuration files
-stow kitty
+if ! command -v brew &> /dev/null; then
+    echo "==> Installing Homebrew"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # Add brew to PATH for the rest of the script
+    if [[ -f /opt/homebrew/bin/brew ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [[ -f /usr/local/bin/brew ]]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+fi
+
+echo "==> Installing packages from Brewfile"
+brew bundle --file="$DOTFILES_DIR/Brewfile"
 
 ####################
-#      Tmux        #
+#  2. Rust         #
 ####################
+# Mirrors: ops/packer/scripts/install_rust.sh
 
-# Install tmux package manager
-rm -rf ~/.tmux
-git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+if ! command -v rustc &> /dev/null; then
+    echo "==> Installing Rust via rustup"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
 
-# Move configuration files
-stow tmux
+echo "==> Installing cargo tools (eza, bob-nvim)"
+cargo install eza
+cargo install bob-nvim
 
-####################
-#       Zsh        #
-####################
-
-# Install oh-my-zsh
-rm -rf ~/.oh-my-zsh
-sh -c "RUNZSH='no' KEEP_ZSHRC='yes' $(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-
-# Install plugins
-git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
-git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
-
-# Move configuration files
-rm -rf ~/.zshrc
-stow zsh
+echo "==> Installing neovim nightly via bob"
+bob use nightly
 
 ####################
-#      Terminfo     #
+#  3. Stow         #
 ####################
+# Mirrors: ops/packer/scripts/deploy_dotfiles.sh
 
-# Install custom terminfo entries
-if command -v tic &> /dev/null; then
-    echo "Installing custom terminfo entries..."
+echo "==> Removing conflicting files"
+rm -f "$HOME/.zshenv" "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_logout" "$HOME/.profile"
 
-    # Create user terminfo directory if it doesn't exist
-    mkdir -p ~/.terminfo
+echo "==> Deploying dotfiles via stow"
+stow -d "$DOTFILES_DIR" -t "$HOME" zsh
+stow -d "$DOTFILES_DIR" -t "$HOME" tmux
+stow -d "$DOTFILES_DIR" -t "$HOME" nvim
+stow -d "$DOTFILES_DIR" -t "$HOME" starship
+stow -d "$DOTFILES_DIR" -t "$HOME" ghostty
+stow -d "$DOTFILES_DIR" -t "$HOME" aerospace
 
-    # Install xterm-ghostty terminfo for proper ghostty support
-    # This enables full OSC 52 (clipboard) support and other ghostty-specific features
-    tic -x -w terminfo/xterm-ghostty.terminfo
+####################
+#  4. Shell plugins #
+####################
+# Mirrors: ops/packer/scripts/install_shell_plugins.sh
 
-    echo "Terminfo entries installed to ~/.terminfo/"
-else
-    echo "Warning: tic command not found, skipping terminfo installation"
+echo "==> Installing Oh My Zsh"
+if [[ ! -d "$HOME/.oh-my-zsh" ]]; then
+    sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+fi
+
+echo "==> Removing Oh My Zsh generated .zshrc and restoring stowed version"
+rm -f "$HOME/.zshrc"
+stow -R -d "$DOTFILES_DIR" -t "$HOME" zsh
+
+echo "==> Installing zsh plugins"
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+[[ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]] && \
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
+[[ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]] && \
+    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
+
+echo "==> Installing TPM (Tmux Plugin Manager)"
+if [[ ! -d "$HOME/.tmux/plugins/tpm" ]]; then
+    git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm"
 fi
 
 ####################
-#      NeoVim      #
+#  5. Terminfo     #
 ####################
 
-cargo install bob-nvim
-bob use nightly
+if command -v tic &> /dev/null; then
+    echo "==> Installing custom terminfo entries"
+    mkdir -p ~/.terminfo
+    tic -x -w "$DOTFILES_DIR/terminfo/xterm-ghostty.terminfo"
+fi
 
-# Move configuration files
-stow lazyvim
+####################
+#  6. Git config   #
+####################
+# Mirrors: ops/packer/scripts/cleanup.sh
+# Deferred to avoid SSH URL rewrite during installs
+
+echo "==> Deploying git config (deferred to avoid SSH URL rewrite during installs)"
+stow -d "$DOTFILES_DIR" -t "$HOME" git
+
+echo "==> Installation complete!"

--- a/ops/packer/scripts/deploy_dotfiles.sh
+++ b/ops/packer/scripts/deploy_dotfiles.sh
@@ -15,5 +15,9 @@ stow -d "$DOTFILES_DIR" -t "$HOME" tmux
 stow -d "$DOTFILES_DIR" -t "$HOME" nvim
 stow -d "$DOTFILES_DIR" -t "$HOME" starship
 
+echo "==> Installing custom terminfo entries"
+mkdir -p "$HOME/.terminfo"
+tic -x -w "$DOTFILES_DIR/terminfo/xterm-ghostty.terminfo"
+
 # NOTE: git config is stowed in cleanup.sh (after shell plugin installs)
 # because it contains url.insteadOf that rewrites HTTPS to SSH

--- a/ops/packer/scripts/validate_tools.sh
+++ b/ops/packer/scripts/validate_tools.sh
@@ -87,6 +87,7 @@ check_path "$HOME/.zshrc" ".zshrc"
 check_path "$HOME/.tmux.conf" ".tmux.conf"
 check_path "$HOME/.config/nvim" "nvim config"
 check_path "$HOME/.config/starship.toml" "starship config"
+check_path "$HOME/.terminfo" "terminfo directory"
 
 echo ""
 echo "=== Default shell ==="


### PR DESCRIPTION
## Summary
- **CLAUDE.md/README.md**: Replace stale references (lazyvim→nvim, kitty→ghostty), add all 15 stow packages, document ops/ infrastructure and CI/CD workflows, remove non-existent Docker testing/images sections
- **install.sh**: Rewrite for macOS mirroring the Packer provisioning pipeline (Homebrew, Rust, stow, shell plugins, terminfo, deferred git config)
- **Packer**: Add xterm-ghostty terminfo installation to deploy_dotfiles.sh and validation check in validate_tools.sh

## Test plan
- [ ] Verify install.sh runs on a clean macOS environment
- [ ] Verify Packer AMI build installs terminfo entries
- [ ] Review CLAUDE.md and README.md for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)