### PR TITLE
refactor: keep VaultRegistry functions small

### DIFF
--- a/internal/vaultregistry/registry_v01_test.go
+++ b/internal/vaultregistry/registry_v01_test.go
@@ -11,14 +11,45 @@ import (
 	"github.com/aviral/dotfiles/internal/vaultregistry"
 )
 
+type v01Scenario struct {
+	root     string
+	run      vaultregistry.Run
+	created  vaultregistry.Run
+	producer *vaultregistry.Producer
+	reader   *vaultregistry.Reader
+	path     string
+}
+
 func TestT01V01RestartUpdateAndUnknownFields(t *testing.T) {
+	s := newV01Scenario(t)
+	assertRestart(t, s)
+	assertRetargetRejected(t, s)
+	assertImmutableMutationsRejected(t, s.run)
+	updated := appendObservations(t, s)
+	assertPersistedRun(t, s, updated)
+}
+
+func newV01Scenario(t *testing.T) v01Scenario {
 	root := t.TempDir()
-	producer, err := vaultregistry.OpenProducer(root)
+	producer := mustProducer(t, root)
+	run := richRun()
+	created, err := producer.Create(run)
 	if err != nil {
 		t.Fatal(err)
 	}
-	exit := 0
-	run := vaultregistry.Run{
+	if created.Revision != 1 {
+		t.Fatalf("create revision = %d, want 1", created.Revision)
+	}
+	reopened := mustProducer(t, root)
+	reader := mustReader(t, root)
+	return v01Scenario{
+		root: root, run: run, created: created, producer: reopened, reader: reader,
+		path: filepath.Join(root, "runs", run.RunID+".json"),
+	}
+}
+
+func richRun() vaultregistry.Run {
+	return vaultregistry.Run{
 		SchemaVersion: 1,
 		RunID:         "task_run-01",
 		InvokedAt:     "2026-07-26T07:00:00Z",
@@ -28,166 +59,153 @@ func TestT01V01RestartUpdateAndUnknownFields(t *testing.T) {
 			FeaturePath: "features/vault-hunter-atlas.md", Kind: "task",
 			Unknown: unknown("task_future", `{"nested":{"kept":true}}`),
 		},
-		Participants: []vaultregistry.Participant{{
-			ParticipantID: "driver", ObservedAt: "2026-07-26T07:00:01Z", Role: "producer", GoalID: "goal-1",
-			Herdr: &vaultregistry.HerdrIdentity{
-				WorkspaceID: "ws", TabID: "tab", PaneID: "pane", TerminalID: "term",
-				Unknown: unknown("herdr_future", `{"level":2}`),
-			},
-			AgentSession: &vaultregistry.AgentSession{
-				Source: "codex", Kind: "session", Value: "session-1",
-				Unknown: unknown("session_future", `["a",{"b":1}]`),
-			},
-			Unknown: unknown("participant_future", `{"enabled":true}`),
-		}},
-		Lifecycle: []vaultregistry.Lifecycle{{
-			ObservationID: "life-1", ObservedAt: "2026-07-26T07:00:02Z", Kind: "recorded",
-			GoalID: "goal-1", State: "in-progress", Detail: "observation only",
-			Unknown: unknown("lifecycle_future", `{"owner":"driver"}`),
-		}},
-		Evidence: []vaultregistry.Evidence{{
-			ObservationID: "evidence-1", ObservedAt: "2026-07-26T07:00:03Z", VerifierID: "T01.V01",
-			State: "running", Command: "scripts/verify-vault-hunter-atlas T01.V01", ExitStatus: &exit,
-			ImplementationTree: "tree-1", ArtifactSHA256: strings.Repeat("a", 64), Detail: "observation only",
-			Unknown: unknown("evidence_future", `{"attempt":1}`),
-		}},
-		Unknown: unknown("run_future", `{"deep":{"values":[1,2,3]}}`),
+		Participants: []vaultregistry.Participant{richParticipant()},
+		Lifecycle:    []vaultregistry.Lifecycle{richLifecycle()},
+		Evidence:     []vaultregistry.Evidence{richEvidence()},
+		Unknown:      unknown("run_future", `{"deep":{"values":[1,2,3]}}`),
 	}
+}
 
-	created, err := producer.Create(run)
-	if err != nil {
-		t.Fatal(err)
+func richParticipant() vaultregistry.Participant {
+	return vaultregistry.Participant{
+		ParticipantID: "driver", ObservedAt: "2026-07-26T07:00:01Z",
+		Role: "producer", GoalID: "goal-1",
+		Herdr: &vaultregistry.HerdrIdentity{
+			WorkspaceID: "ws", TabID: "tab", PaneID: "pane", TerminalID: "term",
+			Unknown: unknown("herdr_future", `{"level":2}`),
+		},
+		AgentSession: &vaultregistry.AgentSession{
+			Source: "codex", Kind: "session", Value: "session-1",
+			Unknown: unknown("session_future", `["a",{"b":1}]`),
+		},
+		Unknown: unknown("participant_future", `{"enabled":true}`),
 	}
-	if created.Revision != 1 {
-		t.Fatalf("create revision = %d, want 1", created.Revision)
-	}
+}
 
-	reopenedProducer, err := vaultregistry.OpenProducer(root)
-	if err != nil {
-		t.Fatal(err)
+func richLifecycle() vaultregistry.Lifecycle {
+	return vaultregistry.Lifecycle{
+		ObservationID: "life-1", ObservedAt: "2026-07-26T07:00:02Z",
+		Kind: "recorded", GoalID: "goal-1", State: "in-progress",
+		Detail:  "observation only",
+		Unknown: unknown("lifecycle_future", `{"owner":"driver"}`),
 	}
-	reader, err := vaultregistry.OpenReader(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fromProducer, err := reopenedProducer.Get(run.RunID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fromReader, err := reader.Get(run.RunID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(created, fromProducer) || !reflect.DeepEqual(created, fromReader) {
-		t.Fatalf("reopened values differ\ncreated: %#v\nproducer: %#v\nreader: %#v", created, fromProducer, fromReader)
-	}
+}
 
-	path := filepath.Join(root, "runs", run.RunID+".json")
-	beforeRetarget, err := os.ReadFile(path)
+func richEvidence() vaultregistry.Evidence {
+	exit := 0
+	return vaultregistry.Evidence{
+		ObservationID: "evidence-1", ObservedAt: "2026-07-26T07:00:03Z",
+		VerifierID: "T01.V01", State: "running",
+		Command: "scripts/verify-vault-hunter-atlas T01.V01", ExitStatus: &exit,
+		ImplementationTree: "tree-1", ArtifactSHA256: strings.Repeat("a", 64),
+		Detail:  "observation only",
+		Unknown: unknown("evidence_future", `{"attempt":1}`),
+	}
+}
+
+func assertRestart(t *testing.T, s v01Scenario) {
+	fromProducer, err := s.producer.Get(s.run.RunID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := reopenedProducer.Update(run.RunID, 1, func(next *vaultregistry.Run) error {
+	fromReader, err := s.reader.Get(s.run.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(s.created, fromProducer) || !reflect.DeepEqual(s.created, fromReader) {
+		t.Fatalf("reopened values differ\ncreated: %#v\nproducer: %#v\nreader: %#v",
+			s.created, fromProducer, fromReader)
+	}
+}
+
+func assertRetargetRejected(t *testing.T, s v01Scenario) {
+	before := mustReadFile(t, s.path)
+	_, err := s.producer.Update(s.run.RunID, 1, func(next *vaultregistry.Run) error {
 		next.Task.ID = "T02"
 		next.Task.Path = "tasks/02.md"
 		return nil
-	}); !errors.Is(err, vaultregistry.ErrMalformed) {
+	})
+	if !errors.Is(err, vaultregistry.ErrMalformed) {
 		t.Fatalf("Task retarget error = %v, want ErrMalformed", err)
 	}
-	afterRetarget, err := os.ReadFile(path)
+	assertFileBytes(t, s.path, before)
+	after, err := s.reader.Get(s.run.RunID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(afterRetarget, beforeRetarget) {
-		t.Fatal("rejected Task retarget changed persisted bytes")
+	if !reflect.DeepEqual(after, s.created) {
+		t.Fatalf("rejected Task retarget changed value\ncreated: %#v\nafter: %#v", s.created, after)
 	}
-	afterRetargetRun, err := reader.Get(run.RunID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(afterRetargetRun, created) {
-		t.Fatalf("rejected Task retarget changed persisted value\ncreated: %#v\nafter: %#v", created, afterRetargetRun)
-	}
+}
 
-	rejectedMutations := []struct {
-		name   string
-		mutate func(*vaultregistry.Run)
-	}{
+type runMutation struct {
+	name   string
+	mutate func(*vaultregistry.Run)
+}
+
+func immutableMutations() []runMutation {
+	return []runMutation{
 		{"InvokedAt change", func(next *vaultregistry.Run) {
 			next.InvokedAt = "2026-07-26T07:00:01Z"
 		}},
-		{"Run unknown erase", func(next *vaultregistry.Run) {
-			next.Unknown = nil
-		}},
+		{"Run unknown erase", func(next *vaultregistry.Run) { next.Unknown = nil }},
 		{"Run unknown replace", func(next *vaultregistry.Run) {
 			next.Unknown = unknown("run_future", `{"replacement":true}`)
 		}},
-		{"Task unknown erase", func(next *vaultregistry.Run) {
-			next.Task.Unknown = nil
-		}},
+		{"Task unknown erase", func(next *vaultregistry.Run) { next.Task.Unknown = nil }},
 		{"Task unknown replace", func(next *vaultregistry.Run) {
 			next.Task.Unknown = unknown("task_future", `{"replacement":true}`)
 		}},
 	}
-	for _, tc := range rejectedMutations {
+}
+
+func assertImmutableMutationsRejected(t *testing.T, run vaultregistry.Run) {
+	for _, tc := range immutableMutations() {
 		t.Run(tc.name, func(t *testing.T) {
-			mutationRoot := t.TempDir()
-			mutationProducer, err := vaultregistry.OpenProducer(mutationRoot)
-			if err != nil {
-				t.Fatal(err)
-			}
-			mutationCreated, err := mutationProducer.Create(run)
-			if err != nil {
-				t.Fatal(err)
-			}
-			mutationReader, err := vaultregistry.OpenReader(mutationRoot)
-			if err != nil {
-				t.Fatal(err)
-			}
-			mutationPath := filepath.Join(mutationRoot, "runs", run.RunID+".json")
-			beforeMutation, err := os.ReadFile(mutationPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := mutationProducer.Update(run.RunID, mutationCreated.Revision, func(next *vaultregistry.Run) error {
-				tc.mutate(next)
-				return nil
-			}); !errors.Is(err, vaultregistry.ErrMalformed) {
-				t.Fatalf("Update error = %v, want ErrMalformed", err)
-			}
-			afterMutation, err := os.ReadFile(mutationPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(afterMutation, beforeMutation) {
-				t.Fatal("rejected mutation changed persisted bytes")
-			}
-			afterMutationRun, err := mutationReader.Get(run.RunID)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if afterMutationRun.Revision != mutationCreated.Revision {
-				t.Fatalf("rejected mutation revision = %d, want %d", afterMutationRun.Revision, mutationCreated.Revision)
-			}
-			if !reflect.DeepEqual(afterMutationRun, mutationCreated) {
-				t.Fatalf("rejected mutation changed persisted value\ncreated: %#v\nafter: %#v", mutationCreated, afterMutationRun)
-			}
+			assertMutationRejected(t, run, tc.mutate)
 		})
 	}
+}
 
-	beforeParticipants := append([]vaultregistry.Participant(nil), fromReader.Participants...)
-	beforeLifecycle := append([]vaultregistry.Lifecycle(nil), fromReader.Lifecycle...)
-	beforeEvidence := append([]vaultregistry.Evidence(nil), fromReader.Evidence...)
-	updated, err := reopenedProducer.Update(run.RunID, 1, func(next *vaultregistry.Run) error {
+func assertMutationRejected(t *testing.T, run vaultregistry.Run, mutate func(*vaultregistry.Run)) {
+	root := t.TempDir()
+	producer := mustProducer(t, root)
+	created, err := producer.Create(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "runs", run.RunID+".json")
+	before := mustReadFile(t, path)
+	_, err = producer.Update(run.RunID, created.Revision, func(next *vaultregistry.Run) error {
+		mutate(next)
+		return nil
+	})
+	if !errors.Is(err, vaultregistry.ErrMalformed) {
+		t.Fatalf("Update error = %v, want ErrMalformed", err)
+	}
+	assertFileBytes(t, path, before)
+	after, err := mustReader(t, root).Get(run.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, created) {
+		t.Fatalf("rejected mutation changed value\ncreated: %#v\nafter: %#v", created, after)
+	}
+}
+
+func appendObservations(t *testing.T, s v01Scenario) vaultregistry.Run {
+	updated, err := s.producer.Update(s.run.RunID, 1, func(next *vaultregistry.Run) error {
 		next.UpdatedAt = "2026-07-26T07:01:00Z"
 		next.Participants = append(next.Participants, vaultregistry.Participant{
 			ParticipantID: "reviewer", ObservedAt: "2026-07-26T07:01:01Z", Role: "reviewer",
 		})
 		next.Lifecycle = append(next.Lifecycle, vaultregistry.Lifecycle{
-			ObservationID: "life-2", ObservedAt: "2026-07-26T07:01:02Z", Kind: "recorded", State: "verifying",
+			ObservationID: "life-2", ObservedAt: "2026-07-26T07:01:02Z",
+			Kind: "recorded", State: "verifying",
 		})
 		next.Evidence = append(next.Evidence, vaultregistry.Evidence{
-			ObservationID: "evidence-2", ObservedAt: "2026-07-26T07:01:03Z", VerifierID: "T01.V01", State: "passed",
+			ObservationID: "evidence-2", ObservedAt: "2026-07-26T07:01:03Z",
+			VerifierID: "T01.V01", State: "passed",
 		})
 		return nil
 	})
@@ -197,39 +215,60 @@ func TestT01V01RestartUpdateAndUnknownFields(t *testing.T) {
 	if updated.Revision != 2 {
 		t.Fatalf("update revision = %d, want 2", updated.Revision)
 	}
-	if !reflect.DeepEqual(updated.Participants[:1], beforeParticipants) ||
-		!reflect.DeepEqual(updated.Lifecycle[:1], beforeLifecycle) ||
-		!reflect.DeepEqual(updated.Evidence[:1], beforeEvidence) {
+	assertHistoryPrefixes(t, s.created, updated)
+	return updated
+}
+
+func assertHistoryPrefixes(t *testing.T, before, after vaultregistry.Run) {
+	if !reflect.DeepEqual(after.Participants[:1], before.Participants) ||
+		!reflect.DeepEqual(after.Lifecycle[:1], before.Lifecycle) ||
+		!reflect.DeepEqual(after.Evidence[:1], before.Evidence) {
 		t.Fatal("update did not preserve history prefixes")
 	}
-	finalReader, err := vaultregistry.OpenReader(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	reloaded, err := finalReader.Get(run.RunID)
+}
+
+func assertPersistedRun(t *testing.T, s v01Scenario, updated vaultregistry.Run) {
+	reloaded, err := mustReader(t, s.root).Get(s.run.RunID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(updated, reloaded) {
 		t.Fatalf("updated value did not survive restart\nupdated: %#v\nreloaded: %#v", updated, reloaded)
 	}
+	data := mustReadFile(t, s.path)
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatal("persisted JSON lacks trailing newline")
+	}
+	info, err := os.Stat(s.path)
+	if err != nil || info.Mode().Perm() != 0600 {
+		t.Fatalf("run mode = %v, err = %v; want 0600", info.Mode().Perm(), err)
+	}
+	assertUnknownMarkers(t, data)
+}
 
+func assertUnknownMarkers(t *testing.T, data []byte) {
+	markers := []string{
+		"run_future", "task_future", "participant_future", "herdr_future",
+		"session_future", "lifecycle_future", "evidence_future",
+	}
+	for _, marker := range markers {
+		if !strings.Contains(string(data), `"`+marker+`"`) {
+			t.Fatalf("persisted JSON lost nested unknown field %q", marker)
+		}
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(data) == 0 || data[len(data)-1] != '\n' {
-		t.Fatal("persisted JSON lacks trailing newline")
-	}
-	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0600 {
-		t.Fatalf("run mode = %v, err = %v; want 0600", info.Mode().Perm(), err)
-	}
-	for _, marker := range []string{
-		"run_future", "task_future", "participant_future", "herdr_future",
-		"session_future", "lifecycle_future", "evidence_future",
-	} {
-		if !strings.Contains(string(data), `"`+marker+`"`) {
-			t.Fatalf("persisted JSON lost nested unknown field %q", marker)
-		}
+	return data
+}
+
+func assertFileBytes(t *testing.T, path string, before []byte) {
+	after := mustReadFile(t, path)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatal("rejected mutation changed persisted bytes")
 	}
 }

--- a/internal/vaultregistry/registry_v02_test.go
+++ b/internal/vaultregistry/registry_v02_test.go
@@ -13,10 +13,19 @@ import (
 )
 
 func TestT01V02RejectsPartialParticipantIdentities(t *testing.T) {
-	cases := []struct {
-		name   string
-		change func(*vaultregistry.Participant)
-	}{
+	for _, tc := range partialIdentityCases() {
+		t.Run(tc.name+"/create", func(t *testing.T) { rejectPartialCreate(t, tc.change) })
+		t.Run(tc.name+"/read", func(t *testing.T) { rejectPartialRead(t, tc.change) })
+	}
+}
+
+type identityCase struct {
+	name   string
+	change func(*vaultregistry.Participant)
+}
+
+func partialIdentityCases() []identityCase {
+	return []identityCase{
 		{"herdr_workspace", func(p *vaultregistry.Participant) {
 			p.Herdr = &vaultregistry.HerdrIdentity{TabID: "tab", PaneID: "pane", TerminalID: "term"}
 		}},
@@ -39,85 +48,92 @@ func TestT01V02RejectsPartialParticipantIdentities(t *testing.T) {
 			p.AgentSession = &vaultregistry.AgentSession{Source: "codex", Kind: "session"}
 		}},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name+"/create", func(t *testing.T) {
-			root := t.TempDir()
-			producer, err := vaultregistry.OpenProducer(root)
-			if err != nil {
-				t.Fatal(err)
-			}
-			run := baseRun("partial_create")
-			run.Participants = []vaultregistry.Participant{baseParticipant()}
-			tc.change(&run.Participants[0])
-			if _, err := producer.Create(run); !errors.Is(err, vaultregistry.ErrMalformed) {
-				t.Fatalf("Create error = %v, want ErrMalformed", err)
-			}
-		})
-		t.Run(tc.name+"/read", func(t *testing.T) {
-			root := t.TempDir()
-			runs := filepath.Join(root, "runs")
-			if err := os.MkdirAll(runs, 0700); err != nil {
-				t.Fatal(err)
-			}
-			run := baseRun("partial_read")
-			run.Revision = 1
-			run.Participants = []vaultregistry.Participant{baseParticipant()}
-			tc.change(&run.Participants[0])
-			before, err := json.Marshal(run)
-			if err != nil {
-				t.Fatal(err)
-			}
-			before = append(before, '\n')
-			path := filepath.Join(runs, run.RunID+".json")
-			if err := os.WriteFile(path, before, 0600); err != nil {
-				t.Fatal(err)
-			}
-			reader, err := vaultregistry.OpenReader(root)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := reader.Get(run.RunID); !errors.Is(err, vaultregistry.ErrMalformed) {
-				t.Fatalf("Get error = %v, want ErrMalformed", err)
-			}
-			after, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(after, before) {
-				t.Fatal("failed read changed source bytes")
-			}
-		})
+}
+
+func rejectPartialCreate(t *testing.T, change func(*vaultregistry.Participant)) {
+	producer, err := vaultregistry.OpenProducer(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := baseRun("partial_create")
+	run.Participants = []vaultregistry.Participant{baseParticipant()}
+	change(&run.Participants[0])
+	if _, err := producer.Create(run); !errors.Is(err, vaultregistry.ErrMalformed) {
+		t.Fatalf("Create error = %v, want ErrMalformed", err)
+	}
+}
+
+func rejectPartialRead(t *testing.T, change func(*vaultregistry.Participant)) {
+	runs := filepath.Join(t.TempDir(), "runs")
+	if err := os.MkdirAll(runs, 0700); err != nil {
+		t.Fatal(err)
+	}
+	run := baseRun("partial_read")
+	run.Revision = 1
+	run.Participants = []vaultregistry.Participant{baseParticipant()}
+	change(&run.Participants[0])
+	before, err := json.Marshal(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before = append(before, '\n')
+	path := filepath.Join(runs, run.RunID+".json")
+	if err = os.WriteFile(path, before, 0600); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := vaultregistry.OpenReader(filepath.Dir(runs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.Get(run.RunID); !errors.Is(err, vaultregistry.ErrMalformed) {
+		t.Fatalf("Get error = %v, want ErrMalformed", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || !reflect.DeepEqual(after, before) {
+		t.Fatalf("failed read changed source bytes: %v", err)
 	}
 }
 
 func TestT01V02ConcurrentUpdateAndAtomicRead(t *testing.T) {
 	root := t.TempDir()
-	first, err := vaultregistry.OpenProducer(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	second, err := vaultregistry.OpenProducer(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	reader, err := vaultregistry.OpenReader(root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	first := mustProducer(t, root)
+	second := mustProducer(t, root)
+	reader := mustReader(t, root)
 	old, err := first.Create(baseRun("concurrent_run"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	newA, newB := winningRuns(old)
+	start, done := make(chan struct{}), make(chan struct{})
+	results := startWriters(first, second, old, start)
+	readErr, ready := watchReads(reader, old, newA, newB, done)
+	<-ready
+	close(start)
+	checkWriterResults(t, results)
+	close(done)
+	if err := <-readErr; err != nil {
+		t.Fatal(err)
+	}
+	final, err := reader.Get(old.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(final, newA) && !reflect.DeepEqual(final, newB) {
+		t.Fatalf("committed document = %#v, want one complete revision 2 document", final)
+	}
+}
+
+func winningRuns(old vaultregistry.Run) (vaultregistry.Run, vaultregistry.Run) {
 	newA := old
 	newA.Revision = 2
 	newA.UpdatedAt = "2026-07-26T08:01:00Z"
 	newA.Unknown = unknown("winner", `"A"`)
 	newB := newA
 	newB.Unknown = unknown("winner", `"B"`)
+	return newA, newB
+}
 
-	start := make(chan struct{})
-	done := make(chan struct{})
-	readerReady := make(chan struct{})
+func startWriters(first, second *vaultregistry.Producer, old vaultregistry.Run, start <-chan struct{}) <-chan error {
 	results := make(chan error, 2)
 	var writers sync.WaitGroup
 	for i, producer := range []*vaultregistry.Producer{first, second} {
@@ -133,19 +149,27 @@ func TestT01V02ConcurrentUpdateAndAtomicRead(t *testing.T) {
 			results <- err
 		}(i, producer)
 	}
-
-	readErr := make(chan error, 1)
 	go func() {
-		ready := false
+		writers.Wait()
+		close(results)
+	}()
+	return results
+}
+
+func watchReads(reader *vaultregistry.Reader, old, newA, newB vaultregistry.Run, done <-chan struct{}) (<-chan error, <-chan struct{}) {
+	readErr := make(chan error, 1)
+	ready := make(chan struct{})
+	go func() {
+		firstRead := true
 		for {
 			got, err := reader.Get(old.RunID)
 			if err != nil {
 				readErr <- err
 				return
 			}
-			if !ready {
-				close(readerReady)
-				ready = true
+			if firstRead {
+				close(ready)
+				firstRead = false
 			}
 			if !reflect.DeepEqual(got, old) && !reflect.DeepEqual(got, newA) && !reflect.DeepEqual(got, newB) {
 				readErr <- errors.New("reader observed neither complete old nor complete new document")
@@ -159,12 +183,10 @@ func TestT01V02ConcurrentUpdateAndAtomicRead(t *testing.T) {
 			}
 		}
 	}()
-	<-readerReady
-	close(start)
+	return readErr, ready
+}
 
-	writers.Wait()
-	close(done)
-	close(results)
+func checkWriterResults(t *testing.T, results <-chan error) {
 	var successes, conflicts int
 	for err := range results {
 		switch {
@@ -179,25 +201,27 @@ func TestT01V02ConcurrentUpdateAndAtomicRead(t *testing.T) {
 	if successes != 1 || conflicts != 1 {
 		t.Fatalf("successes = %d, conflicts = %d; want 1 each", successes, conflicts)
 	}
-	if err := <-readErr; err != nil {
-		t.Fatal(err)
-	}
-	final, err := reader.Get(old.RunID)
+}
+
+func mustProducer(t *testing.T, root string) *vaultregistry.Producer {
+	producer, err := vaultregistry.OpenProducer(root)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(final, newA) && !reflect.DeepEqual(final, newB) {
-		t.Fatalf("committed document = %#v, want one complete revision 2 document", final)
+	return producer
+}
+
+func mustReader(t *testing.T, root string) *vaultregistry.Reader {
+	reader, err := vaultregistry.OpenReader(root)
+	if err != nil {
+		t.Fatal(err)
 	}
+	return reader
 }
 
 func TestT01V02ClassifiedReadsPreserveBytes(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "runs"), 0700); err != nil {
-		t.Fatal(err)
-	}
-	reader, err := vaultregistry.OpenReader(root)
-	if err != nil {
 		t.Fatal(err)
 	}
 	cases := []struct {
@@ -210,21 +234,25 @@ func TestT01V02ClassifiedReadsPreserveBytes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.id, func(t *testing.T) {
-			path := filepath.Join(root, "runs", tc.id+".json")
-			if err := os.WriteFile(path, tc.data, 0600); err != nil {
-				t.Fatal(err)
-			}
-			_, err := reader.Get(tc.id)
-			if !errors.Is(err, tc.want) {
-				t.Fatalf("Get error = %v, want %v", err, tc.want)
-			}
-			after, readErr := os.ReadFile(path)
-			if readErr != nil {
-				t.Fatal(readErr)
-			}
-			if !reflect.DeepEqual(after, tc.data) {
-				t.Fatal("failed read changed source bytes")
-			}
+			assertClassifiedRead(t, root, tc.id, tc.data, tc.want)
 		})
+	}
+}
+
+func assertClassifiedRead(t *testing.T, root, id string, data []byte, want error) {
+	path := filepath.Join(root, "runs", id+".json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := mustReader(t, root).Get(id)
+	if !errors.Is(err, want) {
+		t.Fatalf("Get error = %v, want %v", err, want)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, data) {
+		t.Fatal("failed read changed source bytes")
 	}
 }

--- a/internal/vaultregistry/storage.go
+++ b/internal/vaultregistry/storage.go
@@ -94,6 +94,10 @@ func (p *Producer) Update(runID string, expectedRevision uint64, mutate func(*Ru
 		return Run{}, err
 	}
 	defer unlock()
+	return p.updateLocked(runID, expectedRevision, mutate)
+}
+
+func (p *Producer) updateLocked(runID string, expectedRevision uint64, mutate func(*Run) error) (Run, error) {
 	current, err := load(p.path(runID), runID)
 	if err != nil {
 		return Run{}, err
@@ -108,14 +112,8 @@ func (p *Producer) Update(runID string, expectedRevision uint64, mutate func(*Ru
 	if err := mutate(&next); err != nil {
 		return Run{}, err
 	}
-	if next.SchemaVersion != current.SchemaVersion || next.RunID != current.RunID || next.Revision != current.Revision ||
-		next.InvokedAt != current.InvokedAt || !equalJSON(current.Task, next.Task) ||
-		len(current.Unknown) > 0 && !equalJSON(current.Unknown, next.Unknown) ||
-		!slices.EqualFunc(current.Participants, next.Participants[:min(len(current.Participants), len(next.Participants))], equalJSON) ||
-		!slices.EqualFunc(current.Lifecycle, next.Lifecycle[:min(len(current.Lifecycle), len(next.Lifecycle))], equalJSON) ||
-		!slices.EqualFunc(current.Evidence, next.Evidence[:min(len(current.Evidence), len(next.Evidence))], equalJSON) ||
-		len(next.Participants) < len(current.Participants) || len(next.Lifecycle) < len(current.Lifecycle) || len(next.Evidence) < len(current.Evidence) {
-		return Run{}, fmt.Errorf("%w: immutable fields or history prefixes changed", ErrMalformed)
+	if err := validateUpdate(current, next); err != nil {
+		return Run{}, err
 	}
 	next.Revision = expectedRevision + 1
 	if err := validate(next); err != nil {
@@ -125,6 +123,25 @@ func (p *Producer) Update(runID string, expectedRevision uint64, mutate func(*Ru
 		return Run{}, err
 	}
 	return clone(next)
+}
+
+func validateUpdate(current, next Run) error {
+	scalarsChanged := next.SchemaVersion != current.SchemaVersion ||
+		next.RunID != current.RunID || next.Revision != current.Revision ||
+		next.InvokedAt != current.InvokedAt || !equalJSON(current.Task, next.Task)
+	unknownChanged := len(current.Unknown) > 0 && !equalJSON(current.Unknown, next.Unknown)
+	historyChanged := !historyPrefix(current.Participants, next.Participants) ||
+		!historyPrefix(current.Lifecycle, next.Lifecycle) ||
+		!historyPrefix(current.Evidence, next.Evidence)
+	if scalarsChanged || unknownChanged || historyChanged {
+		return fmt.Errorf("%w: immutable fields or history prefixes changed", ErrMalformed)
+	}
+	return nil
+}
+
+func historyPrefix[T any](current, next []T) bool {
+	return len(next) >= len(current) &&
+		slices.EqualFunc(current, next[:len(current)], equalJSON)
 }
 
 func (p *Producer) Get(runID string) (Run, error) { return load(p.path(runID), runID) }
@@ -163,12 +180,28 @@ func (p *Producer) write(run Run) error {
 	}
 	data = append(data, '\n')
 	dir := filepath.Join(p.root, "runs")
-	tmp, err := os.CreateTemp(dir, ".run-*.tmp")
+	name, err := writeTemp(dir, data)
 	if err != nil {
 		return err
 	}
-	name := tmp.Name()
 	defer os.Remove(name)
+	if err := os.Rename(name, p.path(run.RunID)); err != nil {
+		return err
+	}
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+
+func writeTemp(dir string, data []byte) (string, error) {
+	tmp, err := os.CreateTemp(dir, ".run-*.tmp")
+	if err != nil {
+		return "", err
+	}
+	name := tmp.Name()
 	if err = tmp.Chmod(0600); err == nil {
 		_, err = tmp.Write(data)
 	}
@@ -178,18 +211,11 @@ func (p *Producer) write(run Run) error {
 	if closeErr := tmp.Close(); err == nil {
 		err = closeErr
 	}
-	if err == nil {
-		err = os.Rename(name, p.path(run.RunID))
-	}
 	if err != nil {
-		return err
+		os.Remove(name)
+		return "", err
 	}
-	d, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-	return d.Sync()
+	return name, nil
 }
 
 func load(path, requestedID string) (Run, error) {
@@ -203,18 +229,8 @@ func load(path, requestedID string) (Run, error) {
 	if err != nil {
 		return Run{}, err
 	}
-	var version struct {
-		SchemaVersion json.RawMessage `json:"schema_version"`
-	}
-	if err := json.Unmarshal(data, &version); err != nil {
-		return Run{}, fmt.Errorf("%w: %s: %v", ErrMalformed, path, err)
-	}
-	var n uint64
-	if len(version.SchemaVersion) == 0 || json.Unmarshal(version.SchemaVersion, &n) != nil || n == 0 {
-		return Run{}, fmt.Errorf("%w: %s: invalid schema_version", ErrMalformed, path)
-	}
-	if n != 1 {
-		return Run{}, fmt.Errorf("%w: %s: version %d", ErrUnsupportedVersion, path, n)
+	if err := checkVersion(data, path); err != nil {
+		return Run{}, err
 	}
 	var run Run
 	if err := json.Unmarshal(data, &run); err != nil {
@@ -227,4 +243,21 @@ func load(path, requestedID string) (Run, error) {
 		return Run{}, fmt.Errorf("%w: %s: %v", ErrMalformed, path, err)
 	}
 	return run, nil
+}
+
+func checkVersion(data []byte, path string) error {
+	var version struct {
+		SchemaVersion json.RawMessage `json:"schema_version"`
+	}
+	if err := json.Unmarshal(data, &version); err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrMalformed, path, err)
+	}
+	var n uint64
+	if len(version.SchemaVersion) == 0 || json.Unmarshal(version.SchemaVersion, &n) != nil || n == 0 {
+		return fmt.Errorf("%w: %s: invalid schema_version", ErrMalformed, path)
+	}
+	if n != 1 {
+		return fmt.Errorf("%w: %s: version %d", ErrUnsupportedVersion, path, n)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- extract small helpers from VaultRegistry storage and verifier code without changing behavior
- follow up PR #90 with every Registry function at 30 or fewer physical lines

## Verification

- V01/V02 EX01 green
- complete normal and race suites green
- `go vet ./...` green
- reviewed diff and all-70-function 30-line audit green