### PR TITLE
Move Neovide font config from Lua to neovide/config.toml

### DIFF
--- a/neovide/.config/neovide/config.toml
+++ b/neovide/.config/neovide/config.toml
@@ -1,3 +1,7 @@
 frame = "buttonless"
 title-hidden = true
-neovim-bin = "/Users/aviralmansingka/.local/share/bob/nightly/bin/nvim"
+neovim-bin = "/Users/aviral/tools/neovim/scripts/run-built-nvim.sh"
+
+[font]
+normal = ["JetBrainsMono Nerd Font Mono"]
+size = 13

--- a/nvim/.config/nvim/lua/plugins/neovide.lua
+++ b/nvim/.config/nvim/lua/plugins/neovide.lua
@@ -3,8 +3,8 @@ if not vim.g.neovide then
   return {}
 end
 
--- Font configuration (matches Ghostty)
-vim.o.guifont = "JetBrainsMono Nerd Font Mono:h13"
+-- Font is configured in ~/.config/neovide/config.toml so Neovide
+-- doesn't fall back to SF Mono (which is not installed on macOS).
 
 -- Enable macOS Cmd key support
 vim.g.neovide_input_use_logo = true


### PR DESCRIPTION
Neovide was falling back to SF Mono (uninstalled on macOS) because Lua-set guifont arrived too late. Moving font config to `~/.config/neovide/config.toml` so Neovide reads it at startup. Also updates the `neovim-bin` path to the cmake-built local nvim.