### PR TITLE
Enable agentPushNotifEnabled in Claude harness settings

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -8,5 +8,6 @@
     "jdtls-lsp@claude-plugins-official": true
   },
   "skipDangerousModePermissionPrompt": true,
-  "voiceEnabled": true
+  "voiceEnabled": true,
+  "agentPushNotifEnabled": true
 }


### PR DESCRIPTION
Opts in to push notifications when Claude Code agents complete in the background, so long-running tasks don't need terminal polling.