### PR TITLE
feat(atlas): integrate companions with task runs

### DIFF
--- a/cmd/vault-hunter-atlas/main.go
+++ b/cmd/vault-hunter-atlas/main.go
@@ -47,23 +47,31 @@ func companion(args []string) error {
 		return err
 	}
 	client := atlascompanion.Client{Herdr: "herdr", Executable: executable}
-	var tuple atlascompanion.Tuple
+	var result any
 	switch args[0] {
 	case "attach":
 		if *tabID != "" || *paneID != "" || *terminalID != "" {
 			return errors.New("attach does not accept cleanup tuple flags")
 		}
-		tuple, err = client.Attach(*runID, *workspaceID, *stateDir)
+		reader, openErr := vaultregistry.OpenReader(*stateDir)
+		if openErr != nil {
+			return openErr
+		}
+		run, getErr := reader.Get(*runID)
+		if getErr != nil {
+			return getErr
+		}
+		result, err = client.AttachRun(run, *workspaceID, *stateDir)
 	case "cleanup":
-		tuple = atlascompanion.Tuple{RunID: *runID, WorkspaceID: *workspaceID, TabID: *tabID, PaneID: *paneID, TerminalID: *terminalID}
-		err = client.Cleanup(tuple, *stateDir)
+		tuple := atlascompanion.Tuple{RunID: *runID, WorkspaceID: *workspaceID, TabID: *tabID, PaneID: *paneID, TerminalID: *terminalID}
+		result, err = tuple, client.Cleanup(tuple, *stateDir)
 	default:
 		return fmt.Errorf("unknown companion command %q", args[0])
 	}
 	if err != nil {
 		return err
 	}
-	return json.NewEncoder(os.Stdout).Encode(tuple)
+	return json.NewEncoder(os.Stdout).Encode(result)
 }
 
 func render(args []string) {

--- a/cmd/vault-hunter-atlas/main.go
+++ b/cmd/vault-hunter-atlas/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -8,22 +10,76 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/aviral/dotfiles/internal/atlas"
+	"github.com/aviral/dotfiles/internal/atlascompanion"
 	"github.com/aviral/dotfiles/internal/vaultregistry"
 )
 
 func main() {
-	runID := flag.String("run-id", "", "Run ID to display")
-	stateDir := flag.String("state-dir", "", "Vault Hunter state directory")
-	snapshot := flag.Bool("snapshot", false, "print one deterministic frame")
-	width := flag.Int("width", 0, "frame width")
-	height := flag.Int("height", 0, "frame height")
-	flag.Parse()
+	if len(os.Args) > 1 && os.Args[1] == "companion" {
+		if err := companion(os.Args[2:]); err != nil {
+			fail(err)
+		}
+		return
+	}
+	render(os.Args[1:])
+}
+
+func companion(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: vault-hunter-atlas companion attach|cleanup")
+	}
+	flags := flag.NewFlagSet("companion "+args[0], flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	runID := flags.String("run-id", "", "Run ID")
+	workspaceID := flags.String("workspace-id", "", "Herdr workspace ID")
+	stateDir := flags.String("state-dir", "", "Vault Hunter state directory")
+	tabID := flags.String("tab-id", "", "owned Herdr tab ID")
+	paneID := flags.String("pane-id", "", "owned Herdr pane ID")
+	terminalID := flags.String("terminal-id", "", "owned Herdr terminal ID")
+	if err := flags.Parse(args[1:]); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("unexpected companion arguments")
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	client := atlascompanion.Client{Herdr: "herdr", Executable: executable}
+	var tuple atlascompanion.Tuple
+	switch args[0] {
+	case "attach":
+		if *tabID != "" || *paneID != "" || *terminalID != "" {
+			return errors.New("attach does not accept cleanup tuple flags")
+		}
+		tuple, err = client.Attach(*runID, *workspaceID, *stateDir)
+	case "cleanup":
+		tuple = atlascompanion.Tuple{RunID: *runID, WorkspaceID: *workspaceID, TabID: *tabID, PaneID: *paneID, TerminalID: *terminalID}
+		err = client.Cleanup(tuple, *stateDir)
+	default:
+		return fmt.Errorf("unknown companion command %q", args[0])
+	}
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(os.Stdout).Encode(tuple)
+}
+
+func render(args []string) {
+	flags := flag.NewFlagSet("vault-hunter-atlas", flag.ExitOnError)
+	runID := flags.String("run-id", "", "Run ID to display")
+	stateDir := flags.String("state-dir", "", "Vault Hunter state directory")
+	snapshot := flags.Bool("snapshot", false, "print one deterministic frame")
+	width := flags.Int("width", 0, "frame width")
+	height := flags.Int("height", 0, "frame height")
+	flags.Parse(args)
 	if *runID == "" {
-		flag.Usage()
+		flags.Usage()
 		os.Exit(2)
 	}
 	widthSet, heightSet := false, false
-	flag.Visit(func(f *flag.Flag) {
+	flags.Visit(func(f *flag.Flag) {
 		widthSet = widthSet || f.Name == "width"
 		heightSet = heightSet || f.Name == "height"
 	})

--- a/internal/atlascompanion/companion.go
+++ b/internal/atlascompanion/companion.go
@@ -207,7 +207,7 @@ func (c Client) Attach(runID, workspaceID, stateDir string) (Tuple, error) {
 		return owned[0], nil
 	}
 	if len(owned) == 1 {
-		if err := c.call(nil, "tab", "close", owned[0].TabID); err != nil {
+		if err := c.closeTab(owned[0].TabID); err != nil {
 			return Tuple{}, err
 		}
 	}
@@ -220,36 +220,37 @@ func (c Client) Attach(runID, workspaceID, stateDir string) (Tuple, error) {
 	if err := c.call(&created, "tab", "create", "--workspace", workspaceID, "--label", label(runID, workspaceID), "--no-focus"); err != nil {
 		return Tuple{}, err
 	}
-	rollback := func() {
-		if created.Tab != nil && created.Tab.WorkspaceID == workspaceID && created.Tab.Label == label(runID, workspaceID) && created.Tab.TabID != "" {
-			c.call(nil, "tab", "close", created.Tab.TabID) // best-effort rollback of only the tab just created
-		}
-	}
-	if created.Type != "tab_created" || created.Tab == nil || created.RootPane == nil {
-		rollback()
+	if created.Tab == nil || created.RootPane == nil {
 		return Tuple{}, errors.New("Herdr returned an incomplete companion tuple")
 	}
 	tuple := Tuple{RunID: runID, WorkspaceID: workspaceID, TabID: created.Tab.TabID, PaneID: created.RootPane.PaneID, TerminalID: created.RootPane.TerminalID}
-	if created.Tab.WorkspaceID != workspaceID || created.Tab.Label != label(runID, workspaceID) || created.Tab.PaneCount != 1 || created.RootPane.WorkspaceID != workspaceID || created.RootPane.TabID != created.Tab.TabID || !complete(tuple) {
+	isNew := newTuple(s, tuple)
+	rollback := func() {
+		current, err := c.list(workspaceID)
+		if isNew && err == nil && exactCreated(current, tuple, label(runID, workspaceID)) {
+			_ = c.closeTab(tuple.TabID) // best-effort rollback of only the exact tab just created
+		}
+	}
+	if created.Type != "tab_created" || created.Tab.WorkspaceID != workspaceID || created.Tab.Label != label(runID, workspaceID) || created.Tab.PaneCount != 1 || created.RootPane.WorkspaceID != workspaceID || created.RootPane.TabID != created.Tab.TabID || !complete(tuple) || !isNew {
 		rollback()
 		return Tuple{}, errors.New("Herdr returned an incomplete companion tuple")
 	}
+	current, err := c.list(workspaceID)
+	if err != nil || !exactCreated(current, tuple, label(runID, workspaceID)) {
+		rollback()
+		return Tuple{}, errors.New("Herdr did not create the exact companion tuple")
+	}
 	command := shellCommand(tuple, c.atlasArgv(runID, stateDir))
-	if err := c.call(nil, "pane", "run", tuple.PaneID, command); err != nil {
-		c.call(nil, "tab", "close", tuple.TabID)
+	if err := c.runPane(tuple.PaneID, command); err != nil {
+		rollback()
 		return Tuple{}, err
 	}
-	var info struct {
-		Type        string       `json:"type"`
-		ProcessInfo *processInfo `json:"process_info"`
+	current, err = c.inspect(runID, workspaceID)
+	if err == nil {
+		owned, err = c.exactOwned(current, runID, workspaceID, stateDir)
 	}
-	atlas := c.atlasArgv(runID, stateDir)
-	if err := c.call(&info, "pane", "process-info", "--pane", tuple.PaneID); err != nil {
-		c.call(nil, "tab", "close", tuple.TabID)
-		return Tuple{}, err
-	}
-	if err := validProcessInfo(info.Type, info.ProcessInfo, tuple.PaneID); err != nil || !ownedProcess(info.ProcessInfo.Processes, tuple, atlas) || ambiguousAtlas(info.ProcessInfo.Processes, atlas) || !healthy(info.ProcessInfo.Processes, atlas) {
-		c.call(nil, "tab", "close", tuple.TabID)
+	if err != nil || len(owned) != 1 || owned[0] != tuple || !healthy(current.processes[tuple.PaneID], c.atlasArgv(runID, stateDir)) {
+		rollback()
 		return Tuple{}, errors.New("companion process did not start with exact ownership")
 	}
 	return tuple, nil
@@ -276,7 +277,35 @@ func (c Client) Cleanup(want Tuple, stateDir string) error {
 	if owned[0] != want {
 		return errors.New("companion ownership tuple does not match")
 	}
-	return c.call(nil, "tab", "close", want.TabID)
+	return c.closeTab(want.TabID)
+}
+
+func (c Client) runPane(paneID, command string) error {
+	var result struct {
+		Type   string `json:"type"`
+		PaneID string `json:"pane_id"`
+	}
+	if err := c.call(&result, "pane", "run", paneID, command); err != nil {
+		return err
+	}
+	if result.Type != "pane_run" || result.PaneID != paneID {
+		return errors.New("invalid Herdr pane run result")
+	}
+	return nil
+}
+
+func (c Client) closeTab(tabID string) error {
+	var result struct {
+		Type  string `json:"type"`
+		TabID string `json:"tab_id"`
+	}
+	if err := c.call(&result, "tab", "close", tabID); err != nil {
+		return err
+	}
+	if result.Type != "tab_closed" || result.TabID != tabID {
+		return errors.New("invalid Herdr tab close result")
+	}
+	return nil
 }
 
 func (c Client) validate(runID, workspaceID string) error {
@@ -286,7 +315,7 @@ func (c Client) validate(runID, workspaceID string) error {
 	return nil
 }
 
-func (c Client) inspect(runID, workspaceID string) (snapshot, error) {
+func (c Client) list(workspaceID string) (snapshot, error) {
 	var listedTabs struct {
 		Type string `json:"type"`
 		Tabs []tab  `json:"tabs"`
@@ -317,7 +346,16 @@ func (c Client) inspect(runID, workspaceID string) (snapshot, error) {
 			return snapshot{}, errors.New("invalid Herdr pane list result")
 		}
 	}
-	s := snapshot{tabs: listedTabs.Tabs, panes: listedPanes.Panes, processes: map[string][]process{}, candidates: map[string]bool{}}
+	return snapshot{tabs: listedTabs.Tabs, panes: listedPanes.Panes}, nil
+}
+
+func (c Client) inspect(runID, workspaceID string) (snapshot, error) {
+	s, err := c.list(workspaceID)
+	if err != nil {
+		return snapshot{}, err
+	}
+	s.processes = map[string][]process{}
+	s.candidates = map[string]bool{}
 	expected := label(runID, workspaceID)
 	for _, t := range s.tabs {
 		if t.Label == expected {
@@ -353,6 +391,41 @@ func (c Client) inspect(runID, workspaceID string) (snapshot, error) {
 		}
 	}
 	return s, nil
+}
+
+func newTuple(before snapshot, tuple Tuple) bool {
+	for _, tab := range before.tabs {
+		if tab.TabID == tuple.TabID {
+			return false
+		}
+	}
+	for _, pane := range before.panes {
+		if pane.TabID == tuple.TabID || pane.PaneID == tuple.PaneID || pane.TerminalID == tuple.TerminalID {
+			return false
+		}
+	}
+	return true
+}
+
+func exactCreated(current snapshot, tuple Tuple, expectedLabel string) bool {
+	tabs, panes := 0, 0
+	for _, tab := range current.tabs {
+		if tab.TabID == tuple.TabID {
+			tabs++
+			if tab.WorkspaceID != tuple.WorkspaceID || tab.Label != expectedLabel || tab.PaneCount != 1 {
+				return false
+			}
+		}
+	}
+	for _, pane := range current.panes {
+		if pane.TabID == tuple.TabID || pane.PaneID == tuple.PaneID || pane.TerminalID == tuple.TerminalID {
+			panes++
+			if pane.WorkspaceID != tuple.WorkspaceID || pane.TabID != tuple.TabID || pane.PaneID != tuple.PaneID || pane.TerminalID != tuple.TerminalID {
+				return false
+			}
+		}
+	}
+	return tabs == 1 && panes == 1
 }
 
 func validProcessInfo(resultType string, info *processInfo, paneID string) error {

--- a/internal/atlascompanion/companion.go
+++ b/internal/atlascompanion/companion.go
@@ -1,0 +1,342 @@
+// Package atlascompanion owns the Herdr tab used to display one Atlas Run.
+package atlascompanion
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	labelPrefix  = "Vault Hunter Atlas · "
+	markerPrefix = "vault-hunter-atlas-companion:v1:"
+	wrapper      = `"$@"; while :; do sleep 2147483647; done`
+)
+
+// Tuple is the complete identity callers must retain for cleanup.
+type Tuple struct {
+	RunID       string `json:"run_id"`
+	WorkspaceID string `json:"workspace_id"`
+	TabID       string `json:"tab_id"`
+	PaneID      string `json:"pane_id"`
+	TerminalID  string `json:"terminal_id"`
+}
+
+// Client invokes a Herdr 0.7.1-compatible CLI.
+type Client struct {
+	Herdr      string
+	Executable string
+}
+
+type tab struct {
+	WorkspaceID string `json:"workspace_id"`
+	TabID       string `json:"tab_id"`
+	Label       string `json:"label"`
+	PaneCount   int    `json:"pane_count"`
+}
+
+type pane struct {
+	WorkspaceID string `json:"workspace_id"`
+	TabID       string `json:"tab_id"`
+	PaneID      string `json:"pane_id"`
+	TerminalID  string `json:"terminal_id"`
+}
+
+type process struct {
+	Argv []string `json:"argv"`
+}
+
+type snapshot struct {
+	tabs       []tab
+	panes      []pane
+	processes  map[string][]process
+	candidates map[string]bool
+}
+
+func (c Client) Attach(runID, workspaceID, stateDir string) (Tuple, error) {
+	if err := c.validate(runID, workspaceID); err != nil {
+		return Tuple{}, err
+	}
+	s, err := c.inspect(runID, workspaceID)
+	if err != nil {
+		return Tuple{}, err
+	}
+	owned, err := c.exactOwned(s, runID, workspaceID, stateDir)
+	if err != nil {
+		return Tuple{}, err
+	}
+	if len(owned) == 1 && healthy(s.processes[owned[0].PaneID], c.atlasArgv(runID, stateDir)) {
+		return owned[0], nil
+	}
+	if len(owned) == 1 {
+		if err := c.call(nil, "tab", "close", owned[0].TabID); err != nil {
+			return Tuple{}, err
+		}
+	}
+
+	var created struct {
+		Tab      tab  `json:"tab"`
+		RootPane pane `json:"root_pane"`
+	}
+	if err := c.call(&created, "tab", "create", "--workspace", workspaceID, "--label", label(runID, workspaceID), "--no-focus"); err != nil {
+		return Tuple{}, err
+	}
+	tuple := Tuple{RunID: runID, WorkspaceID: workspaceID, TabID: created.Tab.TabID, PaneID: created.RootPane.PaneID, TerminalID: created.RootPane.TerminalID}
+	if created.Tab.WorkspaceID != workspaceID || created.RootPane.WorkspaceID != workspaceID || created.RootPane.TabID != created.Tab.TabID || !complete(tuple) {
+		c.call(nil, "tab", "close", created.Tab.TabID) // best-effort rollback of only the tab just created
+		return Tuple{}, errors.New("Herdr returned an incomplete companion tuple")
+	}
+	command := shellCommand(tuple, c.atlasArgv(runID, stateDir))
+	if err := c.call(nil, "pane", "run", tuple.PaneID, command); err != nil {
+		c.call(nil, "tab", "close", tuple.TabID)
+		return Tuple{}, err
+	}
+	var info struct {
+		ProcessInfo struct {
+			Processes []process `json:"foreground_processes"`
+		} `json:"process_info"`
+	}
+	atlas := c.atlasArgv(runID, stateDir)
+	if err := c.call(&info, "pane", "process-info", "--pane", tuple.PaneID); err != nil || !ownedProcess(info.ProcessInfo.Processes, tuple, atlas) || ambiguousAtlas(info.ProcessInfo.Processes, atlas) || !healthy(info.ProcessInfo.Processes, atlas) {
+		c.call(nil, "tab", "close", tuple.TabID)
+		if err != nil {
+			return Tuple{}, err
+		}
+		return Tuple{}, errors.New("companion process did not start with exact ownership")
+	}
+	return tuple, nil
+}
+
+func (c Client) Cleanup(want Tuple, stateDir string) error {
+	if err := c.validate(want.RunID, want.WorkspaceID); err != nil || !complete(want) {
+		if err != nil {
+			return err
+		}
+		return errors.New("cleanup requires the complete companion tuple")
+	}
+	s, err := c.inspect(want.RunID, want.WorkspaceID)
+	if err != nil {
+		return err
+	}
+	owned, err := c.exactOwned(s, want.RunID, want.WorkspaceID, stateDir)
+	if err != nil {
+		return err
+	}
+	if len(owned) == 0 {
+		return nil
+	}
+	if owned[0] != want {
+		return errors.New("companion ownership tuple does not match")
+	}
+	return c.call(nil, "tab", "close", want.TabID)
+}
+
+func (c Client) validate(runID, workspaceID string) error {
+	if runID == "" || workspaceID == "" || c.Executable == "" {
+		return errors.New("run ID, workspace ID, and executable are required")
+	}
+	return nil
+}
+
+func (c Client) inspect(runID, workspaceID string) (snapshot, error) {
+	var listedTabs struct {
+		Tabs []tab `json:"tabs"`
+	}
+	if err := c.call(&listedTabs, "tab", "list", "--workspace", workspaceID); err != nil {
+		return snapshot{}, err
+	}
+	var listedPanes struct {
+		Panes []pane `json:"panes"`
+	}
+	if err := c.call(&listedPanes, "pane", "list", "--workspace", workspaceID); err != nil {
+		return snapshot{}, err
+	}
+	s := snapshot{tabs: listedTabs.Tabs, panes: listedPanes.Panes, processes: map[string][]process{}, candidates: map[string]bool{}}
+	expected := label(runID, workspaceID)
+	for _, t := range s.tabs {
+		if t.Label == expected {
+			s.candidates[t.TabID] = true
+			continue
+		}
+		if suffix, ok := strings.CutPrefix(t.Label, labelPrefix); ok {
+			decoded, err := hex.DecodeString(suffix)
+			if err != nil || len(decoded) != sha256.Size {
+				s.candidates[t.TabID] = true
+			}
+		}
+	}
+	for _, p := range s.panes {
+		var info struct {
+			ProcessInfo struct {
+				Processes []process `json:"foreground_processes"`
+			} `json:"process_info"`
+		}
+		if err := c.call(&info, "pane", "process-info", "--pane", p.PaneID); err != nil {
+			return snapshot{}, err
+		}
+		s.processes[p.PaneID] = info.ProcessInfo.Processes
+		for _, proc := range info.ProcessInfo.Processes {
+			for _, arg := range proc.Argv {
+				tuple, ok := decodeMarker(arg)
+				if strings.HasPrefix(arg, markerPrefix) && (!ok || tuple.RunID == runID && tuple.WorkspaceID == workspaceID) {
+					s.candidates[p.TabID] = true
+				}
+			}
+		}
+	}
+	return s, nil
+}
+
+func (c Client) exactOwned(s snapshot, runID, workspaceID, stateDir string) ([]Tuple, error) {
+	var owned []Tuple
+	for tabID := range s.candidates {
+		var found *tab
+		for i := range s.tabs {
+			if s.tabs[i].TabID == tabID {
+				found = &s.tabs[i]
+				break
+			}
+		}
+		matching := make([]pane, 0, 1)
+		for _, p := range s.panes {
+			if p.TabID == tabID {
+				matching = append(matching, p)
+			}
+		}
+		if found == nil || found.WorkspaceID != workspaceID || found.Label != label(runID, workspaceID) || found.PaneCount != 1 || len(matching) != 1 {
+			return nil, errors.New("ambiguous or forged companion candidate")
+		}
+		tuple := Tuple{RunID: runID, WorkspaceID: workspaceID, TabID: tabID, PaneID: matching[0].PaneID, TerminalID: matching[0].TerminalID}
+		atlas := c.atlasArgv(runID, stateDir)
+		if matching[0].WorkspaceID != workspaceID || !complete(tuple) || !ownedProcess(s.processes[tuple.PaneID], tuple, atlas) || ambiguousAtlas(s.processes[tuple.PaneID], atlas) {
+			return nil, errors.New("ambiguous or forged companion candidate")
+		}
+		owned = append(owned, tuple)
+	}
+	if len(owned) > 1 {
+		return nil, errors.New("multiple owned companion candidates")
+	}
+	return owned, nil
+}
+
+func (c Client) atlasArgv(runID, stateDir string) []string {
+	return []string{c.Executable, "--run-id", runID, "--state-dir", stateDir}
+}
+
+func (c Client) call(result any, args ...string) error {
+	name := c.Herdr
+	if name == "" {
+		name = "herdr"
+	}
+	command := exec.Command(name, args...)
+	output, err := command.Output()
+	if err != nil {
+		if exit, ok := err.(*exec.ExitError); ok && len(exit.Stderr) != 0 {
+			return fmt.Errorf("herdr %s: %s", strings.Join(args, " "), strings.TrimSpace(string(exit.Stderr)))
+		}
+		return fmt.Errorf("herdr %s: %w", strings.Join(args, " "), err)
+	}
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(output, &envelope); err != nil || envelope.Error != nil || len(envelope.Result) == 0 {
+		if envelope.Error != nil {
+			return errors.New(envelope.Error.Message)
+		}
+		return errors.New("invalid Herdr JSON response")
+	}
+	if result != nil {
+		if err := json.Unmarshal(envelope.Result, result); err != nil {
+			return fmt.Errorf("invalid Herdr result: %w", err)
+		}
+	}
+	return nil
+}
+
+func label(runID, workspaceID string) string {
+	hash := sha256.Sum256([]byte(runID + "\x00" + workspaceID))
+	return labelPrefix + hex.EncodeToString(hash[:])
+}
+
+func marker(tuple Tuple) string {
+	data, _ := json.Marshal(tuple)
+	return markerPrefix + base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeMarker(value string) (Tuple, bool) {
+	if !strings.HasPrefix(value, markerPrefix) {
+		return Tuple{}, false
+	}
+	data, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(value, markerPrefix))
+	var tuple Tuple
+	if err != nil || json.Unmarshal(data, &tuple) != nil || !complete(tuple) {
+		return Tuple{}, false
+	}
+	return tuple, true
+}
+
+func shellCommand(tuple Tuple, atlas []string) string {
+	args := append([]string{"/bin/sh", "-c", wrapper, marker(tuple)}, atlas...)
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
+	}
+	return strings.Join(quoted, " ")
+}
+
+func ownedProcess(processes []process, tuple Tuple, atlas []string) bool {
+	want := append([]string{"/bin/sh", "-c", wrapper, marker(tuple)}, atlas...)
+	count := 0
+	for _, process := range processes {
+		if equalArgv(process.Argv, want) {
+			count++
+		}
+	}
+	return count == 1
+}
+
+func healthy(processes []process, atlas []string) bool {
+	count := 0
+	for _, process := range processes {
+		if equalArgv(process.Argv, atlas) {
+			count++
+		}
+	}
+	return count == 1
+}
+
+func ambiguousAtlas(processes []process, atlas []string) bool {
+	count := 0
+	for _, process := range processes {
+		if equalArgv(process.Argv, atlas) {
+			count++
+		} else if len(process.Argv) != 0 && process.Argv[0] == atlas[0] {
+			return true
+		}
+	}
+	return count > 1
+}
+
+func equalArgv(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func complete(tuple Tuple) bool {
+	return tuple.RunID != "" && tuple.WorkspaceID != "" && tuple.TabID != "" && tuple.PaneID != "" && tuple.TerminalID != ""
+}

--- a/internal/atlascompanion/companion.go
+++ b/internal/atlascompanion/companion.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/aviral/dotfiles/internal/vaultregistry"
 )
 
 const (
@@ -25,6 +27,32 @@ type Tuple struct {
 	TabID       string `json:"tab_id"`
 	PaneID      string `json:"pane_id"`
 	TerminalID  string `json:"terminal_id"`
+}
+
+// Agent is the live Herdr identity used for exact participant correlation.
+type Agent struct {
+	Name         string                      `json:"name"`
+	Agent        string                      `json:"agent"`
+	AgentStatus  string                      `json:"agent_status"`
+	WorkspaceID  string                      `json:"workspace_id"`
+	TabID        string                      `json:"tab_id"`
+	PaneID       string                      `json:"pane_id"`
+	TerminalID   string                      `json:"terminal_id"`
+	AgentSession *vaultregistry.AgentSession `json:"agent_session,omitempty"`
+}
+
+// Correlation keeps recorded and live identities separately observable.
+type Correlation struct {
+	State    string                    `json:"state"`
+	Recorded vaultregistry.Participant `json:"recorded"`
+	Live     *Agent                    `json:"live,omitempty"`
+}
+
+// Attachment is the owned companion tuple and the read-only participant view used by it.
+type Attachment struct {
+	Tuple
+	Participants []Correlation `json:"participants"`
+	LiveOnly     []Agent       `json:"live_only"`
 }
 
 // Client invokes a Herdr 0.7.1-compatible CLI.
@@ -56,6 +84,97 @@ type snapshot struct {
 	panes      []pane
 	processes  map[string][]process
 	candidates map[string]bool
+}
+
+// AttachRun validates the Reader-produced Run before creating a companion.
+func (c Client) AttachRun(run vaultregistry.Run, workspaceID, stateDir string) (Attachment, error) {
+	participants, liveOnly, err := c.correlate(run, workspaceID)
+	if err != nil {
+		return Attachment{}, err
+	}
+	tuple, err := c.Attach(run.RunID, workspaceID, stateDir)
+	if err != nil {
+		return Attachment{}, err
+	}
+	return Attachment{Tuple: tuple, Participants: participants, LiveOnly: liveOnly}, nil
+}
+
+func (c Client) correlate(run vaultregistry.Run, workspaceID string) ([]Correlation, []Agent, error) {
+	if run.Task.Kind != "task" {
+		return nil, nil, errors.New("only Task Runs can have an Atlas companion")
+	}
+	registered := false
+	for _, participant := range run.Participants {
+		if participant.Herdr != nil && completeHerdr(*participant.Herdr) && participant.Herdr.WorkspaceID == workspaceID {
+			registered = true
+			break
+		}
+	}
+	if !registered {
+		return nil, nil, errors.New("workspace is not registered by a complete participant identity")
+	}
+
+	var listed struct {
+		Agents []Agent `json:"agents"`
+	}
+	if err := c.call(&listed, "agent", "list"); err != nil {
+		return nil, nil, err
+	}
+	correlations, liveOnly := correlate(run.Participants, listed.Agents)
+	return correlations, liveOnly, nil
+}
+
+func correlate(participants []vaultregistry.Participant, agents []Agent) ([]Correlation, []Agent) {
+	used := make([]bool, len(agents))
+	correlations := make([]Correlation, 0, len(participants))
+	for _, recorded := range participants {
+		correlation := Correlation{State: "recorded-only", Recorded: recorded}
+		if recorded.Herdr != nil && completeHerdr(*recorded.Herdr) {
+			correlation.State = "stale"
+			match := -1
+			for i := range agents {
+				if sameHerdr(*recorded.Herdr, agents[i]) {
+					if match != -1 {
+						match = -2
+						break
+					}
+					match = i
+				}
+			}
+			if match >= 0 {
+				live := agents[match]
+				correlation.Live = &live
+				used[match] = true
+				if recorded.AgentSession != nil && live.AgentSession != nil && !sameSession(*recorded.AgentSession, *live.AgentSession) {
+					correlation.State = "contradictory"
+				} else {
+					correlation.State = "matched"
+				}
+			}
+		}
+		correlations = append(correlations, correlation)
+	}
+	var liveOnly []Agent
+	for i, agent := range agents {
+		if !used[i] {
+			liveOnly = append(liveOnly, agent)
+		}
+	}
+	return correlations, liveOnly
+}
+
+func sameHerdr(recorded vaultregistry.HerdrIdentity, live Agent) bool {
+	return completeHerdr(recorded) && live.WorkspaceID != "" && live.TabID != "" && live.PaneID != "" && live.TerminalID != "" &&
+		recorded.WorkspaceID == live.WorkspaceID && recorded.TabID == live.TabID &&
+		recorded.PaneID == live.PaneID && recorded.TerminalID == live.TerminalID
+}
+
+func completeHerdr(identity vaultregistry.HerdrIdentity) bool {
+	return identity.WorkspaceID != "" && identity.TabID != "" && identity.PaneID != "" && identity.TerminalID != ""
+}
+
+func sameSession(recorded, live vaultregistry.AgentSession) bool {
+	return recorded.Source == live.Source && recorded.Kind == live.Kind && recorded.Value == live.Value
 }
 
 func (c Client) Attach(runID, workspaceID, stateDir string) (Tuple, error) {

--- a/internal/atlascompanion/companion.go
+++ b/internal/atlascompanion/companion.go
@@ -79,6 +79,11 @@ type process struct {
 	Argv []string `json:"argv"`
 }
 
+type processInfo struct {
+	PaneID    string    `json:"pane_id"`
+	Processes []process `json:"foreground_processes"`
+}
+
 type snapshot struct {
 	tabs       []tab
 	panes      []pane
@@ -115,10 +120,19 @@ func (c Client) correlate(run vaultregistry.Run, workspaceID string) ([]Correlat
 	}
 
 	var listed struct {
+		Type   string  `json:"type"`
 		Agents []Agent `json:"agents"`
 	}
 	if err := c.call(&listed, "agent", "list"); err != nil {
 		return nil, nil, err
+	}
+	if listed.Type != "agent_list" || listed.Agents == nil {
+		return nil, nil, errors.New("invalid Herdr agent list result")
+	}
+	for _, agent := range listed.Agents {
+		if agent.WorkspaceID == "" || agent.TabID == "" || agent.PaneID == "" || agent.TerminalID == "" {
+			return nil, nil, errors.New("invalid Herdr agent list result")
+		}
 	}
 	correlations, liveOnly := correlate(run.Participants, listed.Agents)
 	return correlations, liveOnly, nil
@@ -199,15 +213,25 @@ func (c Client) Attach(runID, workspaceID, stateDir string) (Tuple, error) {
 	}
 
 	var created struct {
-		Tab      tab  `json:"tab"`
-		RootPane pane `json:"root_pane"`
+		Type     string `json:"type"`
+		Tab      *tab   `json:"tab"`
+		RootPane *pane  `json:"root_pane"`
 	}
 	if err := c.call(&created, "tab", "create", "--workspace", workspaceID, "--label", label(runID, workspaceID), "--no-focus"); err != nil {
 		return Tuple{}, err
 	}
+	rollback := func() {
+		if created.Tab != nil && created.Tab.WorkspaceID == workspaceID && created.Tab.Label == label(runID, workspaceID) && created.Tab.TabID != "" {
+			c.call(nil, "tab", "close", created.Tab.TabID) // best-effort rollback of only the tab just created
+		}
+	}
+	if created.Type != "tab_created" || created.Tab == nil || created.RootPane == nil {
+		rollback()
+		return Tuple{}, errors.New("Herdr returned an incomplete companion tuple")
+	}
 	tuple := Tuple{RunID: runID, WorkspaceID: workspaceID, TabID: created.Tab.TabID, PaneID: created.RootPane.PaneID, TerminalID: created.RootPane.TerminalID}
-	if created.Tab.WorkspaceID != workspaceID || created.RootPane.WorkspaceID != workspaceID || created.RootPane.TabID != created.Tab.TabID || !complete(tuple) {
-		c.call(nil, "tab", "close", created.Tab.TabID) // best-effort rollback of only the tab just created
+	if created.Tab.WorkspaceID != workspaceID || created.Tab.Label != label(runID, workspaceID) || created.Tab.PaneCount != 1 || created.RootPane.WorkspaceID != workspaceID || created.RootPane.TabID != created.Tab.TabID || !complete(tuple) {
+		rollback()
 		return Tuple{}, errors.New("Herdr returned an incomplete companion tuple")
 	}
 	command := shellCommand(tuple, c.atlasArgv(runID, stateDir))
@@ -216,16 +240,16 @@ func (c Client) Attach(runID, workspaceID, stateDir string) (Tuple, error) {
 		return Tuple{}, err
 	}
 	var info struct {
-		ProcessInfo struct {
-			Processes []process `json:"foreground_processes"`
-		} `json:"process_info"`
+		Type        string       `json:"type"`
+		ProcessInfo *processInfo `json:"process_info"`
 	}
 	atlas := c.atlasArgv(runID, stateDir)
-	if err := c.call(&info, "pane", "process-info", "--pane", tuple.PaneID); err != nil || !ownedProcess(info.ProcessInfo.Processes, tuple, atlas) || ambiguousAtlas(info.ProcessInfo.Processes, atlas) || !healthy(info.ProcessInfo.Processes, atlas) {
+	if err := c.call(&info, "pane", "process-info", "--pane", tuple.PaneID); err != nil {
 		c.call(nil, "tab", "close", tuple.TabID)
-		if err != nil {
-			return Tuple{}, err
-		}
+		return Tuple{}, err
+	}
+	if err := validProcessInfo(info.Type, info.ProcessInfo, tuple.PaneID); err != nil || !ownedProcess(info.ProcessInfo.Processes, tuple, atlas) || ambiguousAtlas(info.ProcessInfo.Processes, atlas) || !healthy(info.ProcessInfo.Processes, atlas) {
+		c.call(nil, "tab", "close", tuple.TabID)
 		return Tuple{}, errors.New("companion process did not start with exact ownership")
 	}
 	return tuple, nil
@@ -264,16 +288,34 @@ func (c Client) validate(runID, workspaceID string) error {
 
 func (c Client) inspect(runID, workspaceID string) (snapshot, error) {
 	var listedTabs struct {
-		Tabs []tab `json:"tabs"`
+		Type string `json:"type"`
+		Tabs []tab  `json:"tabs"`
 	}
 	if err := c.call(&listedTabs, "tab", "list", "--workspace", workspaceID); err != nil {
 		return snapshot{}, err
 	}
+	if listedTabs.Type != "tab_list" || listedTabs.Tabs == nil {
+		return snapshot{}, errors.New("invalid Herdr tab list result")
+	}
+	for _, tab := range listedTabs.Tabs {
+		if tab.WorkspaceID != workspaceID || tab.TabID == "" || tab.Label == "" || tab.PaneCount < 1 {
+			return snapshot{}, errors.New("invalid Herdr tab list result")
+		}
+	}
 	var listedPanes struct {
+		Type  string `json:"type"`
 		Panes []pane `json:"panes"`
 	}
 	if err := c.call(&listedPanes, "pane", "list", "--workspace", workspaceID); err != nil {
 		return snapshot{}, err
+	}
+	if listedPanes.Type != "pane_list" || listedPanes.Panes == nil {
+		return snapshot{}, errors.New("invalid Herdr pane list result")
+	}
+	for _, pane := range listedPanes.Panes {
+		if pane.WorkspaceID != workspaceID || pane.TabID == "" || pane.PaneID == "" || pane.TerminalID == "" {
+			return snapshot{}, errors.New("invalid Herdr pane list result")
+		}
 	}
 	s := snapshot{tabs: listedTabs.Tabs, panes: listedPanes.Panes, processes: map[string][]process{}, candidates: map[string]bool{}}
 	expected := label(runID, workspaceID)
@@ -291,11 +333,13 @@ func (c Client) inspect(runID, workspaceID string) (snapshot, error) {
 	}
 	for _, p := range s.panes {
 		var info struct {
-			ProcessInfo struct {
-				Processes []process `json:"foreground_processes"`
-			} `json:"process_info"`
+			Type        string       `json:"type"`
+			ProcessInfo *processInfo `json:"process_info"`
 		}
 		if err := c.call(&info, "pane", "process-info", "--pane", p.PaneID); err != nil {
+			return snapshot{}, err
+		}
+		if err := validProcessInfo(info.Type, info.ProcessInfo, p.PaneID); err != nil {
 			return snapshot{}, err
 		}
 		s.processes[p.PaneID] = info.ProcessInfo.Processes
@@ -309,6 +353,18 @@ func (c Client) inspect(runID, workspaceID string) (snapshot, error) {
 		}
 	}
 	return s, nil
+}
+
+func validProcessInfo(resultType string, info *processInfo, paneID string) error {
+	if resultType != "pane_process_info" || info == nil || info.PaneID != paneID || info.Processes == nil {
+		return errors.New("invalid Herdr process-info result")
+	}
+	for _, process := range info.Processes {
+		if len(process.Argv) == 0 {
+			return errors.New("invalid Herdr process-info result")
+		}
+	}
+	return nil
 }
 
 func (c Client) exactOwned(s snapshot, runID, workspaceID, stateDir string) ([]Tuple, error) {
@@ -366,11 +422,17 @@ func (c Client) call(result any, args ...string) error {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if err := json.Unmarshal(output, &envelope); err != nil || envelope.Error != nil || len(envelope.Result) == 0 {
+	if err := json.Unmarshal(output, &envelope); err != nil || envelope.Error != nil || len(envelope.Result) == 0 || string(envelope.Result) == "null" {
 		if envelope.Error != nil {
 			return errors.New(envelope.Error.Message)
 		}
 		return errors.New("invalid Herdr JSON response")
+	}
+	var shape struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(envelope.Result, &shape); err != nil || shape.Type == "" {
+		return errors.New("invalid Herdr result shape")
 	}
 	if result != nil {
 		if err := json.Unmarshal(envelope.Result, result); err != nil {

--- a/internal/atlascompanion/companion_test.go
+++ b/internal/atlascompanion/companion_test.go
@@ -1,6 +1,9 @@
 package atlascompanion
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -53,6 +56,116 @@ func TestAttachmentEligibilityFailsBeforeHerdr(t *testing.T) {
 			t.Fatalf("eligibility error = %v", err)
 		}
 	}
+}
+
+func TestMalformedHerdrStateFailsClosed(t *testing.T) {
+	validTabs := herdrResponse(map[string]any{"type": "tab_list", "tabs": []any{map[string]any{"workspace_id": "ws", "tab_id": "other-tab", "label": "other", "pane_count": 1}}})
+	validPanes := herdrResponse(map[string]any{"type": "pane_list", "panes": []any{map[string]any{"workspace_id": "ws", "tab_id": "other-tab", "pane_id": "other-pane", "terminal_id": "other-terminal"}}})
+	cases := []struct {
+		name, tabs, panes, info string
+	}{
+		{name: "null response", tabs: "null"},
+		{name: "empty response", tabs: "{}"},
+		{name: "missing result", tabs: `{"id":"fake"}`},
+		{name: "null result", tabs: `{"id":"fake","result":null}`},
+		{name: "empty result", tabs: `{"id":"fake","result":{}}`},
+		{name: "missing tabs", tabs: herdrResponse(map[string]any{"type": "tab_list"})},
+		{name: "null tabs", tabs: herdrResponse(map[string]any{"type": "tab_list", "tabs": nil})},
+		{name: "missing panes", tabs: validTabs, panes: herdrResponse(map[string]any{"type": "pane_list"})},
+		{name: "missing process info", tabs: validTabs, panes: validPanes, info: herdrResponse(map[string]any{"type": "pane_process_info"})},
+		{name: "wrong process pane", tabs: validTabs, panes: validPanes, info: herdrResponse(map[string]any{"type": "pane_process_info", "process_info": map[string]any{"pane_id": "wrong", "foreground_processes": []any{}}})},
+		{name: "missing processes", tabs: validTabs, panes: validPanes, info: herdrResponse(map[string]any{"type": "pane_process_info", "process_info": map[string]any{"pane_id": "other-pane"}})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, log := fakeHerdr(t, tc.tabs, tc.panes, tc.info, "")
+			if _, err := client.Attach("run", "ws", "/state"); err == nil {
+				t.Fatal("attach accepted malformed Herdr state")
+			}
+			want := Tuple{RunID: "run", WorkspaceID: "ws", TabID: "tab", PaneID: "pane", TerminalID: "terminal"}
+			if err := client.Cleanup(want, "/state"); err == nil {
+				t.Fatal("cleanup claimed success for malformed Herdr state")
+			}
+			commands, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(commands), "tab create\n") || strings.Contains(string(commands), "tab close\n") {
+				t.Fatalf("malformed state caused tab mutation:\n%s", commands)
+			}
+		})
+	}
+}
+
+func TestCreateRequiresExactOnePaneResult(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result map[string]any
+	}{
+		{name: "missing root pane", result: map[string]any{"type": "tab_created"}},
+		{name: "two panes", result: map[string]any{
+			"type":      "tab_created",
+			"tab":       map[string]any{"workspace_id": "ws", "tab_id": "created-tab", "label": label("run", "ws"), "pane_count": 2},
+			"root_pane": map[string]any{"workspace_id": "ws", "tab_id": "created-tab", "pane_id": "created-pane", "terminal_id": "created-terminal"},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, log := fakeHerdr(t, "", "", "", herdrResponse(tc.result))
+			if _, err := client.Attach("run", "ws", "/state"); err == nil {
+				t.Fatal("attach accepted malformed tab create result")
+			}
+			commands, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(commands), "tab create\n") || strings.Contains(string(commands), "pane run\n") {
+				t.Fatalf("malformed create result advanced lifecycle:\n%s", commands)
+			}
+		})
+	}
+}
+
+func herdrResponse(result any) string {
+	response, _ := json.Marshal(map[string]any{"id": "fake", "result": result})
+	return string(response)
+}
+
+func fakeHerdr(t *testing.T, tabs, panes, info, create string) (Client, string) {
+	t.Helper()
+	if tabs == "" {
+		tabs = herdrResponse(map[string]any{"type": "tab_list", "tabs": []any{}})
+	}
+	if panes == "" {
+		panes = herdrResponse(map[string]any{"type": "pane_list", "panes": []any{}})
+	}
+	if info == "" {
+		info = herdrResponse(map[string]any{"type": "pane_process_info", "process_info": map[string]any{"pane_id": "other-pane", "foreground_processes": []any{map[string]any{"argv": []string{"other"}}}}})
+	}
+	if create == "" {
+		create = herdrResponse(map[string]any{"type": "tab_created"})
+	}
+	dir := t.TempDir()
+	log := filepath.Join(dir, "commands")
+	script := filepath.Join(dir, "herdr")
+	contents := `#!/bin/sh
+printf '%s %s\n' "$1" "$2" >>"$HERDR_TEST_LOG"
+case "$1 $2" in
+  "tab list") printf '%s\n' "$HERDR_TEST_TABS" ;;
+  "pane list") printf '%s\n' "$HERDR_TEST_PANES" ;;
+  "pane process-info") printf '%s\n' "$HERDR_TEST_INFO" ;;
+  "tab create") printf '%s\n' "$HERDR_TEST_CREATE" ;;
+  "pane run"|"tab close") printf '%s\n' '{"id":"fake","result":{"type":"ok"}}' ;;
+esac
+`
+	if err := os.WriteFile(script, []byte(contents), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_TEST_LOG", log)
+	t.Setenv("HERDR_TEST_TABS", tabs)
+	t.Setenv("HERDR_TEST_PANES", panes)
+	t.Setenv("HERDR_TEST_INFO", info)
+	t.Setenv("HERDR_TEST_CREATE", create)
+	return Client{Herdr: script, Executable: "atlas"}, log
 }
 
 func TestExactOwnershipIdentity(t *testing.T) {

--- a/internal/atlascompanion/companion_test.go
+++ b/internal/atlascompanion/companion_test.go
@@ -97,12 +97,103 @@ func TestMalformedHerdrStateFailsClosed(t *testing.T) {
 	}
 }
 
+func TestMutationResponsesRequireExactIdentity(t *testing.T) {
+	tuple := Tuple{RunID: "run", WorkspaceID: "ws", TabID: "created-tab", PaneID: "created-pane", TerminalID: "created-terminal"}
+	created := herdrResponse(map[string]any{
+		"type":      "tab_created",
+		"tab":       map[string]any{"workspace_id": "ws", "tab_id": tuple.TabID, "label": label("run", "ws"), "pane_count": 1},
+		"root_pane": map[string]any{"workspace_id": "ws", "tab_id": tuple.TabID, "pane_id": tuple.PaneID, "terminal_id": tuple.TerminalID},
+	})
+	afterTabs := herdrResponse(map[string]any{"type": "tab_list", "tabs": []any{map[string]any{"workspace_id": "ws", "tab_id": tuple.TabID, "label": label("run", "ws"), "pane_count": 1}}})
+	afterPanes := herdrResponse(map[string]any{"type": "pane_list", "panes": []any{map[string]any{"workspace_id": "ws", "tab_id": tuple.TabID, "pane_id": tuple.PaneID, "terminal_id": tuple.TerminalID}}})
+	for _, tc := range []struct {
+		name, response string
+	}{
+		{name: "pane run wrong type", response: herdrResponse(map[string]any{"type": "tab_closed", "pane_id": tuple.PaneID})},
+		{name: "pane run wrong ID", response: herdrResponse(map[string]any{"type": "pane_run", "pane_id": "other-pane"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, log := fakeHerdr(t, "", "", "", created)
+			t.Setenv("HERDR_TEST_AFTER_TABS", afterTabs)
+			t.Setenv("HERDR_TEST_AFTER_PANES", afterPanes)
+			t.Setenv("HERDR_TEST_RUN", tc.response)
+			if _, err := client.Attach("run", "ws", "/state"); err == nil {
+				t.Fatal("attach accepted invalid pane run result")
+			}
+			commands, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(commands), "pane run\n") || strings.Contains(string(commands), "pane process-info\n") {
+				t.Fatalf("invalid pane run result advanced attachment:\n%s", commands)
+			}
+		})
+	}
+
+	atlas := []string{"atlas", "--run-id", "run", "--state-dir", "/state"}
+	wrapperProcess := append([]string{"/bin/sh", "-c", wrapper, marker(tuple)}, atlas...)
+	tabs := herdrResponse(map[string]any{"type": "tab_list", "tabs": []any{map[string]any{"workspace_id": "ws", "tab_id": tuple.TabID, "label": label("run", "ws"), "pane_count": 1}}})
+	panes := herdrResponse(map[string]any{"type": "pane_list", "panes": []any{map[string]any{"workspace_id": "ws", "tab_id": tuple.TabID, "pane_id": tuple.PaneID, "terminal_id": tuple.TerminalID}}})
+	info := herdrResponse(map[string]any{"type": "pane_process_info", "process_info": map[string]any{"pane_id": tuple.PaneID, "foreground_processes": []any{map[string]any{"argv": wrapperProcess}}}})
+	for _, tc := range []struct {
+		name, response string
+	}{
+		{name: "tab close wrong type", response: herdrResponse(map[string]any{"type": "pane_run", "tab_id": tuple.TabID})},
+		{name: "tab close wrong ID", response: herdrResponse(map[string]any{"type": "tab_closed", "tab_id": "other-tab"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := fakeHerdr(t, tabs, panes, info, "")
+			t.Setenv("HERDR_TEST_CLOSE", tc.response)
+			if err := client.Cleanup(tuple, "/state"); err == nil {
+				t.Fatal("cleanup accepted invalid tab close result")
+			}
+		})
+	}
+}
+
+func TestCreateRejectsPreexistingIdentitiesWithoutMutation(t *testing.T) {
+	tabs := herdrResponse(map[string]any{"type": "tab_list", "tabs": []any{map[string]any{"workspace_id": "ws", "tab_id": "existing-tab", "label": "other", "pane_count": 1}}})
+	panes := herdrResponse(map[string]any{"type": "pane_list", "panes": []any{map[string]any{"workspace_id": "ws", "tab_id": "existing-tab", "pane_id": "existing-pane", "terminal_id": "existing-terminal"}}})
+	info := herdrResponse(map[string]any{"type": "pane_process_info", "process_info": map[string]any{"pane_id": "existing-pane", "foreground_processes": []any{map[string]any{"argv": []string{"other"}}}}})
+	for _, tc := range []struct {
+		name, tabID, paneID, terminalID string
+	}{
+		{name: "existing tab ID", tabID: "existing-tab", paneID: "new-pane", terminalID: "new-terminal"},
+		{name: "existing pane ID", tabID: "new-tab", paneID: "existing-pane", terminalID: "new-terminal"},
+		{name: "existing terminal ID", tabID: "new-tab", paneID: "new-pane", terminalID: "existing-terminal"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			create := herdrResponse(map[string]any{
+				"type":      "tab_created",
+				"tab":       map[string]any{"workspace_id": "ws", "tab_id": tc.tabID, "label": label("run", "ws"), "pane_count": 1},
+				"root_pane": map[string]any{"workspace_id": "ws", "tab_id": tc.tabID, "pane_id": tc.paneID, "terminal_id": tc.terminalID},
+			})
+			client, log := fakeHerdr(t, tabs, panes, info, create)
+			if _, err := client.Attach("run", "ws", "/state"); err == nil {
+				t.Fatal("attach accepted a preexisting create identity")
+			}
+			commands, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(commands), "pane run\n") || strings.Contains(string(commands), "tab close\n") {
+				t.Fatalf("spoofed create identity caused mutation:\n%s", commands)
+			}
+		})
+	}
+}
+
 func TestCreateRequiresExactOnePaneResult(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		result map[string]any
 	}{
 		{name: "missing root pane", result: map[string]any{"type": "tab_created"}},
+		{name: "tuple absent from live state", result: map[string]any{
+			"type":      "tab_created",
+			"tab":       map[string]any{"workspace_id": "ws", "tab_id": "created-tab", "label": label("run", "ws"), "pane_count": 1},
+			"root_pane": map[string]any{"workspace_id": "ws", "tab_id": "created-tab", "pane_id": "created-pane", "terminal_id": "created-terminal"},
+		}},
 		{name: "two panes", result: map[string]any{
 			"type":      "tab_created",
 			"tab":       map[string]any{"workspace_id": "ws", "tab_id": "created-tab", "label": label("run", "ws"), "pane_count": 2},
@@ -150,21 +241,27 @@ func fakeHerdr(t *testing.T, tabs, panes, info, create string) (Client, string) 
 	contents := `#!/bin/sh
 printf '%s %s\n' "$1" "$2" >>"$HERDR_TEST_LOG"
 case "$1 $2" in
-  "tab list") printf '%s\n' "$HERDR_TEST_TABS" ;;
-  "pane list") printf '%s\n' "$HERDR_TEST_PANES" ;;
+  "tab list")
+    if [ -e "$HERDR_TEST_CREATED" ] && [ -n "${HERDR_TEST_AFTER_TABS-}" ]; then printf '%s\n' "$HERDR_TEST_AFTER_TABS"; else printf '%s\n' "$HERDR_TEST_TABS"; fi ;;
+  "pane list")
+    if [ -e "$HERDR_TEST_CREATED" ] && [ -n "${HERDR_TEST_AFTER_PANES-}" ]; then printf '%s\n' "$HERDR_TEST_AFTER_PANES"; else printf '%s\n' "$HERDR_TEST_PANES"; fi ;;
   "pane process-info") printf '%s\n' "$HERDR_TEST_INFO" ;;
-  "tab create") printf '%s\n' "$HERDR_TEST_CREATE" ;;
-  "pane run"|"tab close") printf '%s\n' '{"id":"fake","result":{"type":"ok"}}' ;;
+  "tab create") : >"$HERDR_TEST_CREATED"; printf '%s\n' "$HERDR_TEST_CREATE" ;;
+  "pane run") printf '%s\n' "$HERDR_TEST_RUN" ;;
+  "tab close") printf '%s\n' "$HERDR_TEST_CLOSE" ;;
 esac
 `
 	if err := os.WriteFile(script, []byte(contents), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("HERDR_TEST_LOG", log)
+	t.Setenv("HERDR_TEST_CREATED", filepath.Join(dir, "created"))
 	t.Setenv("HERDR_TEST_TABS", tabs)
 	t.Setenv("HERDR_TEST_PANES", panes)
 	t.Setenv("HERDR_TEST_INFO", info)
 	t.Setenv("HERDR_TEST_CREATE", create)
+	t.Setenv("HERDR_TEST_RUN", herdrResponse(map[string]any{"type": "pane_run", "pane_id": "created-pane"}))
+	t.Setenv("HERDR_TEST_CLOSE", herdrResponse(map[string]any{"type": "tab_closed", "tab_id": "created-tab"}))
 	return Client{Herdr: script, Executable: "atlas"}, log
 }
 

--- a/internal/atlascompanion/companion_test.go
+++ b/internal/atlascompanion/companion_test.go
@@ -4,7 +4,56 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/aviral/dotfiles/internal/vaultregistry"
 )
+
+func TestExactParticipantCorrelation(t *testing.T) {
+	session := func(value string) *vaultregistry.AgentSession {
+		return &vaultregistry.AgentSession{Source: "herdr:pi", Kind: "path", Value: value}
+	}
+	identity := func(suffix string) *vaultregistry.HerdrIdentity {
+		return &vaultregistry.HerdrIdentity{WorkspaceID: "ws", TabID: "tab-" + suffix, PaneID: "pane-" + suffix, TerminalID: "term-" + suffix}
+	}
+	participants := []vaultregistry.Participant{
+		{ParticipantID: "matched", Herdr: identity("matched"), AgentSession: session("same")},
+		{ParticipantID: "one-sided", Herdr: identity("one-sided")},
+		{ParticipantID: "stale", Herdr: identity("stale")},
+		{ParticipantID: "contradictory", Herdr: identity("contradictory"), AgentSession: session("recorded")},
+		{ParticipantID: "recorded-only"},
+	}
+	agents := []Agent{
+		{WorkspaceID: "ws", TabID: "tab-matched", PaneID: "pane-matched", TerminalID: "term-matched", AgentSession: session("same")},
+		{WorkspaceID: "ws", TabID: "tab-one-sided", PaneID: "pane-one-sided", TerminalID: "term-one-sided", AgentSession: session("live")},
+		{WorkspaceID: "ws", TabID: "tab-contradictory", PaneID: "pane-contradictory", TerminalID: "term-contradictory", AgentSession: session("live")},
+		{Name: "same-name-is-not-identity", WorkspaceID: "ws", TabID: "tab-live", PaneID: "pane-live", TerminalID: "term-live"},
+	}
+
+	got, liveOnly := correlate(participants, agents)
+	states := []string{"matched", "matched", "stale", "contradictory", "recorded-only"}
+	for i := range states {
+		if got[i].State != states[i] {
+			t.Fatalf("participant %s state = %q, want %q", participants[i].ParticipantID, got[i].State, states[i])
+		}
+	}
+	if got[2].Live != nil || got[4].Live != nil || len(liveOnly) != 1 || liveOnly[0].TerminalID != "term-live" {
+		t.Fatalf("recorded/live separation lost: correlations=%#v live-only=%#v", got, liveOnly)
+	}
+}
+
+func TestAttachmentEligibilityFailsBeforeHerdr(t *testing.T) {
+	client := Client{Herdr: "/does/not/exist", Executable: "atlas"}
+	eligibleIdentity := &vaultregistry.HerdrIdentity{WorkspaceID: "ws", TabID: "tab", PaneID: "pane", TerminalID: "term"}
+	for _, run := range []vaultregistry.Run{
+		{Task: vaultregistry.Task{Kind: "feature"}, Participants: []vaultregistry.Participant{{Herdr: eligibleIdentity}}},
+		{Task: vaultregistry.Task{Kind: "task"}, Participants: []vaultregistry.Participant{{Herdr: &vaultregistry.HerdrIdentity{WorkspaceID: "ws"}}}},
+		{Task: vaultregistry.Task{Kind: "task"}, Participants: []vaultregistry.Participant{{Herdr: &vaultregistry.HerdrIdentity{WorkspaceID: "other", TabID: "tab", PaneID: "pane", TerminalID: "term"}}}},
+	} {
+		if _, _, err := client.correlate(run, "ws"); err == nil || strings.Contains(err.Error(), "does/not/exist") {
+			t.Fatalf("eligibility error = %v", err)
+		}
+	}
+}
 
 func TestExactOwnershipIdentity(t *testing.T) {
 	tuple := Tuple{RunID: "run ' one", WorkspaceID: "workspace", TabID: "tab", PaneID: "pane", TerminalID: "terminal"}

--- a/internal/atlascompanion/companion_test.go
+++ b/internal/atlascompanion/companion_test.go
@@ -1,0 +1,39 @@
+package atlascompanion
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestExactOwnershipIdentity(t *testing.T) {
+	tuple := Tuple{RunID: "run ' one", WorkspaceID: "workspace", TabID: "tab", PaneID: "pane", TerminalID: "terminal"}
+	atlas := []string{"/tmp/vault hunter atlas", "--run-id", tuple.RunID, "--state-dir", "/tmp/state ' one"}
+	encoded := marker(tuple)
+	decoded, ok := decodeMarker(encoded)
+	if !ok || decoded != tuple {
+		t.Fatalf("marker round trip = %#v, %v", decoded, ok)
+	}
+	if strings.Contains(label(tuple.RunID, tuple.WorkspaceID), tuple.RunID) {
+		t.Fatal("ownership label leaked the untrusted Run ID")
+	}
+	processes := []process{
+		{Argv: append([]string{"/bin/sh", "-c", wrapper, encoded}, atlas...)},
+		{Argv: atlas},
+	}
+	if !ownedProcess(processes, tuple, atlas) || !healthy(processes, atlas) {
+		t.Fatal("exact wrapper and Atlas process were not accepted")
+	}
+	forged := append([]process(nil), processes...)
+	forged[0].Argv = append([]string(nil), forged[0].Argv...)
+	forged[0].Argv[3] += "forged"
+	if ownedProcess(forged, tuple, atlas) {
+		t.Fatal("forged ownership marker was accepted")
+	}
+	if got := shellCommand(tuple, atlas); !strings.Contains(got, `'run '\'' one'`) {
+		t.Fatalf("shell command did not quote untrusted input: %s", got)
+	}
+	if !reflect.DeepEqual(processes[1].Argv, atlas) {
+		t.Fatal("test setup changed Atlas argv")
+	}
+}

--- a/scripts/verifiers/vault-hunter-atlas-t03-support
+++ b/scripts/verifiers/vault-hunter-atlas-t03-support
@@ -1,7 +1,7 @@
 # Shared setup for the T03 Atlas verifier scripts.
 
 install_fake_herdr() {
-  unset HERDR_FAKE_STRICT_CLOSE
+  unset HERDR_FAKE_STRICT_CLOSE HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
   HERDR_FAKE_ERROR_NOUN=command
   case ${1-} in
     strict-close) export HERDR_FAKE_STRICT_CLOSE=1 ;;
@@ -19,6 +19,10 @@ with open(path) as stream:
     state = json.load(stream)
 with open(log_path, "a") as stream:
     stream.write(json.dumps(args, separators=(",", ":")) + "\n")
+
+if args[:2] == os.environ.get("HERDR_FAKE_RESPONSE_COMMAND", "").split()[:2]:
+    print(os.environ["HERDR_FAKE_RESPONSE"])
+    sys.exit(0)
 
 def emit(result):
     print(json.dumps({"id": "fake", "result": result}, separators=(",", ":")))

--- a/scripts/verifiers/vault-hunter-atlas-t03-support
+++ b/scripts/verifiers/vault-hunter-atlas-t03-support
@@ -1,0 +1,94 @@
+# Shared setup for the T03 Atlas verifier scripts.
+
+install_fake_herdr() {
+  unset HERDR_FAKE_STRICT_CLOSE
+  HERDR_FAKE_ERROR_NOUN=command
+  case ${1-} in
+    strict-close) export HERDR_FAKE_STRICT_CLOSE=1 ;;
+    action) HERDR_FAKE_ERROR_NOUN=action ;;
+  esac
+  export HERDR_FAKE_ERROR_NOUN
+  cat >"$tmp/bin/herdr" <<'PY'
+#!/usr/bin/env python3
+import json, os, shlex, sys
+
+path = os.environ["HERDR_FAKE_STATE"]
+log_path = os.environ["HERDR_FAKE_LOG"]
+args = sys.argv[1:]
+with open(path) as stream:
+    state = json.load(stream)
+with open(log_path, "a") as stream:
+    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
+
+def emit(result):
+    print(json.dumps({"id": "fake", "result": result}, separators=(",", ":")))
+
+def save():
+    with open(path, "w") as stream:
+        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
+        stream.write("\n")
+
+def option(name):
+    return args[args.index(name) + 1]
+
+if args[:2] == ["agent", "list"]:
+    emit({"type": "agent_list", "agents": state["agents"]})
+elif args[:2] == ["tab", "list"]:
+    workspace = option("--workspace")
+    emit({"type": "tab_list", "tabs": [tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "list"]:
+    workspace = option("--workspace")
+    emit({"type": "pane_list", "panes": [{k: v for k, v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "process-info"]:
+    pane_id = option("--pane")
+    pane = next((pane for pane in state["panes"] if pane["pane_id"] == pane_id), None)
+    if pane is None:
+        sys.exit(1)
+    emit({"type": "pane_process_info", "process_info": {"pane_id": pane_id, "foreground_processes": pane["processes"]}})
+elif args[:2] == ["tab", "create"]:
+    workspace = option("--workspace")
+    state["counter"] += 1
+    n = state["counter"]
+    tab = {"workspace_id": workspace, "tab_id": f"tab-{n}", "label": option("--label"), "pane_count": 1}
+    pane = {"workspace_id": workspace, "tab_id": tab["tab_id"], "pane_id": f"pane-{n}", "terminal_id": f"term-{n}", "processes": [{"argv": ["/bin/sh"]}]}
+    state["tabs"].append(tab)
+    state["panes"].append(pane)
+    save()
+    emit({"type": "tab_created", "tab": tab, "root_pane": {k: v for k, v in pane.items() if k != "processes"}})
+elif args[:2] == ["pane", "run"]:
+    pane_id, command = args[2], args[3]
+    pane = next(pane for pane in state["panes"] if pane["pane_id"] == pane_id)
+    argv = shlex.split(command)
+    pane["processes"] = [{"argv": argv}, {"argv": argv[4:]}]
+    save()
+    emit({"type": "pane_run", "pane_id": pane_id})
+elif args[:2] == ["tab", "close"]:
+    tab_id = args[2]
+    if os.environ.get("HERDR_FAKE_STRICT_CLOSE") and not any(tab["tab_id"] == tab_id for tab in state["tabs"]):
+        sys.exit(1)
+    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
+    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
+    save()
+    emit({"type": "tab_closed", "tab_id": tab_id})
+else:
+    print("forbidden fake Herdr " + os.environ["HERDR_FAKE_ERROR_NOUN"] + ": " + " ".join(args), file=sys.stderr)
+    sys.exit(97)
+PY
+  chmod +x "$tmp/bin/herdr"
+}
+
+manifest() {
+  (
+    cd "$1"
+    find . -type f -print | LC_ALL=C sort | while IFS= read -r file; do
+      shasum -a 256 "$file"
+    done
+  )
+}
+
+assert_manifests() {
+  manifest "$tmp/state" >"$tmp/state.current"
+  manifest "$tmp/vault" >"$tmp/vault.current"
+  cmp "$tmp/state.manifest" "$tmp/state.current"
+  cmp "$tmp/vault.manifest" "$tmp/vault.current"
+}

--- a/scripts/verifiers/vault-hunter-atlas-t03-v01
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v01
@@ -3,78 +3,13 @@ set -eu
 
 cd "$(dirname "$0")/../.."
 
+. scripts/verifiers/vault-hunter-atlas-t03-support
+
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/bin" "$tmp/state"
 
-cat >"$tmp/bin/herdr" <<'PY'
-#!/usr/bin/env python3
-import json, os, shlex, sys
-
-path = os.environ["HERDR_FAKE_STATE"]
-log_path = os.environ["HERDR_FAKE_LOG"]
-args = sys.argv[1:]
-with open(path) as stream:
-    state = json.load(stream)
-with open(log_path, "a") as stream:
-    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
-
-def emit(result):
-    print(json.dumps({"id": "fake", "result": result}, separators=(",", ":")))
-
-def save():
-    with open(path, "w") as stream:
-        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
-        stream.write("\n")
-
-def option(name):
-    return args[args.index(name) + 1]
-
-if args[:2] == ["agent", "list"]:
-    emit({"type": "agent_list", "agents": state["agents"]})
-elif args[:2] == ["tab", "list"]:
-    workspace = option("--workspace")
-    emit({"type": "tab_list", "tabs": [tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
-elif args[:2] == ["pane", "list"]:
-    workspace = option("--workspace")
-    emit({"type": "pane_list", "panes": [{k: v for k, v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
-elif args[:2] == ["pane", "process-info"]:
-    pane_id = option("--pane")
-    pane = next((pane for pane in state["panes"] if pane["pane_id"] == pane_id), None)
-    if pane is None:
-        sys.exit(1)
-    emit({"type": "pane_process_info", "process_info": {"pane_id": pane_id, "foreground_processes": pane["processes"]}})
-elif args[:2] == ["tab", "create"]:
-    workspace = option("--workspace")
-    label = option("--label")
-    state["counter"] += 1
-    n = state["counter"]
-    tab = {"workspace_id": workspace, "tab_id": f"tab-{n}", "label": label, "pane_count": 1}
-    pane = {"workspace_id": workspace, "tab_id": tab["tab_id"], "pane_id": f"pane-{n}", "terminal_id": f"term-{n}", "processes": [{"argv": ["/bin/sh"]}]}
-    state["tabs"].append(tab)
-    state["panes"].append(pane)
-    save()
-    emit({"type": "tab_created", "tab": tab, "root_pane": {k: v for k, v in pane.items() if k != "processes"}})
-elif args[:2] == ["pane", "run"]:
-    pane_id, command = args[2], args[3]
-    pane = next(pane for pane in state["panes"] if pane["pane_id"] == pane_id)
-    argv = shlex.split(command)
-    pane["processes"] = [{"argv": argv}, {"argv": argv[4:]}]
-    save()
-    emit({"type": "pane_run", "pane_id": pane_id})
-elif args[:2] == ["tab", "close"]:
-    tab_id = args[2]
-    if not any(tab["tab_id"] == tab_id for tab in state["tabs"]):
-        sys.exit(1)
-    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
-    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
-    save()
-    emit({"type": "tab_closed", "tab_id": tab_id})
-else:
-    print("forbidden fake Herdr command: " + " ".join(args), file=sys.stderr)
-    sys.exit(97)
-PY
-chmod +x "$tmp/bin/herdr"
+install_fake_herdr strict-close
 
 cat >"$tmp/herdr.json" <<'JSON'
 {"counter":10,"agents":[{"name":"worker","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"agent-tab","pane_id":"agent-pane","terminal_id":"agent-terminal"}],"tabs":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","label":"unrelated","pane_count":1},{"workspace_id":"ws-other","tab_id":"other-tab","label":"other workspace","pane_count":1}],"panes":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","pane_id":"unrelated-pane","terminal_id":"unrelated-terminal","processes":[{"argv":["unrelated-process"]}]},{"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal","processes":[{"argv":["other-process"]}]}]}

--- a/scripts/verifiers/vault-hunter-atlas-t03-v01
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v01
@@ -1,0 +1,248 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/state"
+
+cat >"$tmp/bin/herdr" <<'PY'
+#!/usr/bin/env python3
+import json, os, shlex, sys
+
+path = os.environ["HERDR_FAKE_STATE"]
+log_path = os.environ["HERDR_FAKE_LOG"]
+args = sys.argv[1:]
+with open(path) as stream:
+    state = json.load(stream)
+with open(log_path, "a") as stream:
+    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
+
+def emit(result):
+    print(json.dumps({"id": "fake", "result": result}, separators=(",", ":")))
+
+def save():
+    with open(path, "w") as stream:
+        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
+        stream.write("\n")
+
+def option(name):
+    return args[args.index(name) + 1]
+
+if args[:2] == ["tab", "list"]:
+    workspace = option("--workspace")
+    emit({"type": "tab_list", "tabs": [tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "list"]:
+    workspace = option("--workspace")
+    emit({"type": "pane_list", "panes": [{k: v for k, v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "process-info"]:
+    pane_id = option("--pane")
+    pane = next((pane for pane in state["panes"] if pane["pane_id"] == pane_id), None)
+    if pane is None:
+        sys.exit(1)
+    emit({"type": "pane_process_info", "process_info": {"pane_id": pane_id, "foreground_processes": pane["processes"]}})
+elif args[:2] == ["tab", "create"]:
+    workspace = option("--workspace")
+    label = option("--label")
+    state["counter"] += 1
+    n = state["counter"]
+    tab = {"workspace_id": workspace, "tab_id": f"tab-{n}", "label": label, "pane_count": 1}
+    pane = {"workspace_id": workspace, "tab_id": tab["tab_id"], "pane_id": f"pane-{n}", "terminal_id": f"term-{n}", "processes": [{"argv": ["/bin/sh"]}]}
+    state["tabs"].append(tab)
+    state["panes"].append(pane)
+    save()
+    emit({"type": "tab_created", "tab": tab, "root_pane": {k: v for k, v in pane.items() if k != "processes"}})
+elif args[:2] == ["pane", "run"]:
+    pane_id, command = args[2], args[3]
+    pane = next(pane for pane in state["panes"] if pane["pane_id"] == pane_id)
+    argv = shlex.split(command)
+    pane["processes"] = [{"argv": argv}, {"argv": argv[4:]}]
+    save()
+    emit({"type": "pane_run", "pane_id": pane_id})
+elif args[:2] == ["tab", "close"]:
+    tab_id = args[2]
+    if not any(tab["tab_id"] == tab_id for tab in state["tabs"]):
+        sys.exit(1)
+    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
+    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
+    save()
+    emit({"type": "tab_closed", "tab_id": tab_id})
+else:
+    print("forbidden fake Herdr command: " + " ".join(args), file=sys.stderr)
+    sys.exit(97)
+PY
+chmod +x "$tmp/bin/herdr"
+
+cat >"$tmp/herdr.json" <<'JSON'
+{"counter":10,"tabs":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","label":"unrelated","pane_count":1},{"workspace_id":"ws-other","tab_id":"other-tab","label":"other workspace","pane_count":1}],"panes":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","pane_id":"unrelated-pane","terminal_id":"unrelated-terminal","processes":[{"argv":["unrelated-process"]}]},{"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal","processes":[{"argv":["other-process"]}]}]}
+JSON
+: >"$tmp/herdr.log"
+
+go test -count=1 ./internal/atlascompanion
+go build -o "$tmp/vault-hunter-atlas" ./cmd/vault-hunter-atlas
+export HERDR_FAKE_STATE="$tmp/herdr.json" HERDR_FAKE_LOG="$tmp/herdr.log"
+PATH="$tmp/bin:$PATH"
+export PATH
+
+attach() {
+  "$tmp/vault-hunter-atlas" companion attach --run-id run-03 --workspace-id ws-target --state-dir "$tmp/state"
+}
+cleanup() {
+  "$tmp/vault-hunter-atlas" companion cleanup --run-id run-03 --workspace-id ws-target \
+    --tab-id "$1" --pane-id "$2" --terminal-id "$3" --state-dir "$tmp/state"
+}
+state_hash() {
+  shasum -a 256 "$tmp/herdr.json" | awk '{print $1}'
+}
+assert_fails_closed() {
+  name=$1
+  before=$(state_hash)
+  if attach >"$tmp/$name.stdout" 2>"$tmp/$name.stderr"; then
+    echo "$name candidate unexpectedly attached" >&2
+    exit 1
+  fi
+  test ! -s "$tmp/$name.stdout"
+  test "$before" = "$(state_hash)"
+}
+
+attach >"$tmp/first.json"
+attach >"$tmp/second.json"
+cmp "$tmp/first.json" "$tmp/second.json"
+eval "$(python3 - "$tmp/first.json" <<'PY'
+import json, shlex, sys
+value = json.load(open(sys.argv[1]))
+assert set(value) == {"run_id", "workspace_id", "tab_id", "pane_id", "terminal_id"}
+assert value["run_id"] == "run-03" and value["workspace_id"] == "ws-target"
+for key in ("tab_id", "pane_id", "terminal_id"):
+    print(f"{key}={shlex.quote(value[key])}")
+PY
+)"
+python3 - "$tmp/herdr.json" "$tmp/vault-hunter-atlas" "$tmp/state" <<'PY'
+import json, sys
+state = json.load(open(sys.argv[1]))
+atlas = [sys.argv[2], "--run-id", "run-03", "--state-dir", sys.argv[3]]
+assert sum(process["argv"] == atlas for pane in state["panes"] for process in pane["processes"]) == 1
+assert sum(tab["label"].startswith("Vault Hunter Atlas · ") for tab in state["tabs"]) == 1
+assert {tab["tab_id"] for tab in state["tabs"]} >= {"unrelated-tab", "other-tab"}
+PY
+
+# A surviving exact ownership wrapper and missing Atlas child uniquely prove a dead owned companion.
+python3 - "$tmp/herdr.json" "$pane_id" <<'PY'
+import json, sys
+path, pane_id = sys.argv[1:]
+state = json.load(open(path))
+pane = next(p for p in state["panes"] if p["pane_id"] == pane_id)
+pane["processes"] = pane["processes"][:1]
+json.dump(state, open(path, "w"), sort_keys=True, separators=(",", ":"))
+open(path, "a").write("\n")
+PY
+attach >"$tmp/replaced.json"
+if cmp -s "$tmp/first.json" "$tmp/replaced.json"; then
+  echo "dead companion tuple was reused" >&2
+  exit 1
+fi
+old_tab_id=$tab_id
+eval "$(python3 - "$tmp/replaced.json" <<'PY'
+import json, shlex, sys
+value = json.load(open(sys.argv[1]))
+for key in ("tab_id", "pane_id", "terminal_id"):
+    print(f"{key}={shlex.quote(value[key])}")
+PY
+)"
+python3 - "$tmp/herdr.json" "$old_tab_id" "$tab_id" <<'PY'
+import json, sys
+state = json.load(open(sys.argv[1]))
+tab_ids = {tab["tab_id"] for tab in state["tabs"]}
+assert sys.argv[2] not in tab_ids and sys.argv[3] in tab_ids
+assert "unrelated-tab" in tab_ids and "other-tab" in tab_ids
+PY
+
+# Two exact owned tuples are ambiguous.
+python3 - "$tmp/herdr.json" "$tab_id" "$pane_id" <<'PY'
+import base64, json, sys
+path, tab_id, pane_id = sys.argv[1:]
+state = json.load(open(path))
+tab = next(t for t in state["tabs"] if t["tab_id"] == tab_id)
+pane = next(p for p in state["panes"] if p["pane_id"] == pane_id)
+tuple_ = {"run_id":"run-03","workspace_id":"ws-target","tab_id":"duplicate-tab","pane_id":"duplicate-pane","terminal_id":"duplicate-terminal"}
+marker = "vault-hunter-atlas-companion:v1:" + base64.urlsafe_b64encode(json.dumps(tuple_, separators=(",", ":")).encode()).decode().rstrip("=")
+wrapper = pane["processes"][0]["argv"][:]
+wrapper[3] = marker
+state["tabs"].append({"workspace_id":"ws-target","tab_id":"duplicate-tab","label":tab["label"],"pane_count":1})
+state["panes"].append({"workspace_id":"ws-target","tab_id":"duplicate-tab","pane_id":"duplicate-pane","terminal_id":"duplicate-terminal","processes":[{"argv":wrapper},{"argv":pane["processes"][1]["argv"]}]})
+json.dump(state, open(path, "w"), sort_keys=True, separators=(",", ":")); open(path, "a").write("\n")
+PY
+assert_fails_closed ambiguous
+python3 - "$tmp/herdr.json" <<'PY'
+import json, sys
+path = sys.argv[1]; state = json.load(open(path))
+state["tabs"] = [t for t in state["tabs"] if t["tab_id"] != "duplicate-tab"]
+state["panes"] = [p for p in state["panes"] if p["tab_id"] != "duplicate-tab"]
+json.dump(state, open(path, "w"), sort_keys=True, separators=(",", ":")); open(path, "a").write("\n")
+PY
+
+# An exact label without the exact ownership process is forged.
+python3 - "$tmp/herdr.json" "$tab_id" <<'PY'
+import json, sys
+path, tab_id = sys.argv[1:]; state = json.load(open(path))
+label = next(t["label"] for t in state["tabs"] if t["tab_id"] == tab_id)
+state["tabs"].append({"workspace_id":"ws-target","tab_id":"forged-tab","label":label,"pane_count":1})
+state["panes"].append({"workspace_id":"ws-target","tab_id":"forged-tab","pane_id":"forged-pane","terminal_id":"forged-terminal","processes":[{"argv":["forged"]}]})
+json.dump(state, open(path, "w"), sort_keys=True, separators=(",", ":")); open(path, "a").write("\n")
+PY
+assert_fails_closed forged
+python3 - "$tmp/herdr.json" <<'PY'
+import json, sys
+path = sys.argv[1]; state = json.load(open(path))
+state["tabs"] = [t for t in state["tabs"] if t["tab_id"] != "forged-tab"]
+state["panes"] = [p for p in state["panes"] if p["tab_id"] != "forged-tab"]
+json.dump(state, open(path, "w"), sort_keys=True, separators=(",", ":")); open(path, "a").write("\n")
+PY
+
+# A truncated ownership label is partial and must not be claimed.
+python3 - "$tmp/herdr.json" "$tab_id" <<'PY'
+import json, sys
+path, tab_id = sys.argv[1:]; state = json.load(open(path))
+label = next(t["label"] for t in state["tabs"] if t["tab_id"] == tab_id)
+state["tabs"].append({"workspace_id":"ws-target","tab_id":"partial-tab","label":label[:-1],"pane_count":1})
+state["panes"].append({"workspace_id":"ws-target","tab_id":"partial-tab","pane_id":"partial-pane","terminal_id":"partial-terminal","processes":[{"argv":["partial"]}]})
+json.dump(state, open(path, "w"), sort_keys=True, separators=(",", ":")); open(path, "a").write("\n")
+PY
+assert_fails_closed partial
+python3 - "$tmp/herdr.json" <<'PY'
+import json, sys
+path = sys.argv[1]; state = json.load(open(path))
+state["tabs"] = [t for t in state["tabs"] if t["tab_id"] != "partial-tab"]
+state["panes"] = [p for p in state["panes"] if p["tab_id"] != "partial-tab"]
+json.dump(state, open(path, "w"), sort_keys=True, separators=(",", ":")); open(path, "a").write("\n")
+PY
+
+# A mismatched retained tuple cannot close the live companion.
+before=$(state_hash)
+if cleanup "$tab_id" "$pane_id" forged-terminal >"$tmp/mismatch.stdout" 2>"$tmp/mismatch.stderr"; then
+  echo "mismatched cleanup unexpectedly succeeded" >&2
+  exit 1
+fi
+test "$before" = "$(state_hash)"
+cleanup "$tab_id" "$pane_id" "$terminal_id" >"$tmp/cleanup-first.json"
+cleanup "$tab_id" "$pane_id" "$terminal_id" >"$tmp/cleanup-second.json"
+cmp "$tmp/cleanup-first.json" "$tmp/cleanup-second.json"
+cmp "$tmp/replaced.json" "$tmp/cleanup-first.json"
+
+python3 - "$tmp/herdr.json" "$tmp/herdr.log" <<'PY'
+import json, sys
+state = json.load(open(sys.argv[1]))
+assert {tab["tab_id"] for tab in state["tabs"]} == {"unrelated-tab", "other-tab"}
+assert {pane["pane_id"] for pane in state["panes"]} == {"unrelated-pane", "other-pane"}
+allowed = {("tab","list"), ("pane","list"), ("pane","process-info"), ("tab","create"), ("pane","run"), ("tab","close")}
+for line in open(sys.argv[2]):
+    args = json.loads(line)
+    assert tuple(args[:2]) in allowed, args
+    if args[:2] == ["tab", "close"]:
+        assert args[2] not in {"unrelated-tab", "other-tab"}
+    if args[:2] == ["tab", "create"]:
+        assert args[args.index("--workspace") + 1] == "ws-target" and "--no-focus" in args
+PY
+
+echo "T03.V01 exact-one Atlas companion lifecycle: PASS"

--- a/scripts/verifiers/vault-hunter-atlas-t03-v01
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v01
@@ -176,6 +176,57 @@ attached, cleaned = map(lambda path: json.load(open(path)), sys.argv[1:])
 assert {key: attached[key] for key in cleaned} == cleaned
 PY
 
+command_count() {
+  python3 - "$tmp/herdr.log" "$1" <<'PY'
+import json, sys
+want = sys.argv[2].split()
+print(sum(json.loads(line)[:2] == want for line in open(sys.argv[1])))
+PY
+}
+assert_malformed_state_fails_closed() {
+  name=$1
+  HERDR_FAKE_RESPONSE_COMMAND=$2
+  HERDR_FAKE_RESPONSE=$3
+  export HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+  before_create=$(command_count 'tab create')
+  before_close=$(command_count 'tab close')
+  if attach >"$tmp/$name-attach.stdout" 2>"$tmp/$name-attach.stderr"; then
+    echo "$name malformed state unexpectedly attached" >&2
+    exit 1
+  fi
+  test ! -s "$tmp/$name-attach.stdout"
+  if cleanup "$tab_id" "$pane_id" "$terminal_id" >"$tmp/$name-cleanup.stdout" 2>"$tmp/$name-cleanup.stderr"; then
+    echo "$name malformed state cleanup unexpectedly succeeded" >&2
+    exit 1
+  fi
+  test ! -s "$tmp/$name-cleanup.stdout"
+  test "$before_create" = "$(command_count 'tab create')"
+  test "$before_close" = "$(command_count 'tab close')"
+  unset HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+}
+
+assert_malformed_state_fails_closed null-response 'tab list' 'null'
+assert_malformed_state_fails_closed empty-response 'tab list' '{}'
+assert_malformed_state_fails_closed null-result 'tab list' '{"id":"fake","result":null}'
+assert_malformed_state_fails_closed empty-result 'tab list' '{"id":"fake","result":{}}'
+assert_malformed_state_fails_closed missing-tabs 'tab list' '{"id":"fake","result":{"type":"tab_list"}}'
+assert_malformed_state_fails_closed missing-panes 'pane list' '{"id":"fake","result":{"type":"pane_list"}}'
+assert_malformed_state_fails_closed missing-process-info 'pane process-info' '{"id":"fake","result":{"type":"pane_process_info"}}'
+assert_malformed_state_fails_closed wrong-process-pane 'pane process-info' '{"id":"fake","result":{"type":"pane_process_info","process_info":{"pane_id":"wrong","foreground_processes":[]}}}'
+
+# A create response without its required exact-one-pane tuple cannot advance to pane mutation.
+HERDR_FAKE_RESPONSE_COMMAND='tab create'
+HERDR_FAKE_RESPONSE='{"id":"fake","result":{"type":"tab_created"}}'
+export HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+before_run=$(command_count 'pane run')
+if attach >"$tmp/malformed-create.stdout" 2>"$tmp/malformed-create.stderr"; then
+  echo "malformed create result unexpectedly attached" >&2
+  exit 1
+fi
+test ! -s "$tmp/malformed-create.stdout"
+test "$before_run" = "$(command_count 'pane run')"
+unset HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+
 python3 - "$tmp/herdr.json" "$tmp/herdr.log" <<'PY'
 import json, sys
 state = json.load(open(sys.argv[1]))

--- a/scripts/verifiers/vault-hunter-atlas-t03-v01
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v01
@@ -30,7 +30,9 @@ def save():
 def option(name):
     return args[args.index(name) + 1]
 
-if args[:2] == ["tab", "list"]:
+if args[:2] == ["agent", "list"]:
+    emit({"type": "agent_list", "agents": state["agents"]})
+elif args[:2] == ["tab", "list"]:
     workspace = option("--workspace")
     emit({"type": "tab_list", "tabs": [tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
 elif args[:2] == ["pane", "list"]:
@@ -75,12 +77,16 @@ PY
 chmod +x "$tmp/bin/herdr"
 
 cat >"$tmp/herdr.json" <<'JSON'
-{"counter":10,"tabs":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","label":"unrelated","pane_count":1},{"workspace_id":"ws-other","tab_id":"other-tab","label":"other workspace","pane_count":1}],"panes":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","pane_id":"unrelated-pane","terminal_id":"unrelated-terminal","processes":[{"argv":["unrelated-process"]}]},{"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal","processes":[{"argv":["other-process"]}]}]}
+{"counter":10,"agents":[{"name":"worker","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"agent-tab","pane_id":"agent-pane","terminal_id":"agent-terminal"}],"tabs":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","label":"unrelated","pane_count":1},{"workspace_id":"ws-other","tab_id":"other-tab","label":"other workspace","pane_count":1}],"panes":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","pane_id":"unrelated-pane","terminal_id":"unrelated-terminal","processes":[{"argv":["unrelated-process"]}]},{"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal","processes":[{"argv":["other-process"]}]}]}
 JSON
 : >"$tmp/herdr.log"
 
 go test -count=1 ./internal/atlascompanion
 go build -o "$tmp/vault-hunter-atlas" ./cmd/vault-hunter-atlas
+go build -o "$tmp/vault-hunter-registry" ./cmd/vault-hunter-registry
+cat <<JSON | "$tmp/vault-hunter-registry" >/dev/null
+{"action":"create","root":"$tmp/state","run":{"schema_version":1,"run_id":"run-03","invoked_at":"2026-07-26T12:00:00Z","updated_at":"2026-07-26T12:00:00Z","task":{"id":"T03","title":"Integrate Atlas","path":"tasks/03.md","feature_path":"features/atlas.md","kind":"task"},"participants":[{"participant_id":"worker","observed_at":"2026-07-26T12:00:01Z","role":"worker","goal_id":"V01","herdr":{"workspace_id":"ws-target","tab_id":"agent-tab","pane_id":"agent-pane","terminal_id":"agent-terminal"},"agent_session":null}]}}
+JSON
 export HERDR_FAKE_STATE="$tmp/herdr.json" HERDR_FAKE_LOG="$tmp/herdr.log"
 PATH="$tmp/bin:$PATH"
 export PATH
@@ -112,8 +118,9 @@ cmp "$tmp/first.json" "$tmp/second.json"
 eval "$(python3 - "$tmp/first.json" <<'PY'
 import json, shlex, sys
 value = json.load(open(sys.argv[1]))
-assert set(value) == {"run_id", "workspace_id", "tab_id", "pane_id", "terminal_id"}
+assert set(value) == {"run_id", "workspace_id", "tab_id", "pane_id", "terminal_id", "participants", "live_only"}
 assert value["run_id"] == "run-03" and value["workspace_id"] == "ws-target"
+assert [item["state"] for item in value["participants"]] == ["matched"] and value["live_only"] is None
 for key in ("tab_id", "pane_id", "terminal_id"):
     print(f"{key}={shlex.quote(value[key])}")
 PY
@@ -228,14 +235,18 @@ test "$before" = "$(state_hash)"
 cleanup "$tab_id" "$pane_id" "$terminal_id" >"$tmp/cleanup-first.json"
 cleanup "$tab_id" "$pane_id" "$terminal_id" >"$tmp/cleanup-second.json"
 cmp "$tmp/cleanup-first.json" "$tmp/cleanup-second.json"
-cmp "$tmp/replaced.json" "$tmp/cleanup-first.json"
+python3 - "$tmp/replaced.json" "$tmp/cleanup-first.json" <<'PY'
+import json, sys
+attached, cleaned = map(lambda path: json.load(open(path)), sys.argv[1:])
+assert {key: attached[key] for key in cleaned} == cleaned
+PY
 
 python3 - "$tmp/herdr.json" "$tmp/herdr.log" <<'PY'
 import json, sys
 state = json.load(open(sys.argv[1]))
 assert {tab["tab_id"] for tab in state["tabs"]} == {"unrelated-tab", "other-tab"}
 assert {pane["pane_id"] for pane in state["panes"]} == {"unrelated-pane", "other-pane"}
-allowed = {("tab","list"), ("pane","list"), ("pane","process-info"), ("tab","create"), ("pane","run"), ("tab","close")}
+allowed = {("agent","list"), ("tab","list"), ("pane","list"), ("pane","process-info"), ("tab","create"), ("pane","run"), ("tab","close")}
 for line in open(sys.argv[2]):
     args = json.loads(line)
     assert tuple(args[:2]) in allowed, args

--- a/scripts/verifiers/vault-hunter-atlas-t03-v01
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v01
@@ -36,6 +36,14 @@ cleanup() {
 state_hash() {
   shasum -a 256 "$tmp/herdr.json" | awk '{print $1}'
 }
+topology_hash() {
+  python3 - "$tmp/herdr.json" <<'PY'
+import hashlib, json, sys
+state = json.load(open(sys.argv[1]))
+value = json.dumps({key: state[key] for key in ("agents", "tabs", "panes")}, sort_keys=True, separators=(",", ":"))
+print(hashlib.sha256(value.encode()).hexdigest())
+PY
+}
 assert_fails_closed() {
   name=$1
   before=$(state_hash)
@@ -183,6 +191,78 @@ want = sys.argv[2].split()
 print(sum(json.loads(line)[:2] == want for line in open(sys.argv[1])))
 PY
 }
+assert_bad_pane_run() {
+  name=$1
+  HERDR_FAKE_RESPONSE_COMMAND='pane run'
+  HERDR_FAKE_RESPONSE=$2
+  export HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+  before=$(topology_hash)
+  before_run=$(command_count 'pane run')
+  before_close=$(command_count 'tab close')
+  if attach >"$tmp/$name.stdout" 2>"$tmp/$name.stderr"; then
+    echo "$name pane run response unexpectedly attached" >&2
+    exit 1
+  fi
+  test ! -s "$tmp/$name.stdout"
+  test "$before" = "$(topology_hash)"
+  test "$((before_run + 1))" = "$(command_count 'pane run')"
+  test "$((before_close + 1))" = "$(command_count 'tab close')"
+  unset HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+}
+assert_bad_pane_run wrong-run-type '{"id":"fake","result":{"type":"tab_closed","pane_id":"wrong"}}'
+assert_bad_pane_run wrong-run-id '{"id":"fake","result":{"type":"pane_run","pane_id":"wrong"}}'
+
+# Cleanup must not report success for the wrong mutation type or identity.
+attach >"$tmp/mutation-close.json"
+eval "$(python3 - "$tmp/mutation-close.json" <<'PY'
+import json, shlex, sys
+value = json.load(open(sys.argv[1]))
+for key in ("tab_id", "pane_id", "terminal_id"):
+    print(f"{key}={shlex.quote(value[key])}")
+PY
+)"
+assert_bad_close() {
+  name=$1
+  HERDR_FAKE_RESPONSE_COMMAND='tab close'
+  HERDR_FAKE_RESPONSE=$2
+  export HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+  before=$(state_hash)
+  before_close=$(command_count 'tab close')
+  if cleanup "$tab_id" "$pane_id" "$terminal_id" >"$tmp/$name.stdout" 2>"$tmp/$name.stderr"; then
+    echo "$name tab close response unexpectedly cleaned up" >&2
+    exit 1
+  fi
+  test ! -s "$tmp/$name.stdout"
+  test "$before" = "$(state_hash)"
+  test "$((before_close + 1))" = "$(command_count 'tab close')"
+  unset HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+}
+assert_bad_close wrong-close-type "{\"id\":\"fake\",\"result\":{\"type\":\"pane_run\",\"tab_id\":\"$tab_id\"}}"
+assert_bad_close wrong-close-id '{"id":"fake","result":{"type":"tab_closed","tab_id":"unrelated-tab"}}'
+cleanup "$tab_id" "$pane_id" "$terminal_id" >"$tmp/mutation-close-cleanup.json"
+
+# A create response may not claim identities from the complete pre-create snapshot.
+companion_label=$(python3 - <<'PY'
+import hashlib
+print("Vault Hunter Atlas · " + hashlib.sha256(b"run-03\0ws-target").hexdigest())
+PY
+)
+HERDR_FAKE_RESPONSE_COMMAND='tab create'
+HERDR_FAKE_RESPONSE="{\"id\":\"fake\",\"result\":{\"type\":\"tab_created\",\"tab\":{\"workspace_id\":\"ws-target\",\"tab_id\":\"unrelated-tab\",\"label\":\"$companion_label\",\"pane_count\":1},\"root_pane\":{\"workspace_id\":\"ws-target\",\"tab_id\":\"unrelated-tab\",\"pane_id\":\"unrelated-pane\",\"terminal_id\":\"unrelated-terminal\"}}}"
+export HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+before=$(state_hash)
+before_run=$(command_count 'pane run')
+before_close=$(command_count 'tab close')
+if attach >"$tmp/spoofed-existing.stdout" 2>"$tmp/spoofed-existing.stderr"; then
+  echo "spoofed existing create identities unexpectedly attached" >&2
+  exit 1
+fi
+test ! -s "$tmp/spoofed-existing.stdout"
+test "$before" = "$(state_hash)"
+test "$before_run" = "$(command_count 'pane run')"
+test "$before_close" = "$(command_count 'tab close')"
+unset HERDR_FAKE_RESPONSE_COMMAND HERDR_FAKE_RESPONSE
+
 assert_malformed_state_fails_closed() {
   name=$1
   HERDR_FAKE_RESPONSE_COMMAND=$2
@@ -238,6 +318,8 @@ for line in open(sys.argv[2]):
     assert tuple(args[:2]) in allowed, args
     if args[:2] == ["tab", "close"]:
         assert args[2] not in {"unrelated-tab", "other-tab"}
+    if args[:2] == ["pane", "run"]:
+        assert args[2] not in {"unrelated-pane", "other-pane"}
     if args[:2] == ["tab", "create"]:
         assert args[args.index("--workspace") + 1] == "ws-target" and "--no-focus" in args
 PY

--- a/scripts/verifiers/vault-hunter-atlas-t03-v02
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v02
@@ -1,0 +1,182 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/state" "$tmp/requests"
+
+cat >"$tmp/bin/herdr" <<'PY'
+#!/usr/bin/env python3
+import json, os, shlex, sys
+
+path = os.environ["HERDR_FAKE_STATE"]
+log_path = os.environ["HERDR_FAKE_LOG"]
+args = sys.argv[1:]
+with open(path) as stream:
+    state = json.load(stream)
+with open(log_path, "a") as stream:
+    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
+
+def emit(result):
+    print(json.dumps({"id": "fake", "result": result}, separators=(",", ":")))
+
+def save():
+    with open(path, "w") as stream:
+        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
+        stream.write("\n")
+
+def option(name):
+    return args[args.index(name) + 1]
+
+if args[:2] == ["agent", "list"]:
+    emit({"type": "agent_list", "agents": state["agents"]})
+elif args[:2] == ["tab", "list"]:
+    workspace = option("--workspace")
+    emit({"type": "tab_list", "tabs": [tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "list"]:
+    workspace = option("--workspace")
+    emit({"type": "pane_list", "panes": [{k: v for k, v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "process-info"]:
+    pane_id = option("--pane")
+    pane = next((pane for pane in state["panes"] if pane["pane_id"] == pane_id), None)
+    if pane is None:
+        sys.exit(1)
+    emit({"type": "pane_process_info", "process_info": {"pane_id": pane_id, "foreground_processes": pane["processes"]}})
+elif args[:2] == ["tab", "create"]:
+    workspace = option("--workspace")
+    state["counter"] += 1
+    n = state["counter"]
+    tab = {"workspace_id": workspace, "tab_id": f"tab-{n}", "label": option("--label"), "pane_count": 1}
+    pane = {"workspace_id": workspace, "tab_id": tab["tab_id"], "pane_id": f"pane-{n}", "terminal_id": f"term-{n}", "processes": [{"argv": ["/bin/sh"]}]}
+    state["tabs"].append(tab)
+    state["panes"].append(pane)
+    save()
+    emit({"type": "tab_created", "tab": tab, "root_pane": {k: v for k, v in pane.items() if k != "processes"}})
+elif args[:2] == ["pane", "run"]:
+    pane = next(pane for pane in state["panes"] if pane["pane_id"] == args[2])
+    argv = shlex.split(args[3])
+    pane["processes"] = [{"argv": argv}, {"argv": argv[4:]}]
+    save()
+    emit({"type": "pane_run", "pane_id": args[2]})
+elif args[:2] == ["tab", "close"]:
+    tab_id = args[2]
+    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
+    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
+    save()
+    emit({"type": "tab_closed", "tab_id": tab_id})
+else:
+    print("forbidden fake Herdr command: " + " ".join(args), file=sys.stderr)
+    sys.exit(97)
+PY
+chmod +x "$tmp/bin/herdr"
+
+cat >"$tmp/herdr.json" <<'JSON'
+{"counter":20,"agents":[{"name":"matched","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"tab-matched","pane_id":"pane-matched","terminal_id":"term-matched","agent_session":{"source":"herdr:pi","kind":"path","value":"session-matched"}},{"name":"one-sided","agent":"pi","agent_status":"idle","workspace_id":"ws-target","tab_id":"tab-one-sided","pane_id":"pane-one-sided","terminal_id":"term-one-sided","agent_session":{"source":"herdr:pi","kind":"path","value":"session-live-only-side"}},{"name":"contradictory","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"tab-contradictory","pane_id":"pane-contradictory","terminal_id":"term-contradictory","agent_session":{"source":"herdr:pi","kind":"path","value":"session-live"}},{"name":"stale","agent":"pi","agent_status":"done","workspace_id":"ws-target","tab_id":"tab-stale","pane_id":"pane-stale","terminal_id":"term-stale-live"},{"name":"live-only","agent":"codex","agent_status":"working","workspace_id":"ws-other","tab_id":"tab-live","pane_id":"pane-live","terminal_id":"term-live"}],"tabs":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","label":"unrelated","pane_count":1},{"workspace_id":"ws-other","tab_id":"other-tab","label":"other","pane_count":1}],"panes":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","pane_id":"unrelated-pane","terminal_id":"unrelated-terminal","processes":[{"argv":["unrelated"]}]},{"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal","processes":[{"argv":["other"]}]}]}
+JSON
+: >"$tmp/herdr.log"
+
+python3 - "$tmp" <<'PY'
+import json, os, sys
+root = sys.argv[1]
+
+def herdr(suffix, terminal=None):
+    return {"workspace_id":"ws-target", "tab_id":"tab-"+suffix, "pane_id":"pane-"+suffix, "terminal_id":terminal or "term-"+suffix}
+
+def session(value):
+    return {"source":"herdr:pi", "kind":"path", "value":value}
+
+def participant(identifier, identity=None, agent_session=None):
+    return {"participant_id":identifier, "observed_at":"2026-07-26T12:00:01Z", "role":"worker", "goal_id":"V02", "herdr":identity, "agent_session":agent_session}
+
+mixed = [
+    participant("matched", herdr("matched"), session("session-matched")),
+    participant("one-sided", herdr("one-sided")),
+    participant("stale", herdr("stale", "term-stale-recorded")),
+    participant("contradictory", herdr("contradictory"), session("session-recorded")),
+    participant("recorded-only"),
+]
+runs = [
+    ("run-mixed", "task", mixed),
+    ("run-unregistered", "task", [participant("other", {"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal"})]),
+    ("run-feature", "feature", [participant("target", herdr("matched"))]),
+    ("run-issue", "issue", [participant("target", herdr("matched"))]),
+    ("run-wayfinder", "wayfinder", [participant("target", herdr("matched"))]),
+]
+for i, (run_id, kind, participants) in enumerate(runs):
+    request = {"action":"create", "root":os.path.join(root, "state"), "run":{
+        "schema_version":1, "run_id":run_id, "invoked_at":"2026-07-26T12:00:00Z", "updated_at":"2026-07-26T12:00:00Z",
+        "task":{"id":"T03", "title":run_id, "path":"tasks/03.md", "feature_path":"features/atlas.md", "kind":kind},
+        "participants":participants,
+    }}
+    with open(os.path.join(root, "requests", str(i)+".json"), "w") as stream:
+        json.dump(request, stream, separators=(",", ":"))
+PY
+
+go test -count=1 ./internal/atlascompanion
+go build -o "$tmp/vault-hunter-atlas" ./cmd/vault-hunter-atlas
+go build -o "$tmp/vault-hunter-registry" ./cmd/vault-hunter-registry
+for request in "$tmp"/requests/*.json; do
+  "$tmp/vault-hunter-registry" <"$request" >/dev/null
+done
+
+export HERDR_FAKE_STATE="$tmp/herdr.json" HERDR_FAKE_LOG="$tmp/herdr.log"
+PATH="$tmp/bin:$PATH"
+export PATH
+
+"$tmp/vault-hunter-atlas" companion attach --run-id run-mixed --workspace-id ws-target --state-dir "$tmp/state" >"$tmp/attached.json"
+python3 - "$tmp/attached.json" "$tmp/herdr.json" <<'PY'
+import json, sys
+attached = json.load(open(sys.argv[1]))
+state = json.load(open(sys.argv[2]))
+assert {key: attached[key] for key in ("run_id","workspace_id")} == {"run_id":"run-mixed","workspace_id":"ws-target"}
+assert all(attached[key] for key in ("tab_id","pane_id","terminal_id"))
+states = {item["recorded"]["participant_id"]: item["state"] for item in attached["participants"]}
+assert states == {"matched":"matched", "one-sided":"matched", "stale":"stale", "contradictory":"contradictory", "recorded-only":"recorded-only"}, states
+by_id = {item["recorded"]["participant_id"]: item for item in attached["participants"]}
+assert by_id["matched"]["live"]["terminal_id"] == "term-matched"
+assert by_id["one-sided"]["live"]["agent_session"]["value"] == "session-live-only-side"
+assert by_id["contradictory"]["live"]["agent_session"]["value"] == "session-live"
+assert "live" not in by_id["stale"] and "live" not in by_id["recorded-only"]
+assert {agent["terminal_id"] for agent in attached["live_only"]} == {"term-stale-live", "term-live"}
+assert sum(tab["label"].startswith("Vault Hunter Atlas · ") for tab in state["tabs"]) == 1
+assert {tab["tab_id"] for tab in state["tabs"]} >= {"unrelated-tab", "other-tab"}
+PY
+
+eval "$(python3 - "$tmp/attached.json" <<'PY'
+import json, shlex, sys
+value = json.load(open(sys.argv[1]))
+for key in ("tab_id", "pane_id", "terminal_id"):
+    print(f"{key}={shlex.quote(value[key])}")
+PY
+)"
+"$tmp/vault-hunter-atlas" companion cleanup --run-id run-mixed --workspace-id ws-target \
+  --tab-id "$tab_id" --pane-id "$pane_id" --terminal-id "$terminal_id" --state-dir "$tmp/state" >/dev/null
+
+state_hash() { shasum -a 256 "$tmp/herdr.json" | awk '{print $1}'; }
+log_hash() { shasum -a 256 "$tmp/herdr.log" | awk '{print $1}'; }
+for run_id in run-unregistered run-feature run-issue run-wayfinder; do
+  before_state=$(state_hash)
+  before_log=$(log_hash)
+  if "$tmp/vault-hunter-atlas" companion attach --run-id "$run_id" --workspace-id ws-target --state-dir "$tmp/state" >"$tmp/$run_id.stdout" 2>"$tmp/$run_id.stderr"; then
+    echo "$run_id unexpectedly attached" >&2
+    exit 1
+  fi
+  test ! -s "$tmp/$run_id.stdout"
+  test "$before_state" = "$(state_hash)"
+  test "$before_log" = "$(log_hash)"
+done
+
+python3 - "$tmp/herdr.json" "$tmp/herdr.log" <<'PY'
+import json, sys
+state = json.load(open(sys.argv[1]))
+assert {tab["tab_id"] for tab in state["tabs"]} == {"unrelated-tab", "other-tab"}
+assert {pane["pane_id"] for pane in state["panes"]} == {"unrelated-pane", "other-pane"}
+allowed = {("agent","list"), ("tab","list"), ("pane","list"), ("pane","process-info"), ("tab","create"), ("pane","run"), ("tab","close")}
+commands = [json.loads(line) for line in open(sys.argv[2])]
+assert sum(command[:2] == ["agent", "list"] for command in commands) == 1
+assert all(tuple(command[:2]) in allowed for command in commands)
+PY
+
+echo "T03.V02 exact participant correlation and eligibility: PASS"

--- a/scripts/verifiers/vault-hunter-atlas-t03-v02
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v02
@@ -3,74 +3,13 @@ set -eu
 
 cd "$(dirname "$0")/../.."
 
+. scripts/verifiers/vault-hunter-atlas-t03-support
+
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/bin" "$tmp/state" "$tmp/requests"
 
-cat >"$tmp/bin/herdr" <<'PY'
-#!/usr/bin/env python3
-import json, os, shlex, sys
-
-path = os.environ["HERDR_FAKE_STATE"]
-log_path = os.environ["HERDR_FAKE_LOG"]
-args = sys.argv[1:]
-with open(path) as stream:
-    state = json.load(stream)
-with open(log_path, "a") as stream:
-    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
-
-def emit(result):
-    print(json.dumps({"id": "fake", "result": result}, separators=(",", ":")))
-
-def save():
-    with open(path, "w") as stream:
-        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
-        stream.write("\n")
-
-def option(name):
-    return args[args.index(name) + 1]
-
-if args[:2] == ["agent", "list"]:
-    emit({"type": "agent_list", "agents": state["agents"]})
-elif args[:2] == ["tab", "list"]:
-    workspace = option("--workspace")
-    emit({"type": "tab_list", "tabs": [tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
-elif args[:2] == ["pane", "list"]:
-    workspace = option("--workspace")
-    emit({"type": "pane_list", "panes": [{k: v for k, v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
-elif args[:2] == ["pane", "process-info"]:
-    pane_id = option("--pane")
-    pane = next((pane for pane in state["panes"] if pane["pane_id"] == pane_id), None)
-    if pane is None:
-        sys.exit(1)
-    emit({"type": "pane_process_info", "process_info": {"pane_id": pane_id, "foreground_processes": pane["processes"]}})
-elif args[:2] == ["tab", "create"]:
-    workspace = option("--workspace")
-    state["counter"] += 1
-    n = state["counter"]
-    tab = {"workspace_id": workspace, "tab_id": f"tab-{n}", "label": option("--label"), "pane_count": 1}
-    pane = {"workspace_id": workspace, "tab_id": tab["tab_id"], "pane_id": f"pane-{n}", "terminal_id": f"term-{n}", "processes": [{"argv": ["/bin/sh"]}]}
-    state["tabs"].append(tab)
-    state["panes"].append(pane)
-    save()
-    emit({"type": "tab_created", "tab": tab, "root_pane": {k: v for k, v in pane.items() if k != "processes"}})
-elif args[:2] == ["pane", "run"]:
-    pane = next(pane for pane in state["panes"] if pane["pane_id"] == args[2])
-    argv = shlex.split(args[3])
-    pane["processes"] = [{"argv": argv}, {"argv": argv[4:]}]
-    save()
-    emit({"type": "pane_run", "pane_id": args[2]})
-elif args[:2] == ["tab", "close"]:
-    tab_id = args[2]
-    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
-    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
-    save()
-    emit({"type": "tab_closed", "tab_id": tab_id})
-else:
-    print("forbidden fake Herdr command: " + " ".join(args), file=sys.stderr)
-    sys.exit(97)
-PY
-chmod +x "$tmp/bin/herdr"
+install_fake_herdr
 
 cat >"$tmp/herdr.json" <<'JSON'
 {"counter":20,"agents":[{"name":"matched","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"tab-matched","pane_id":"pane-matched","terminal_id":"term-matched","agent_session":{"source":"herdr:pi","kind":"path","value":"session-matched"}},{"name":"one-sided","agent":"pi","agent_status":"idle","workspace_id":"ws-target","tab_id":"tab-one-sided","pane_id":"pane-one-sided","terminal_id":"term-one-sided","agent_session":{"source":"herdr:pi","kind":"path","value":"session-live-only-side"}},{"name":"contradictory","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"tab-contradictory","pane_id":"pane-contradictory","terminal_id":"term-contradictory","agent_session":{"source":"herdr:pi","kind":"path","value":"session-live"}},{"name":"stale","agent":"pi","agent_status":"done","workspace_id":"ws-target","tab_id":"tab-stale","pane_id":"pane-stale","terminal_id":"term-stale-live"},{"name":"live-only","agent":"codex","agent_status":"working","workspace_id":"ws-other","tab_id":"tab-live","pane_id":"pane-live","terminal_id":"term-live"}],"tabs":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","label":"unrelated","pane_count":1},{"workspace_id":"ws-other","tab_id":"other-tab","label":"other","pane_count":1}],"panes":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","pane_id":"unrelated-pane","terminal_id":"unrelated-terminal","processes":[{"argv":["unrelated"]}]},{"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal","processes":[{"argv":["other"]}]}]}

--- a/scripts/verifiers/vault-hunter-atlas-t03-v03
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v03
@@ -3,88 +3,13 @@ set -eu
 
 cd "$(dirname "$0")/../.."
 
+. scripts/verifiers/vault-hunter-atlas-t03-support
+
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/bin" "$tmp/state" "$tmp/vault" "$tmp/home"
 
-manifest() {
-  (
-    cd "$1"
-    find . -type f -print | LC_ALL=C sort | while IFS= read -r file; do
-      shasum -a 256 "$file"
-    done
-  )
-}
-assert_manifests() {
-  manifest "$tmp/state" >"$tmp/state.current"
-  manifest "$tmp/vault" >"$tmp/vault.current"
-  cmp "$tmp/state.manifest" "$tmp/state.current"
-  cmp "$tmp/vault.manifest" "$tmp/vault.current"
-}
-
-cat >"$tmp/bin/herdr" <<'PY'
-#!/usr/bin/env python3
-import json, os, shlex, sys
-
-path = os.environ["HERDR_FAKE_STATE"]
-log_path = os.environ["HERDR_FAKE_LOG"]
-args = sys.argv[1:]
-with open(path) as stream:
-    state = json.load(stream)
-with open(log_path, "a") as stream:
-    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
-
-def emit(result):
-    print(json.dumps({"id":"fake", "result":result}, separators=(",", ":")))
-
-def save():
-    with open(path, "w") as stream:
-        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
-        stream.write("\n")
-
-def option(name):
-    return args[args.index(name) + 1]
-
-if args[:2] == ["agent", "list"]:
-    emit({"type":"agent_list", "agents":state["agents"]})
-elif args[:2] == ["tab", "list"]:
-    workspace = option("--workspace")
-    emit({"type":"tab_list", "tabs":[tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
-elif args[:2] == ["pane", "list"]:
-    workspace = option("--workspace")
-    emit({"type":"pane_list", "panes":[{k:v for k,v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
-elif args[:2] == ["pane", "process-info"]:
-    pane = next((pane for pane in state["panes"] if pane["pane_id"] == option("--pane")), None)
-    if pane is None:
-        sys.exit(1)
-    emit({"type":"pane_process_info", "process_info":{"pane_id":pane["pane_id"], "foreground_processes":pane["processes"]}})
-elif args[:2] == ["tab", "create"]:
-    workspace = option("--workspace")
-    state["counter"] += 1
-    n = state["counter"]
-    tab = {"workspace_id":workspace, "tab_id":f"tab-{n}", "label":option("--label"), "pane_count":1}
-    pane = {"workspace_id":workspace, "tab_id":tab["tab_id"], "pane_id":f"pane-{n}", "terminal_id":f"term-{n}", "processes":[{"argv":["/bin/sh"]}]}
-    state["tabs"].append(tab)
-    state["panes"].append(pane)
-    save()
-    emit({"type":"tab_created", "tab":tab, "root_pane":{k:v for k,v in pane.items() if k != "processes"}})
-elif args[:2] == ["pane", "run"]:
-    pane = next(pane for pane in state["panes"] if pane["pane_id"] == args[2])
-    argv = shlex.split(args[3])
-    pane["processes"] = [{"argv":argv}, {"argv":argv[4:]}]
-    save()
-    emit({"type":"pane_run", "pane_id":args[2]})
-elif args[:2] == ["tab", "close"]:
-    tab_id = args[2]
-    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
-    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
-    save()
-    emit({"type":"tab_closed", "tab_id":tab_id})
-else:
-    print("forbidden fake Herdr action: " + " ".join(args), file=sys.stderr)
-    sys.exit(97)
-PY
-chmod +x "$tmp/bin/herdr"
+install_fake_herdr action
 
 cat >"$tmp/bin/action-trap" <<'SH'
 #!/bin/sh

--- a/scripts/verifiers/vault-hunter-atlas-t03-v03
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v03
@@ -1,0 +1,182 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/state" "$tmp/vault" "$tmp/home"
+
+manifest() {
+  (
+    cd "$1"
+    find . -type f -print | LC_ALL=C sort | while IFS= read -r file; do
+      shasum -a 256 "$file"
+    done
+  )
+}
+assert_manifests() {
+  manifest "$tmp/state" >"$tmp/state.current"
+  manifest "$tmp/vault" >"$tmp/vault.current"
+  cmp "$tmp/state.manifest" "$tmp/state.current"
+  cmp "$tmp/vault.manifest" "$tmp/vault.current"
+}
+
+cat >"$tmp/bin/herdr" <<'PY'
+#!/usr/bin/env python3
+import json, os, shlex, sys
+
+path = os.environ["HERDR_FAKE_STATE"]
+log_path = os.environ["HERDR_FAKE_LOG"]
+args = sys.argv[1:]
+with open(path) as stream:
+    state = json.load(stream)
+with open(log_path, "a") as stream:
+    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
+
+def emit(result):
+    print(json.dumps({"id":"fake", "result":result}, separators=(",", ":")))
+
+def save():
+    with open(path, "w") as stream:
+        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
+        stream.write("\n")
+
+def option(name):
+    return args[args.index(name) + 1]
+
+if args[:2] == ["agent", "list"]:
+    emit({"type":"agent_list", "agents":state["agents"]})
+elif args[:2] == ["tab", "list"]:
+    workspace = option("--workspace")
+    emit({"type":"tab_list", "tabs":[tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "list"]:
+    workspace = option("--workspace")
+    emit({"type":"pane_list", "panes":[{k:v for k,v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "process-info"]:
+    pane = next((pane for pane in state["panes"] if pane["pane_id"] == option("--pane")), None)
+    if pane is None:
+        sys.exit(1)
+    emit({"type":"pane_process_info", "process_info":{"pane_id":pane["pane_id"], "foreground_processes":pane["processes"]}})
+elif args[:2] == ["tab", "create"]:
+    workspace = option("--workspace")
+    state["counter"] += 1
+    n = state["counter"]
+    tab = {"workspace_id":workspace, "tab_id":f"tab-{n}", "label":option("--label"), "pane_count":1}
+    pane = {"workspace_id":workspace, "tab_id":tab["tab_id"], "pane_id":f"pane-{n}", "terminal_id":f"term-{n}", "processes":[{"argv":["/bin/sh"]}]}
+    state["tabs"].append(tab)
+    state["panes"].append(pane)
+    save()
+    emit({"type":"tab_created", "tab":tab, "root_pane":{k:v for k,v in pane.items() if k != "processes"}})
+elif args[:2] == ["pane", "run"]:
+    pane = next(pane for pane in state["panes"] if pane["pane_id"] == args[2])
+    argv = shlex.split(args[3])
+    pane["processes"] = [{"argv":argv}, {"argv":argv[4:]}]
+    save()
+    emit({"type":"pane_run", "pane_id":args[2]})
+elif args[:2] == ["tab", "close"]:
+    tab_id = args[2]
+    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
+    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
+    save()
+    emit({"type":"tab_closed", "tab_id":tab_id})
+else:
+    print("forbidden fake Herdr action: " + " ".join(args), file=sys.stderr)
+    sys.exit(97)
+PY
+chmod +x "$tmp/bin/herdr"
+
+cat >"$tmp/bin/action-trap" <<'SH'
+#!/bin/sh
+printf '%s %s\n' "$0" "$*" >>"$ATLAS_T03_V03_TRAP_LOG"
+exit 97
+SH
+chmod +x "$tmp/bin/action-trap"
+for command in vault-hunter vault-hunter-registry vault-hunter-registry-writer pi codex feedback resume acceptance session goal agent workspace-create worktree-create git vault-hunter-feedback vault-hunter-resume; do
+  ln -s action-trap "$tmp/bin/$command"
+done
+
+cat >"$tmp/herdr.json" <<'JSON'
+{"counter":30,"agents":[{"name":"replay-worker","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"agent-tab","pane_id":"agent-pane","terminal_id":"agent-terminal","agent_session":{"source":"herdr:pi","kind":"path","value":"session-03"}}],"tabs":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","label":"unrelated","pane_count":1},{"workspace_id":"ws-other","tab_id":"other-tab","label":"other","pane_count":1}],"panes":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","pane_id":"unrelated-pane","terminal_id":"unrelated-terminal","processes":[{"argv":["unrelated"]}]},{"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal","processes":[{"argv":["other"]}]}]}
+JSON
+: >"$tmp/herdr.log"
+: >"$tmp/trap.log"
+printf '%s\n' 'vault bytes must remain untouched' >"$tmp/vault/sentinel"
+
+cat >"$tmp/create.json" <<JSON
+{"action":"create","root":"$tmp/state","run":{"schema_version":1,"run_id":"run-replay","invoked_at":"2026-07-26T14:00:00Z","updated_at":"2026-07-26T14:00:00Z","task":{"id":"T03","title":"Immutable replay","path":"tasks/03.md","feature_path":"features/atlas.md","kind":"task"}}}
+JSON
+cat >"$tmp/append.json" <<JSON
+{"action":"append","root":"$tmp/state","run_id":"run-replay","updated_at":"2026-07-26T14:00:01Z","participant":{"participant_id":"replay-worker","observed_at":"2026-07-26T14:00:01Z","role":"worker","goal_id":"T03.V03","herdr":{"workspace_id":"ws-target","tab_id":"agent-tab","pane_id":"agent-pane","terminal_id":"agent-terminal"},"agent_session":{"source":"herdr:pi","kind":"path","value":"session-03"}},"lifecycle":{"observation_id":"replay-active","observed_at":"2026-07-26T14:00:01Z","kind":"verifier","goal_id":"T03.V03","state":"active","detail":"duplicate replay"}}
+JSON
+
+go test -count=1 ./internal/atlascompanion
+go build -o "$tmp/vault-hunter-atlas" ./cmd/vault-hunter-atlas
+go build -o "$tmp/t01-producer" ./cmd/vault-hunter-registry
+"$tmp/t01-producer" <"$tmp/create.json" >/dev/null
+"$tmp/t01-producer" <"$tmp/append.json" >"$tmp/produced.json"
+python3 - "$tmp/produced.json" <<'PY'
+import json, sys
+run = json.load(open(sys.argv[1]))
+assert run["revision"] == 2
+assert len(run["participants"]) == 1 and len(run["lifecycle"]) == 1
+PY
+manifest "$tmp/state" >"$tmp/state.manifest"
+manifest "$tmp/vault" >"$tmp/vault.manifest"
+
+export HERDR_FAKE_STATE="$tmp/herdr.json" HERDR_FAKE_LOG="$tmp/herdr.log"
+export ATLAS_T03_V03_TRAP_LOG="$tmp/trap.log"
+PATH="$tmp/bin:$PATH"
+export PATH
+export HOME="$tmp/home" XDG_STATE_HOME="$tmp/home/state"
+export VAULT_HUNTER_STATE_DIR="$tmp/home/retained-registry-must-not-be-used"
+
+"$tmp/vault-hunter-atlas" companion attach --run-id run-replay --workspace-id ws-target --state-dir "$tmp/state" >"$tmp/attached-before.json"
+assert_manifests
+"$tmp/vault-hunter-atlas" --run-id run-replay --state-dir "$tmp/state" --snapshot --width 100 --height 30 >"$tmp/frame-before"
+assert_manifests
+
+"$tmp/t01-producer" <"$tmp/append.json" >"$tmp/replayed.json"
+cmp "$tmp/produced.json" "$tmp/replayed.json"
+assert_manifests
+
+"$tmp/vault-hunter-atlas" --run-id run-replay --state-dir "$tmp/state" --snapshot --width 100 --height 30 >"$tmp/frame-after"
+cmp "$tmp/frame-before" "$tmp/frame-after"
+"$tmp/vault-hunter-atlas" companion attach --run-id run-replay --workspace-id ws-target --state-dir "$tmp/state" >"$tmp/attached-after.json"
+cmp "$tmp/attached-before.json" "$tmp/attached-after.json"
+assert_manifests
+
+eval "$(python3 - "$tmp/attached-before.json" <<'PY'
+import json, shlex, sys
+value = json.load(open(sys.argv[1]))
+assert value["run_id"] == "run-replay" and value["workspace_id"] == "ws-target"
+assert [(item["recorded"]["participant_id"], item["state"]) for item in value["participants"]] == [("replay-worker", "matched")]
+assert value["live_only"] is None
+for key in ("tab_id", "pane_id", "terminal_id"):
+    print(f"{key}={shlex.quote(value[key])}")
+PY
+)"
+grep -Fq 'replay-worker · worker' "$tmp/frame-before"
+grep -Fq 'verifier · active' "$tmp/frame-before"
+grep -Fq 'duplicate replay' "$tmp/frame-before"
+
+"$tmp/vault-hunter-atlas" companion cleanup --run-id run-replay --workspace-id ws-target \
+  --tab-id "$tab_id" --pane-id "$pane_id" --terminal-id "$terminal_id" --state-dir "$tmp/state" >/dev/null
+assert_manifests
+
+test ! -s "$tmp/trap.log"
+test ! -e "$tmp/home/retained-registry-must-not-be-used"
+python3 - "$tmp/herdr.json" "$tmp/herdr.log" <<'PY'
+import json, sys
+state = json.load(open(sys.argv[1]))
+assert {tab["tab_id"] for tab in state["tabs"]} == {"unrelated-tab", "other-tab"}
+assert {pane["pane_id"] for pane in state["panes"]} == {"unrelated-pane", "other-pane"}
+allowed = {("agent","list"), ("tab","list"), ("pane","list"), ("pane","process-info"), ("tab","create"), ("pane","run"), ("tab","close")}
+commands = [json.loads(line) for line in open(sys.argv[2])]
+assert commands and all(tuple(command[:2]) in allowed for command in commands), commands
+assert all(command[:2] not in (["agent","start"], ["session","create"], ["goal","create"], ["workspace","create"], ["worktree","create"]) for command in commands)
+assert sum(command[:2] == ["tab","create"] for command in commands) == 1
+assert sum(command[:2] == ["tab","close"] for command in commands) == 1
+PY
+
+echo "T03.V03 immutable replay correlation and authority boundary: PASS"

--- a/scripts/verifiers/vault-hunter-atlas-t03-v04
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v04
@@ -3,88 +3,13 @@ set -eu
 
 cd "$(dirname "$0")/../.."
 
+. scripts/verifiers/vault-hunter-atlas-t03-support
+
 tmp=$(mktemp -d)
 trap 'chmod -R u+w "$tmp"; rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/bin" "$tmp/state" "$tmp/vault" "$tmp/home"
 
-manifest() {
-  (
-    cd "$1"
-    find . -type f -print | LC_ALL=C sort | while IFS= read -r file; do
-      shasum -a 256 "$file"
-    done
-  )
-}
-assert_manifests() {
-  manifest "$tmp/state" >"$tmp/state.current"
-  manifest "$tmp/vault" >"$tmp/vault.current"
-  cmp "$tmp/state.manifest" "$tmp/state.current"
-  cmp "$tmp/vault.manifest" "$tmp/vault.current"
-}
-
-cat >"$tmp/bin/herdr" <<'PY'
-#!/usr/bin/env python3
-import json, os, shlex, sys
-
-path = os.environ["HERDR_FAKE_STATE"]
-log_path = os.environ["HERDR_FAKE_LOG"]
-args = sys.argv[1:]
-with open(path) as stream:
-    state = json.load(stream)
-with open(log_path, "a") as stream:
-    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
-
-def emit(result):
-    print(json.dumps({"id":"fake", "result":result}, separators=(",", ":")))
-
-def save():
-    with open(path, "w") as stream:
-        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
-        stream.write("\n")
-
-def option(name):
-    return args[args.index(name) + 1]
-
-if args[:2] == ["agent", "list"]:
-    emit({"type":"agent_list", "agents":state["agents"]})
-elif args[:2] == ["tab", "list"]:
-    workspace = option("--workspace")
-    emit({"type":"tab_list", "tabs":[tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
-elif args[:2] == ["pane", "list"]:
-    workspace = option("--workspace")
-    emit({"type":"pane_list", "panes":[{k:v for k,v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
-elif args[:2] == ["pane", "process-info"]:
-    pane = next((pane for pane in state["panes"] if pane["pane_id"] == option("--pane")), None)
-    if pane is None:
-        sys.exit(1)
-    emit({"type":"pane_process_info", "process_info":{"pane_id":pane["pane_id"], "foreground_processes":pane["processes"]}})
-elif args[:2] == ["tab", "create"]:
-    workspace = option("--workspace")
-    state["counter"] += 1
-    n = state["counter"]
-    tab = {"workspace_id":workspace, "tab_id":f"tab-{n}", "label":option("--label"), "pane_count":1}
-    pane = {"workspace_id":workspace, "tab_id":tab["tab_id"], "pane_id":f"pane-{n}", "terminal_id":f"term-{n}", "processes":[{"argv":["/bin/sh"]}]}
-    state["tabs"].append(tab)
-    state["panes"].append(pane)
-    save()
-    emit({"type":"tab_created", "tab":tab, "root_pane":{k:v for k,v in pane.items() if k != "processes"}})
-elif args[:2] == ["pane", "run"]:
-    pane = next(pane for pane in state["panes"] if pane["pane_id"] == args[2])
-    argv = shlex.split(args[3])
-    pane["processes"] = [{"argv":argv}, {"argv":argv[4:]}]
-    save()
-    emit({"type":"pane_run", "pane_id":args[2]})
-elif args[:2] == ["tab", "close"]:
-    tab_id = args[2]
-    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
-    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
-    save()
-    emit({"type":"tab_closed", "tab_id":tab_id})
-else:
-    print("forbidden fake Herdr action: " + " ".join(args), file=sys.stderr)
-    sys.exit(97)
-PY
-chmod +x "$tmp/bin/herdr"
+install_fake_herdr action
 
 cat >"$tmp/bin/action-trap" <<'SH'
 #!/bin/sh

--- a/scripts/verifiers/vault-hunter-atlas-t03-v04
+++ b/scripts/verifiers/vault-hunter-atlas-t03-v04
@@ -1,0 +1,209 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+tmp=$(mktemp -d)
+trap 'chmod -R u+w "$tmp"; rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/state" "$tmp/vault" "$tmp/home"
+
+manifest() {
+  (
+    cd "$1"
+    find . -type f -print | LC_ALL=C sort | while IFS= read -r file; do
+      shasum -a 256 "$file"
+    done
+  )
+}
+assert_manifests() {
+  manifest "$tmp/state" >"$tmp/state.current"
+  manifest "$tmp/vault" >"$tmp/vault.current"
+  cmp "$tmp/state.manifest" "$tmp/state.current"
+  cmp "$tmp/vault.manifest" "$tmp/vault.current"
+}
+
+cat >"$tmp/bin/herdr" <<'PY'
+#!/usr/bin/env python3
+import json, os, shlex, sys
+
+path = os.environ["HERDR_FAKE_STATE"]
+log_path = os.environ["HERDR_FAKE_LOG"]
+args = sys.argv[1:]
+with open(path) as stream:
+    state = json.load(stream)
+with open(log_path, "a") as stream:
+    stream.write(json.dumps(args, separators=(",", ":")) + "\n")
+
+def emit(result):
+    print(json.dumps({"id":"fake", "result":result}, separators=(",", ":")))
+
+def save():
+    with open(path, "w") as stream:
+        json.dump(state, stream, sort_keys=True, separators=(",", ":"))
+        stream.write("\n")
+
+def option(name):
+    return args[args.index(name) + 1]
+
+if args[:2] == ["agent", "list"]:
+    emit({"type":"agent_list", "agents":state["agents"]})
+elif args[:2] == ["tab", "list"]:
+    workspace = option("--workspace")
+    emit({"type":"tab_list", "tabs":[tab for tab in state["tabs"] if tab["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "list"]:
+    workspace = option("--workspace")
+    emit({"type":"pane_list", "panes":[{k:v for k,v in pane.items() if k != "processes"} for pane in state["panes"] if pane["workspace_id"] == workspace]})
+elif args[:2] == ["pane", "process-info"]:
+    pane = next((pane for pane in state["panes"] if pane["pane_id"] == option("--pane")), None)
+    if pane is None:
+        sys.exit(1)
+    emit({"type":"pane_process_info", "process_info":{"pane_id":pane["pane_id"], "foreground_processes":pane["processes"]}})
+elif args[:2] == ["tab", "create"]:
+    workspace = option("--workspace")
+    state["counter"] += 1
+    n = state["counter"]
+    tab = {"workspace_id":workspace, "tab_id":f"tab-{n}", "label":option("--label"), "pane_count":1}
+    pane = {"workspace_id":workspace, "tab_id":tab["tab_id"], "pane_id":f"pane-{n}", "terminal_id":f"term-{n}", "processes":[{"argv":["/bin/sh"]}]}
+    state["tabs"].append(tab)
+    state["panes"].append(pane)
+    save()
+    emit({"type":"tab_created", "tab":tab, "root_pane":{k:v for k,v in pane.items() if k != "processes"}})
+elif args[:2] == ["pane", "run"]:
+    pane = next(pane for pane in state["panes"] if pane["pane_id"] == args[2])
+    argv = shlex.split(args[3])
+    pane["processes"] = [{"argv":argv}, {"argv":argv[4:]}]
+    save()
+    emit({"type":"pane_run", "pane_id":args[2]})
+elif args[:2] == ["tab", "close"]:
+    tab_id = args[2]
+    state["tabs"] = [tab for tab in state["tabs"] if tab["tab_id"] != tab_id]
+    state["panes"] = [pane for pane in state["panes"] if pane["tab_id"] != tab_id]
+    save()
+    emit({"type":"tab_closed", "tab_id":tab_id})
+else:
+    print("forbidden fake Herdr action: " + " ".join(args), file=sys.stderr)
+    sys.exit(97)
+PY
+chmod +x "$tmp/bin/herdr"
+
+cat >"$tmp/bin/action-trap" <<'SH'
+#!/bin/sh
+printf '%s %s\n' "$0" "$*" >>"$ATLAS_T03_V04_TRAP_LOG"
+exit 97
+SH
+chmod +x "$tmp/bin/action-trap"
+for command in vault-hunter vault-hunter-registry vault-hunter-registry-writer pi codex feedback resume acceptance session goal agent workspace-create worktree-create git vault-hunter-feedback vault-hunter-resume orchestration-callback; do
+  ln -s action-trap "$tmp/bin/$command"
+done
+
+cat >"$tmp/herdr.json" <<'JSON'
+{"counter":40,"agents":[{"name":"matched-worker","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"matched-tab","pane_id":"matched-pane","terminal_id":"matched-terminal","agent_session":{"source":"herdr:pi","kind":"path","value":"session-exact"}},{"name":"contradictory-worker","agent":"pi","agent_status":"working","workspace_id":"ws-target","tab_id":"contradictory-tab","pane_id":"contradictory-pane","terminal_id":"contradictory-terminal","agent_session":{"source":"herdr:pi","kind":"path","value":"session-live"}},{"name":"near-match","agent":"pi","agent_status":"done","workspace_id":"ws-target","tab_id":"stale-tab","pane_id":"stale-pane","terminal_id":"different-terminal"},{"name":"live-only","agent":"codex","agent_status":"idle","workspace_id":"ws-other","tab_id":"live-tab","pane_id":"live-pane","terminal_id":"live-terminal"}],"tabs":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","label":"unrelated","pane_count":1},{"workspace_id":"ws-other","tab_id":"other-tab","label":"other","pane_count":1}],"panes":[{"workspace_id":"ws-target","tab_id":"unrelated-tab","pane_id":"unrelated-pane","terminal_id":"unrelated-terminal","processes":[{"argv":["unrelated"]}]},{"workspace_id":"ws-other","tab_id":"other-tab","pane_id":"other-pane","terminal_id":"other-terminal","processes":[{"argv":["other"]}]}]}
+JSON
+: >"$tmp/herdr.log"
+: >"$tmp/trap.log"
+printf '%s\n' 'vault bytes must remain untouched' >"$tmp/vault/sentinel"
+
+python3 - "$tmp" <<'PY'
+import json, os, sys
+root = sys.argv[1]
+requests = [
+    {"action":"create", "root":root+"/state", "run":{"schema_version":1, "run_id":"run-e2e", "invoked_at":"2026-07-26T15:00:00Z", "updated_at":"2026-07-26T15:00:00Z", "task":{"id":"T03", "title":"End-to-end conformance", "path":"tasks/03.md", "feature_path":"features/atlas.md", "kind":"task"}}},
+    {"action":"append", "root":root+"/state", "run_id":"run-e2e", "updated_at":"2026-07-26T15:00:01Z", "participant":{"participant_id":"matched-worker", "observed_at":"2026-07-26T15:00:01Z", "role":"worker", "goal_id":"T03.V04", "herdr":{"workspace_id":"ws-target", "tab_id":"matched-tab", "pane_id":"matched-pane", "terminal_id":"matched-terminal"}, "agent_session":{"source":"herdr:pi", "kind":"path", "value":"session-exact"}}, "lifecycle":{"observation_id":"e2e-active", "observed_at":"2026-07-26T15:00:01Z", "kind":"verifier", "goal_id":"T03.V04", "state":"active", "detail":"end-to-end attach"}},
+    {"action":"append", "root":root+"/state", "run_id":"run-e2e", "updated_at":"2026-07-26T15:00:02Z", "participant":{"participant_id":"contradictory-worker", "observed_at":"2026-07-26T15:00:02Z", "role":"reviewer", "goal_id":"T03.V04", "herdr":{"workspace_id":"ws-target", "tab_id":"contradictory-tab", "pane_id":"contradictory-pane", "terminal_id":"contradictory-terminal"}, "agent_session":{"source":"herdr:pi", "kind":"path", "value":"session-recorded"}}},
+    {"action":"append", "root":root+"/state", "run_id":"run-e2e", "updated_at":"2026-07-26T15:00:03Z", "participant":{"participant_id":"stale-worker", "observed_at":"2026-07-26T15:00:03Z", "role":"observer", "goal_id":"T03.V04", "herdr":{"workspace_id":"ws-target", "tab_id":"stale-tab", "pane_id":"stale-pane", "terminal_id":"stale-terminal"}}},
+    {"action":"append", "root":root+"/state", "run_id":"run-e2e", "updated_at":"2026-07-26T15:00:04Z", "participant":{"participant_id":"recorded-only", "observed_at":"2026-07-26T15:00:04Z", "role":"observer", "goal_id":"T03.V04"}, "lifecycle":{"observation_id":"e2e-ready", "observed_at":"2026-07-26T15:00:04Z", "kind":"verifier", "goal_id":"T03.V04", "state":"ready", "detail":"mixed identities recorded"}},
+]
+for i, request in enumerate(requests):
+    with open(os.path.join(root, f"request-{i}.json"), "w") as stream:
+        json.dump(request, stream, separators=(",", ":"))
+PY
+
+go test -count=1 ./internal/atlascompanion
+go build -o "$tmp/vault-hunter-atlas" ./cmd/vault-hunter-atlas
+go build -o "$tmp/t01-producer" ./cmd/vault-hunter-registry
+for request in "$tmp"/request-*.json; do
+  "$tmp/t01-producer" <"$request" >"$tmp/produced.json"
+done
+python3 - "$tmp/produced.json" "$tmp/state" <<'PY'
+import json, os, sys
+run = json.load(open(sys.argv[1]))
+assert run["revision"] == 5 and run["task"]["kind"] == "task"
+assert len(run["participants"]) == 4 and len(run["lifecycle"]) == 2
+assert os.listdir(os.path.join(sys.argv[2], "runs")) == ["run-e2e.json"]
+PY
+manifest "$tmp/state" >"$tmp/state.manifest"
+manifest "$tmp/vault" >"$tmp/vault.manifest"
+chmod -R a-w "$tmp/state" "$tmp/vault"
+
+export HERDR_FAKE_STATE="$tmp/herdr.json" HERDR_FAKE_LOG="$tmp/herdr.log"
+export ATLAS_T03_V04_TRAP_LOG="$tmp/trap.log"
+PATH="$tmp/bin:$PATH"
+export PATH
+export HOME="$tmp/home" XDG_STATE_HOME="$tmp/home/state"
+export VAULT_HUNTER_STATE_DIR="$tmp/home/retained-registry-must-not-be-used"
+
+"$tmp/vault-hunter-atlas" companion attach --run-id run-e2e --workspace-id ws-target --state-dir "$tmp/state" >"$tmp/attached-first.json"
+assert_manifests
+"$tmp/vault-hunter-atlas" --run-id run-e2e --state-dir "$tmp/state" --snapshot --width 120 --height 40 >"$tmp/frame"
+assert_manifests
+"$tmp/vault-hunter-atlas" companion attach --run-id run-e2e --workspace-id ws-target --state-dir "$tmp/state" >"$tmp/attached-second.json"
+cmp "$tmp/attached-first.json" "$tmp/attached-second.json"
+assert_manifests
+
+eval "$(python3 - "$tmp/attached-first.json" "$tmp/herdr.json" "$tmp/vault-hunter-atlas" "$tmp/state" <<'PY'
+import json, shlex, sys
+value = json.load(open(sys.argv[1]))
+state = json.load(open(sys.argv[2]))
+atlas, registry = sys.argv[3:]
+assert value["run_id"] == "run-e2e" and value["workspace_id"] == "ws-target"
+by_id = {item["recorded"]["participant_id"]:item for item in value["participants"]}
+assert {key:item["state"] for key,item in by_id.items()} == {"matched-worker":"matched", "contradictory-worker":"contradictory", "stale-worker":"stale", "recorded-only":"recorded-only"}
+assert {key:by_id["matched-worker"]["live"][key] for key in ("workspace_id", "tab_id", "pane_id", "terminal_id")} == {"workspace_id":"ws-target", "tab_id":"matched-tab", "pane_id":"matched-pane", "terminal_id":"matched-terminal"}
+assert by_id["matched-worker"]["live"]["agent_session"] == {"source":"herdr:pi", "kind":"path", "value":"session-exact"}
+assert by_id["contradictory-worker"]["live"]["agent_session"]["value"] == "session-live"
+assert "live" not in by_id["stale-worker"] and "live" not in by_id["recorded-only"]
+assert {item["terminal_id"] for item in value["live_only"]} == {"different-terminal", "live-terminal"}
+assert sum(tab["label"].startswith("Vault Hunter Atlas · ") for tab in state["tabs"]) == 1
+assert any(pane["pane_id"] == value["pane_id"] and pane["tab_id"] == value["tab_id"] and pane["terminal_id"] == value["terminal_id"] for pane in state["panes"])
+want = [atlas, "--run-id", "run-e2e", "--state-dir", registry]
+assert sum(process["argv"] == want for pane in state["panes"] for process in pane["processes"]) == 1
+for key in ("tab_id", "pane_id", "terminal_id"):
+    print(f"{key}={shlex.quote(value[key])}")
+PY
+)"
+grep -Fq 'matched-worker · worker' "$tmp/frame"
+grep -Fq 'contradictory-worker · reviewer' "$tmp/frame"
+grep -Fq 'verifier · ready' "$tmp/frame"
+grep -Fq 'mixed identities recorded' "$tmp/frame"
+
+"$tmp/vault-hunter-atlas" companion cleanup --run-id run-e2e --workspace-id ws-target \
+  --tab-id "$tab_id" --pane-id "$pane_id" --terminal-id "$terminal_id" --state-dir "$tmp/state" >"$tmp/cleaned.json"
+python3 - "$tmp/attached-first.json" "$tmp/cleaned.json" <<'PY'
+import json, sys
+attached, cleaned = (json.load(open(path)) for path in sys.argv[1:])
+assert {key:attached[key] for key in cleaned} == cleaned
+PY
+assert_manifests
+
+test ! -s "$tmp/trap.log"
+test ! -e "$tmp/home/retained-registry-must-not-be-used"
+python3 - "$tmp/herdr.json" "$tmp/herdr.log" "$tab_id" "$pane_id" <<'PY'
+import json, sys
+state = json.load(open(sys.argv[1]))
+commands = [json.loads(line) for line in open(sys.argv[2])]
+owned_tab, owned_pane = sys.argv[3:]
+assert {tab["tab_id"] for tab in state["tabs"]} == {"unrelated-tab", "other-tab"}
+assert {pane["pane_id"] for pane in state["panes"]} == {"unrelated-pane", "other-pane"}
+allowed = {("agent","list"), ("tab","list"), ("pane","list"), ("pane","process-info"), ("tab","create"), ("pane","run"), ("tab","close")}
+assert commands and all(tuple(command[:2]) in allowed for command in commands), commands
+assert all(command[:2] not in (["agent","start"], ["session","create"], ["goal","create"], ["workspace","create"], ["worktree","create"]) for command in commands)
+assert sum(command[:2] == ["tab","create"] for command in commands) == 1
+assert sum(command[:2] == ["pane","run"] for command in commands) == 1
+assert sum(command[:2] == ["tab","close"] for command in commands) == 1
+created = next(command for command in commands if command[:2] == ["tab","create"])
+assert created[created.index("--workspace") + 1] == "ws-target" and created[-1] == "--no-focus"
+assert next(command for command in commands if command[:2] == ["pane","run"])[2] == owned_pane
+assert next(command for command in commands if command[:2] == ["tab","close"])[2] == owned_tab
+PY
+
+echo "T03.V04 producer-to-companion end-to-end conformance: PASS"

--- a/scripts/verify-vault-hunter-atlas
+++ b/scripts/verify-vault-hunter-atlas
@@ -22,8 +22,11 @@ case "${1-}" in
   T03.V01)
     exec scripts/verifiers/vault-hunter-atlas-t03-v01
     ;;
+  T03.V02)
+    exec scripts/verifiers/vault-hunter-atlas-t03-v02
+    ;;
   *)
-    echo "usage: scripts/verify-vault-hunter-atlas T01.V01|T01.V02|T02.V01|T02.V02|T02.V03|T03.V01" >&2
+    echo "usage: scripts/verify-vault-hunter-atlas T01.V01|T01.V02|T02.V01|T02.V02|T02.V03|T03.V01|T03.V02" >&2
     exit 2
     ;;
 esac

--- a/scripts/verify-vault-hunter-atlas
+++ b/scripts/verify-vault-hunter-atlas
@@ -25,8 +25,11 @@ case "${1-}" in
   T03.V02)
     exec scripts/verifiers/vault-hunter-atlas-t03-v02
     ;;
+  T03.V03)
+    exec scripts/verifiers/vault-hunter-atlas-t03-v03
+    ;;
   *)
-    echo "usage: scripts/verify-vault-hunter-atlas T01.V01|T01.V02|T02.V01|T02.V02|T02.V03|T03.V01|T03.V02" >&2
+    echo "usage: scripts/verify-vault-hunter-atlas T01.V01|T01.V02|T02.V01|T02.V02|T02.V03|T03.V01|T03.V02|T03.V03" >&2
     exit 2
     ;;
 esac

--- a/scripts/verify-vault-hunter-atlas
+++ b/scripts/verify-vault-hunter-atlas
@@ -19,8 +19,11 @@ case "${1-}" in
   T02.V03)
     exec scripts/verifiers/vault-hunter-atlas-v03
     ;;
+  T03.V01)
+    exec scripts/verifiers/vault-hunter-atlas-t03-v01
+    ;;
   *)
-    echo "usage: scripts/verify-vault-hunter-atlas T01.V01|T01.V02|T02.V01|T02.V02|T02.V03" >&2
+    echo "usage: scripts/verify-vault-hunter-atlas T01.V01|T01.V02|T02.V01|T02.V02|T02.V03|T03.V01" >&2
     exit 2
     ;;
 esac

--- a/scripts/verify-vault-hunter-atlas
+++ b/scripts/verify-vault-hunter-atlas
@@ -28,8 +28,11 @@ case "${1-}" in
   T03.V03)
     exec scripts/verifiers/vault-hunter-atlas-t03-v03
     ;;
+  T03.V04)
+    exec scripts/verifiers/vault-hunter-atlas-t03-v04
+    ;;
   *)
-    echo "usage: scripts/verify-vault-hunter-atlas T01.V01|T01.V02|T02.V01|T02.V02|T02.V03|T03.V01|T03.V02|T03.V03" >&2
+    echo "usage: scripts/verify-vault-hunter-atlas T01.V01|T01.V02|T02.V01|T02.V02|T02.V03|T03.V01|T03.V02|T03.V03|T03.V04" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary
- add a Reader-only Atlas companion CLI for eligible Vault Hunter Task Runs
- correlate exact recorded Herdr and agent-session identities with live state
- enforce fail-closed exact-one attachment, replacement, rollback, and cleanup
- add T03 V01-V04 conformance verifiers with shared fake-Herdr support

## Validation
- scripts/verify-vault-hunter-atlas T03.V01
- scripts/verify-vault-hunter-atlas T03.V02
- scripts/verify-vault-hunter-atlas T03.V03
- scripts/verify-vault-hunter-atlas T03.V04
- go test -count=1 ./...
- go vet ./...
- complete 14-check evidence: T03.FINAL.EX03 (all exit 0)
- independent review convergence: accept, no actionable findings