### PR TITLE
Document current Sidekick context keymaps

### DIFF
--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -363,6 +363,8 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - `<C-.>` toggles the last picker-selected Sidekick session, falling back to the cwd session picker.
 - `<C-;>` opens the local session picker.
 - `<C-r>` renames the selected session in the picker.
+- `<leader>at` sends the current context/object through Sidekick's native `{this}` placeholder.
+- `<leader>ap` opens prompt selection.
 - Sidekick supports sending context, prompting, toggling float/split, opening local sessions, and creating named sessions.
 - Sidekick keymaps include ask/edit/apply/reject/yank, context/prompt sending, the local picker, and named-session creation.
 - Sidekick cwd session picker includes previews.


### PR DESCRIPTION
Adds explicit `<leader>at` and `<leader>ap` behavior to the current feature inventory.

Docs-only.

Validation passed:
- `scripts/verify-nvim agent-keymaps`
- `scripts/verify-project-structure`
- `PASS T03 context documentation sync`