### PR TITLE
Fix <leader>O Octo keys not registering due to group= syntax

### DIFF
--- a/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/nvim/.config/nvim/lua/plugins/octo.lua
@@ -90,7 +90,7 @@ return {
     { "<leader>gr", false },
     { "<leader>gS", false },
     -- <leader>O Octo namespace
-    { "<leader>O",  group = "octo" },
+    { "<leader>O",  "",                                                                 desc = "+octo" },
     { "<leader>OO", smart_entry,                                                        desc = "Smart entry (review/list)" },
     { "<leader>Op", "<cmd>Octo pr list<CR>",                                            desc = "PR list" },
     { "<leader>OP", "<cmd>Octo pr search<CR>",                                          desc = "PR search" },


### PR DESCRIPTION
The `{ "<leader>O", group = "octo" }` entry was malformed for Lazy's keys handler — `group = ...` is a which-key spec field, not a Lazy keys-spec one. Lazy silently dropped that entry plus all the `<leader>O*` entries after it (and the `<leader>g*` `false` suppressions), so the new Octo namespace never wired up.

Switching to LazyVim's working convention (`{ "<leader>O", "", desc = "+octo" }`). Diagnosed against the user's live nvim session via neovim-debugger.