### PR TITLE
Add hostbench and mm Claude skills

### DIFF
--- a/claude/.claude/skills/hostbench/SKILL.md
+++ b/claude/.claude/skills/hostbench/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: hostbench
+description: Use when the user types /hostbench or asks to run, kick off, or invoke a command from ops/modal_host_bench/main.py (bench, compare, compare-files, evaluate, evaluate-files, inspect). Scans the current conversation for hints (subcommand verbs, instance types, IPs/worker IDs, cloud/region, dates, file paths) and pre-fills AskUserQuestion options so the user mostly just confirms, then runs `uv run main.py ...` from the modal_host_bench directory.
+allowed-tools: Bash, Read, AskUserQuestion
+---
+
+# hostbench
+
+Driver for `ops/modal_host_bench/main.py`. Prompts the user for the subcommand
+and its required arguments via `AskUserQuestion`, builds the final command, and
+runs it from the `modal_host_bench` directory.
+
+The `main.py` script is run with `uv run main.py ...` (PEP-723 inline
+dependencies). The `bench` subcommand additionally needs AWS creds, so it must
+be wrapped in `uv run inv cloud prod -- uv run main.py ...`.
+
+## Workflow
+
+**Before asking anything, scan the conversation for context.** The skill's job
+is to make the prompts feel pre-filled, not to interrogate the user. Re-read
+the user's recent turns and pull out:
+
+- Subcommand hints — verbs like "compare", "evaluate", "inspect", "kick off a
+  bench"; nouns like "pass rates" → `evaluate`, "percentiles" → `compare`,
+  "two JSON files" → `compare-files`, "one run" → `inspect`, "raw JSON" →
+  `inspect`, "thresholds" → `evaluate-files`.
+- `--instance-type` — strings matching `g5.2xlarge`, `bm.gpu.h100.8`,
+  `sfc.h100v`, `c5.4xlarge`, etc.
+- `--ip-addresses` / `--worker-ips` — IPv4 like `10.0.0.1`, hostnames like
+  `peyton-sfc-test`, worker IDs like `wo-HpLLUytryeKAqOmAygSwIu`, or a path
+  ending in `.txt` / referenced as a "worker IPs file".
+- `--cloud` / `--region` — `aws`, `oci`, `sfc`; `us-east-1`, `us-west-2`,
+  region names mentioned earlier.
+- `--username` — `ubuntu` (default), `root` (sfc), `modal` (oci prod workers).
+- `--ssh-key` — paths under `~/.ssh/`, e.g. `~/.ssh/global_worker`.
+- `--since` / `--until` — any `YYYY-MM-DD` dates in the conversation.
+- `files` (for `evaluate-files`) — paths under `bench_results/`.
+- Local-vs-S3 intent — "local only", "ad-hoc", "don't upload" → `--local-only`;
+  otherwise default to S3 upload (which forces `--cloud`/`--region`).
+
+1. **Pick the subcommand.** Ask via `AskUserQuestion` (single-select,
+   `header: "Subcommand"`). **Order the options so the inferred best guess is
+   first**, and label it `<name> (Recommended)`. Always include all 6 so the
+   user can override.
+   - `bench` — Run benchmarks on a host (SSH-driven)
+   - `compare` — Compare percentile distributions across (cloud, instance_type, region) triples
+   - `compare-files` — Interactively compare two benchmark JSON files under `bench_results/`
+   - `evaluate` — Aggregate evaluate pass-rates across triples
+   - `evaluate-files` — Evaluate local benchmark JSON files against hostbench thresholds
+   - `inspect` — Pretty-print raw benchmark JSON for one S3 run
+
+   If exactly one subcommand is unambiguously implied (the user literally
+   said "/modal-host-bench evaluate" or "compare runs"), skip this prompt
+   and announce the choice instead.
+
+2. **Collect required args** for the chosen subcommand (see table below).
+   For each `AskUserQuestion`:
+   - Put the value extracted from conversation context as the **first option**
+     and append `(Recommended)` to its label.
+   - Add 2–3 other plausible options drawn from the README examples (e.g. for
+     `--instance-type`: `g5.2xlarge`, `bm.gpu.h100.8`, `sfc.h100v`).
+   - The "Other" escape hatch is added automatically — rely on it for fully
+     free-form input rather than guessing.
+   - If a value is already pinned in the conversation (e.g. user said "use
+     instance type g5.2xlarge"), do NOT re-ask — just use it and tell the
+     user what you inferred.
+   - Convert relative dates ("last week", "since Tuesday") to absolute
+     `YYYY-MM-DD` before pre-filling.
+
+3. **Confirm and run.** Print the assembled command verbatim (with all
+   inferred values inlined), then execute it via `Bash` from
+   `/Users/aviral/modal/ops/modal_host_bench/`. Stream output to the user.
+   Mention which values came from context vs. which the user picked, so they
+   can catch a wrong inference before secrets are sent over SSH.
+
+## Required arguments per subcommand
+
+| Subcommand | Must ask the user for | Optional but commonly asked |
+|---|---|---|
+| `bench` | `--instance-type` (free-form), one of `--ip-addresses` (comma-separated) or `--worker-ips` (path), and whether this is a `--local-only` run or an S3-uploading run (then `--cloud` and `--region` are also required) | `--ssh-key`, `--username` (default `ubuntu`), `--port`, `--parallel`, `--only`, `--run-blobnet`, `--run-full-ping-test`, `--s3-only`, `--require-s3-upload`, `--dry-run-s3` |
+| `compare` | nothing required | `--since YYYY-MM-DD`, `--until YYYY-MM-DD` |
+| `compare-files` | nothing (fully interactive) | — |
+| `evaluate` | nothing required | `--since YYYY-MM-DD`, `--until YYYY-MM-DD` |
+| `evaluate-files` | `files` (one or more paths under `bench_results/`) | `--thresholds` (currently unused) |
+| `inspect` | nothing required | `--since YYYY-MM-DD`, `--until YYYY-MM-DD` |
+
+For `bench`, also ask whether to wrap in `uv run inv cloud prod --` (default
+**yes** unless `--local-only` is set and the user has no AWS use). The wrap is
+required whenever the run uploads to S3 or signs R2 URLs.
+
+## Command shapes
+
+Local-only `bench`:
+
+```bash
+uv run inv cloud prod -- uv run main.py bench \
+  --local-only \
+  --instance-type <type> \
+  --ssh-key <path> \
+  --ip-addresses <ip[,ip...]>
+```
+
+S3-uploading `bench`:
+
+```bash
+uv run inv cloud prod -- uv run main.py bench \
+  --cloud <aws|oci|sfc|...> --region <region> \
+  --instance-type <type> \
+  --ssh-key <path> \
+  --ip-addresses <ip[,ip...]>
+```
+
+Read-only commands (no AWS wrap needed for `compare-files`/`evaluate-files`;
+`compare`/`evaluate`/`inspect` read S3 indices, so wrap them):
+
+```bash
+uv run inv cloud prod -- uv run main.py compare  [--since DATE] [--until DATE]
+uv run inv cloud prod -- uv run main.py evaluate [--since DATE] [--until DATE]
+uv run inv cloud prod --no-log -- uv run main.py inspect [--since DATE] [--until DATE]
+uv run main.py compare-files
+uv run main.py evaluate-files <file> [<file> ...]
+```
+
+## Validation rules (enforced by main.py)
+
+- `--s3-only` is incompatible with `--local-only`.
+- When the run uploads to S3 (i.e. not `--local-only` and not `--only`),
+  `--cloud` and `--region` are mandatory.
+- `--parallel` must be a positive integer.
+
+If the user picks a combination that violates these, surface the conflict
+before invoking — don't let argparse fail after `inv cloud prod` has already
+authenticated.
+
+## Running it
+
+Always `cd` to (or run from) `/Users/aviral/modal/ops/modal_host_bench/`.
+Echo the assembled command back to the user before executing so they can
+sanity-check secrets/paths.
+
+## When NOT to use this skill
+
+- The user already wrote a complete `uv run main.py ...` invocation — just run
+  it; don't re-prompt for arguments they already supplied.
+- The user is asking *about* main.py (how it works, what it does) rather than
+  asking to *run* it. Use `Read` instead.

--- a/claude/.claude/skills/mm/SKILL.md
+++ b/claude/.claude/skills/mm/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: mm
+description: Machine-manager dev cycle: tests, generate, build (debug/release), OCI image build/load/push, deploy, migrations. Use when user types /mm or asks how to test/build/push/deploy machine-manager.
+allowed-tools: Bash, Read
+---
+
+# Machine-Manager Dev Cycle
+
+Reference for the `go/machine-manager` service. Two build systems coexist —
+**Go toolchain** (fast iteration) and **Bazel** (CI, hermetic, OCI images).
+All paths below are relative to the repo root unless noted.
+
+## 0. One-time setup
+
+| Action | Command |
+|---|---|
+| Start local Postgres | `inv services -d` |
+| Apply River job migrations | `go install github.com/riverqueue/river/cmd/river@latest && river migrate-up --database-url "postgresql://postgres:f850b7013a703351b403b10beed24df2@localhost:5433/machinemanager?sslmode=disable"` |
+| Generate embedded assets (audit binary, UI dist, sqlc) | `cd go/machine-manager && make generate` |
+
+`make generate` runs three steps — invoke individually if only one changed:
+`make generate-audit`, `make generate-ui`, `make generate-sqlc`.
+
+## 1. Tests & lint
+
+| Action | Command | Notes |
+|---|---|---|
+| Run all Go tests | `cd go/machine-manager && make test` | Uses `gotestsum`, `-count=1`, `-parallel=10`. |
+| Run plain `go test` | `cd go/machine-manager && go test ./...` | |
+| Update snapshot tests | `cd go/machine-manager && UPDATE_SNAPS=true go test ./...` | |
+| Lint (Go, all of `go/`) | `cd go && make lint` | Pins golangci-lint v2.10.1. **Required before commit.** |
+| Bazel test (targeted) | `bazel test --config=remote //go/machine-manager:machine-manager_test` | Use `--config=remote` first; fall back to local if cache miss. |
+| Bazel test workspace-wide | `bazel test --config=remote //go/machine-manager/...` | |
+
+After ANY Go change, also run `cd go && make lint` (per `go/AGENTS.md`).
+
+## 2. Build (Go toolchain)
+
+Build from repo root or `go/`. The `ui` build tag controls whether the
+Svelte UI is embedded; without it `ui_embed_stub.go` is used.
+
+| Variant | Command |
+|---|---|
+| Debug (default, full symbols, suitable for `dlv`) | `cd go && go build -gcflags="all=-N -l" -o ./bin/machine-manager ./machine-manager` |
+| Standard | `cd go && go build -o ./bin/machine-manager ./machine-manager` |
+| With UI embedded | `cd go && go build -tags ui -o ./bin/machine-manager ./machine-manager` |
+| Release / stripped | `cd go && go build -tags ui -trimpath -ldflags="-s -w" -o ./bin/machine-manager ./machine-manager` |
+| Build `mmctl` CLI | `cd go/machine-manager && make mmctl` (output: `bin/mmctl`) |
+
+`-s -w` strip the symbol and DWARF tables (~30% size reduction). `-trimpath`
+removes local filesystem paths from the binary for reproducibility.
+
+## 3. Build (Bazel)
+
+| Action | Command |
+|---|---|
+| Build server binary | `bazel build --config=remote //go/machine-manager:machine-manager` |
+| Build server `go_library` only | `bazel build --config=remote //go/machine-manager:machine-manager_lib` |
+| Build OCI image (no push) | `bazel build --config=remote //go/machine-manager:machine_manager_oci_image` |
+| Load OCI image into local Docker | `bazel run //go/machine-manager:machine_manager_oci_tarball` |
+
+Bazel always builds with `gotags = ["audit_binary", "ui"]` (see
+`go/machine-manager/BUILD.bazel`), so the embedded UI and audit binary are
+always included. Base image is `@distroless_static` (Go static binary, CA
+certs only). For Bazel issues, see the `bazel-recovery` and
+`bazel-keep-in-sync` skills.
+
+## 4. OCI image: tag, push, deploy
+
+The image is content-addressed; the tag is human-readable only.
+Stamped builds use the short git SHA (`{{SHORT_SHA}}-bazel`); unstamped
+builds tag `dev-bazel`.
+
+| Action | Command |
+|---|---|
+| Push to **prod** ECR | `bazel run --config=ci --config=x86_64 --stamp //tools:bazel_push -- --targets machine_manager_oci` |
+| Push to **dev** ECR | `bazel run --config=ci --config=x86_64 --stamp //tools:bazel_push -- --dev --targets machine_manager_oci` |
+| Push **all** services in parallel (CI pattern) | `bazel run --config=ci --config=x86_64 --stamp //tools:bazel_push -- --parallel -o image-refs.values.yaml --json image-refs.json` |
+| List discoverable push targets | `bazel run //tools:bazel_push -- --list` |
+| Deploy machine-manager to dev cluster | `inv k-deploy --cluster dev-us-east-1 --chart machine-manager --build-images` |
+
+`--build-images` rebuilds the image as part of deploy. Without it, deploy
+uses the most recently pushed digest. **machine-manager is restricted to
+the `dev-us-east-1` cluster** (see `go/machine-manager/README.md`).
+
+The push target writes `repo@sha256:digest` references that the Helm chart
+consumes — the digest, not the tag, is the deploy unit.
+
+## 5. Database & migrations
+
+| Action | Command |
+|---|---|
+| Open local psql shell | `cd go/machine-manager && ./scripts/psql` |
+| Roll back last migration on dev cluster DB | `cd go/machine-manager && ./scripts/migrate --env dev down 1` |
+| Migrate down (server-side) | `./go/bin/machine-manager migrate-down` (refuses in `prod`) |
+
+Migrations apply automatically on server startup. Rolling back is for the
+case where a feature branch with a migration was tested on dev but not
+merged, leaving the dev DB ahead of `main`.
+
+## 6. Pre-commit
+
+After modifying any files, run pre-commit hooks:
+
+```
+uv run pre-commit run --files $(git diff --name-only origin/main...)
+```
+
+## Quick decision guide
+
+- **Just want fast feedback while editing Go?** → `make test` + `make lint`.
+- **Need to run the binary locally with the UI?** → `make generate-ui` then
+  `go build -tags ui ...`.
+- **CI failing on Bazel only?** → `bazel test --config=remote //go/machine-manager:machine-manager_test`.
+- **Testing a UI/server change end-to-end on real hardware?** →
+  `inv k-deploy --cluster dev-us-east-1 --chart machine-manager --build-images`.
+- **Just want the image in local Docker to inspect it?** →
+  `bazel run //go/machine-manager:machine_manager_oci_tarball`, then
+  `docker run <repo>:latest`.
+
+## Related skills
+
+- `bazel-verify` — choosing remote vs. local execution and target scope.
+- `bazel-recovery` — when Bazel hangs on a stale lock.
+- `bazel-keep-in-sync` — after adding/moving Go files, run Gazelle.
+- `modal-objlookup` — debugging Modal entities (`wo-`, `cu-`, etc.) that
+  machine-manager produces.


### PR DESCRIPTION
Two service-specific skills:

- **hostbench**: drives `ops/modal_host_bench/main.py` (bench, compare, compare-files, evaluate, evaluate-files, inspect). Pre-fills AskUserQuestion options from conversation hints (instance type, IPs/worker IDs, dates, file paths) and runs `uv run main.py ...`.
- **mm**: reference for the `go/machine-manager` dev cycle — tests, generate, build (debug/release), OCI image build/load/push, deploy, migrations. Bridges the Go toolchain and Bazel paths.