### PR TITLE
feat(pi): harden Plaid investment retrieval

### DIFF
--- a/pi/.pi/agent/extensions/plaid.ts
+++ b/pi/.pi/agent/extensions/plaid.ts
@@ -1,0 +1,86 @@
+import { Type, StringEnum } from "@earendil-works/pi-ai";
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { spawn } from "node:child_process";
+
+const PLAID_CLI = process.env.PLAID_CLI ?? `${process.env.HOME}/.local/bin/plaid-cli`;
+
+function runPlaid(args: string[]): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(PLAID_CLI, args, { env: process.env });
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (chunk) => (stdout += chunk));
+		child.stderr.on("data", (chunk) => (stderr += chunk));
+		child.on("error", reject);
+		child.on("close", (code) => {
+			if (code === 0) resolve(stdout.trim() || stderr.trim());
+			else reject(new Error((stderr || stdout || `plaid-cli exited ${code}`).trim()));
+		});
+	});
+}
+
+const plaidTransactions = defineTool({
+	name: "plaid_transactions",
+	label: "Plaid Transactions",
+	description: "Retrieve banking and/or investment transactions from linked Plaid institutions.",
+	promptSnippet: "Retrieve personal financial transactions through the configured Plaid CLI",
+	promptGuidelines: [
+		"Use plaid_transactions for Chase, Bilt, E-Trade, Wells Fargo, Fidelity, and Human401K transaction retrieval when the user asks for personal finance transaction data.",
+		"If the Plaid item is not linked yet, tell the user to run plaid-cli link <name> on homelab; do not ask for bank passwords in chat.",
+	],
+	parameters: Type.Object({
+		kind: StringEnum(["banking", "investments", "both"] as const, {
+			description: "Transaction type to retrieve. Use both unless the user asks for one type.",
+			default: "both",
+		}),
+		item: Type.Optional(Type.String({ description: "Optional Plaid item nickname, e.g. chase, bilt, etrade, wells-fargo, fidelity, human401k." })),
+		start_date: Type.Optional(Type.String({ description: "Start date YYYY-MM-DD. Defaults to 90 days ago." })),
+		end_date: Type.Optional(Type.String({ description: "End date YYYY-MM-DD. Defaults to today." })),
+	}),
+	async execute(_toolCallId, params) {
+		const base = (command: string) => {
+			const args = [command, "--json"];
+			if (params.item) args.push("--item", params.item);
+			if (params.start_date) args.push("--start-date", params.start_date);
+			if (params.end_date) args.push("--end-date", params.end_date);
+			return args;
+		};
+
+		if (params.kind === "banking") {
+			const text = await runPlaid(base("transactions"));
+			return { content: [{ type: "text", text }], details: JSON.parse(text) };
+		}
+		if (params.kind === "investments") {
+			const text = await runPlaid(base("investment-transactions"));
+			return { content: [{ type: "text", text }], details: JSON.parse(text) };
+		}
+
+		const [banking, investments] = await Promise.all([
+			runPlaid(base("transactions")).then(JSON.parse).catch((error) => ({ errors: [String(error)] })),
+			runPlaid(base("investment-transactions")).then(JSON.parse).catch((error) => ({ errors: [String(error)] })),
+		]);
+		const result = { banking, investments };
+		return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+	},
+});
+
+const plaidStatus = defineTool({
+	name: "plaid_status",
+	label: "Plaid Status",
+	description: "Show Plaid CLI credential and linked-institution status.",
+	promptSnippet: "Check configured Plaid CLI credentials and linked institutions",
+	parameters: Type.Object({}),
+	async execute() {
+		const text = await runPlaid(["status", "--json"]);
+		return { content: [{ type: "text", text }], details: JSON.parse(text) };
+	},
+});
+
+export default function (pi: ExtensionAPI) {
+	pi.registerTool(plaidTransactions);
+	pi.registerTool(plaidStatus);
+	pi.registerCommand("plaid-status", {
+		description: "Show Plaid CLI status",
+		handler: async (_args, ctx) => ctx.ui.notify(await runPlaid(["status"]), "info"),
+	});
+}

--- a/pi/bin/plaid-cli
+++ b/pi/bin/plaid-cli
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+CONFIG_DIR = Path(os.environ.get("PLAID_CLI_CONFIG_DIR", Path.home() / ".config" / "plaid-cli"))
+ENV_FILE = CONFIG_DIR / "env"
+STORE = Path(os.environ.get("PLAID_CLI_STORE", Path.home() / ".local" / "share" / "plaid-cli" / "items.json"))
+ENDPOINTS = {
+    "sandbox": "https://sandbox.plaid.com",
+    "development": "https://development.plaid.com",
+    "production": "https://production.plaid.com",
+}
+
+
+class PlaidError(Exception):
+    def __init__(self, status: int, payload: object):
+        self.status = status
+        self.payload = payload
+        super().__init__(json.dumps(payload) if isinstance(payload, dict) else str(payload))
+
+
+def load_env() -> None:
+    if not ENV_FILE.exists():
+        return
+    for raw in ENV_FILE.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def env(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name, default)
+    return value if value not in ("", None) else None
+
+
+def require_env(name: str) -> str:
+    value = env(name)
+    if not value:
+        raise SystemExit(f"Missing {name}. Put it in {ENV_FILE} or export it.")
+    return value
+
+
+def endpoint() -> str:
+    plaid_env = env("PLAID_ENV", "development") or "development"
+    if plaid_env not in ENDPOINTS:
+        raise SystemExit(f"PLAID_ENV must be one of: {', '.join(ENDPOINTS)}")
+    return ENDPOINTS[plaid_env]
+
+
+def plaid_post(path: str, payload: dict) -> dict:
+    body = {
+        "client_id": require_env("PLAID_CLIENT_ID"),
+        "secret": require_env("PLAID_SECRET"),
+        **payload,
+    }
+    req = urllib.request.Request(
+        endpoint() + path,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=90) as res:
+            return json.loads(res.read().decode())
+    except urllib.error.HTTPError as exc:
+        text = exc.read().decode(errors="replace")
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            payload = text
+        raise PlaidError(exc.code, payload) from exc
+
+
+def load_store() -> dict:
+    if not STORE.exists():
+        return {"items": []}
+    return json.loads(STORE.read_text())
+
+
+def save_store(data: dict) -> None:
+    STORE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(STORE.parent, 0o700)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile("w", dir=STORE.parent, prefix=f".{STORE.name}.", delete=False) as handle:
+            temporary = Path(handle.name)
+            os.fchmod(handle.fileno(), 0o600)
+            json.dump(data, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, STORE)
+    finally:
+        if temporary and temporary.exists():
+            temporary.unlink()
+
+
+def items(name: str | None = None) -> list[dict]:
+    all_items = load_store().get("items", [])
+    if name:
+        all_items = [item for item in all_items if item.get("name") == name or item.get("institution") == name]
+        if not all_items:
+            raise SystemExit(f"No Plaid item named {name!r}. Run: plaid-cli status")
+    return all_items
+
+
+def upsert_item(record: dict) -> None:
+    data = load_store()
+    kept = [item for item in data.get("items", []) if item.get("name") != record["name"]]
+    data["items"] = [*kept, record]
+    save_store(data)
+
+
+def date_range(args) -> tuple[str, str]:
+    end = args.end_date or dt.date.today().isoformat()
+    start = args.start_date or (dt.date.fromisoformat(end) - dt.timedelta(days=args.days)).isoformat()
+    return start, end
+
+
+def normalized_error(item: dict, exc: Exception) -> dict:
+    if isinstance(exc, PlaidError):
+        payload = exc.payload if isinstance(exc.payload, dict) else {}
+        return {
+            "item": item.get("name"),
+            "status": exc.status,
+            "error": {
+                key: payload[key]
+                for key in ("error_type", "error_code", "error_message", "display_message")
+                if payload.get(key) is not None
+            },
+        }
+    return {"item": item.get("name"), "error": str(exc)}
+
+
+def public_fields(data: dict, fields: tuple[str, ...]) -> dict:
+    return {field: data[field] for field in fields if data.get(field) is not None}
+
+
+def public_item(item: dict) -> dict:
+    return {
+        "name": item.get("name"),
+        "institution": item.get("institution"),
+        "products": item.get("products", []),
+        "account_count": len(item.get("accounts", [])),
+    }
+
+
+def public_banking_transaction(tx: dict, item: dict) -> dict:
+    return {
+        **public_fields(tx, (
+            "date",
+            "merchant_name",
+            "name",
+            "amount",
+            "iso_currency_code",
+            "unofficial_currency_code",
+            "pending",
+            "payment_channel",
+            "category",
+        )),
+        "item_name": item.get("name"),
+        "institution": item.get("institution"),
+    }
+
+
+def public_investment_transaction(tx: dict, item: dict, security: dict) -> dict:
+    return {
+        **public_fields(tx, (
+            "date",
+            "name",
+            "type",
+            "subtype",
+            "quantity",
+            "amount",
+            "price",
+            "fees",
+            "iso_currency_code",
+            "unofficial_currency_code",
+        )),
+        "item_name": item.get("name"),
+        "institution": item.get("institution"),
+        **public_fields({
+            "security_name": security.get("name"),
+            "ticker_symbol": security.get("ticker_symbol"),
+        }, ("security_name", "ticker_symbol")),
+    }
+
+
+def cmd_status(args) -> None:
+    data = load_store()
+    configured = bool(env("PLAID_CLIENT_ID") and env("PLAID_SECRET"))
+    if args.json:
+        print(json.dumps({
+            "env": env("PLAID_ENV", "development"),
+            "configured": configured,
+            "store": str(STORE),
+            "items": [public_item(item) for item in data.get("items", [])],
+        }, indent=2))
+        return
+    print(f"env: {env('PLAID_ENV', 'development')}")
+    print(f"credentials: {'ok' if configured else 'missing'}")
+    print(f"store: {STORE}")
+    for item in data.get("items", []):
+        products = ",".join(item.get("products", []))
+        print(f"- {item.get('name')} [{item.get('institution')}] products={products} accounts={len(item.get('accounts', []))}")
+
+
+def cmd_link(args) -> None:
+    products = [p.strip() for p in args.products.split(",") if p.strip()]
+    redirect_uri = args.redirect_uri or env("PLAID_REDIRECT_URI") or f"http://127.0.0.1:{args.port}/oauth"
+    public_url = (args.public_url or env("PLAID_PUBLIC_URL") or redirect_uri.removesuffix("/oauth")).rstrip("/")
+    token = plaid_post("/link/token/create", {
+        "client_name": env("PLAID_CLIENT_NAME", "Personal Agent"),
+        "country_codes": [c.strip() for c in args.country_codes.split(",") if c.strip()],
+        "language": "en",
+        "products": products,
+        "redirect_uri": redirect_uri,
+        "user": {"client_user_id": env("PLAID_USER_ID", os.environ.get("USER", "user"))},
+    })["link_token"]
+
+    state: dict = {"done": False, "error": None, "record": None}
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *values):
+            print("HTTP " + (fmt % values), flush=True)
+
+        def _send(self, code: int, body: str, content_type: str = "text/html") -> None:
+            self.send_response(code)
+            self.send_header("Content-Type", content_type)
+            self.end_headers()
+            self.wfile.write(body.encode())
+
+        def do_GET(self):
+            if self.path.startswith("/done"):
+                self._send(200, "<h1>Plaid item linked.</h1><p>You can close this tab.</p>")
+                return
+            html = f"""<!doctype html>
+<meta name=viewport content="width=device-width, initial-scale=1">
+<title>Plaid Link</title>
+<script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+<button id="open">Link {args.name}</button>
+<pre id="out"></pre>
+<script>
+const out = document.getElementById('out');
+function log(x) {{ out.textContent = typeof x === 'string' ? x : JSON.stringify(x, null, 2); }}
+function openLink() {{
+  const config = {{
+    token: {json.dumps(token)},
+    onSuccess: async (public_token, metadata) => {{
+      log('Exchanging public token...');
+      const res = await fetch('/exchange', {{method:'POST', headers:{{'content-type':'application/json'}}, body: JSON.stringify({{public_token, metadata}})}});
+      const text = await res.text();
+      if (!res.ok) {{ log(text); return; }}
+      log('Plaid item linked. You can close this tab.');
+    }},
+    onExit: (err, metadata) => log(err || metadata),
+  }};
+  if (location.search.includes('oauth_state_id=')) config.receivedRedirectUri = location.href;
+  Plaid.create(config).open();
+}}
+document.getElementById('open').onclick = openLink;
+openLink();
+</script>"""
+            self._send(200, html)
+
+        def do_POST(self):
+            length = int(self.headers.get("content-length", "0"))
+            payload = json.loads(self.rfile.read(length).decode() or "{}")
+            if self.path == "/client-log":
+                print("CLIENT " + json.dumps(payload, sort_keys=True), flush=True)
+                self._send(200, "ok", "text/plain")
+                return
+            if self.path != "/exchange":
+                self._send(404, "not found", "text/plain")
+                return
+            try:
+                exchanged = plaid_post("/item/public_token/exchange", {"public_token": payload["public_token"]})
+                accounts = plaid_post("/accounts/get", {"access_token": exchanged["access_token"]}).get("accounts", [])
+                metadata = payload.get("metadata") or {}
+                institution = (metadata.get("institution") or {}).get("name") or args.name
+                record = {
+                    "name": args.name,
+                    "institution": institution,
+                    "item_id": exchanged.get("item_id"),
+                    "access_token": exchanged["access_token"],
+                    "products": products,
+                    "accounts": accounts,
+                    "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+                }
+                upsert_item(record)
+                state.update(done=True, record=record)
+                self._send(200, "ok", "text/plain")
+            except Exception as exc:
+                state.update(done=True, error=str(exc))
+                self._send(500, str(exc), "text/plain")
+
+    server = HTTPServer((args.host, args.port), Handler)
+    print(f"Open Plaid Link: {public_url}/")
+    if public_url != f"http://127.0.0.1:{args.port}":
+        print(f"Local fallback: http://127.0.0.1:{args.port}/")
+    print(f"OAuth redirect URI to register in Plaid: {redirect_uri}")
+    deadline = time.time() + args.timeout
+    while not state["done"] and time.time() < deadline:
+        server.timeout = 1
+        server.handle_request()
+    server.server_close()
+    if state["error"]:
+        raise SystemExit(state["error"])
+    if not state["done"]:
+        raise SystemExit("Timed out waiting for Plaid Link")
+    record = state["record"] or {}
+    print(f"Linked {record.get('name')} [{record.get('institution')}]")
+
+
+def banking_transactions(item: dict, start: str, end: str, page_size: int) -> list[dict]:
+    out: list[dict] = []
+    offset = 0
+    while True:
+        result = plaid_post("/transactions/get", {
+            "access_token": item["access_token"],
+            "start_date": start,
+            "end_date": end,
+            "options": {"count": page_size, "offset": offset},
+        })
+        batch = result.get("transactions", [])
+        out.extend(public_banking_transaction(tx, item) for tx in batch)
+        offset += len(batch)
+        if offset >= result.get("total_transactions", len(out)) or not batch:
+            return out
+
+
+def investment_transactions(item: dict, start: str, end: str, page_size: int) -> list[dict]:
+    out: list[dict] = []
+    offset = 0
+    while True:
+        result = plaid_post("/investments/transactions/get", {
+            "access_token": item["access_token"],
+            "start_date": start,
+            "end_date": end,
+            "options": {"count": page_size, "offset": offset},
+        })
+        batch = result.get("investment_transactions", [])
+        securities = {security.get("security_id"): security for security in result.get("securities", [])}
+        out.extend(
+            public_investment_transaction(tx, item, securities.get(tx.get("security_id"), {}))
+            for tx in batch
+        )
+        offset += len(batch)
+        if offset >= result.get("total_investment_transactions", len(out)) or not batch:
+            return out
+
+
+def print_banking(rows: list[dict]) -> None:
+    for tx in sorted(rows, key=lambda t: t.get("date", "")):
+        print("\t".join(str(x or "") for x in [
+            tx.get("date"), tx.get("item_name"), tx.get("merchant_name") or tx.get("name"), tx.get("amount"), tx.get("iso_currency_code"),
+        ]))
+
+
+def print_investment(rows: list[dict]) -> None:
+    for tx in sorted(rows, key=lambda t: t.get("date", "")):
+        print("\t".join(str(x or "") for x in [
+            tx.get("date"), tx.get("item_name"), tx.get("name"), tx.get("type"), tx.get("subtype"), tx.get("quantity"), tx.get("amount"), tx.get("ticker_symbol") or tx.get("security_name"),
+        ]))
+
+
+def cmd_transactions(args) -> None:
+    start, end = date_range(args)
+    rows: list[dict] = []
+    errors: list[dict] = []
+    for item in items(args.item):
+        try:
+            rows.extend(banking_transactions(item, start, end, args.page_size))
+        except Exception as exc:
+            errors.append(normalized_error(item, exc))
+    if args.json:
+        print(json.dumps({"start_date": start, "end_date": end, "transactions": rows, "errors": errors}, indent=2, sort_keys=True))
+    else:
+        print_banking(rows)
+        for error in errors:
+            print(f"ERROR {error}", file=sys.stderr)
+    if errors and not rows:
+        raise SystemExit(1)
+
+
+def cmd_investment_transactions(args) -> None:
+    start, end = date_range(args)
+    rows: list[dict] = []
+    errors: list[dict] = []
+    for item in items(args.item):
+        try:
+            rows.extend(investment_transactions(item, start, end, args.page_size))
+        except Exception as exc:
+            errors.append(normalized_error(item, exc))
+    if args.json:
+        print(json.dumps({"start_date": start, "end_date": end, "investment_transactions": rows, "errors": errors}, indent=2, sort_keys=True))
+    else:
+        print_investment(rows)
+        for error in errors:
+            print(f"ERROR {error}", file=sys.stderr)
+    if errors and not rows:
+        raise SystemExit(1)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Minimal Plaid CLI for a personal agent")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    status = sub.add_parser("status")
+    status.add_argument("--json", action="store_true")
+    status.set_defaults(func=cmd_status)
+
+    link = sub.add_parser("link")
+    link.add_argument("name", help="Local nickname, e.g. chase or fidelity")
+    link.add_argument("--products", default="transactions", help="Comma-separated Plaid products: transactions,investments")
+    link.add_argument("--country-codes", default="US")
+    link.add_argument("--redirect-uri")
+    link.add_argument("--public-url")
+    link.add_argument("--host", default="127.0.0.1")
+    link.add_argument("--port", type=int, default=8787)
+    link.add_argument("--timeout", type=int, default=900)
+    link.set_defaults(func=cmd_link)
+
+    for name, func in [("transactions", cmd_transactions), ("investment-transactions", cmd_investment_transactions)]:
+        p = sub.add_parser(name)
+        p.add_argument("--item")
+        p.add_argument("--start-date")
+        p.add_argument("--end-date")
+        p.add_argument("--days", type=int, default=90)
+        p.add_argument("--json", action="store_true")
+        p.add_argument("--page-size", type=int, default=500)
+        p.set_defaults(func=func)
+    return parser
+
+
+def main() -> None:
+    load_env()
+    args = build_parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-pi-plaid
+++ b/scripts/verify-pi-plaid
@@ -343,15 +343,17 @@ def live_permissions() -> None:
     data_dir = Path.home() / ".local" / "share" / "plaid-cli"
     store = Path(os.environ.get("PLAID_CLI_STORE", data_dir / "items.json"))
     link_logs = sorted(data_dir.glob("*-link.log"))
+    data_dir_mode = stat.S_IMODE(data_dir.stat().st_mode)
     store_mode = stat.S_IMODE(store.stat().st_mode)
     link_log_modes = [stat.S_IMODE(path.stat().st_mode) for path in link_logs]
-    if store_mode != 0o600 or any(mode != 0o600 for mode in link_log_modes):
+    if data_dir_mode != 0o700 or store_mode != 0o600 or any(mode != 0o600 for mode in link_log_modes):
         fail(
-            f"live modes are store={store_mode:03o}, "
+            f"live modes are directory={data_dir_mode:03o}, store={store_mode:03o}, "
             f"link_logs={sorted({f'{mode:03o}' for mode in link_log_modes})}"
         )
     print(json.dumps({
         "passed": True,
+        "data_directory_mode": f"{data_dir_mode:03o}",
         "store_mode": f"{store_mode:03o}",
         "link_log_count": len(link_logs),
         "link_log_modes": sorted({f"{mode:03o}" for mode in link_log_modes}),

--- a/scripts/verify-pi-plaid
+++ b/scripts/verify-pi-plaid
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI_PATH = ROOT / "pi" / "bin" / "plaid-cli"
+START_DATE = "2025-07-25"
+END_DATE = "2026-07-25"
+
+STATUS_ITEM_KEYS = {"name", "institution", "products", "account_count"}
+BANKING_KEYS = {
+    "date",
+    "item_name",
+    "institution",
+    "merchant_name",
+    "name",
+    "amount",
+    "iso_currency_code",
+    "unofficial_currency_code",
+    "pending",
+    "payment_channel",
+    "category",
+}
+INVESTMENT_KEYS = {
+    "date",
+    "item_name",
+    "institution",
+    "name",
+    "type",
+    "subtype",
+    "quantity",
+    "amount",
+    "price",
+    "fees",
+    "iso_currency_code",
+    "unofficial_currency_code",
+    "security_name",
+    "ticker_symbol",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL verify-pi-plaid: {message}")
+
+
+def load_cli(label: str):
+    loader = importlib.machinery.SourceFileLoader(f"plaid_cli_{label}", str(CLI_PATH))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    if spec is None:
+        fail("could not create CLI module spec")
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def output_boundary() -> None:
+    module = load_cli("output_boundary")
+    with tempfile.TemporaryDirectory(prefix="verify-pi-plaid-") as tmp:
+        module.STORE = Path(tmp) / "items.json"
+        module.STORE.write_text(json.dumps({
+            "items": [{
+                "name": "fixture",
+                "institution": "Fixture Bank",
+                "item_id": "private-item-id",
+                "access_token": "private-access-token",
+                "products": ["investments"],
+                "accounts": [{
+                    "account_id": "private-account-id",
+                    "mask": "1234",
+                    "balances": {"current": 1},
+                    "name": "Fixture Account",
+                }],
+            }],
+        }))
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            module.cmd_status(argparse.Namespace(json=True))
+        status_payload = json.loads(stdout.getvalue())
+
+    status_items = status_payload.get("items", [])
+    if len(status_items) != 1 or set(status_items[0]) != STATUS_ITEM_KEYS:
+        fail(f"status item keys are {sorted(status_items[0]) if status_items else []}")
+
+    def banking_post(_path, payload):
+        offset = payload["options"]["offset"]
+        return {
+            "accounts": [{
+                "account_id": "private-account-id",
+                "mask": "1234",
+                "balances": {"current": 1},
+                "name": "Fixture Account",
+            }],
+            "transactions": [] if offset else [{
+                "account_id": "private-account-id",
+                "transaction_id": "private-transaction-id",
+                "date": "2026-01-01",
+                "name": "Fixture",
+                "merchant_name": "Fixture",
+                "amount": 1,
+                "iso_currency_code": "USD",
+                "pending": False,
+                "payment_channel": "online",
+                "category": ["Fixture"],
+                "private_raw_field": "private",
+            }],
+            "total_transactions": 1,
+        }
+
+    module.plaid_post = banking_post
+    item = {"access_token": "private", "name": "fixture", "institution": "Fixture Bank"}
+    banking_rows = module.banking_transactions(item, START_DATE, END_DATE, 100)
+    banking_extra = set().union(*(set(row) for row in banking_rows)) - BANKING_KEYS
+    if banking_extra:
+        fail(f"banking result exposes keys {sorted(banking_extra)}")
+
+    def investment_post(_path, _payload):
+        return {
+            "accounts": [{
+                "account_id": "private-account-id",
+                "mask": "1234",
+                "balances": {"current": 1},
+                "name": "Fixture Account",
+            }],
+            "securities": [{
+                "security_id": "private-security-id",
+                "name": "Fixture Security",
+                "ticker_symbol": "FIX",
+            }],
+            "investment_transactions": [{
+                "account_id": "private-account-id",
+                "investment_transaction_id": "private-transaction-id",
+                "security_id": "private-security-id",
+                "date": "2026-01-01",
+                "name": "Fixture",
+                "type": "buy",
+                "subtype": "buy",
+                "quantity": 1,
+                "amount": 1,
+                "price": 1,
+                "fees": 0,
+                "iso_currency_code": "USD",
+                "private_raw_field": "private",
+            }],
+            "total_investment_transactions": 1,
+        }
+
+    module.plaid_post = investment_post
+    try:
+        investment_result = module.investment_transactions(item, START_DATE, END_DATE, 100)
+    except TypeError:
+        investment_result = module.investment_transactions(item, START_DATE, END_DATE)
+    investment_rows = (
+        investment_result
+        if isinstance(investment_result, list)
+        else investment_result.get("investment_transactions", [])
+    )
+    investment_extra = set().union(*(set(row) for row in investment_rows)) - INVESTMENT_KEYS
+    if investment_extra:
+        fail(f"investment result exposes keys {sorted(investment_extra)}")
+
+    print(json.dumps({
+        "passed": True,
+        "status_item_keys": sorted(STATUS_ITEM_KEYS),
+        "banking_result_keys": sorted(set().union(*(set(row) for row in banking_rows))),
+        "investment_result_keys": sorted(set().union(*(set(row) for row in investment_rows))),
+    }, indent=2))
+
+
+def pagination() -> None:
+    module = load_cli("pagination")
+    calls: list[dict] = []
+
+    def fake_post(_path, payload):
+        options = payload.get("options")
+        calls.append(options or {})
+        offset = (options or {}).get("offset", 0)
+        batch_size = 2 if offset == 0 else 1
+        return {
+            "accounts": [],
+            "securities": [],
+            "investment_transactions": [
+                {"date": f"2026-01-0{offset + index + 1}", "name": "Fixture"}
+                for index in range(batch_size)
+            ],
+            "total_investment_transactions": 3,
+        }
+
+    module.plaid_post = fake_post
+    item = {"access_token": "private", "name": "fixture", "institution": "Fixture Bank"}
+    try:
+        result = module.investment_transactions(item, START_DATE, END_DATE, 2)
+    except TypeError:
+        fail("investment_transactions does not accept a page size")
+    rows = result if isinstance(result, list) else result.get("investment_transactions", [])
+    expected_options = [{"count": 2, "offset": 0}, {"count": 2, "offset": 2}]
+    if calls != expected_options:
+        fail(f"pagination options are {calls}, expected {expected_options}")
+    if len(rows) != 3 or len({row["date"] for row in rows}) != 3:
+        fail(f"pagination returned {len(rows)} rows, expected 3 unique rows")
+    print(json.dumps({
+        "passed": True,
+        "request_count": len(calls),
+        "offsets": [call["offset"] for call in calls],
+        "returned_count": len(rows),
+    }, indent=2))
+
+
+def store_mode() -> None:
+    module = load_cli("store_mode")
+    root = Path(tempfile.mkdtemp(prefix="verify-pi-plaid-store-"))
+    module.STORE = root / "items.json"
+    original_chmod = Path.chmod
+    old_umask = os.umask(0o022)
+
+    def fail_chmod(self, mode, *, follow_symlinks=True):
+        raise RuntimeError("simulated crash before chmod")
+
+    Path.chmod = fail_chmod
+    try:
+        try:
+            module.save_store({"items": []})
+        except RuntimeError:
+            pass
+    finally:
+        Path.chmod = original_chmod
+        os.umask(old_umask)
+
+    mode = stat.S_IMODE(module.STORE.stat().st_mode)
+    module.STORE.unlink()
+    root.rmdir()
+    if mode != 0o600:
+        fail(f"mode after simulated pre-chmod crash is {mode:03o}, expected 600")
+    print(json.dumps({"passed": True, "mode_after_simulated_crash": f"{mode:03o}"}, indent=2))
+
+
+def live(item_name: str) -> None:
+    if item_name not in {"etrade", "robinhood"}:
+        fail("live item must be etrade or robinhood")
+    expected_args = {
+        "kind": "investments",
+        "item": item_name,
+        "start_date": START_DATE,
+        "end_date": END_DATE,
+    }
+    prompt = (
+        f"Call plaid_transactions exactly once with kind investments, item {item_name}, "
+        f"start_date {START_DATE}, and end_date {END_DATE}. Return only a JSON object with "
+        "keys retrieved, transaction_count, error_count, and error_code. Do not include "
+        "transaction details, account data, identifiers, balances, or tokens."
+    )
+    completed = subprocess.run(
+        [
+            "pi",
+            "--mode", "json",
+            "--no-session",
+            "--print",
+            "--no-builtin-tools",
+            "--tools", "plaid_transactions",
+            prompt,
+        ],
+        cwd=Path.home() / "vault",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        fail(f"Pi exited {completed.returncode}")
+    events = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+    starts = [
+        event for event in events
+        if event.get("type") == "tool_execution_start"
+        and event.get("toolName") == "plaid_transactions"
+    ]
+    ends = [
+        event for event in events
+        if event.get("type") == "tool_execution_end"
+        and event.get("toolName") == "plaid_transactions"
+    ]
+    if len(starts) != 1 or starts[0].get("args") != expected_args:
+        fail("Pi did not issue exactly one plaid_transactions call with the expected arguments")
+    if len(ends) != 1 or ends[0].get("isError") is not False:
+        fail("Pi did not complete exactly one successful plaid_transactions call")
+
+    details = (ends[0].get("result") or {}).get("details") or {}
+    expected_result_keys = {"start_date", "end_date", "investment_transactions", "errors"}
+    if set(details) != expected_result_keys:
+        fail(f"tool result keys are {sorted(details)}, expected {sorted(expected_result_keys)}")
+    transaction_count = len(details.get("investment_transactions") or [])
+    error_count = len(details.get("errors") or [])
+
+    summaries = []
+    for event in events:
+        if event.get("type") != "message_end" or (event.get("message") or {}).get("role") != "assistant":
+            continue
+        text = "".join(
+            part.get("text", "")
+            for part in (event.get("message") or {}).get("content", [])
+            if part.get("type") == "text"
+        )
+        if not text:
+            continue
+        try:
+            summaries.append(json.loads(text))
+        except json.JSONDecodeError:
+            fail("assistant final text was not JSON")
+    if len(summaries) != 1:
+        fail(f"Pi returned {len(summaries)} non-empty assistant summaries, expected 1")
+    summary = summaries[0]
+    if set(summary) != {"retrieved", "transaction_count", "error_count", "error_code"}:
+        fail(f"assistant summary keys are {sorted(summary)}")
+    if (
+        summary["retrieved"] is not True
+        or summary["transaction_count"] != transaction_count
+        or summary["error_count"] != error_count
+        or summary["error_count"] != 0
+        or summary["error_code"] is not None
+    ):
+        fail("assistant summary does not match the successful tool result")
+
+    print(json.dumps({
+        "passed": True,
+        "tool_name": "plaid_transactions",
+        "args": expected_args,
+        "result_keys": sorted(details),
+        "transaction_count": transaction_count,
+        "error_count": error_count,
+        "final_summary": summary,
+    }, indent=2))
+
+
+def live_permissions() -> None:
+    data_dir = Path.home() / ".local" / "share" / "plaid-cli"
+    store = Path(os.environ.get("PLAID_CLI_STORE", data_dir / "items.json"))
+    link_logs = sorted(data_dir.glob("*-link.log"))
+    store_mode = stat.S_IMODE(store.stat().st_mode)
+    link_log_modes = [stat.S_IMODE(path.stat().st_mode) for path in link_logs]
+    if store_mode != 0o600 or any(mode != 0o600 for mode in link_log_modes):
+        fail(
+            f"live modes are store={store_mode:03o}, "
+            f"link_logs={sorted({f'{mode:03o}' for mode in link_log_modes})}"
+        )
+    print(json.dumps({
+        "passed": True,
+        "store_mode": f"{store_mode:03o}",
+        "link_log_count": len(link_logs),
+        "link_log_modes": sorted({f"{mode:03o}" for mode in link_log_modes}),
+    }, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "case",
+        choices=["all", "output-boundary", "pagination", "store-mode", "live", "live-permissions"],
+    )
+    parser.add_argument("item", nargs="?")
+    args = parser.parse_args()
+
+    if args.case in {"all", "output-boundary"}:
+        output_boundary()
+    if args.case in {"all", "pagination"}:
+        pagination()
+    if args.case in {"all", "store-mode"}:
+        store_mode()
+    if args.case == "live":
+        if args.item is None:
+            fail("live requires an item")
+        live(args.item)
+    if args.case == "live-permissions":
+        live_permissions()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-pi-plaid
+++ b/scripts/verify-pi-plaid
@@ -270,6 +270,7 @@ def live(item_name: str) -> None:
             prompt,
         ],
         cwd=Path.home() / "vault",
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
## Summary

- whitelist Plaid status and transaction result shapes before Pi sees them
- paginate Investments retrieval to Plaid’s declared total
- make item-store writes atomic and mode 0600 from first creation
- add deterministic and live sanitized verification, including Pi JSON-event assertions

## Verification

- `uv run --no-project scripts/verify-pi-plaid all`
- sanitized live V01-V08 suite on homelab
- independent Herdr review pass two: no findings and no remaining bug or major specification/architecture violation

Vault task: `1_projects/pi-agent/themes/finance/features/plaid-transaction-retrieval/tasks/04-validate-investment-transaction-retrieval.md`