### PR TITLE
zsh: dvim alias for cmake-built Neovim

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -30,6 +30,10 @@ vim() {
     bob run nightly "$@"
   fi
 }
+
+# CMake-built Neovim from this checkout (sets VIMRUNTIME + NVIM_GHOSTTY_VT); see scripts/run-built-nvim.sh.
+alias dvim='$HOME/tools/neovim/scripts/run-built-nvim.sh'
+
 alias rg='rg --hidden'
 alias ls='eza --icons -l'
 alias inv='uv run inv'


### PR DESCRIPTION
## Summary
Convenience alias `dvim` -> `~/tools/neovim/scripts/run-built-nvim.sh` for testing the locally-compiled CMake build of Neovim without overriding the main `vim` function (which manages bob nightly switching).

## Keymaps
None — shell alias only.

## Example flow
```
cd ~/tools/neovim && cmake --build build
dvim some_file.txt   # runs the just-built nvim
```

## Validation
Manual: `dvim --version` reports the CMake build hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)