### PR TITLE
Octo PR review flow: <leader>O namespace, comment templates, threads picker

### DIFF
--- a/docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md
+++ b/docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md
@@ -63,18 +63,28 @@ All global, mode `n` unless noted.
 
 | Key | Action | Implementation |
 |---|---|---|
-| `<leader>OO` | Smart entry: if current branch has an open PR, start/resume review; else open PR list | Detects PR via `gh pr view --json number,state --jq` then `:Octo review start`/`resume`; else `:Octo pr list` |
+| `<leader>OO` | Smart entry — three states (see below) | `gh pr view --json number,state` to detect, then `:Octo review start`/`:Octo review resume`/`:Octo pr list` |
 | `<leader>Op` | PR list (default scope) | `:Octo pr list` |
 | `<leader>OP` | PR search (free-form within PRs) | `:Octo pr search` |
 | `<leader>Om` | PRs authored by me | `:Octo pr list author=@me` |
 | `<leader>Or` | PRs requesting my review | `:Octo pr list reviewer=@me state=open` (verify flag syntax at impl) |
 | `<leader>OA` | Prompt for author, then list | `vim.ui.input` → `:Octo pr list author=<input>` |
-| `<leader>OS` | Free-form Octo search (all kinds) | `:Octo search` |
 | `<leader>OT` | Threads picker for current PR | `require('plugins.octo.threads_picker').open()` |
-| `<leader>Oi` | Issue list | `:Octo issue list` |
-| `<leader>OI` | Issue search | `:Octo issue search` |
-| `<leader>Oc` | Checkout PR (picker if not in a PR buffer); commonly chained with `<leader>OO` to start the review on the checked-out branch | `:Octo pr checkout` |
+| `<leader>Oc` | Checkout PR (picker if not in a PR buffer); | |
+| | commonly chained with `<leader>OO` to start the review on the checked-out branch | `:Octo pr checkout` |
 | `<leader>Ob` | Open PR in browser | `:Octo pr browser` |
+
+### `<leader>OO` smart-entry states
+
+The smart entry has three deterministic branches based on the current branch's PR state. The implementation checks via `gh pr view --json number,state` (silently — non-zero exit means "no PR for branch").
+
+| Detected state | Action |
+|---|---|
+| Current branch has an open PR **and** a pending review exists for it | `:Octo review resume` — reopens the review tab where you left off |
+| Current branch has an open PR **but no pending review** | `:Octo review start` — opens a fresh review tab |
+| Current branch has no associated open PR | `:Octo pr list` — falls back to the PR picker |
+
+Detecting "pending review exists" is done by querying `pullRequest.reviewRequests` / `pendingReview` via Octo's own state if cheap, else by trying `:Octo review resume` and falling through to `:Octo review start` on error. Confirm the exact cheap-check API during the implementation spike.
 
 ### Comment template keymaps (buffer-local)
 
@@ -133,6 +143,28 @@ Picking by author has two paths because they serve different use cases: `<leader
 - `<C-m>` comment
 - `<C-r>` request changes
 - `<C-c>` close tab without submitting
+
+### Switching between reviewing and executing
+
+Common mid-review need: jump out of the diff view to run/debug/test the PR's code in your normal editor (LSP, tests, debugger all attached to the working tree), then come back to keep reviewing. This is supported but spread across affordances rather than a single swap key. The spec deliberately documents them rather than adding a new keymap.
+
+**Precondition.** The working tree must be on the PR's head branch — otherwise "executing" runs your old branch's code, not the PR's. Enter the review via the `<leader>Oc` → `<leader>OO` chain (Phase 1, row 5) when you anticipate needing to execute. If you started via one of the no-checkout entry paths and later realize you need to execute, run `<leader>Oc` (with the picker, or while inside the PR buffer it's the current PR) and then `<leader>OO` to resume — the pending review survives the branch switch.
+
+**Reviewing → executing.**
+
+| Goal | Keys |
+|---|---|
+| Open the working file at a specific thread's location | `<leader>OT` → highlight thread → `<CR>` (spec: threads-picker actions) |
+| Leave the review tab entirely, keep working tree on the PR branch | `<C-c>` in the review tab (closes review tab; pending review is preserved server-side until you submit or discard) |
+
+**Executing → reviewing.**
+
+| Goal | Keys |
+|---|---|
+| Resume the pending review tab (file panel + diff) | `<leader>OO` — smart-entry sees pending review for current branch, runs `:Octo review resume` |
+| Open the review tab at a specific thread's `path:line` | `<leader>OT` → highlight thread → `<C-x>` (spec: threads-picker actions) |
+
+**Edge case — review-tab close vs. discard.** `<C-c>` closes the *tab* but leaves the review server-side as pending. `<localleader>vd` (existing default) actively discards the pending review. The smart-entry `<leader>OO` distinguishes them: discarded → `:Octo review start`; merely closed-tab → `:Octo review resume`.
 
 ### Author flow (own PR with comments to triage)
 

--- a/docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md
+++ b/docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md
@@ -95,7 +95,16 @@ Existing `<localleader>ca` (raw comment), `<localleader>sa` (suggestion), `<loca
 
 Four phases.
 
-**Phase 1 — Find.** `<leader>Or` opens the snacks PR picker filtered to PRs requesting your review. The existing author-display patch surfaces `@author` in each row. `<CR>` opens the PR's `octo://` buffer.
+**Phase 1 — Find.** Pick an entry point based on intent. All four open the snacks PR picker; the existing author-display patch surfaces `@author` in each row, and the fuzzy-match field includes the author handle so you can narrow further by typing `@name`. `<CR>` opens the highlighted PR's `octo://` buffer.
+
+| Intent | Key | What it runs |
+|---|---|---|
+| "PRs assigned to me to review" | `<leader>Or` | `:Octo pr list reviewer=@me state=open` |
+| "PRs by a specific teammate" | `<leader>OA` | `vim.ui.input` prompts for author handle, then `:Octo pr list author=<input>` |
+| "PRs I authored" (catch-up on my own backlog) | `<leader>Om` | `:Octo pr list author=@me` |
+| "All open PRs, narrow with the picker" | `<leader>Op` | `:Octo pr list` — fuzzy-match in the picker by `#NN`, title, or `@author` |
+
+Picking by author has two paths because they serve different use cases: `<leader>OA` is best when you know exactly whose PRs you want (one-shot, no scrolling); `<leader>Op` + typing `@name` in the picker is best when you're browsing or unsure of the handle. Both rely on the same author field in the existing GraphQL query.
 
 **Phase 2 — Survey.** Read the PR description, scan existing comments. `]c`/`[c` step through existing comments in this buffer. `<localleader>pc` lists commits if the PR is multi-commit. No review tab open yet.
 

--- a/docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md
+++ b/docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md
@@ -73,7 +73,7 @@ All global, mode `n` unless noted.
 | `<leader>OT` | Threads picker for current PR | `require('plugins.octo.threads_picker').open()` |
 | `<leader>Oi` | Issue list | `:Octo issue list` |
 | `<leader>OI` | Issue search | `:Octo issue search` |
-| `<leader>Oc` | Checkout PR | `:Octo pr checkout` |
+| `<leader>Oc` | Checkout PR (picker if not in a PR buffer); commonly chained with `<leader>OO` to start the review on the checked-out branch | `:Octo pr checkout` |
 | `<leader>Ob` | Open PR in browser | `:Octo pr browser` |
 
 ### Comment template keymaps (buffer-local)
@@ -103,8 +103,11 @@ Four phases.
 | "PRs by a specific teammate" | `<leader>OA` | `vim.ui.input` prompts for author handle, then `:Octo pr list author=<input>` |
 | "PRs I authored" (catch-up on my own backlog) | `<leader>Om` | `:Octo pr list author=@me` |
 | "All open PRs, narrow with the picker" | `<leader>Op` | `:Octo pr list` — fuzzy-match in the picker by `#NN`, title, or `@author` |
+| "Check out this PR locally so I can run/debug it, then review" | `<leader>Oc` → `<leader>OO` | `:Octo pr checkout` (picker if not in a PR buffer) switches the working tree to the PR's head branch; then smart-entry detects the PR for the current branch, opens the PR buffer and starts the review |
 
 Picking by author has two paths because they serve different use cases: `<leader>OA` is best when you know exactly whose PRs you want (one-shot, no scrolling); `<leader>Op` + typing `@name` in the picker is best when you're browsing or unsure of the handle. Both rely on the same author field in the existing GraphQL query.
+
+**Checkout-then-review chain.** `<leader>Oc` invokes `:Octo pr checkout`, which is global (works anywhere — see `octo/commands.lua:599`): if the current buffer is not an Octo PR buffer it opens the PR picker, on selection it shells `gh pr checkout <n>` and your working tree moves to the PR's head branch. The picker step is skipped if you're already in a PR buffer. Importantly, checkout does **not** open the PR's Octo buffer afterwards — you end up on the branch but in whatever file you started from. To start the review from there, follow up with `<leader>OO`: the smart-entry detects an open PR for the current branch and runs `:Octo review start` (or `resume`). Two keystrokes total. This is the path to use when you want full LSP / test-runner / debugger support against the PR's code, not just diff-reading.
 
 **Phase 2 — Survey.** Read the PR description, scan existing comments. `]c`/`[c` step through existing comments in this buffer. `<localleader>pc` lists commits if the PR is multi-commit. No review tab open yet.
 

--- a/docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md
+++ b/docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md
@@ -1,0 +1,249 @@
+# Octo PR review flow — design
+
+**Date:** 2026-05-11
+**Branch context:** brainstorming session; no implementation branch yet
+**Status:** draft, awaiting approval before plan
+
+## Goal
+
+Make PR review work in Neovim feel like a coherent flow rather than a pile of `:Octo …` commands. Standardise on Octo as the cockpit for both sides (reviewer and author), close three concrete gaps in the default UX:
+
+1. Discoverability — no top-level Octo namespace, no entry-point for "review current branch's PR" or "PRs by author=X".
+2. Comment authoring — visual-select + `<localleader>ca` is fine for raw comments, but there's no fast path for prefixed comments (`nit:`, `Q:`, `blocker:`, `+1`) that the author can later triage by kind.
+3. Thread triage — `]c`/`[c` and `]t`/`[t` are step-throughs, not a "single pane of glass" for what's left to handle. Default Octo has no threads picker.
+
+Explicitly out of scope: AI/LLM integration (no prbot bridge in this design), changes to gitsigns/lazygit, and gh CLI wrappers in zsh.
+
+## Current state inventory
+
+What exists today in this repo:
+
+- `nvim/.config/nvim/lua/plugins/octo.lua` — Octo plugin spec with non-trivial customisation:
+  - Custom `pull_requests` GraphQL query adding `author { login }`.
+  - Snacks picker provider monkey-patched to display `#NN  title  @author` and fuzzy-match on author.
+  - HTML→Markdown converter run over PR/comment bodies via patched `octo.ui.writers`.
+  - One custom picker mapping: `open_in_browser = <leader>gO`.
+- `nvim/.config/nvim/lua/config/lazy.lua` imports `lazyvim.plugins.extras.util.octo`, which provides:
+  - Top-level keys under `<leader>g…`: `gi`, `gI`, `gp`, `gP`, `gr`, `gS`.
+  - `<localleader>` group labels for `a/c/l/i/r/p/v/g` in `octo` filetype.
+  - Picker selection logic (telescope → fzf-lua → snacks).
+- Octo defaults the user relies on, unchanged: `<localleader>vs` start/submit review, `<localleader>ca` add comment, `<localleader>sa` add suggestion, `<localleader>cr` reply, `<localleader>rt`/`rT` resolve/unresolve thread, `]c`/`[c` next/prev comment, `]t`/`[t` next/prev thread, `]q`/`[q` next/prev file, `]u`/`[u` next/prev unviewed file, `<localleader><space>` toggle viewed, `<C-a>`/`<C-m>`/`<C-r>` approve/comment/request-changes in submit window, `<leader>qa` approve PR (global), `auto_show_threads = true`.
+- Skills available for adjacent work but **not used in this design**: `/prbot review|resolve|summarize`, `/ci`, `/review`, `/security-review`. They stay independent of Octo.
+
+What does **not** conflict (verified):
+
+- `gitsigns.nvim` keymaps are `<leader>h*` (hunk) and `]c`/`[c` (hunk navigation). `]c`/`[c` are buffer-local in Octo filetypes, so buffer-local resolution applies — no fix needed.
+- No third-party PR tooling (no Neogit, Diffview, Fugitive) is configured.
+
+## Architecture
+
+### File layout
+
+```
+nvim/.config/nvim/lua/plugins/
+  octo.lua                  # existing — extended with top-level `keys` table
+  octo/
+    threads_picker.lua      # new — Snacks-based picker for current PR's review threads
+    comment_templates.lua   # new — wraps Octo add_*comment fns with prefix injection
+```
+
+`octo.lua` already holds 192 lines of writers/queries patches; new code goes under `octo/` to keep concerns separate. The two new files are small and self-contained, and only `octo.lua` needs to require them (via `init`/`config`) so lazy.nvim doesn't need extra plugin entries.
+
+### Namespace cleanup
+
+LazyVim octo extras' top-level keys move out of `<leader>g…` into a dedicated `<leader>O…` namespace. The `<leader>g…` group returns to local-git only (lazygit, gitsigns hunks).
+
+- Disable in plugin override: `<leader>gi`, `<leader>gI`, `<leader>gp`, `<leader>gP`, `<leader>gr`, `<leader>gS` (set `false` via Lazy `keys` table).
+- Keep the existing custom picker mapping `<leader>gO` (open in browser) — user explicitly wants this preserved.
+- Add `<leader>O` group label via which-key.
+
+### Top-level keymap table
+
+All global, mode `n` unless noted.
+
+| Key | Action | Implementation |
+|---|---|---|
+| `<leader>OO` | Smart entry: if current branch has an open PR, start/resume review; else open PR list | Detects PR via `gh pr view --json number,state --jq` then `:Octo review start`/`resume`; else `:Octo pr list` |
+| `<leader>Op` | PR list (default scope) | `:Octo pr list` |
+| `<leader>OP` | PR search (free-form within PRs) | `:Octo pr search` |
+| `<leader>Om` | PRs authored by me | `:Octo pr list author=@me` |
+| `<leader>Or` | PRs requesting my review | `:Octo pr list reviewer=@me state=open` (verify flag syntax at impl) |
+| `<leader>OA` | Prompt for author, then list | `vim.ui.input` → `:Octo pr list author=<input>` |
+| `<leader>OS` | Free-form Octo search (all kinds) | `:Octo search` |
+| `<leader>OT` | Threads picker for current PR | `require('plugins.octo.threads_picker').open()` |
+| `<leader>Oi` | Issue list | `:Octo issue list` |
+| `<leader>OI` | Issue search | `:Octo issue search` |
+| `<leader>Oc` | Checkout PR | `:Octo pr checkout` |
+| `<leader>Ob` | Open PR in browser | `:Octo pr browser` |
+
+### Comment template keymaps (buffer-local)
+
+Mode `n` and `x`, filetypes `octo` and `octo_diff` (and any other review-context filetype Octo uses — verify list at impl).
+
+| Key | Prefix | Calls |
+|---|---|---|
+| `<localleader>cn` | `nit: ` | `add_review_comment` or `add_comment` depending on context |
+| `<localleader>cq` | `Q: ` | same |
+| `<localleader>cb` | `blocker: ` | same |
+| `<localleader>c+` | `+1, ` | same |
+
+Existing `<localleader>ca` (raw comment), `<localleader>sa` (suggestion), `<localleader>cr` (reply), `<localleader>cd` (delete), `<localleader>ce` (edit history) remain untouched.
+
+## Flows within a review
+
+### Reviewer flow (someone else's PR)
+
+Four phases.
+
+**Phase 1 — Find.** `<leader>Or` opens the snacks PR picker filtered to PRs requesting your review. The existing author-display patch surfaces `@author` in each row. `<CR>` opens the PR's `octo://` buffer.
+
+**Phase 2 — Survey.** Read the PR description, scan existing comments. `]c`/`[c` step through existing comments in this buffer. `<localleader>pc` lists commits if the PR is multi-commit. No review tab open yet.
+
+**Phase 3 — Start review.** `<localleader>vs` opens the review tab: file panel left, diff right. `<localleader>e` toggles focus to the file panel. `<localleader>b` hides/shows the panel.
+
+**Phase 4 — Walk and comment.** For each changed file:
+
+- Navigate: `]q`/`[q` next/prev file, or `]u`/`[u` next/prev *unviewed* file (closer to how GitHub's "viewed" checkbox flow works).
+- Mark viewed: `<localleader><space>` when done with a file.
+- Comment on lines: visual-select range → template keymap.
+  - `<localleader>cn` for `nit: …` (stylistic, non-blocking).
+  - `<localleader>cq` for `Q: …` (question, not a change request).
+  - `<localleader>cb` for `blocker: …` (must fix before merge).
+  - `<localleader>c+` for `+1, …` (praise).
+  - `<localleader>ca` raw, no prefix.
+  - `<localleader>sa` inline suggestion block.
+- Each template opens the review-comment compose buffer, writes the prefix, leaves the cursor at end-of-prefix in insert mode. The user finishes the sentence; `<localleader>vs` from the comment buffer commits the comment to the pending review (existing Octo behaviour).
+- Revisit threads on the current file: `]t`/`[t` (existing default).
+
+**Phase 5 — Finalize.** `<localleader>vs` from the review tab again opens the submit window. The submit window has a freeform text area for the overall review summary. Then:
+
+- `<C-a>` approve
+- `<C-m>` comment
+- `<C-r>` request changes
+- `<C-c>` close tab without submitting
+
+### Author flow (own PR with comments to triage)
+
+Three phases.
+
+**Phase 1 — Enumerate.** `<leader>OO` smart-entry detects the open PR and opens the PR buffer. `<leader>OT` opens the threads picker, default-filtered to unresolved threads. Rows: `[unresolved] path:line @author preview…`.
+
+**Phase 2 — Resolve loop.** For each thread:
+
+- `<CR>` jumps to `path:line` in the working file (not the diff view) so normal LSP editing is available. The latest comment shows in a floating preview (`auto_show_threads = true` already on).
+- Decide:
+  - **Fix code** — edit the file, save. The push will close the thread implicitly, or use `<localleader>rt` to mark resolved explicitly.
+  - **Reply only** — `<localleader>cr` reply, write response, `<localleader>vs` submit reply.
+  - **Disagree** — reply with reasoning; leave thread unresolved for the reviewer to close.
+- In the threads picker, `<C-r>` resolves the highlighted thread without leaving the picker (useful for bulk wrap-up too).
+
+**Phase 3 — Push.** Standard git workflow via `<leader>gg` (lazygit) or terminal. No polling; refresh the threads picker manually when needed.
+
+## Custom component specs
+
+### Threads picker — `nvim/.config/nvim/lua/plugins/octo/threads_picker.lua`
+
+**Data source.** GraphQL query for `pullRequest.reviewThreads`, paged, fetching per thread: `id`, `isResolved`, `isOutdated`, `path`, `line`, `startLine`, latest `comment.body`, latest `comment.author.login`. Reuse Octo's `octo.gh.queries.review_threads` if it exists; otherwise add a new query string in `octo.lua` next to the `pull_requests` patch.
+
+**Picker shape.** Mirrors the existing `snacks_provider.pull_requests` monkey-patch.
+
+- Item shape:
+  ```lua
+  { thread_id, path, line, resolved, outdated, author, preview, raw }
+  ```
+- `text` field for fuzzy matching: `"<path>:<line> @<author> <preview>"`.
+- Format columns: `[●/○]` resolved icon (Comment hl) · `path:line` (Comment hl) · `@author` (Comment hl) · `preview` (Normal hl, truncated to ~60 chars).
+- Default filter: `not isResolved and not isOutdated`.
+
+**In-picker actions.**
+
+| Key | Action |
+|---|---|
+| `<CR>` | Open `path:line` in working buffer (`vim.cmd.edit` + `nvim_win_set_cursor`); render thread popup (verify Octo API at impl) |
+| `<C-r>` | Resolve highlighted thread via Octo API or `gh api graphql` mutation `resolveReviewThread`; refresh picker |
+| `<C-b>` | Open thread in browser (PR URL + `#discussion_r<id>`) |
+| `<C-x>` | Open in review tab at `path:line` (start review if none pending, then jump) |
+| `<C-u>` | Toggle unresolved-only filter (default on) |
+| `<C-o>` | Toggle outdated visibility |
+| `<C-y>` | Filter to "threads where I commented" |
+
+**Entry point.** `require('plugins.octo.threads_picker').open()`. If `octo.utils.get_pull_request()` returns nil (no PR associated with current branch), show error toast: `"no PR for current branch"`.
+
+**Implementation risk.** Octo's internal API for resolving threads and rendering thread popups is not formally stable. Implementation must grep Octo source for the actual function names. If the internal API turns out to be unreliable, fall back to shelling out: `gh api graphql -f query='mutation { resolveReviewThread(input: { threadId: "..." }) { thread { id } } }'`. Slower but bulletproof. The plan should include a small spike to pick the path before committing to one.
+
+### Comment templates — `nvim/.config/nvim/lua/plugins/octo/comment_templates.lua`
+
+**Templates table.**
+
+```lua
+{
+  nit = "nit: ",
+  q   = "Q: ",
+  b   = "blocker: ",
+  ["+"] = "+1, ",
+}
+```
+
+**`compose(kind)` function.**
+
+1. Capture current visual range (`getpos("'<")`/`getpos("'>")`) or current line in normal mode.
+2. Detect context: if filetype is `octo_diff` (review tab), call Octo's `add_review_comment`; if `octo` (PR buffer), call `add_comment`. Verify function names at impl.
+3. Octo opens the compose buffer asynchronously. Use `vim.api.nvim_create_autocmd("BufEnter", { pattern = "octo://*reviewcomment*", once = true })` to inject the prefix when the buffer opens. Inside the autocmd:
+   - `nvim_buf_set_lines(buf, 0, 0, false, { prefix })`
+   - Set cursor at end of prefix line
+   - `vim.cmd("startinsert!")`
+4. User completes the sentence and uses the existing submit chord (no change).
+
+**Implementation risk.** The BufEnter+autocmd pattern is the most plausible way to inject text into an async-opened Octo buffer, but it depends on Octo's buffer naming convention. The plan should spike this with a single template (`nit`) before generalising to all four.
+
+## Keymap migration table
+
+What gets removed, kept, and added.
+
+**Removed (override to `false` in Lazy `keys` for the LazyVim octo extra):**
+
+| Old key | Reason |
+|---|---|
+| `<leader>gi` | moves to `<leader>Oi` |
+| `<leader>gI` | moves to `<leader>OI` |
+| `<leader>gp` | moves to `<leader>Op` |
+| `<leader>gP` | moves to `<leader>OP` |
+| `<leader>gr` | dropped (`Octo repo list` is rare; reachable via `:Octo repo list`) |
+| `<leader>gS` | moves to `<leader>OS` |
+
+**Kept unchanged:**
+
+- All `<localleader>` defaults from Octo (`vs`, `ca`, `sa`, `cr`, `rt`, `rT`, `pc`, `e`, `b`, `<space>`, etc.).
+- All gitsigns `<leader>h*` and `]c`/`[c` (buffer-local resolution against Octo's `]c`/`[c`).
+- `<leader>qa` (Octo's global approve-PR shortcut).
+- Submit window `<C-a>`/`<C-m>`/`<C-r>`/`<C-c>`.
+- Custom picker mapping `<leader>gO` (open in browser).
+
+**Added (top-level):** the 11-row table in the Architecture section.
+
+**Added (buffer-local, `octo` and `octo_diff`):** the four `<localleader>c{n,q,b,+}` template keys.
+
+## Cleanup checklist for implementation
+
+The plan must include explicit steps for:
+
+- LazyVim octo extras override: in `octo.lua`'s plugin spec, add `keys = { { "<leader>gi", false }, { "<leader>gI", false }, … }` for the six keys above. Confirm the override survives the LazyVim extras' own `keys` registration order.
+- Which-key group label: `{ "<leader>O", group = "octo" }`. Done via the same `keys` table or a `which-key` config block.
+- Smoke-test buffer-local `]c`/`[c`: open a real PR in `:Octo pr` and confirm `]c` moves between comments, not gitsigns hunks. If broken, set buffer-local `nmap` explicitly in an `FileType octo` autocmd.
+
+## Non-goals (explicit)
+
+- No Claude/prbot integration. The prbot REVIEW.md flow stays independent; if a future design wants to bridge it to GitHub review comments, that's a separate spec.
+- No changes to gitsigns, lazygit, neogit-if-added.
+- No new gh CLI wrappers in `zsh/.zshrc`.
+- No automated polling for new comments. Manual refresh of the threads picker is enough.
+- No multi-PR dashboard. One PR at a time, surfaced via the existing PR-list picker.
+
+## Open questions for the plan
+
+These are deliberately deferred to the implementation plan, not resolved here:
+
+1. Exact Octo function names for `add_review_comment` / `add_comment` / thread resolution / thread popup rendering. Resolved via reading `~/.local/share/nvim/lazy/octo.nvim` source.
+2. Correct flag for "PRs requesting my review" — likely `reviewer=@me` but needs verification against Octo's `pr list` arg parsing.
+3. Whether the threads-picker resolve action should use Octo internal API or `gh api graphql` fallback — decided after a spike during implementation.
+4. Whether the comment-template autocmd pattern fires reliably for both review and non-review comments — spike with `nit` template before generalising.

--- a/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/nvim/.config/nvim/lua/plugins/octo.lua
@@ -67,8 +67,45 @@ local function html_to_markdown(text)
   return text
 end
 
+local function smart_entry()
+  require("octo.reviews").start_or_resume_review()
+end
+
+local function prompt_author()
+  vim.ui.input({ prompt = "Author handle: " }, function(input)
+    if input and input ~= "" then
+      vim.cmd("Octo pr search author:" .. input .. " state:open")
+    end
+  end)
+end
+
 return {
   "pwntester/octo.nvim",
+  keys = {
+    -- Disable LazyVim octo extras' <leader>g* keys; the Octo namespace lives under <leader>O
+    { "<leader>gi", false },
+    { "<leader>gI", false },
+    { "<leader>gp", false },
+    { "<leader>gP", false },
+    { "<leader>gr", false },
+    { "<leader>gS", false },
+    -- <leader>O Octo namespace
+    { "<leader>O",  group = "octo" },
+    { "<leader>OO", smart_entry,                                                        desc = "Smart entry (review/list)" },
+    { "<leader>Op", "<cmd>Octo pr list<CR>",                                            desc = "PR list" },
+    { "<leader>OP", "<cmd>Octo pr search<CR>",                                          desc = "PR search" },
+    { "<leader>Om", "<cmd>Octo pr search author:@me state:open<CR>",                    desc = "My PRs" },
+    { "<leader>Or", "<cmd>Octo pr search review-requested:@me state:open<CR>",          desc = "PRs to review" },
+    { "<leader>OA", prompt_author,                                                      desc = "PRs by author..." },
+    { "<leader>OT", function() require("plugins.octo.threads_picker").open() end,       desc = "Threads picker" },
+    { "<leader>Oc", "<cmd>Octo pr checkout<CR>",                                        desc = "Checkout PR" },
+    { "<leader>Ob", "<cmd>Octo pr browser<CR>",                                         desc = "Open PR in browser" },
+    -- Comment-prefix templates (active when inside a review session; no-op otherwise)
+    { "<localleader>cn", function() require("plugins.octo.comment_templates").compose("nit") end, mode = { "n", "x" }, desc = "nit comment" },
+    { "<localleader>cq", function() require("plugins.octo.comment_templates").compose("q")   end, mode = { "n", "x" }, desc = "question comment" },
+    { "<localleader>cb", function() require("plugins.octo.comment_templates").compose("b")   end, mode = { "n", "x" }, desc = "blocker comment" },
+    { "<localleader>c+", function() require("plugins.octo.comment_templates").compose("+")   end, mode = { "n", "x" }, desc = "praise comment" },
+  },
   opts = {
     picker_config = {
       mappings = {

--- a/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/nvim/.config/nvim/lua/plugins/octo.lua
@@ -107,6 +107,9 @@ return {
     { "<localleader>c+", function() require("plugins.octo.comment_templates").compose("+")   end, mode = { "n", "x" }, desc = "praise comment" },
   },
   opts = {
+    -- Disable Projects v2 fields in PR/issue queries; the gh token does not
+    -- have `read:project` and the failures cascade into empty PR buffers.
+    default_to_projects_v2 = false,
     picker_config = {
       mappings = {
         open_in_browser = { lhs = "<leader>gO", desc = "open in browser" },

--- a/nvim/.config/nvim/lua/plugins/octo/comment_templates.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/comment_templates.lua
@@ -1,0 +1,45 @@
+local M = {}
+
+local PREFIXES = {
+  nit = "nit: ",
+  q = "Q: ",
+  b = "blocker: ",
+  ["+"] = "+1, ",
+}
+
+---Open an Octo review comment buffer pre-filled with a prefix.
+---Must be called from a review diff buffer with an active review session.
+---Falls back to a notification with no other side effect when called from
+---outside a review context.
+---@param kind string one of "nit", "q", "b", "+"
+function M.compose(kind)
+  local prefix = PREFIXES[kind]
+  if not prefix then
+    vim.notify("comment_templates: unknown kind " .. tostring(kind), vim.log.levels.ERROR)
+    return
+  end
+
+  local ok, reviews = pcall(require, "octo.reviews")
+  if not ok then
+    vim.notify("octo.reviews not available", vim.log.levels.ERROR)
+    return
+  end
+
+  local review = reviews.get_current_review()
+  if not review or review.id == -1 then
+    vim.notify("comment_templates: no active review (use <localleader>vs to start one)", vim.log.levels.WARN)
+    return
+  end
+
+  reviews.add_review_comment(false)
+
+  -- Octo's add_review_comment is synchronous: by return it has created the
+  -- thread compose buffer, swapped it into the alt window, run `normal! vvGk`
+  -- and queued `:startinsert`. We defer one tick so startinsert takes effect,
+  -- then feed the prefix as typed input.
+  vim.schedule(function()
+    vim.api.nvim_feedkeys(prefix, "n", false)
+  end)
+end
+
+return M

--- a/nvim/.config/nvim/lua/plugins/octo/threads_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/threads_picker.lua
@@ -1,0 +1,228 @@
+local M = {}
+
+---@param body string
+---@return string
+local function one_line_preview(body)
+  if not body or body == "" then return "" end
+  local first = body:match("[^\r\n]+") or body
+  if #first > 80 then first = first:sub(1, 77) .. "..." end
+  return first
+end
+
+---@param thread table  -- a ReviewThread node from the GraphQL response
+---@return integer
+local function thread_line(thread)
+  return thread.line or thread.originalLine or thread.startLine or thread.originalStartLine or 1
+end
+
+---@param thread table
+---@return string
+local function thread_author(thread)
+  local first = thread.comments and thread.comments.nodes and thread.comments.nodes[1]
+  if first and first.author and first.author.login then return first.author.login end
+  return ""
+end
+
+---@param thread table
+---@return string
+local function thread_preview(thread)
+  local first = thread.comments and thread.comments.nodes and thread.comments.nodes[1]
+  if not first then return "" end
+  return one_line_preview(first.body)
+end
+
+---Build the item list shown by the picker.
+---@param threads table[]
+---@param show_resolved boolean
+---@return table[]
+local function build_items(threads, show_resolved)
+  local items = {}
+  for _, t in ipairs(threads) do
+    if show_resolved or not t.isResolved then
+      local line = thread_line(t)
+      local author = thread_author(t)
+      local preview = thread_preview(t)
+      table.insert(items, {
+        thread_id = t.id,
+        path = t.path,
+        line = line,
+        resolved = t.isResolved,
+        outdated = t.isOutdated,
+        author = author,
+        preview = preview,
+        text = string.format("%s:%d @%s %s", t.path or "", line, author, preview),
+      })
+    end
+  end
+  return items
+end
+
+---@param pr_url string  -- e.g. https://github.com/owner/name/pull/42
+---@param thread_id string
+---@return string
+local function thread_browser_url(pr_url, thread_id)
+  -- GitHub anchors threads via #discussion_r<commentId>; we have a thread node id (base64)
+  -- which doesn't map directly. Fall back to opening the PR Files tab; user can scroll.
+  return pr_url .. "/files"
+end
+
+---Resolve a thread via the GitHub GraphQL API.
+---@param thread_id string
+---@param on_done fun()
+local function resolve_thread(thread_id, on_done)
+  local gh = require("octo.gh")
+  local mutations = require("octo.gh.mutations")
+  local mutation = string.format(mutations.resolve_review_thread, thread_id)
+  gh.api.graphql({
+    query = mutation,
+    opts = {
+      cb = gh.create_callback({
+        success = function(_)
+          vim.notify("thread resolved", vim.log.levels.INFO)
+          on_done()
+        end,
+      }),
+    },
+  })
+end
+
+---Render the Snacks picker for the given threads.
+---@param threads table[]
+---@param pr table  -- pull-request object with .repo and .url
+local function render_picker(threads, pr)
+  local Snacks = require("snacks")
+  local show_resolved = false
+
+  local function reopen()
+    M._render(threads, pr, show_resolved)
+  end
+
+  M._render = function(threads_, pr_, show_resolved_)
+    local items = build_items(threads_, show_resolved_)
+    if #items == 0 then
+      vim.notify("threads_picker: no threads to show (filter=" ..
+        (show_resolved_ and "all" or "unresolved") .. ")", vim.log.levels.INFO)
+      return
+    end
+
+    Snacks.picker.pick({
+      title = string.format("PR #%d review threads (%s)", pr_.number,
+        show_resolved_ and "all" or "unresolved"),
+      items = items,
+      format = function(item, _)
+        local ret = {}
+        local icon = item.resolved and "● " or "○ "
+        local icon_hl = item.resolved and "Comment" or "DiagnosticWarn"
+        ret[#ret + 1] = { icon, icon_hl }
+        ret[#ret + 1] = { string.format("%s:%d", item.path or "?", item.line), "Comment" }
+        if item.author and item.author ~= "" then
+          ret[#ret + 1] = { "  @" .. item.author, "Comment" }
+        end
+        if item.preview and item.preview ~= "" then
+          ret[#ret + 1] = { "  " .. item.preview, "Normal" }
+        end
+        if item.outdated then
+          ret[#ret + 1] = { "  [outdated]", "Comment" }
+        end
+        return ret
+      end,
+      confirm = function(picker, item)
+        picker:close()
+        if not item.path then return end
+        vim.cmd.edit(item.path)
+        pcall(vim.api.nvim_win_set_cursor, 0, { item.line, 0 })
+      end,
+      win = {
+        input = {
+          keys = {
+            ["<C-r>"] = { "resolve_thread", mode = { "n", "i" } },
+            ["<C-b>"] = { "open_browser", mode = { "n", "i" } },
+            ["<C-u>"] = { "toggle_resolved", mode = { "n", "i" } },
+          },
+        },
+      },
+      actions = {
+        resolve_thread = function(picker, item)
+          if not item or item.resolved then return end
+          resolve_thread(item.thread_id, function()
+            picker:close()
+            -- Re-fetch the PR threads to pick up the resolved state
+            vim.schedule(function() M.open() end)
+          end)
+        end,
+        open_browser = function(_picker, item)
+          if not item or not pr_.url then return end
+          local url = thread_browser_url(pr_.url, item.thread_id)
+          require("octo.navigation").open_in_browser_raw(url)
+        end,
+        toggle_resolved = function(picker, _item)
+          picker:close()
+          show_resolved = not show_resolved
+          M._render(threads_, pr_, show_resolved)
+        end,
+      },
+    })
+  end
+
+  M._render(threads, pr, show_resolved)
+end
+
+---Fetch and show review threads for a PR.
+---@param pr table  -- pull request object with .owner, .name, .number, .url
+local function fetch_and_show(pr)
+  local gh = require("octo.gh")
+  local queries = require("octo.gh.queries")
+  local utils = require("octo.utils")
+
+  gh.api.graphql({
+    query = queries.review_threads,
+    F = { owner = pr.owner, name = pr.name, number = pr.number },
+    paginate = true,
+    jq = ".",
+    opts = {
+      cb = gh.create_callback({
+        success = function(output)
+          local resp = utils.aggregate_pages(output,
+            "data.repository.pullRequest.reviewThreads.nodes")
+          local threads = resp.data.repository.pullRequest.reviewThreads.nodes
+          if not threads or #threads == 0 then
+            vim.notify("threads_picker: PR #" .. pr.number .. " has no review threads",
+              vim.log.levels.INFO)
+            return
+          end
+          render_picker(threads, pr)
+        end,
+      }),
+    },
+  })
+end
+
+---Entry point: detect the PR for the current context and open the picker.
+function M.open()
+  local octo_utils = require("octo.utils")
+  local buffer = octo_utils.get_current_buffer()
+
+  if buffer and buffer.node and buffer.node.number then
+    local pr = buffer.node
+    -- buffer carries the PR with full URL; ensure we have owner+name
+    local owner, name = octo_utils.split_repo(buffer.repo)
+    pr.owner = pr.owner or owner
+    pr.name = pr.name or name
+    pr.repo = buffer.repo
+    fetch_and_show(pr)
+    return
+  end
+
+  octo_utils.get_pull_request_for_current_branch(function(pr)
+    if not pr then
+      vim.notify("threads_picker: no PR for current branch", vim.log.levels.WARN)
+      return
+    end
+    local owner, name = octo_utils.split_repo(pr.repo)
+    pr.owner = pr.owner or owner
+    pr.name = pr.name or name
+    fetch_and_show(pr)
+  end)
+end
+
+return M


### PR DESCRIPTION
## Summary

Standardises on Octo as the cockpit for PR review work in Neovim. Three concrete gaps in the default UX are closed:

- **Discoverability + entry** — top-level `<leader>O` namespace replaces scattered `<leader>g{i,I,p,P,r,S}` Octo bindings from LazyVim's octo extra. Eleven entry-point keys including a smart-entry that resumes pending reviews or falls back to the PR picker.
- **Comment authoring** — `<localleader>c{n,q,b,+}` open the review-comment buffer pre-filled with `nit: ` / `Q: ` / `blocker: ` / `+1, `. Forces the reviewer to label the kind of comment, making author-side triage easier.
- **Thread triage** — `<leader>OT` opens a Snacks-based threads picker for the current PR, defaulting to unresolved-only. `<CR>` jumps to the working file at `path:line`, `<C-r>` resolves via the `resolveReviewThread` mutation, `<C-u>` toggles the resolved filter.

Design spec is at `docs/superpowers/specs/2026-05-11-octo-pr-review-flow-design.md` — four commits incrementally refine it through the brainstorming session, then the fifth commit implements.

## Notable implementation decisions

- `<leader>OO` uses `octo.reviews.start_or_resume_review()` directly rather than the manual `gh pr view` + decision tree the spec originally described. Octo already has the exact three-state logic baked in.
- Author/reviewer filters use `:Octo pr search` (GitHub search syntax: `is:pr review-requested:@me state:open`) rather than `:Octo pr list`. The list GraphQL query does not accept `author` or `reviewer` parameters; the search path does.
- Comment template prefix injection is synchronous from Octo's perspective — `Review:add_comment` creates the thread buffer and queues `:startinsert` inline. We defer one `vim.schedule` tick so startinsert lands, then `nvim_feedkeys` types the prefix as if entered in insert mode.
- Disabling LazyVim octo extras' `<leader>g*` keys is done via `keys = { { "<leader>gi", false }, ... }`. The `<leader>gO` picker action and the existing `octo.lua` monkey-patches (HTML→markdown, author column in PR picker) are preserved.

## Test plan

- [ ] Restart Neovim against this branch
- [ ] `<leader>O` triggers which-key showing the Octo group
- [ ] `<leader>Op` opens the PR list; `<leader>Om` filters to my PRs; `<leader>Or` to PRs requesting my review; `<leader>OA` prompts for an author
- [ ] `<leader>Oc` from any buffer pops the PR picker, then checks out the selected PR
- [ ] On a branch with an open PR, `<leader>OO` resumes a pending review (or starts one if none); on a branch without a PR, falls back to PR list
- [ ] In a review tab, visual-select a line then `<localleader>cn` opens a comment buffer pre-filled with `nit: ` in insert mode; same for `cq`/`cb`/`c+`
- [ ] `<leader>OT` opens the threads picker filtered to unresolved; `<CR>` jumps to the working file at the right line; `<C-r>` resolves a thread; `<C-u>` toggles to show all threads
- [ ] Old `<leader>g{i,I,p,P,r,S}` Octo bindings are absent (suppressed)
- [ ] No regressions in gitsigns `<leader>h*` hunks or LazyVim's `<leader>gg` lazygit

🤖 Generated with [Claude Code](https://claude.com/claude-code)