### PR TITLE
Make Octo's RIGHT review pane editable

### DIFF
--- a/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/nvim/.config/nvim/lua/plugins/octo.lua
@@ -124,6 +124,25 @@ return {
   config = function(_, opts)
     require("octo").setup(opts)
 
+    -- Octo's reviews/file-entry.lua sets modifiable=false on both diff
+    -- buffers after creation, even when use_local_fs=true makes the
+    -- RIGHT buffer a real working-tree file. Re-enable modifiable on
+    -- RIGHT-side buffers backed by a real file path so LSP code actions
+    -- and inline edits work in the review tab.
+    vim.api.nvim_create_autocmd("BufWinEnter", {
+      group = vim.api.nvim_create_augroup("OctoRightPaneEditable", { clear = true }),
+      callback = function(args)
+        local ok, props = pcall(vim.api.nvim_buf_get_var, args.buf, "octo_diff_props")
+        if not ok or not props or props.split ~= "RIGHT" then
+          return
+        end
+        if vim.api.nvim_buf_get_name(args.buf):match("^octo://") then
+          return -- not a local-fs buffer
+        end
+        vim.bo[args.buf].modifiable = true
+      end,
+    })
+
     -- Add author to the pull_requests GraphQL query
     local queries = require("octo.gh.queries")
     queries.pull_requests = [[


### PR DESCRIPTION
Octo unconditionally sets `modifiable = false` on both diff buffers after creation (`reviews/file-entry.lua:542`), even when `use_local_fs = true` makes the RIGHT buffer a real working-tree file. That blocks LSP code actions, format-on-save, and inline edits on the surface where we'd want them.

Adds a `BufWinEnter` autocmd that flips modifiable back on for diff buffers tagged `split=RIGHT` whose buffer name is a real path (not an `octo://` URI). LEFT side stays read-only since it's a fetched base-rev buffer.

**Caveat**: editing the file mid-review can drift line numbers away from the PR's commit, so `<localleader>ca` may compute the wrong diff hunk or refuse. Comment-first-edit-later is the safe pattern.