### PR TITLE
Split Packer build into base and devbox layers

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -8,21 +8,48 @@ on:
     branches: [main]
     paths: [ops/packer/**]
   workflow_dispatch:
+    inputs:
+      build_base:
+        description: 'Rebuild the base AMI'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  build:
-    name: Build AMI
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      base_changed: ${{ steps.changes.outputs.base }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for base layer changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "base=${{ inputs.build_base }}" >> "$GITHUB_OUTPUT"
+          else
+            BASE_PATTERNS="ops/packer/base.pkr.hcl|ops/packer/variables.pkr.hcl|ops/packer/scripts/install_system_packages.sh|ops/packer/scripts/install_rust.sh|ops/packer/scripts/install_cli_tools.sh"
+            if git diff --name-only HEAD~1 HEAD | grep -qE "$BASE_PATTERNS"; then
+              echo "base=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "base=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+  validate-templates:
+    name: Validate Templates
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ops/packer
-    outputs:
-      ami_id: ${{ steps.build.outputs.ami_id }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,18 +69,78 @@ jobs:
       - name: Packer Validate
         run: packer validate .
 
-      - name: Packer Build
+  build-base:
+    name: Build Base AMI
+    needs: [detect-changes, validate-templates]
+    if: >-
+      needs.detect-changes.outputs.base_changed == 'true' &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ops/packer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@main
+
+      - name: Packer Init
+        run: packer init .
+
+      - name: Packer Build Base
+        run: packer build -only=amazon-ebs.base .
+
+  build-devbox:
+    name: Build Devbox AMI
+    needs: [detect-changes, validate-templates, build-base]
+    if: >-
+      always() &&
+      needs.validate-templates.result == 'success' &&
+      (needs.build-base.result == 'success' || needs.build-base.result == 'skipped') &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ops/packer
+    outputs:
+      ami_id: ${{ steps.build.outputs.ami_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@main
+
+      - name: Packer Init
+        run: packer init .
+
+      - name: Packer Build Devbox
         id: build
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: |
-          packer build -machine-readable . | tee build.log
+          packer build -only=amazon-ebs.devbox -machine-readable . | tee build.log
           AMI_ID=$(grep 'artifact,0,id' build.log | cut -d: -f2)
           echo "ami_id=$AMI_ID" >> "$GITHUB_OUTPUT"
 
   validate:
     name: Validate AMI
-    needs: build
-    if: needs.build.outputs.ami_id != ''
+    needs: build-devbox
+    if: needs.build-devbox.outputs.ami_id != ''
     runs-on: ubuntu-latest
 
     env:

--- a/ops/packer/base.pkr.hcl
+++ b/ops/packer/base.pkr.hcl
@@ -1,0 +1,66 @@
+source "amazon-ebs" "base" {
+  ami_name      = "${var.base_ami_name_prefix}-{{timestamp}}"
+  instance_type = var.instance_type
+  region        = var.aws_region
+  profile       = var.aws_profile
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/*ubuntu-noble-24.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"] # Canonical
+  }
+
+  ssh_username            = "ubuntu"
+  temporary_key_pair_type = "ed25519"
+
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = 30
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name     = "devbox-base"
+    built-by = "packer"
+  }
+
+  run_tags = {
+    Name = "packer-build-devbox-base"
+  }
+
+  ami_description = "Base layer: system packages, Rust toolchain, and CLI tools"
+}
+
+build {
+  sources = ["source.amazon-ebs.base"]
+
+  # Phase 1: System packages
+  provisioner "shell" {
+    script      = "${path.root}/scripts/install_system_packages.sh"
+    max_retries = 3
+  }
+
+  # Phase 2: Rust toolchain + cargo-installed tools (eza, bob-nvim)
+  provisioner "shell" {
+    script = "${path.root}/scripts/install_rust.sh"
+  }
+
+  # Phase 3: CLI tools installed via curl/binary downloads
+  provisioner "shell" {
+    script      = "${path.root}/scripts/install_cli_tools.sh"
+    max_retries = 2
+  }
+
+  # Clean up to reduce base AMI size
+  provisioner "shell" {
+    inline = [
+      "sudo apt-get clean",
+      "sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*"
+    ]
+  }
+}

--- a/ops/packer/devbox.pkr.hcl
+++ b/ops/packer/devbox.pkr.hcl
@@ -15,12 +15,12 @@ source "amazon-ebs" "devbox" {
 
   source_ami_filter {
     filters = {
-      name                = "ubuntu/images/*ubuntu-noble-24.04-amd64-server-*"
+      name                = "${var.base_ami_name_prefix}-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }
     most_recent = true
-    owners      = ["099720109477"] # Canonical
+    owners      = ["self"]
   }
 
   ssh_username            = "ubuntu"
@@ -47,23 +47,6 @@ source "amazon-ebs" "devbox" {
 
 build {
   sources = ["source.amazon-ebs.devbox"]
-
-  # Phase 1: System packages
-  provisioner "shell" {
-    script      = "${path.root}/scripts/install_system_packages.sh"
-    max_retries = 3
-  }
-
-  # Phase 2: Rust toolchain + cargo-installed tools (eza, bob-nvim)
-  provisioner "shell" {
-    script = "${path.root}/scripts/install_rust.sh"
-  }
-
-  # Phase 3: CLI tools installed via curl/binary downloads
-  provisioner "shell" {
-    script      = "${path.root}/scripts/install_cli_tools.sh"
-    max_retries = 2
-  }
 
   # Phase 4: Clone and deploy dotfiles via stow
   provisioner "shell" {

--- a/ops/packer/scripts/deploy_dotfiles.sh
+++ b/ops/packer/scripts/deploy_dotfiles.sh
@@ -19,5 +19,9 @@ echo "==> Installing custom terminfo entries"
 mkdir -p "$HOME/.terminfo"
 tic -x -w "$DOTFILES_DIR/terminfo/xterm-ghostty.terminfo"
 
+echo "==> Installing Neovim plugins via lazy.nvim"
+export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"
+nvim --headless "+Lazy! sync" +qa
+
 # NOTE: git config is stowed in cleanup.sh (after shell plugin installs)
 # because it contains url.insteadOf that rewrites HTTPS to SSH

--- a/ops/packer/scripts/validate_tools.sh
+++ b/ops/packer/scripts/validate_tools.sh
@@ -74,6 +74,9 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+check_path "$HOME/.local/share/nvim/lazy/lazy.nvim" "lazy.nvim plugin manager"
+check_path "$HOME/.local/share/nvim/lazy/LazyVim" "LazyVim distribution"
+
 echo ""
 echo "=== Shell configuration ==="
 check_path "$HOME/.oh-my-zsh" "Oh My Zsh"

--- a/ops/packer/variables.pkr.hcl
+++ b/ops/packer/variables.pkr.hcl
@@ -17,3 +17,8 @@ variable "ami_name_prefix" {
   type    = string
   default = "dotfiles-devbox"
 }
+
+variable "base_ami_name_prefix" {
+  type    = string
+  default = "devbox-base"
+}

--- a/ops/terraform/devbox.tf
+++ b/ops/terraform/devbox.tf
@@ -53,7 +53,7 @@ resource "aws_instance" "devbox" {
   count = var.devbox_enabled ? 1 : 0
 
   ami                    = data.aws_ami.devbox[0].id
-  instance_type          = "t3.medium"
+  instance_type          = "c5.2xlarge"
   key_name               = aws_key_pair.devbox[0].key_name
   vpc_security_group_ids = [aws_security_group.devbox[0].id]
 


### PR DESCRIPTION
## Summary
- Split Packer AMI build into two stages: a base layer (system packages, Rust, CLI tools) and a devbox layer (dotfiles, shell plugins, Neovim)
- Updated CI workflow with change detection to only rebuild base when relevant files change, plus `workflow_dispatch` input for manual base rebuilds
- Added Neovim lazy.nvim plugin sync and validation to AMI build pipeline
- Renamed `ec2.tf` to `devbox.tf` and updated instance type to c5.2xlarge

## Test plan
- [ ] Trigger workflow_dispatch with `build_base=true` to build base AMI
- [ ] Push a change to `ops/packer/scripts/deploy_dotfiles.sh` to verify only devbox layer rebuilds
- [ ] Verify `terraform plan` succeeds with renamed devbox.tf

🤖 Generated with [Claude Code](https://claude.com/claude-code)