### PR TITLE
Delegate conform format-on-save to LazyVim's BufWritePre handler

### DIFF
--- a/nvim/.config/nvim/lua/config/autocmds.lua
+++ b/nvim/.config/nvim/lua/config/autocmds.lua
@@ -7,10 +7,3 @@
 -- Or remove existing autocmds by their group name (which is prefixed with `lazyvim_` for the defaults)
 -- e.g. vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")
 
--- Disable auto-formatting for Python files (linting still works via Ruff LSP)
-vim.api.nvim_create_autocmd("FileType", {
-  pattern = "python",
-  callback = function()
-    vim.b.autoformat = false
-  end,
-})

--- a/nvim/.config/nvim/lua/plugins/conform.lua
+++ b/nvim/.config/nvim/lua/plugins/conform.lua
@@ -1,14 +1,11 @@
 return {
   "stevearc/conform.nvim",
   opts = {
-    -- S2: Enable format on save for markdown and python
-    format_on_save = function(bufnr)
-      local ft = vim.bo[bufnr].filetype
-      if ft == "markdown" or ft == "python" then
-        return { timeout_ms = 2000, lsp_fallback = false }
-      end
-      return nil
-    end,
+    -- format-on-save is wired up by LazyVim's own BufWritePre handler
+    -- (lazyvim/util/format.lua). It respects vim.b.autoformat /
+    -- vim.g.autoformat so you can toggle with <leader>uf. Don't set
+    -- conform's own format_on_save here — LazyVim strips it and warns.
+    default_format_opts = { timeout_ms = 2000, lsp_format = "never" },
     formatters = {
       -- Let Prettier handle tables, code blocks, etc. but NOT prose wrapping
       prettier = {


### PR DESCRIPTION
LazyVim already has a BufWritePre handler that respects `vim.b.autoformat` / `vim.g.autoformat`, so conform's own `format_on_save` was redundant (LazyVim strips it and warns). Replaces it with `default_format_opts` and removes the per-python autoformat-disable autocmd since `<leader>uf` is the supported toggle path.