### PR TITLE
feat(nvim): add read-only verifier agent

### DIFF
--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -614,8 +614,9 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Verification checks Sidekick registry parsing.
 - Verification checks Sidekick branding lookup.
 - Verification checks `<C-.>` local fallback.
-- Verification can create a temporary real tmux Pi session.
-- Verification checks tmux discovery and rehydration.
+- Verification checks Herdr-backed Sidekick sessions, workspaces, and task routing.
 - Verification checks local picker visibility.
-- Verification checks `SIDEKICK_BRANCH` metadata readback.
 - Verification checks search snapshot capture.
+- `scripts/nvim-verifier` launches a Pi verifier with no shell or file-mutation tools.
+- The verifier runs the selected checkout's config and returns structured PASS/FAIL evidence without replacing raw
+  harness output.

--- a/pi/.pi/agent/extensions/nvim-verifier.ts
+++ b/pi/.pi/agent/extensions/nvim-verifier.ts
@@ -1,0 +1,71 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { Type } from "typebox";
+
+const execFileAsync = promisify(execFile);
+const CASE_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "verify_nvim",
+    label: "Verify Neovim",
+    description: "Run one named scripts/verify-nvim case and return its unmodified exit status, stdout, and stderr.",
+    promptSnippet: "Run a deterministic Neovim harness case without exposing a general-purpose shell.",
+    parameters: Type.Object({
+      case: Type.String({ description: "Harness case name, such as agent-keymaps." }),
+    }),
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const script = join(ctx.cwd, "scripts", "verify-nvim");
+      const configHome = join(ctx.cwd, "nvim", ".config");
+      const command = `XDG_CONFIG_HOME="$PWD/nvim/.config" scripts/verify-nvim ${params.case}`;
+
+      if (!CASE_PATTERN.test(params.case)) {
+        const details = {
+          command,
+          cwd: ctx.cwd,
+          exit_code: 2,
+          stdout: "",
+          stderr: `Invalid case name: ${params.case}`,
+        };
+        return { content: [{ type: "text", text: JSON.stringify(details, null, 2) }], details };
+      }
+
+      try {
+        await access(script, constants.X_OK);
+        const result = await execFileAsync(script, [params.case], {
+          cwd: ctx.cwd,
+          encoding: "utf8",
+          env: { ...process.env, XDG_CONFIG_HOME: configHome },
+          maxBuffer: 1024 * 1024,
+          signal,
+        });
+        const details = {
+          command,
+          cwd: ctx.cwd,
+          exit_code: 0,
+          stdout: String(result.stdout ?? ""),
+          stderr: String(result.stderr ?? ""),
+        };
+        return { content: [{ type: "text", text: JSON.stringify(details, null, 2) }], details };
+      } catch (error) {
+        const failure = error as Error & {
+          code?: number | string;
+          stdout?: string | Buffer;
+          stderr?: string | Buffer;
+        };
+        const details = {
+          command,
+          cwd: ctx.cwd,
+          exit_code: typeof failure.code === "number" ? failure.code : 1,
+          stdout: String(failure.stdout ?? ""),
+          stderr: String(failure.stderr ?? failure.message),
+        };
+        return { content: [{ type: "text", text: JSON.stringify(details, null, 2) }], details };
+      }
+    },
+  });
+}

--- a/pi/.pi/agent/prompts/nvim-verifier.md
+++ b/pi/.pi/agent/prompts/nvim-verifier.md
@@ -1,0 +1,25 @@
+---
+description: Verify a Neovim config change with read-only evidence
+argument-hint: "[harness-case]"
+---
+Verify this Neovim config change using harness case `${1:-agent-keymaps}`.
+
+You are a read-only verifier. You have no shell, edit, or write tool. Do not
+modify files. Keep deterministic harness output separate from your
+interpretation.
+
+1. Run `verify_nvim` exactly once with the requested case.
+2. Treat its exit code, stdout, and stderr as the source of truth.
+3. Inspect only relevant files or artifact paths reported by the harness. Do
+   not treat old or unreported artifacts as evidence.
+4. Return exactly one JSON object with these fields:
+   - `verdict`: `PASS` only when the harness exits zero, otherwise `FAIL`.
+   - `commands_run`: exact commands reported by the tool.
+   - `artifacts_reviewed`: artifact paths actually inspected; use `[]` when
+     none were reported.
+   - `evidence`: concise facts from harness output and reviewed artifacts.
+   - `likely_cause`: evidence-backed cause for a failure, otherwise `null`.
+   - `recommended_next_step`: one bounded action; never make the change.
+
+Do not use code inspection alone to claim that behavior works. Do not invent
+artifacts, evidence, causes, or commands.

--- a/scripts/nvim-verifier
+++ b/scripts/nvim-verifier
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case_name="${1:-agent-keymaps}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_root="$(cd "$script_dir/.." && pwd)"
+repo_root="${2:-$default_root}"
+extension="$default_root/pi/.pi/agent/extensions/nvim-verifier.ts"
+prompt="$default_root/pi/.pi/agent/prompts/nvim-verifier.md"
+
+cd "$repo_root"
+pi \
+  --print \
+  --no-session \
+  --no-extensions \
+  --no-skills \
+  --no-prompt-templates \
+  --no-context-files \
+  --extension "$extension" \
+  --prompt-template "$prompt" \
+  --tools read,grep,find,ls,verify_nvim \
+  "/nvim-verifier $case_name" |
+  sed $'s/\033\\[[0-9;]*m//g'


### PR DESCRIPTION
## Summary

- add a Pi launcher with no shell or file-mutation tools
- expose only the deterministic Neovim harness through a safe custom tool
- return structured PASS/FAIL evidence from a reusable prompt contract

## Verification

- `scripts/verify-nvim agent-keymaps`
- `scripts/verify-nvim sidekick-pi`
- `scripts/verify-nvim sidekick-herdr`
- passing and intentionally failing `scripts/nvim-verifier agent-keymaps` runs