### PR TITLE
Enable Octo use_local_fs so LSP attaches to review diffs

### DIFF
--- a/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/nvim/.config/nvim/lua/plugins/octo.lua
@@ -110,6 +110,11 @@ return {
     -- Disable Projects v2 fields in PR/issue queries; the gh token does not
     -- have `read:project` and the failures cascade into empty PR buffers.
     default_to_projects_v2 = false,
+    -- Open the working-tree file (with real filetype + path) on the RIGHT
+    -- side of review diffs so LSP/treesitter/format-on-save/tests attach.
+    -- Octo prompts to `gh pr checkout` when starting a review off the
+    -- PR's head branch, so the local file matches the PR's content.
+    use_local_fs = true,
     picker_config = {
       mappings = {
         open_in_browser = { lhs = "<leader>gO", desc = "open in browser" },


### PR DESCRIPTION
Flips `use_local_fs` from false to true. The RIGHT split in a review tab now opens the working-tree file (real path + filetype + buftype) instead of an in-memory `octo://` buffer, so LSP/treesitter/format-on-save/tests attach normally on the PR-content side.

LEFT (base) stays as a fetched `octo://` buffer since the tree only holds one version at a time. Octo prompts to `gh pr checkout` when starting a review off the PR's head branch (default No), so worst case is an extra prompt — no surprise checkouts.