### PR TITLE
Drop BUILD.bazel from project.nvim detection patterns

### DIFF
--- a/nvim/.config/nvim/lua/plugins/project.lua
+++ b/nvim/.config/nvim/lua/plugins/project.lua
@@ -5,7 +5,7 @@ return {
       detection_methods = { "pattern" },
       -- BUILD.bazel before .git: rules_go packages (e.g. modal/go/machine-manager) stay rooted
       -- there instead of the monorepo git root when you :cd into the service directory.
-      patterns = { "init.lua", "build.gradle", "BUILD.bazel", ".git" },
+      patterns = { "init.lua", "build.gradle", ".git" },
       silent_chdir = true,
       sync_root_with_cwd = true,
       respect_buf_cwd = true,


### PR DESCRIPTION
BUILD.bazel was rooting projects at sub-package level for rules_go services like `modal/go/machine-manager`. In practice the monorepo git root is the better project boundary for gopls/ripgrep/etc., so dropping BUILD.bazel falls through to `.git`.