### PR TITLE
fix(vault-hunter): finish cleanup on vault main

### DIFF
--- a/.agents/skills/vault-hunter/SKILL.md
+++ b/.agents/skills/vault-hunter/SKILL.md
@@ -156,10 +156,15 @@ Always run this goal, even when it completes immediately:
 2. Close every Neovim Workspace Tab bound to that workspace.
 3. Verify those tabs are gone. Preserve other Herdr workspaces and Unbound Neovim Tabs.
 4. Add PR, merge, final verifier, post-merge, and cleanup evidence to the Task note.
-5. Synchronize the Task frontmatter and authoritative Feature checklist bullet.
-6. Commit and push vault checkpoint two directly. Never open a vault PR.
+5. Set the Task note frontmatter to `status: done`, change its authoritative Feature checklist bullet to `[x]`, and
+   derive the Feature status from its complete checklist.
+6. Commit vault checkpoint two on the vault's `main` branch and push `origin main`. If the update was prepared on
+   another vault branch, merge it into vault `main` first. Never open a vault PR.
+7. Run `git fetch origin main:refs/remotes/origin/main` in the vault and verify the checkpoint-two commit is an
+   ancestor of `origin/main`. Cleanup is incomplete until this remote-main check passes.
 
 ## Completion
 
-Report the Feature and Task links, implementation PR and merge state, final verifier evidence, vault commits, and
-workspace cleanup evidence. State any deferred optional polish or unrelated dirty state preserved.
+Report the Feature and Task links, implementation PR and merge state, final verifier evidence, vault commits,
+remote-main verification, and workspace cleanup evidence. State any deferred optional polish or unrelated dirty state
+preserved.

--- a/.agents/skills/vault/SKILL.md
+++ b/.agents/skills/vault/SKILL.md
@@ -131,8 +131,10 @@ System card categories:
   fixing CI failures in the same task run. Never bypass required approvals or branch protection. Without CI, merge
   only when the pull request is mergeable and the complete local verifier set is green.
 - After merge, run post-merge checks against merged `main`, then close every Herdr tab in the task's Herdr Workspace
-  and every Neovim Workspace Tab bound to it. Verify those tabs are gone, preserve cleanup evidence in the task note,
-  and leave other Herdr Workspaces and Unbound Neovim Tabs untouched.
+  and every Neovim Workspace Tab bound to it. Mark the Task note `status: done`, change its Feature checklist bullet
+  to `[x]`, derive the Feature status, commit checkpoint two on vault `main`, and push `origin main`. Fetch with
+  `git fetch origin main:refs/remotes/origin/main` and verify that commit is on `origin/main`; cleanup is incomplete
+  until it is. Preserve other Herdr Workspaces and Unbound Neovim Tabs.
 - Create `issues/` under a feature lazily for temporary decisions and investigations with known ownership. Keep
   cross-feature or not-yet-owned issues under the project's `issues/`, then move them under the owning feature once
   that ownership becomes clear.


### PR DESCRIPTION
## Summary
- mark completed Task notes `status: done` and their authoritative Feature bullets `[x]`
- derive Feature status during post-merge cleanup
- require checkpoint two to be committed on vault `main` and pushed to `origin main`
- verify the checkpoint commit against an explicitly fetched `origin/main` ref

## Verification
- `uv run --with pyyaml /Users/aviral/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/vault-hunter`
- `/Users/aviral/vault/scripts/verify-project-structure`
- `git diff --check`
- vault checkpoint documentation commit `a872574` verified as an ancestor of `origin/main`