### PR TITLE
Trigger packer build when dependencies.json changes

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -40,12 +40,12 @@ jobs:
             echo "base=${{ inputs.build_base }}" >> "$GITHUB_OUTPUT"
           else
             CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
-            if echo "$CHANGED_FILES" | grep -qE '^ops/packer/'; then
+            if echo "$CHANGED_FILES" | grep -qE '^ops/packer/|^dependencies\.json$'; then
               echo "packer=true" >> "$GITHUB_OUTPUT"
             else
               echo "packer=false" >> "$GITHUB_OUTPUT"
             fi
-            BASE_PATTERNS="ops/packer/base.pkr.hcl|ops/packer/variables.pkr.hcl|ops/packer/scripts/install_system_packages.sh|ops/packer/scripts/install_rust.sh|ops/packer/scripts/install_cli_tools.sh"
+            BASE_PATTERNS="ops/packer/base.pkr.hcl|ops/packer/variables.pkr.hcl|ops/packer/scripts/install_system_packages.sh|ops/packer/scripts/install_rust.sh|ops/packer/scripts/install_cli_tools.sh|^dependencies\.json$"
             if echo "$CHANGED_FILES" | grep -qE "$BASE_PATTERNS"; then
               echo "base=true" >> "$GITHUB_OUTPUT"
             else


### PR DESCRIPTION
## Summary
- Add `dependencies.json` to packer change detection so AMI rebuilds trigger when dependencies change
- Add to base change detection as well, since dependency changes affect base image packages

## Test plan
- [ ] Verify `Packer Result` check passes on this PR (no packer files changed, should auto-pass)
- [ ] Verify a future PR changing `dependencies.json` triggers the full packer pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)