### PR TITLE
fix(vault-hunter): commit in-progress state before output

### DIFF
--- a/.agents/skills/vault-hunter/SKILL.md
+++ b/.agents/skills/vault-hunter/SKILL.md
@@ -13,6 +13,18 @@ implementation repository for code, and temporary `issues/` notes only for unres
 Accept `/vault-hunter <reference>`, where `<reference>` identifies a Feature, Task, or Issue by vault path, `path:line`,
 or wikilink. Resolve the referenced note or checklist line before routing.
 
+Immediately after invocation, resolve only enough vault context to identify the referenced item, then:
+
+1. Mark it in progress:
+   - Feature → set its frontmatter to `status: in-progress`
+   - Task → change its Feature checklist bullet to `[~]` and, when linked, set its note to `status: in-progress`
+   - Issue or Wayfinder effort → set its note or map frontmatter to `status: in-progress`
+2. Commit that lifecycle transition in the vault. Do not push it yet.
+3. Only after the commit succeeds, provide substantive user-facing content or continue with broader discovery.
+
+Before this commit, send no plan, clarification, or progress detail beyond any minimal skill-use acknowledgment required
+by the host. If the item cannot be resolved or committed safely, stop and report that blocker instead of continuing.
+
 The bundled Neovim picker action is `<C-a>` **(Vault hunter) Action**. It accepts Feature and Task rows and launches
 the exact `/vault-hunter <path:line>` form. Feature rows use the feature workspace without a task worktree; Task rows
 retain isolated task-worktree routing. Issue references are accepted through the command even though the picker does
@@ -64,18 +76,14 @@ Wayfinder tickets are temporary issues, never implementation Tasks.
 
 1. If the Task is only a checkbox, use `$grill-with-docs` with its checkbox and nested bullets and create a durable
    Task note.
-2. Before specification, verifier, or implementation work:
-   - keep the authoritative Feature checklist bullet pending as `[ ]`
-   - set the Task note frontmatter to `status: in-progress`
-   - commit this lifecycle transition in the vault, but do not push it yet
-3. Use `$to-spec` for structure and testing seams, but store the result only in the canonical vault Task note.
-4. Draft every verifier before coding as stable `V01`, `V02`, … entries. Record for each:
+2. Use `$to-spec` for structure and testing seams, but store the result only in the canonical vault Task note.
+3. Draft every verifier before coding as stable `V01`, `V02`, … entries. Record for each:
    - externally observable behavior
    - exact command or manual observation
    - baseline-red evidence
    - latest result and evidence
-5. Ask clarifying questions only for a genuine missing decision.
-6. Use `$ponytail` throughout implementation and review.
+4. Ask clarifying questions only for a genuine missing decision.
+5. Use `$ponytail` throughout implementation and review.
 
 ## Execute the Task timeline
 
@@ -88,8 +96,8 @@ Write evidence into the local Task note as each stage settles. Push the vault on
 ### Vault checkpoint one
 
 - Store the Task Spec and complete verifier ledger.
-- Commit any remaining checkpoint-one vault changes, then push the lifecycle transition and Task Spec/verifier ledger
-  commits together. Never open a vault PR.
+- Commit any remaining checkpoint-one vault changes, then push the invocation lifecycle commit and Task Spec/verifier
+  ledger commits together. Never open a vault PR.
 
 ### One goal per verifier
 
@@ -148,7 +156,7 @@ Always run this goal, even when it completes immediately:
 2. Close every Neovim Workspace Tab bound to that workspace.
 3. Verify those tabs are gone. Preserve other Herdr workspaces and Unbound Neovim Tabs.
 4. Add PR, merge, final verifier, post-merge, and cleanup evidence to the Task note.
-5. End the in-flight status exception: synchronize the Task frontmatter and authoritative Feature checklist bullet.
+5. Synchronize the Task frontmatter and authoritative Feature checklist bullet.
 6. Commit and push vault checkpoint two directly. Never open a vault PR.
 
 ## Completion

--- a/.agents/skills/vault/SKILL.md
+++ b/.agents/skills/vault/SKILL.md
@@ -102,10 +102,9 @@ System card categories:
 - Give every task a stable `T01`, `T02`, … number. Never renumber existing tasks.
 - Treat the feature checklist as authoritative. A linked task note must mirror `[ ]` as `pending-work`, `[~]` as
   `in-progress`, and `[x]` as `done` in its frontmatter.
-- During a Vault Hunter Task Run only, commit the lifecycle transition before specification, verifier, or
-  implementation work: keep the Feature checklist bullet pending as `[ ]` while setting the linked Task note to
-  `status: in-progress`. Do not push that commit until vault checkpoint one. Vault checkpoint two ends this exception
-  by synchronizing both states.
+- Immediately after Vault Hunter resolves a referenced item, mark it in progress and commit that lifecycle transition
+  before broader discovery or substantive user-facing output. For a Task, use `[~]` in the Feature checklist and
+  `status: in-progress` in its linked note. Do not push that commit until vault checkpoint one.
 - Derive feature status from its checklist: all complete is `done`; any in-progress or a mixture of complete and open
   is `in-progress`; all open is `pending-work`; no tasks on an implemented capability is `maintained`.
 - Preserve useful completed designs and verifier evidence in completed task notes. Put bulky raw evidence in an


### PR DESCRIPTION
## Summary
- add an invocation gate that marks the referenced Feature, Task, Issue, or Wayfinder effort in progress
- commit the lifecycle transition before broader discovery or substantive user-facing output
- keep the invocation commit local until vault checkpoint one
- synchronize the canonical vault contract

## Verification
- `uv run --with pyyaml /Users/aviral/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/vault-hunter`
- `/Users/aviral/vault/scripts/verify-project-structure`
- `git diff --check`