### PR TITLE
Fix: restore dap_eval_repl (REPL window) accidentally reverted in #24

### DIFF
--- a/nvim/.config/nvim/lua/plugins/dap.lua
+++ b/nvim/.config/nvim/lua/plugins/dap.lua
@@ -112,45 +112,19 @@ local function find_repl_window()
   return nil
 end
 
--- Module-level state for eval/yank lifecycle. Tracks the persistent hover
--- float (auto/manual <localleader>g) and the last expression so
--- <localleader>y can re-evaluate the stringified form.
+-- Module-level state for eval/yank lifecycle. Single REPL session at a time
+-- (matches nvim-dap's model — one REPL per debug session).
 local _eval_state = {
   last_expr = nil,
-  hover_buf = nil,
-  hover_win = nil,
   idle_timer = nil,
 }
 
-local function close_hover()
-  if _eval_state.hover_win and vim.api.nvim_win_is_valid(_eval_state.hover_win) then
-    pcall(vim.api.nvim_win_close, _eval_state.hover_win, true)
-  end
-  _eval_state.hover_buf = nil
-  _eval_state.hover_win = nil
-end
-
-local function get_cursor_expression()
-  if vim.bo.filetype == "dap-repl" then
-    return nil
-  end
-  local node = expression_under_cursor()
-  if not node then
-    return nil
-  end
-  local text = vim.treesitter.get_node_text(node, 0)
-  if not text or text == "" then
-    return nil
-  end
-  return text
-end
-
--- Render the eval result in a hover float at the cursor (rounded border,
--- persistent — only closes on q/<Esc> or when a new auto-trigger replaces
--- it). opts.source = "manual" focuses an already-open hover on re-press;
--- "auto" silently skips re-eval if the cursor is still on the same
--- expression.
-local function dap_eval_hover(opts)
+-- Open the REPL with the current expression, or focus the existing REPL
+-- if a manual press came in while the REPL is already visible. opts.source
+-- controls behavior: "manual" notifies on missing session and focuses an
+-- already-open REPL on re-press; "auto" is silent and skips re-eval if the
+-- cursor is on the same expression we just evaluated.
+local function dap_eval_repl(opts)
   opts = opts or {}
   local ok_dap, dap = pcall(require, "dap")
   if not ok_dap then
@@ -164,107 +138,36 @@ local function dap_eval_hover(opts)
     return
   end
 
-  -- Manual re-press: if hover is visible and we're not in it, jump in.
-  if
-    opts.source == "manual"
-    and _eval_state.hover_win
-    and vim.api.nvim_win_is_valid(_eval_state.hover_win)
-    and vim.api.nvim_get_current_win() ~= _eval_state.hover_win
-  then
-    vim.api.nvim_set_current_win(_eval_state.hover_win)
+  local existing_repl = find_repl_window()
+
+  -- Manual re-press while REPL is open and we're not in it: focus into REPL.
+  if opts.source == "manual" and existing_repl and vim.api.nvim_get_current_win() ~= existing_repl then
+    vim.api.nvim_set_current_win(existing_repl)
     return
   end
 
-  -- Don't auto-trigger from inside the hover itself.
-  if _eval_state.hover_buf and vim.api.nvim_get_current_buf() == _eval_state.hover_buf then
+  -- Don't try to evaluate from inside the REPL itself.
+  if vim.bo.filetype == "dap-repl" then
     return
   end
 
-  local expression = get_cursor_expression()
-  if not expression then
+  local node = expression_under_cursor()
+  if not node then
+    return
+  end
+  local expression = vim.treesitter.get_node_text(node, 0)
+  if not expression or expression == "" then
     return
   end
 
-  if
-    opts.source == "auto"
-    and expression == _eval_state.last_expr
-    and _eval_state.hover_win
-    and vim.api.nvim_win_is_valid(_eval_state.hover_win)
-  then
-    return
-  end
-  _eval_state.last_expr = expression
-
-  local frame_id = session.current_frame and session.current_frame.id
-  local source_ft = vim.bo.filetype
-  session:request("evaluate", {
-    expression = expression,
-    frameId = frame_id,
-    context = "repl",
-  }, function(err, response)
-    vim.schedule(function()
-      close_hover()
-
-      local body
-      if err then
-        body = { "**Error:** " .. (err.message or vim.inspect(err)) }
-      else
-        local result = (response and response.result) or "(no result)"
-        body = { "```" .. (source_ft or ""), expression, "```", "" }
-        for line in (result .. "\n"):gmatch("([^\n]*)\n") do
-          if line ~= "" or #body > 5 then
-            table.insert(body, line)
-          end
-        end
-      end
-
-      local fb, fw = vim.lsp.util.open_floating_preview(body, "markdown", {
-        border = "rounded",
-        wrap = true,
-        max_width = 100,
-        max_height = 20,
-        focusable = true,
-        close_events = {},
-      })
-      _eval_state.hover_buf = fb
-      _eval_state.hover_win = fw
-
-      if fb then
-        vim.keymap.set("n", "<localleader>y", function()
-          dap_yank_stringify()
-        end, { buffer = fb, desc = "DAP: Yank stringified value" })
-        vim.keymap.set("n", "q", function()
-          close_hover()
-        end, { buffer = fb, desc = "DAP: Close eval hover" })
-        vim.keymap.set("n", "<Esc>", function()
-          close_hover()
-        end, { buffer = fb, desc = "DAP: Close eval hover" })
-      end
-    end)
-  end)
-end
-
--- Run the cursor expression in the bottom REPL split (open if not present).
--- Focus stays on the source window.
-local function dap_eval_repl_split()
-  local ok_dap, dap = pcall(require, "dap")
-  if not ok_dap then
-    return
-  end
-  local session = dap.session()
-  if not session or not session.stopped_thread_id then
-    vim.notify("DAP: no paused session", vim.log.levels.WARN)
-    return
-  end
-
-  local expression = get_cursor_expression()
-  if not expression then
+  -- Auto-trigger: skip re-eval if cursor is on the same expression as last time.
+  if opts.source == "auto" and expression == _eval_state.last_expr then
     return
   end
   _eval_state.last_expr = expression
 
   local prev_win = vim.api.nvim_get_current_win()
-  if not find_repl_window() then
+  if not existing_repl then
     dap.repl.open({ height = 10 })
   end
   dap.repl.execute(expression)
@@ -316,9 +219,9 @@ local function dap_yank_stringify()
   end)
 end
 
--- Idle auto-trigger: 2s of cursor stillness in a Python/Go source buffer
--- with an active paused DAP session evaluates the cursor expression and
--- renders it in a hover float. CursorMoved resets the timer.
+-- Idle auto-trigger: 3s of cursor stillness in a Python/Go source buffer
+-- with an active paused DAP session evaluates the cursor expression in the
+-- REPL. CursorMoved resets the timer (token-free with vim.uv.new_timer).
 local AUTO_TRIGGER_FILETYPES = { python = true, go = true }
 local function reset_idle_timer()
   if _eval_state.idle_timer then
@@ -343,7 +246,7 @@ vim.api.nvim_create_autocmd({ "CursorMoved", "BufEnter", "InsertEnter", "WinEnte
 
     _eval_state.idle_timer = vim.uv.new_timer()
     _eval_state.idle_timer:start(
-      2000,
+      3000,
       0,
       vim.schedule_wrap(function()
         reset_idle_timer()
@@ -354,7 +257,7 @@ vim.api.nvim_create_autocmd({ "CursorMoved", "BufEnter", "InsertEnter", "WinEnte
         if not sess or not sess.stopped_thread_id then
           return
         end
-        dap_eval_hover({ source = "auto" })
+        dap_eval_repl({ source = "auto" })
       end)
     )
   end,


### PR DESCRIPTION
## Summary
PR #24 (modal-debug-launch) bundled an unintended dap.lua revert that lost the REPL-window-based eval (`dap_eval_repl`) and replaced it with the older hover-float implementation (`dap_eval_hover`). This restores the intended file content.

## Validation
File diff matches the pre-#24 working tree captured in the local snapshot branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)