### PR TITLE
Add <c-.> cwd-scoped peek picker for sidekick sessions

### DIFF
--- a/docs/superpowers/plans/2026-05-09-sidekick-cwd-picker.md
+++ b/docs/superpowers/plans/2026-05-09-sidekick-cwd-picker.md
@@ -1,0 +1,516 @@
+# Sidekick `<c-.>` Cwd-Scoped Peek Picker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `<c-.>`'s current behavior with a Snacks-based floating picker that lists named sidekick sessions whose cwd is the current working directory or a descendant, shows a chat-preview pane on top, fuzzy-matches via a 3-row list, and opens the selected session on `<CR>`.
+
+**Architecture:** New module `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua` reuses `registry.discover()` for source data, applies a cwd-subtree filter, and calls `Snacks.picker.pick` with a custom vertical layout (preview → list → input). The `<c-.>` keymap in `nvim/.config/nvim/lua/plugins/sidekick.lua` is rewired to invoke this new module. `<leader>al` (the existing global picker) stays untouched.
+
+**Tech Stack:** Neovim Lua, Snacks.nvim (already a dependency via `<leader>al`), tmux (`capture-pane`, `kill-session`), sidekick.nvim.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-sidekick-cwd-picker-design.md`
+
+---
+
+## File Structure
+
+- **Create:** `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua` — single-purpose module exposing `M.open()`. Owns the cwd filter, item builder, kill helper, layout config, and Snacks call.
+- **Modify:** `nvim/.config/nvim/lua/plugins/sidekick.lua` — change the `<c-.>` keymap body to invoke `cwd_picker.open()`. No other lines touched.
+
+No test infrastructure exists in this repo for nvim plugins (verified: `find nvim -name '*_spec.lua' -o -name 'test_*.lua' 2>/dev/null` returns nothing). The repo's existing sidekick modules (`picker.lua`, `registry.lua`, `resume.lua`) are also untested by harness — they're verified manually via the steps documented in `docs/superpowers/specs/2026-05-01-sidekick-named-sessions-design.md` and follow-on specs. We follow the same convention here: each task ends with a manual `:source` + interactive verification recipe rather than an automated test runner. This is consistent with how prior sidekick plans (e.g. `2026-05-01-sidekick-named-sessions.md`) were executed.
+
+---
+
+## Task 1: Create the module skeleton with cwd filter helper
+
+**Files:**
+- Create: `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua`
+
+- [ ] **Step 1: Create the file with the module skeleton, requires, and a pure cwd-subtree predicate**
+
+```lua
+-- nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+-- Cwd-scoped peek picker for sidekick named sessions.
+-- Bound to <c-.> in plugins/sidekick.lua.
+local internal = require("plugins.sidekick.internal")
+local registry = require("plugins.sidekick.registry")
+
+local M = {}
+
+---@param p string
+---@return string
+local function normalize(p)
+  if not p or p == "" then
+    return ""
+  end
+  return vim.fs.normalize(vim.fn.fnamemodify(p, ":p")):gsub("/$", "")
+end
+
+---@param entry_cwd string|nil
+---@param root string  already normalized
+---@return boolean
+local function in_cwd_subtree(entry_cwd, root)
+  if not entry_cwd or entry_cwd == "" or root == "" then
+    return false
+  end
+  local n = normalize(entry_cwd)
+  if n == root then
+    return true
+  end
+  return n:sub(1, #root + 1) == root .. "/"
+end
+
+return M
+```
+
+- [ ] **Step 2: Verify the module loads without syntax errors**
+
+Run from inside an active nvim instance (or `nvim --headless`):
+
+```bash
+nvim --headless -c 'lua require("plugins.sidekick.cwd_picker")' -c 'qa' 2>&1
+```
+
+Expected: no output (module loads silently). Any error string means a syntax bug.
+
+- [ ] **Step 3: Smoke-test the predicate**
+
+```bash
+nvim --headless -c 'lua local m = loadfile(vim.fn.expand("~/dotfiles/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua"))() print("loaded ok")' -c 'qa' 2>&1
+```
+
+Note: the predicate is local, so we'll exercise it indirectly when `M.list_items` is added in Task 2.
+
+Expected: prints `loaded ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+git commit -m "Add sidekick cwd_picker skeleton with subtree predicate"
+```
+
+---
+
+## Task 2: Add the cwd-filtered item builder
+
+**Files:**
+- Modify: `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua`
+
+- [ ] **Step 1: Add `M.list_items()` that calls `registry.discover()` and filters by cwd subtree**
+
+Insert *after* the `in_cwd_subtree` function and *before* the `return M` line:
+
+```lua
+---@return snacks.picker.finder.Item[]
+function M.list_items()
+  local root = normalize(vim.fn.getcwd())
+  local home = normalize(vim.fn.expand("~"))
+  local items = {}
+  for label, entry in pairs(registry.discover()) do
+    if in_cwd_subtree(entry.cwd, root) then
+      local cwd_display = entry.cwd or ""
+      if home ~= "" and cwd_display:sub(1, #home) == home then
+        cwd_display = "~" .. cwd_display:sub(#home + 1)
+      end
+      items[#items + 1] = {
+        text = string.format("[%s] %s  %s", entry.tool, label, cwd_display),
+        label = label,
+        tool = entry.tool,
+        slug = entry.slug,
+        pane_id = entry.pane_id,
+        session_id = entry.session_id,
+        cwd = entry.cwd,
+      }
+    end
+  end
+  table.sort(items, function(a, b)
+    if a.tool ~= b.tool then
+      return a.tool < b.tool
+    end
+    return a.label < b.label
+  end)
+  return items
+end
+```
+
+- [ ] **Step 2: Verify the function is callable**
+
+```bash
+nvim --headless -c 'lua print(vim.inspect(require("plugins.sidekick.cwd_picker").list_items()))' -c 'qa' 2>&1
+```
+
+Expected: prints `{}` (empty table) when no named sessions exist in the cwd, OR a non-empty array of items if any are running.
+
+- [ ] **Step 3: Manual verification with a live session**
+
+In an interactive nvim from `~/dotfiles`:
+1. `<leader>an` → claude → "peektest" — starts a named session.
+2. `:lua print(vim.inspect(require("plugins.sidekick.cwd_picker").list_items()))`
+3. Expected: an array containing one item with `label = "claude-peektest"` and `tool = "claude"`.
+4. From `~/some-other-dir`: `:lua print(vim.inspect(require("plugins.sidekick.cwd_picker").list_items()))`
+5. Expected: empty array `{}` — the session's cwd is `~/dotfiles`, which is not a subtree of the unrelated directory.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+git commit -m "Add cwd-filtered list_items to sidekick cwd_picker"
+```
+
+---
+
+## Task 3: Add the preview helper and kill-session helper
+
+**Files:**
+- Modify: `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua`
+
+- [ ] **Step 1: Add the preview helper above `M.list_items`**
+
+Place these two helpers between `in_cwd_subtree` and `M.list_items`:
+
+```lua
+---@param item table|nil
+---@return string[]
+local function preview_lines(item)
+  if not item or item._empty or not item.pane_id then
+    return { "(no session)" }
+  end
+  local out = vim.fn.systemlist({
+    "tmux",
+    "capture-pane",
+    "-p",
+    "-S",
+    "-",
+    "-E",
+    "-",
+    "-t",
+    item.pane_id,
+  })
+  if vim.v.shell_error ~= 0 then
+    return { "(capture-pane failed)" }
+  end
+  return out
+end
+
+---@param session_id string|nil
+---@return boolean
+local function kill_session(session_id)
+  if not session_id or session_id == "" then
+    return false
+  end
+  local out = vim.fn.systemlist({ "tmux", "kill-session", "-t", session_id })
+  if vim.v.shell_error == 0 then
+    return true
+  end
+  for _, line in ipairs(out) do
+    if line:match("can't find session") or line:match("no such session") then
+      return true
+    end
+  end
+  vim.notify("Sidekick: tmux kill-session failed: " .. table.concat(out, " "), vim.log.levels.WARN)
+  return false
+end
+```
+
+These mirror `picker.lua:37-75` but with two intentional differences:
+- `preview_lines` honors a new `item._empty` flag (used for the empty-state placeholder in Task 5).
+- The capture window is full scrollback (`-S -`) instead of `-S -200`, because the user wants to mouse-scroll up to read history.
+
+- [ ] **Step 2: Verify the file still loads**
+
+```bash
+nvim --headless -c 'lua require("plugins.sidekick.cwd_picker")' -c 'qa' 2>&1
+```
+
+Expected: silent.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+git commit -m "Add preview and kill helpers to sidekick cwd_picker"
+```
+
+---
+
+## Task 4: Add `M.open()` for the populated case
+
+**Files:**
+- Modify: `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua`
+
+- [ ] **Step 1: Add `M.open()` between `M.list_items` and `return M`**
+
+```lua
+function M.open()
+  registry.rehydrate()
+  local items = M.list_items()
+  local empty = #items == 0
+  if empty then
+    items = { {
+      text = "(no named sessions in cwd)",
+      _empty = true,
+    } }
+  end
+
+  Snacks.picker.pick({
+    source = "sidekick_cwd_peek",
+    title = "Sidekick Sessions in Cwd",
+    items = items,
+    format = "text",
+    layout = {
+      preset = "default",
+      layout = {
+        box = "vertical",
+        width = 0.8,
+        height = 0.8,
+        border = "none",
+        { win = "preview", border = "rounded" },
+        { win = "list", height = 5, border = "rounded" },
+        { win = "input", height = 3, border = "rounded" },
+      },
+    },
+    preview = function(ctx)
+      vim.api.nvim_buf_set_lines(ctx.buf, 0, -1, false, preview_lines(ctx.item))
+      return true
+    end,
+    confirm = function(picker, item)
+      picker:close()
+      if not item or item._empty then
+        return
+      end
+      if item.label then
+        internal.toggle_tool_session(item.label, true)
+      end
+    end,
+    win = {
+      input = {
+        keys = {
+          ["<c-x>"] = { "sidekick_kill_session", mode = { "n", "i" } },
+        },
+      },
+      list = {
+        keys = {
+          ["<c-x>"] = { "sidekick_kill_session", mode = { "n" } },
+        },
+      },
+    },
+    actions = {
+      sidekick_kill_session = function(picker, item)
+        if not item or item._empty or not item.session_id then
+          return
+        end
+        if kill_session(item.session_id) then
+          picker:close()
+          vim.schedule(function()
+            M.open()
+          end)
+        end
+      end,
+    },
+  })
+end
+```
+
+Notes for the engineer:
+- The `box = "vertical"` layout stacks children top-to-bottom. Children appear in array order, so order is: preview, list, input — matching the spec.
+- `list.height = 5` = 3 inner rows + 2 rounded-border rows. `input.height = 3` = 1 inner + 2 border. The `preview` box has no fixed height, so Snacks fills it with the remaining space.
+- `width = 0.8` and `height = 0.8` give the 80% × 80% float per spec.
+- `<c-n>/<c-p>` cycle and `<Esc>` dismiss are Snacks defaults — we don't bind them explicitly.
+
+- [ ] **Step 2: Verify the file loads**
+
+```bash
+nvim --headless -c 'lua require("plugins.sidekick.cwd_picker")' -c 'qa' 2>&1
+```
+
+Expected: silent.
+
+- [ ] **Step 3: Manual verification — populated case**
+
+In an interactive nvim from `~/dotfiles`, with no named sessions running:
+1. `<leader>an` → claude → "peektest" — starts a named session in `~/dotfiles`.
+2. `:lua require("plugins.sidekick.cwd_picker").open()`
+3. Expected: an 80%×80% centered float with three stacked rounded boxes:
+   - Top: large preview area showing the captured tmux scrollback of the `claude-peektest` pane.
+   - Middle: 3-row list with `[claude] claude-peektest  ~/dotfiles`.
+   - Bottom: 1-row input with cursor.
+4. Type `peek` → list narrows (still one match).
+5. `<CR>` → picker closes; the `claude-peektest` sidekick float opens.
+6. `<c-.>` would still call the OLD binding (we wire it in Task 6), so test re-opening via `:lua require("plugins.sidekick.cwd_picker").open()` again.
+7. Press `<c-x>` on the visible match → tmux kills the session, picker reopens with the empty placeholder.
+
+- [ ] **Step 4: Manual verification — empty case**
+
+From a directory with no sessions (e.g. `cd /tmp && nvim`):
+1. `:lua require("plugins.sidekick.cwd_picker").open()`
+2. Expected: same float layout. List shows `(no named sessions in cwd)`. Preview shows `(no session)`. `<CR>` closes silently. `<Esc>` dismisses.
+
+- [ ] **Step 5: Manual verification — mouse scroll on preview**
+
+With a session whose history exceeds the preview height:
+1. Open the picker.
+2. Mouse-wheel up over the preview pane.
+3. Expected: scrollback scrolls. Mouse wheel does NOT enter copy-mode (we are not using a tmux embed; this is a normal scratch buffer).
+
+If wheel scroll doesn't work, verify `:set mouse?` shows `mouse=a` (LazyVim default).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+git commit -m "Add M.open with stacked layout, kill action, empty state"
+```
+
+---
+
+## Task 5: Rewire the `<c-.>` keybind
+
+**Files:**
+- Modify: `nvim/.config/nvim/lua/plugins/sidekick.lua` (lines 72-79 only)
+
+- [ ] **Step 1: Read the current binding**
+
+Confirm lines 72-79 look like this before editing:
+
+```lua
+    {
+      "<c-.>",
+      function()
+        require("sidekick.cli").toggle()
+      end,
+      desc = "Sidekick Toggle",
+      mode = { "n", "t", "i", "x" },
+    },
+```
+
+- [ ] **Step 2: Replace the body**
+
+Use the Edit tool with this exact replacement:
+
+old_string:
+```lua
+    {
+      "<c-.>",
+      function()
+        require("sidekick.cli").toggle()
+      end,
+      desc = "Sidekick Toggle",
+      mode = { "n", "t", "i", "x" },
+    },
+```
+
+new_string:
+```lua
+    {
+      "<c-.>",
+      function()
+        require("plugins.sidekick.cwd_picker").open()
+      end,
+      desc = "Sidekick Peek Sessions in Cwd",
+      mode = { "n", "t", "i", "x" },
+    },
+```
+
+The mode list is preserved verbatim so terminal/insert/visual access still triggers the new picker.
+
+- [ ] **Step 3: Reload the running nvim sessions and the keybind**
+
+In each open nvim:
+1. `:Lazy reload sidekick.nvim`
+2. `<c-.>` should now open the new picker instead of `sidekick.cli.toggle()`.
+
+If reload doesn't pick up the new keymap (LazyVim caches keys), restart the nvim session.
+
+- [ ] **Step 4: End-to-end verification**
+
+From `~/dotfiles`:
+1. Start a named session via `<leader>an` → claude → "e2e".
+2. Press `<c-.>` from normal mode.
+3. Expected: the new floating picker opens, lists `claude-e2e`, shows its scrollback in the preview.
+4. From insert mode of any buffer, press `<c-.>` — same picker opens (mode list includes `i`).
+5. From a `:terminal` buffer, press `<c-.>` — same picker opens (mode `t`).
+
+- [ ] **Step 5: Confirm the existing pickers are untouched**
+
+1. `<leader>al` → still opens the original full-list horizontal picker.
+2. `<leader>aa` → still toggles the default sidekick CLI.
+3. No other binding regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nvim/.config/nvim/lua/plugins/sidekick.lua
+git commit -m "Rewire <c-.> to sidekick cwd_picker"
+```
+
+---
+
+## Task 6: Final integration check
+
+**Files:** None (verification-only task)
+
+- [ ] **Step 1: Run the full verification recipe from the spec**
+
+From `~/dotfiles`:
+
+1. `<leader>an` → claude → "foo"
+2. `<leader>an` → cursor → "bar"
+3. `cd nvim/`, `<leader>an` → claude → "sub"
+4. Return to `~/dotfiles`. Press `<c-.>`.
+5. Expected: 3 entries — `claude-foo`, `cursor-bar`, `claude-sub`. Sub is included because its cwd `~/dotfiles/nvim` is a descendant of `~/dotfiles`.
+6. From `~/some-other-repo` (any unrelated dir), press `<c-.>`.
+7. Expected: empty-state UI.
+8. From `~/dotfiles`, press `<c-.>`, type `f`.
+9. Expected: list narrows to `claude-foo`; preview updates.
+10. `<c-n>` / `<c-p>` cycles selection.
+11. `<CR>` opens the highlighted session.
+12. Reopen `<c-.>`, press `<c-x>` on a match — that tmux session is killed; picker reopens with one fewer entry.
+13. `<Esc>` from input — picker dismisses.
+14. Mouse-wheel up over preview — scrollback scrolls.
+
+If any step fails, fix and recommit before merging.
+
+- [ ] **Step 2: Clean up test sessions (optional)**
+
+```bash
+tmux kill-session -t claude-foo 2>/dev/null
+tmux kill-session -t cursor-bar 2>/dev/null
+tmux kill-session -t claude-sub 2>/dev/null
+tmux kill-session -t claude-e2e 2>/dev/null
+tmux kill-session -t claude-peektest 2>/dev/null
+```
+
+- [ ] **Step 3: No new commit needed** — verification-only task.
+
+---
+
+## Self-Review (completed by author)
+
+**Spec coverage:**
+- 80% × 80% float, centered, three stacked rounded boxes (preview / list / input) — Task 4 Step 1.
+- Cwd + descendants filter — Task 1 (predicate) + Task 2 (filter).
+- Snapshot preview, no auto-refresh — Task 3 (`preview_lines`) + Task 4 (`preview = function(ctx)` fires only on selection change).
+- `<c-n>/<c-p>` cycle — Snacks default, called out in Task 4 Step 1 notes.
+- `<CR>` confirm — Task 4 (`confirm` callback).
+- `<c-x>` kill — Task 4 (`sidekick_kill_session` action).
+- `<Esc>` dismiss — Snacks default.
+- Mouse-wheel scroll on preview — verified in Task 4 Step 5 and Task 6 Step 1.14.
+- Empty-state placeholder — Task 4 (`empty` branch).
+- `<leader>al` left untouched — Task 5 Step 5 verifies.
+- Keybind rewire on `<c-.>` keeping the mode list — Task 5.
+
+**Placeholder scan:** No "TBD"/"TODO"/"similar to". Every code step shows full code; every command has expected output.
+
+**Type consistency:** `M.list_items` returns items with the same shape used by `preview_lines`, `confirm`, and `sidekick_kill_session`. The `_empty` flag is consistently checked in all three places.
+
+**Scope check:** Two-file change, six tasks, single PR. Appropriately scoped.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-09-sidekick-cwd-picker.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-09-sidekick-cwd-picker-design.md
+++ b/docs/superpowers/specs/2026-05-09-sidekick-cwd-picker-design.md
@@ -1,0 +1,201 @@
+# Sidekick `<c-.>` Cwd-Scoped Peek Picker
+
+## Problem
+
+Today `<c-.>` is bound to `sidekick.cli.toggle()` (see `nvim/.config/nvim/lua/plugins/sidekick.lua:73-79`), which opens sidekick.nvim's built-in tool/session picker. That picker only shows session names — there is no way to peek into a session's chat before deciding whether to open it. When the user has several named claude/cursor/codex sessions running, they often want to glance at the last few exchanges to decide whether the session needs attention before switching to it.
+
+The existing `<leader>al` picker (`nvim/.config/nvim/lua/plugins/sidekick/picker.lua`) does include a tmux-pane preview, but it lists every named session across every cwd in a horizontal split layout that's optimized for full-list browsing, not a quick "peek into the session I'm probably about to focus" flow.
+
+## Goal
+
+Replace `<c-.>`'s behavior with a new floating picker that:
+
+- Lists only named sessions whose cwd is the current working directory or a descendant of it.
+- Shows a large chat-preview pane on top so the user can read the most recent scrollback before opening.
+- Uses an fzf-style fuzzy-match input below the preview.
+- Opens the selected session as a regular sidekick session on `<CR>`.
+
+Existing `<leader>al` keeps its current behavior unchanged.
+
+## Non-goals
+
+- No live-streaming preview. The preview re-captures only on selection change.
+- No support for sessions outside the current cwd subtree (that's what `<leader>al` is for).
+- No new session-creation flows. `<leader>an` still owns that.
+- No replacement of `<leader>al` or any other sidekick keybind.
+
+## User experience
+
+Layout occupies an 80%-wide × 80%-tall float, centered, no outer border. Top-to-bottom inside the float:
+
+```
+╭───────────────────────────────────╮
+│  CHAT PREVIEW                     │   ≈ float_height − 8 rows
+│  (tmux capture-pane scrollback,   │   rounded border
+│   mouse-wheel scrollable)         │
+╰───────────────────────────────────╯
+╭───────────────────────────────────╮
+│ > claude-foo  ~/dotfiles          │   3 inner rows, rounded border
+│   claude-bar  ~/dotfiles/sub      │
+│   cursor-baz  ~/dotfiles          │
+╰───────────────────────────────────╯
+╭───────────────────────────────────╮
+│ > query_                          │   1 inner row, rounded border
+╰───────────────────────────────────╯
+```
+
+Each section has its own rounded border. Match list shows exactly 3 visible items at a time; additional matches are reachable by `<c-n>` / `<c-p>` which scroll the visible window.
+
+### Keymaps
+
+| Key | Action |
+|-----|--------|
+| typing in input | fuzzy-filters the list (Snacks default matcher) |
+| `<c-n>` / `<c-p>` | cycle selection up/down (Snacks default) |
+| `<CR>` | confirm: `internal.toggle_tool_session(item.label, true)`, then close picker |
+| `<c-x>` | `tmux kill-session -t <session_id>`, then reopen picker — mirrors `picker.lua:103-124` |
+| `<Esc>` | dismiss (Snacks default) |
+| mouse wheel on preview | scroll the preview buffer (it is a normal scratch buffer) |
+
+### Empty state
+
+If the cwd-filtered list is empty, the picker still opens. The list shows a single non-selectable placeholder row `(no named sessions in cwd)`; the preview shows `(no session)`. `<CR>` is a no-op; `<Esc>` dismisses.
+
+## Architecture
+
+New module **`nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua`**.
+
+- Public surface: `M.open()`.
+- Reuses `plugins.sidekick.registry.discover()` for the source data and `plugins.sidekick.internal.toggle_tool_session` for the confirm action.
+- The cwd filter is applied in `cwd_picker.lua` after `registry.rehydrate()`.
+
+### Source list
+
+```lua
+local function in_cwd_subtree(entry_cwd, root)
+  if not entry_cwd or entry_cwd == "" then return false end
+  return entry_cwd == root or entry_cwd:sub(1, #root + 1) == root .. "/"
+end
+```
+
+`root` is `vim.fn.getcwd()` normalized via `vim.fs.normalize(vim.fn.fnamemodify(..., ":p"))` to match how `internal.normalize_cwd` produces stored cwds. Both `root` and `entry_cwd` are normalized before comparison so trailing slashes and symlinks don't trip the prefix match.
+
+Item shape mirrors `picker.lua:16-24`:
+
+```lua
+{
+  text = string.format("[%s] %s  %s", entry.tool, label, cwd_display),
+  label = label,
+  tool = entry.tool,
+  slug = entry.slug,
+  pane_id = entry.pane_id,
+  session_id = entry.session_id,
+  cwd = entry.cwd,
+}
+```
+
+Sort by `tool` then `label` (same comparator as `picker.lua:26-31`).
+
+### Layout
+
+Snacks picker `layout` configured per-call:
+
+```lua
+layout = {
+  preset = "default",
+  layout = {
+    box = "vertical",
+    width = 0.8,
+    height = 0.8,
+    border = "none",
+    { win = "preview", border = "rounded" },           -- fills remaining height
+    { win = "list",    height = 5, border = "rounded" }, -- 3 inner + 2 border
+    { win = "input",   height = 3, border = "rounded" }, -- 1 inner + 2 border
+  },
+}
+```
+
+The `preview` box has no fixed height so it absorbs whatever's left after `list` (5) and `input` (3) are subtracted from the float's 80% height. On a typical 50-row terminal, 80% = 40 rows → preview ≈ 32 rows.
+
+### Preview rendering
+
+Identical to `picker.lua:37-56` — `tmux capture-pane -p -S - -E - -t <pane_id>` for full scrollback (vs. `-S -200` in the existing picker; here we want full history so the user can mouse-scroll up). On `tmux capture-pane` failure, write `{ "(capture-pane failed)" }` into the preview buffer.
+
+The preview buffer is a regular scratch buffer (Snacks default). Mouse-wheel scroll works because LazyVim's defaults set `vim.opt.mouse = "a"`; the wheel events translate into normal-mode `<ScrollWheelUp>/<ScrollWheelDown>` mappings that scroll the buffer.
+
+### Confirm and kill actions
+
+```lua
+confirm = function(picker, item)
+  picker:close()
+  if item and item.label then
+    internal.toggle_tool_session(item.label, true)
+  end
+end,
+```
+
+Kill action is copied verbatim from `picker.lua:103-124` — same `<c-x>` binding on both `input` and `list` windows, same `kill_session` helper that treats "no such session" as success.
+
+### Empty state implementation
+
+Detected before the Snacks call. Instead of `vim.notify("Sidekick: no named sessions in cwd")` (which is what `picker.lua:80-83` does for the global empty case), `cwd_picker.lua` opens the picker with `items = { { text = "(no named sessions in cwd)", _empty = true } }`. The `confirm` callback ignores items with `_empty = true`. The `preview` callback writes `{ "(no session)" }` into the buffer for empty items. The `<c-x>` action also early-returns when `item._empty` or `item.session_id` is missing, so kill-on-placeholder is a no-op.
+
+### Keybinding wiring
+
+In `nvim/.config/nvim/lua/plugins/sidekick.lua`, replace the `<c-.>` entry (currently at lines 72-79):
+
+```lua
+{
+  "<c-.>",
+  function()
+    require("plugins.sidekick.cwd_picker").open()
+  end,
+  desc = "Sidekick Peek Sessions in Cwd",
+  mode = { "n", "t", "i", "x" },
+},
+```
+
+The mode list (`n`, `t`, `i`, `x`) is preserved from the existing binding so terminal/insert/visual access still works.
+
+## Edge cases
+
+- **No tmux on `$PATH`** — `registry.discover()` already returns `{}` in that case, so the empty-state UI will open. No new handling needed.
+- **`tmux capture-pane` fails for one session** — preview shows `(capture-pane failed)`; the picker stays usable. Same as today's `picker.lua`.
+- **Selected session was killed externally between open and `<CR>`** — `internal.toggle_tool_session` will respawn it via the registered tool config. Acceptable; matches today's behavior for `<leader>al`.
+- **`<c-x>` kills the only visible session** — after the kill, `M.open()` is re-invoked, re-runs the cwd filter, and the empty-state UI shows.
+- **Cwd contains a symlink** — both sides of the prefix comparison are run through `vim.fs.normalize ∘ fnamemodify(..., ":p")` so symlinked roots and physical roots compare equal.
+- **Session's cwd is a parent of the editor cwd** — does *not* match (we want descendants only). Intentional: the user said "cwd and children".
+
+## Testing
+
+Manual verification recipe:
+
+1. From `~/dotfiles`, start two named sessions: `<leader>an` claude / "foo", `<leader>an` cursor / "bar".
+2. `cd nvim/`, start `<leader>an` claude / "sub".
+3. Return to `~/dotfiles`. Press `<c-.>`.
+   - Expect 3 entries (foo, bar, sub) — sub is in a child cwd so it is included.
+4. From `~/some-other-repo`, press `<c-.>`.
+   - Expect the empty-state UI: `(no named sessions in cwd)` in list, `(no session)` in preview.
+5. From `~/dotfiles`, press `<c-.>`, type `f`.
+   - Expect list narrows to "foo"; preview updates to that session's tmux scrollback.
+6. Press `<c-n>` / `<c-p>` — selection cycles, preview updates.
+7. Press `<CR>` on a match — picker closes, the session opens as a normal sidekick float.
+8. Reopen `<c-.>`, press `<c-x>` on a match — that tmux session is killed, the picker reopens with one fewer entry.
+9. `<Esc>` from input — picker dismisses without acting.
+10. Mouse-wheel up over the preview pane — scrollback scrolls. (Requires a session with > visible-rows of history.)
+
+Failures in any step are bugs to fix before merging.
+
+## File-level diff summary
+
+- **New**: `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua` (~80 LOC).
+- **Edit**: `nvim/.config/nvim/lua/plugins/sidekick.lua` — replace the `<c-.>` keymap body (lines 72-79).
+- No other files touched. `picker.lua`, `registry.lua`, `internal.lua` are reused as-is.
+
+## Out of scope / explicit YAGNI
+
+- Auto-refresh timer for the preview.
+- Embedding the live tmux pane via `tmux attach -r`.
+- Including base sessions (claude, cursor, codex, opencode without slugs) — only named sessions are listed, matching the user's stated source filter.
+- Cross-cwd session listing — that's `<leader>al`.
+- A new "create session" affordance from inside the picker — `<leader>an` is unchanged.

--- a/nvim/.config/nvim/lua/plugins/sidekick.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick.lua
@@ -72,9 +72,9 @@ return {
     {
       "<c-.>",
       function()
-        require("sidekick.cli").toggle()
+        require("plugins.sidekick.cwd_picker").open()
       end,
-      desc = "Sidekick Toggle",
+      desc = "Sidekick Peek Sessions in Cwd",
       mode = { "n", "t", "i", "x" },
     },
     {

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -29,6 +29,48 @@ local function in_cwd_subtree(entry_cwd, root)
   return n:sub(1, #root + 1) == root .. "/"
 end
 
+---@param item table|nil
+---@return string[]
+local function preview_lines(item)
+  if not item or item._empty or not item.pane_id then
+    return { "(no session)" }
+  end
+  local out = vim.fn.systemlist({
+    "tmux",
+    "capture-pane",
+    "-p",
+    "-S",
+    "-",
+    "-E",
+    "-",
+    "-t",
+    item.pane_id,
+  })
+  if vim.v.shell_error ~= 0 then
+    return { "(capture-pane failed)" }
+  end
+  return out
+end
+
+---@param session_id string|nil
+---@return boolean
+local function kill_session(session_id)
+  if not session_id or session_id == "" then
+    return false
+  end
+  local out = vim.fn.systemlist({ "tmux", "kill-session", "-t", session_id })
+  if vim.v.shell_error == 0 then
+    return true
+  end
+  for _, line in ipairs(out) do
+    if line:match("can't find session") or line:match("no such session") then
+      return true
+    end
+  end
+  vim.notify("Sidekick: tmux kill-session failed: " .. table.concat(out, " "), vim.log.levels.WARN)
+  return false
+end
+
 ---@return snacks.picker.finder.Item[]
 function M.list_items()
   local root = normalize(vim.fn.getcwd())

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -19,6 +19,8 @@ end
 ---@param root string  already normalized
 ---@return boolean
 local function in_cwd_subtree(entry_cwd, root)
+  -- root == "" only when getcwd() was "/" (normalize strips its only slash).
+  -- Treat as "match nothing" — a degenerate scenario, opt for safe empty state.
   if not entry_cwd or entry_cwd == "" or root == "" then
     return false
   end

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -102,4 +102,73 @@ function M.list_items()
   return items
 end
 
+function M.open()
+  registry.rehydrate()
+  local items = M.list_items()
+  local empty = #items == 0
+  if empty then
+    items = { {
+      text = "(no named sessions in cwd)",
+      _empty = true,
+    } }
+  end
+
+  Snacks.picker.pick({
+    source = "sidekick_cwd_peek",
+    title = "Sidekick Sessions in Cwd",
+    items = items,
+    format = "text",
+    layout = {
+      preset = "default",
+      layout = {
+        box = "vertical",
+        width = 0.8,
+        height = 0.8,
+        border = "none",
+        { win = "preview", border = "rounded" },
+        { win = "list", height = 5, border = "rounded" },
+        { win = "input", height = 3, border = "rounded" },
+      },
+    },
+    preview = function(ctx)
+      vim.api.nvim_buf_set_lines(ctx.buf, 0, -1, false, preview_lines(ctx.item))
+      return true
+    end,
+    confirm = function(picker, item)
+      picker:close()
+      if not item or item._empty then
+        return
+      end
+      if item.label then
+        internal.toggle_tool_session(item.label, true)
+      end
+    end,
+    win = {
+      input = {
+        keys = {
+          ["<c-x>"] = { "sidekick_kill_session", mode = { "n", "i" } },
+        },
+      },
+      list = {
+        keys = {
+          ["<c-x>"] = { "sidekick_kill_session", mode = { "n" } },
+        },
+      },
+    },
+    actions = {
+      sidekick_kill_session = function(picker, item)
+        if not item or item._empty or not item.session_id then
+          return
+        end
+        if kill_session(item.session_id) then
+          picker:close()
+          vim.schedule(function()
+            M.open()
+          end)
+        end
+      end,
+    },
+  })
+end
+
 return M

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1,0 +1,32 @@
+-- nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+-- Cwd-scoped peek picker for sidekick named sessions.
+-- Bound to <c-.> in plugins/sidekick.lua.
+local internal = require("plugins.sidekick.internal")
+local registry = require("plugins.sidekick.registry")
+
+local M = {}
+
+---@param p string
+---@return string
+local function normalize(p)
+  if not p or p == "" then
+    return ""
+  end
+  return vim.fs.normalize(vim.fn.fnamemodify(p, ":p")):gsub("/$", "")
+end
+
+---@param entry_cwd string|nil
+---@param root string  already normalized
+---@return boolean
+local function in_cwd_subtree(entry_cwd, root)
+  if not entry_cwd or entry_cwd == "" or root == "" then
+    return false
+  end
+  local n = normalize(entry_cwd)
+  if n == root then
+    return true
+  end
+  return n:sub(1, #root + 1) == root .. "/"
+end
+
+return M

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -133,6 +133,7 @@ function M.open()
       },
     },
     preview = function(ctx)
+      vim.bo[ctx.buf].modifiable = true
       vim.api.nvim_buf_set_lines(ctx.buf, 0, -1, false, preview_lines(ctx.item))
       return true
     end,

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -29,4 +29,35 @@ local function in_cwd_subtree(entry_cwd, root)
   return n:sub(1, #root + 1) == root .. "/"
 end
 
+---@return snacks.picker.finder.Item[]
+function M.list_items()
+  local root = normalize(vim.fn.getcwd())
+  local home = normalize(vim.fn.expand("~"))
+  local items = {}
+  for label, entry in pairs(registry.discover()) do
+    if in_cwd_subtree(entry.cwd, root) then
+      local cwd_display = entry.cwd or ""
+      if home ~= "" and cwd_display:sub(1, #home) == home then
+        cwd_display = "~" .. cwd_display:sub(#home + 1)
+      end
+      items[#items + 1] = {
+        text = string.format("[%s] %s  %s", entry.tool, label, cwd_display),
+        label = label,
+        tool = entry.tool,
+        slug = entry.slug,
+        pane_id = entry.pane_id,
+        session_id = entry.session_id,
+        cwd = entry.cwd,
+      }
+    end
+  end
+  table.sort(items, function(a, b)
+    if a.tool ~= b.tool then
+      return a.tool < b.tool
+    end
+    return a.label < b.label
+  end)
+  return items
+end
+
 return M


### PR DESCRIPTION
## Summary

- Replaces `<c-.>` with a Snacks-based floating picker that lists named sidekick sessions in the current cwd (and descendants), with a chat-preview pane on top so you can peek before opening.
- New module `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua` (sibling to existing `picker.lua`). `<leader>al` is untouched.
- 80% × 80% float, rounded borders, stack: preview → 3-row fuzzy list → 1-row input. `<c-n>/<c-p>` cycle, `<CR>` opens, `<c-x>` kills + reopens, `<Esc>` dismisses, mouse wheel scrolls preview.

## Design + Plan

- Spec: `docs/superpowers/specs/2026-05-09-sidekick-cwd-picker-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-sidekick-cwd-picker.md`

## Validation (clean isolated nvim, branch `feat/sidekick-cwd-picker` @ 4359bf1)

Driven via `--listen` socket against a tmux-hosted nvim using a fresh `XDG_CONFIG_HOME` so no contamination from the daily config.

| # | Check | Result |
|---|-------|--------|
| 1 | Module loads, `open`/`list_items` are functions | ✅ |
| 2 | `<C-.>` bound to "Sidekick Peek Sessions in Cwd" via `cwd_picker.open()` | ✅ |
| 3 | `<leader>al` still points at `plugins.sidekick.picker.open()` | ✅ |
| 4 | `list_items()` in test cwd returns `{}` (no sessions in env) | ✅ |
| 4b | `cd /tmp` → `list_items()` returns `{}` | ✅ |
| 5 | Empty-state UI opens 4 floats (preview / list / input + backdrop) | ✅ |
| 5b | Layout dimensions: preview h=34, list h=5, input h=3, container 160×48 (80% of 200×60) | ✅ |
| 5c | List buffer contains `(no named sessions in cwd)` placeholder | ✅ |
| 5d | Preview buffer contains `(no session)` (after fix) | ✅ |
| 7 | Root `cd /` edge case: `list_items()` returns `{}` (documented behavior) | ✅ |

### Bug found and fixed during validation

Initial run showed the preview pane rendering a `Buffer is not 'modifiable'` stack trace plus a raw item dump instead of `(no session)`. Newer Snacks versions mark picker preview buffers as non-modifiable by default. Fixed in `4359bf1` by setting `vim.bo[ctx.buf].modifiable = true` before `nvim_buf_set_lines`. Re-validation confirms preview now renders `(no session)`.

### Manual checks still owed to the human

- `<CR>` opens the highlighted session (needs a real named session running)
- `<c-x>` kills + reopens with one fewer entry (needs a real named session)
- Mouse-wheel scroll over preview (can't simulate reliably via remote-send)
- `<leader>al` continues to work end-to-end

## Test plan

- [x] Module loads, both public functions exposed
- [x] `<c-.>` keymap wires through to `cwd_picker.open()`
- [x] `<leader>al` keymap unchanged
- [x] Cwd-subtree filter returns expected items for current cwd
- [x] Cwd filter returns empty for unrelated cwds
- [x] Empty-state UI opens with correct dimensions and placeholder text
- [x] Empty-state preview shows `(no session)` after fix
- [x] Root `/` edge case returns empty list (documented behavior)
- [ ] Real session: `<CR>` opens it (manual)
- [ ] Real session: `<c-x>` kills + reopens (manual)
- [ ] Real session: mouse-wheel scroll on preview (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)