### PR TITLE
Fix CI validate S3 access and add branch-scoped state keys

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -182,7 +182,7 @@ jobs:
         run: |
           AMI_ID="${{ needs.build-devbox.outputs.ami_id }}"
           echo "Validating AMI: $AMI_ID"
-          terraform init -backend-config="key=ci/terraform.tfstate"
+          terraform init -backend-config="bucket=aviral-dotfiles-terraform-state" -backend-config="key=ci/terraform.tfstate"
           terraform apply -auto-approve \
             -target=aws_key_pair.devbox \
             -target=aws_security_group.devbox \
@@ -230,7 +230,7 @@ jobs:
       - name: Cleanup ephemeral state
         if: always()
         run: |
-          aws s3 rm "s3://aviral-devbox-terraform-state/ci/terraform.tfstate" || true
+          aws s3 rm "s3://aviral-dotfiles-terraform-state/ci/terraform.tfstate" || true
 
       - name: Deregister PR AMI
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -182,7 +182,7 @@ jobs:
         run: |
           AMI_ID="${{ needs.build-devbox.outputs.ami_id }}"
           echo "Validating AMI: $AMI_ID"
-          terraform init -backend-config="bucket=aviral-dotfiles-terraform-state" -backend-config="key=ci/terraform.tfstate"
+          terraform init -backend-config="bucket=aviral-dotfiles-terraform-state" -backend-config="key=ci/$BRANCH_NAME/terraform.tfstate"
           terraform apply -auto-approve \
             -target=aws_key_pair.devbox \
             -target=aws_security_group.devbox \
@@ -230,7 +230,7 @@ jobs:
       - name: Cleanup ephemeral state
         if: always()
         run: |
-          aws s3 rm "s3://aviral-dotfiles-terraform-state/ci/terraform.tfstate" || true
+          aws s3 rm "s3://aviral-dotfiles-terraform-state/ci/$BRANCH_NAME/terraform.tfstate" || true
 
       - name: Deregister PR AMI
         if: always() && github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Use `aviral-dotfiles-terraform-state` bucket for CI validation (the devbox bucket permissions from PR #18 haven't been deployed yet)
- Prefix terraform state key with branch name (`ci/$BRANCH_NAME/terraform.tfstate`) to prevent collisions between concurrent PR validations

## Test plan
- [ ] Confirm validate job can init terraform backend without S3 403 errors
- [ ] Confirm state is created under branch-scoped key in S3
- [ ] Confirm state cleanup removes the branch-scoped key

🤖 Generated with [Claude Code](https://claude.com/claude-code)