### PR TITLE
docs: evaluate libvirt user VM machine types

### DIFF
--- a/ops/pi-user-vm/machine-type-evaluation.md
+++ b/ops/pi-user-vm/machine-type-evaluation.md
@@ -474,3 +474,204 @@ The following resources are intentionally retained exclusively for immediate V03
 - SSH state directory `/home/avirus/.local/state/t20-v02-q35` (owner `avirus:avirus`, mode 700), containing private key `id_ed25519` (mode 600), its public key, and `known_hosts`. The exact private-key path is `/home/avirus/.local/state/t20-v02-q35/id_ed25519`; its contents were never printed or committed.
 
 V03 owns final teardown: gracefully stop `t20-v02-q35`, undefine it with its NVRAM, destroy/undefine `t20-v02-pool`, and remove `/var/tmp/t20-v02-pool` plus `/home/avirus/.local/state/t20-v02-q35`. Any ordinary dynamic DHCP record should be left for normal expiry rather than changing the shared `default` network. V02 did not execute V03 lifecycle checks or teardown. Unrelated host state, including the existing network, firewall, Tailscale state, services, other domains/pools/files, and the STT Worker VM, was left untouched.
+
+## V03 cold-lifecycle and persistence verifier evidence
+
+The canonical Run's immutable pre-V02 absence evidence remains the accepted V03 baseline-red proof. V03 did not inspect or edit the vault or touch its foreign-owned shared lock. The artifact entered V03 at commit `7422e330c6ef0b4a5c8c2c7abcad7a0faf85dd63`, tree `b12ceb6ff1f2010b8b8935d44c37d73cbe06fb93`, and SHA-256 `e61584126a6e50765e57ff2629a6a932525b7434305e06454b085bbc5e1e822b`, with a clean worktree.
+
+### Ownership and address preflight
+
+The exact outer invocation for each host-side block in this section was `ssh -o BatchMode=yes homelab 'bash -s'`; no `sudo` was used. The preflight block used `set -eu` and ran at `2026-07-26T17:39:09Z`. Its gating reads were:
+
+```sh
+T20_URI='qemu:///system'
+T20_DOMAIN='t20-v02-q35'
+T20_POOL='t20-v02-pool'
+T20_KEY='/home/avirus/.local/state/t20-v02-q35/id_ed25519'
+id -un
+virsh -c "$T20_URI" uri
+virsh -c "$T20_URI" dominfo "$T20_DOMAIN"
+virsh -c "$T20_URI" pool-info "$T20_POOL"
+virsh -c "$T20_URI" domblklist "$T20_DOMAIN" --details
+virsh -c "$T20_URI" pool-dumpxml "$T20_POOL"
+virsh -c "$T20_URI" dumpxml "$T20_DOMAIN"
+stat -c 'path=%n owner=%U:%G mode=%a type=%F' \
+  /var/tmp/t20-v02-pool \
+  /var/tmp/t20-v02-pool/t20-v02-q35.qcow2 \
+  /var/tmp/t20-v02-pool/t20-v02-q35-seed.img \
+  /var/lib/libvirt/qemu/nvram/t20-v02-q35_VARS.fd \
+  /home/avirus/.local/state/t20-v02-q35 \
+  "$T20_KEY" \
+  /home/avirus/.local/state/t20-v02-q35/id_ed25519.pub \
+  /home/avirus/.local/state/t20-v02-q35/known_hosts
+T20_IP=$(virsh -c "$T20_URI" domifaddr "$T20_DOMAIN" --source lease | awk '$3 == "ipv4" {sub(/\/.*/, "", $4); print $4; exit}')
+test -n "$T20_IP"
+test "$(stat -c %a "$T20_KEY")" = 600
+test "$(stat -c %U:%G "$T20_KEY")" = avirus:avirus
+test "$(virsh -c "$T20_URI" domstate "$T20_DOMAIN")" = running
+test "$(virsh -c "$T20_URI" dominfo "$T20_DOMAIN" | awk -F: '/^Autostart:/ {gsub(/[ \t]/, "", $2); print $2}')" = disable
+test "$(virsh -c "$T20_URI" pool-info "$T20_POOL" | awk -F: '/^State:/ {gsub(/[ \t]/, "", $2); print $2}')" = running
+test "$(virsh -c "$T20_URI" pool-info "$T20_POOL" | awk -F: '/^Autostart:/ {gsub(/[ \t]/, "", $2); print $2}')" = no
+if ss -H -ltn 'sport = :18767' | grep -q .; then exit 1; fi
+```
+
+Selected output is redacted only by omitting UUIDs, MAC addresses, XML not needed by the checks, and all key contents (which were not read):
+
+```text
+operator=avirus
+uri=qemu:///system
+domain_name=t20-v02-q35
+domain_state=running
+domain_persistent=yes
+domain_autostart=disable
+pool_name=t20-v02-pool
+pool_state=running
+pool_persistent=yes
+pool_autostart=no
+domain_block_devices:
+ file   disk     vda      /var/tmp/t20-v02-pool/t20-v02-q35.qcow2
+ file   disk     vdb      /var/tmp/t20-v02-pool/t20-v02-q35-seed.img
+pool_target=/var/tmp/t20-v02-pool
+domain_nvram=/var/lib/libvirt/qemu/nvram/t20-v02-q35_VARS.fd
+path=/var/tmp/t20-v02-pool owner=avirus:avirus mode=755 type=directory
+path=/var/tmp/t20-v02-pool/t20-v02-q35.qcow2 owner=libvirt-qemu:kvm mode=644 type=regular file
+path=/var/tmp/t20-v02-pool/t20-v02-q35-seed.img owner=libvirt-qemu:kvm mode=644 type=regular file
+path=/var/lib/libvirt/qemu/nvram/t20-v02-q35_VARS.fd owner=libvirt-qemu:kvm mode=600 type=regular file
+path=/home/avirus/.local/state/t20-v02-q35 owner=avirus:avirus mode=700 type=directory
+path=/home/avirus/.local/state/t20-v02-q35/id_ed25519 owner=avirus:avirus mode=600 type=regular file
+path=/home/avirus/.local/state/t20-v02-q35/id_ed25519.pub owner=avirus:avirus mode=644 type=regular file
+path=/home/avirus/.local/state/t20-v02-q35/known_hosts owner=avirus:avirus mode=644 type=regular file
+guest_address=192.168.122.164
+listener_18767=absent
+preflight=PASS
+local_ssh_wrapper_exit=0
+```
+
+This matched the V02 handoff exactly, so no ownership conflict was present and V03 continued.
+
+### Complete cold-lifecycle verifier
+
+Two preliminary invocations are recorded for completeness. At `2026-07-26T17:39:54Z`, `timeout 60 ssh_guest ...` attempted to pass a shell function to `timeout`; `timeout` returned 127 (`failed to run command 'ssh_guest': No such file or directory`) before any guest command or state change. At `17:40:32Z–17:40:35Z`, the corrected invocation created and synced marker `T20-V03-PERSIST-20260726T174032Z-2828916`, gracefully reached `shut off` on poll 2, and started the domain, but its SSH polling helper lacked `ssh -n` and consumed the remaining parent standard input. The host wrapper exited 0 without recording the required post-start assertions; that incomplete result was not accepted. It left the guest running and the marker in place. The complete invocation below replaced that marker with a new unique value and removed the marker path after all assertions passed.
+
+The accepted verifier ran under `set -eu`. These are its exact lifecycle commands (the address was freshly obtained from `virsh domifaddr --source lease` immediately before the shown block):
+
+```sh
+T20_URI='qemu:///system'
+T20_DOMAIN='t20-v02-q35'
+T20_POOL='t20-v02-pool'
+T20_IP=$(virsh -c "$T20_URI" domifaddr "$T20_DOMAIN" --source lease | awk '$3 == "ipv4" {sub(/\/.*/, "", $4); print $4; exit}')
+test -n "$T20_IP"
+T20_GUEST="t20eval@$T20_IP"
+T20_KEY='/home/avirus/.local/state/t20-v02-q35/id_ed25519'
+T20_KNOWN_HOSTS='/home/avirus/.local/state/t20-v02-q35/known_hosts'
+T20_MARKER="T20-V03-PERSIST-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+ssh_guest() {
+  ssh -n -i "$T20_KEY" -o BatchMode=yes -o IdentitiesOnly=yes \
+    -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$T20_KNOWN_HOSTS" \
+    -o ConnectTimeout=2 "$T20_GUEST" "$@"
+}
+
+timeout 60 ssh -i "$T20_KEY" -o BatchMode=yes -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$T20_KNOWN_HOSTS" \
+  -o ConnectTimeout=2 "$T20_GUEST" "bash -s -- '$T20_MARKER'" <<'GUEST_CREATE'
+set -eu
+expected=$1
+marker_path="$HOME/.t20-v03-persistence"
+printf '%s\n' "$expected" >"$marker_path"
+sync
+actual=$(cat "$marker_path")
+test "$actual" = "$expected"
+printf 'marker_created=%s\n' "$actual"
+printf 'marker_sync=pass\n'
+GUEST_CREATE
+
+virsh -c "$T20_URI" shutdown "$T20_DOMAIN"
+stop_attempts=0
+stop_state=''
+while [ "$stop_attempts" -lt 60 ]; do
+  stop_attempts=$((stop_attempts + 1))
+  stop_state=$(virsh -c "$T20_URI" domstate "$T20_DOMAIN")
+  if [ "$stop_state" = 'shut off' ]; then break; fi
+  if [ "$stop_attempts" -lt 60 ]; then sleep 2; fi
+done
+test "$stop_state" = 'shut off'
+
+virsh -c "$T20_URI" start "$T20_DOMAIN"
+ssh_attempts=0
+ssh_ready=false
+while [ "$ssh_attempts" -lt 60 ]; do
+  ssh_attempts=$((ssh_attempts + 1))
+  if ssh_guest /usr/bin/true >/dev/null 2>&1; then
+    ssh_ready=true
+    break
+  fi
+  if [ "$ssh_attempts" -lt 60 ]; then sleep 3; fi
+done
+test "$ssh_ready" = true
+
+timeout 60 ssh -i "$T20_KEY" -o BatchMode=yes -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$T20_KNOWN_HOSTS" \
+  -o ConnectTimeout=2 "$T20_GUEST" "bash -s -- '$T20_MARKER'" <<'GUEST_VERIFY'
+set -eu
+expected=$1
+marker_path="$HOME/.t20-v03-persistence"
+actual=$(cat "$marker_path")
+test "$actual" = "$expected"
+printf 'persisted_marker=%s exact_match=yes\n' "$actual"
+systemd-run --user --wait --collect --quiet /usr/bin/true
+printf 'systemd_user_transient=pass\n'
+rm -f -- "$marker_path"
+test ! -e "$marker_path"
+printf 'marker_removed=yes\n'
+GUEST_VERIFY
+
+test "$(virsh -c "$T20_URI" domstate "$T20_DOMAIN")" = running
+test "$(virsh -c "$T20_URI" dominfo "$T20_DOMAIN" | awk -F: '/^Autostart:/ {gsub(/[ \t]/, "", $2); print $2}')" = disable
+test "$(virsh -c "$T20_URI" pool-info "$T20_POOL" | awk -F: '/^State:/ {gsub(/[ \t]/, "", $2); print $2}')" = running
+test "$(virsh -c "$T20_URI" pool-info "$T20_POOL" | awk -F: '/^Autostart:/ {gsub(/[ \t]/, "", $2); print $2}')" = no
+test "$(stat -c %a "$T20_KEY")" = 600
+test -f /var/tmp/t20-v02-pool/t20-v02-q35.qcow2
+test -f /var/tmp/t20-v02-pool/t20-v02-q35-seed.img
+test -f /var/lib/libvirt/qemu/nvram/t20-v02-q35_VARS.fd
+test -f "$T20_KEY"
+if ss -H -ltn 'sport = :18767' | grep -q .; then exit 1; fi
+```
+
+The complete invocation ran from `2026-07-26T17:41:32Z` through `17:41:46Z`. Relevant output was:
+
+```text
+guest_address=192.168.122.164
+marker_created=T20-V03-PERSIST-20260726T174132Z-2837397
+marker_sync=pass
+marker_create_ssh_exit=0
+shutdown_request_utc=2026-07-26T17:41:33Z
+Domain 't20-v02-q35' is being shutdown
+virsh_shutdown_exit=0
+shutdown_observed_utc=2026-07-26T17:41:35Z
+shutdown_state=shut off poll_attempts=2 max_attempts=60 delay_seconds=2
+start_request_utc=2026-07-26T17:41:35Z
+Domain 't20-v02-q35' started
+virsh_start_exit=0
+ssh_ready_utc=2026-07-26T17:41:46Z
+batch_ssh_ready=true poll_attempts=3 max_attempts=60 delay_seconds=3
+persisted_marker=T20-V03-PERSIST-20260726T174132Z-2837397 exact_match=yes
+systemd_user_transient=pass
+marker_removed=yes
+post_start_guest_check_exit=0
+postcheck_utc=2026-07-26T17:41:46Z
+domain_state=running
+domain_autostart=disable
+pool_state=running
+pool_autostart=no
+listener_18767=absent
+retained_disk_seed_nvram_ssh_state=yes
+v03_end_utc=2026-07-26T17:41:46Z
+V03_VERIFIER=PASS
+local_ssh_wrapper_exit=0
+```
+
+### Retained state and later cleanup obligation
+
+V03 deliberately performed no final cleanup. Domain `t20-v02-q35` remains running and persistent with autostart disabled; pool `t20-v02-pool` remains active and persistent with autostart `no`. The qcow2 disk, seed image, libvirt-managed NVRAM, and complete SSH state remain at the V02 paths and ownership/modes shown above. The V03 marker was removed, and listener port 18767 remains absent. V03 did not run the V02 listener and did not inspect or alter Tailscale, networking, the firewall, unrelated resources, or the STT Worker VM.
+
+A later authorized cleanup still must gracefully stop `t20-v02-q35`, undefine it with its NVRAM, destroy and undefine `t20-v02-pool`, and remove `/var/tmp/t20-v02-pool` and `/home/avirus/.local/state/t20-v02-q35`. Leave any dynamic DHCP record for normal expiry; do not alter the shared `default` network.

--- a/ops/pi-user-vm/machine-type-evaluation.md
+++ b/ops/pi-user-vm/machine-type-evaluation.md
@@ -2,7 +2,7 @@
 
 **Evaluation host:** `homelab` (Linux/KVM)
 **Evidence collected:** 2026-07-26 15:42:14Z–15:55:28Z
-**Status:** recommendation complete; **final owner approval is pending** at the parent/user checkpoint. No production VM was provisioned and no vault ADR was changed.
+**Status:** recommendation complete and **owner approved**. Canonical approval source: Vault Hunter Run `vh-T20-1785077639159`, Run observation `T20.V01.q35-selection.approved.2026-07-26` at Registry revision 12. No production VM was provisioned and no vault ADR was changed; the required new vault ADR remains pending before V02.
 
 ## Recommendation
 
@@ -10,7 +10,7 @@ Recommend **QEMU/KVM Q35**, managed by libvirt's QEMU driver at `qemu:///system`
 
 Both Q35 and a carefully minimized `microvm` booted the approved Ubuntu fixture and passed the same block, network, console, and cold-lifecycle probes. The approved tie-break is operational maturity and compatibility first. Q35 worked through the ordinary `virt-install` path with Ubuntu 24.04 OS metadata and UEFI. `microvm` first failed with `No PCI buses available` and required hand-authored XML, explicit `virtio-mmio` addresses, and explicit suppression of libvirt's implicit USB, balloon, and video devices. That narrower and less conventional device/firmware path provides no material benefit required by T20, so Q35 wins the tie-break. Cloud Hypervisor cannot be managed by the installed libvirt build and was excluded before boot.
 
-This is a recommendation, not an owner-approved selection. After owner approval, create the required new vault ADR before V02; do not treat this document as that ADR.
+This is an owner-approved selection. Create the required new vault ADR before V02; do not treat this document as that ADR.
 
 ## Fixture and host identity
 
@@ -41,13 +41,13 @@ The image was downloaded only to `/var/tmp/t20-v01-work`, copied into the dispos
 | Graceful stop/start | **Pass.** `virsh shutdown` reached `shut off` on poll 2; start succeeded; SSH returned on poll 3. | **Pass.** Same result. | Not testable because native management is unavailable. |
 | Stable alias / version pin | **Recommend stable alias `q35`.** Record resolved `pc-q35-noble` as V02's expected XML value on this host; do not request the downstream resolved name as a production pin. | If selected, request stable `microvm`; no versioned alternative was reported. Rejected. | Not applicable. |
 | Material limitations | Larger, conventional PC/PCI device surface; host-specific alias resolution means V02 must compare against the live observed value recorded below. | Default Ubuntu `virt-install` XML was incompatible; no automatic x86 EFI firmware was advertised for `microvm`; reduced PCI/USB/video/balloon support; requires specialized XML and virtio-mmio devices. | Installed libvirt has no `ch` connection driver, and the hypervisor executable is absent. |
-| Disposition / rejection reason | **Recommended, owner approval pending.** Best maturity and compatibility. | **Rejected by tie-break**, despite functional probes: materially more specialized integration for no required benefit. | **Rejected/unavailable:** no native libvirt management on the target host. |
+| Disposition / rejection reason | **Recommended and owner approved.** Best maturity and compatibility. | **Rejected by tie-break**, despite functional probes: materially more specialized integration for no required benefit. | **Rejected/unavailable:** no native libvirt management on the target host. |
 
 The DHCP addresses above are historical evidence only. Both domains, their interfaces, storage, and scratch data were removed; no evaluated guest is currently reachable at either value. Any DHCP lease-record expiry remains owned by the unchanged existing network.
 
 ## Reproduction values for V02 and V03
 
-These values describe the recommended configuration. They are intentionally **not yet executable**: owner approval and a new ADR must precede V02, and values that can exist only after the V02 disposable guest and TCP probe are prepared are explicitly TBD rather than invented.
+These values describe the recommended configuration. They are intentionally **not yet executable**: a new ADR must precede V02, and values that can exist only after the V02 disposable guest and TCP probe are prepared are explicitly TBD rather than invented.
 
 ```sh
 T20_URI='qemu:///system'
@@ -62,7 +62,7 @@ T20_PEER_PORT='TBD before V02'
 
 Before V02:
 
-1. obtain owner approval and add the separate machine-type ADR;
+1. add the separate machine-type ADR;
 2. create a new disposable `t20-v02-q35` by requesting `q35` through `qemu:///system` (do not recreate or reuse either V01 domain);
 3. set `T20_GUEST` to that guest's actual `user@address`;
 4. select and start the operator-owned same-libvirt-network TCP peer, then replace both peer TBD values; and
@@ -361,4 +361,4 @@ cleanup_failed=0
 - [x] Unknown guest/TCP-peer values are `TBD before V02`, not invented.
 - [x] Operational maturity and compatibility are applied as the approved tie-break.
 - [x] Disposable resources were prefixed `t20-`, did not reuse an existing name/path, had autostart disabled, and were removed.
-- [ ] Final owner approval is deliberately pending. This is the one V01 contract item not yet satisfiable by the implementation writer; the exact required human decision is to approve or reject the QEMU/KVM Q35 recommendation at the parent/user checkpoint.
+- [x] Final owner approval of the QEMU/KVM Q35 recommendation is recorded from the canonical source above.

--- a/ops/pi-user-vm/machine-type-evaluation.md
+++ b/ops/pi-user-vm/machine-type-evaluation.md
@@ -1,8 +1,8 @@
-# T20 V01 machine-type evaluation
+# T20 Q35 machine-type evaluation and V02 evidence
 
 **Evaluation host:** `homelab` (Linux/KVM)
-**Evidence collected:** 2026-07-26 15:42:14Z–15:55:28Z
-**Status:** recommendation complete and **owner approved**. Canonical approval source: Vault Hunter Run `vh-T20-1785077639159`, Run observation `T20.V01.q35-selection.approved.2026-07-26` at Registry revision 12. No production VM was provisioned and no vault ADR was changed; the required new vault ADR remains pending before V02.
+**Evidence collected:** V01: 2026-07-26 15:42:14Z–15:55:28Z; V02: 2026-07-26 17:23:04Z–17:26:33Z
+**Status:** V01 recommendation complete and **owner approved**; V02 verifier **passed**. Canonical V01 approval source: Vault Hunter Run `vh-T20-1785077639159`, Run observation `T20.V01.q35-selection.approved.2026-07-26` at Registry revision 12. The V02 host-local endpoint was separately approved in Run observation `T20.V02.host-local-probe.approved.2026-07-26`. No production VM was provisioned and no vault path was inspected or changed during V02.
 
 ## Recommendation
 
@@ -10,7 +10,7 @@ Recommend **QEMU/KVM Q35**, managed by libvirt's QEMU driver at `qemu:///system`
 
 Both Q35 and a carefully minimized `microvm` booted the approved Ubuntu fixture and passed the same block, network, console, and cold-lifecycle probes. The approved tie-break is operational maturity and compatibility first. Q35 worked through the ordinary `virt-install` path with Ubuntu 24.04 OS metadata and UEFI. `microvm` first failed with `No PCI buses available` and required hand-authored XML, explicit `virtio-mmio` addresses, and explicit suppression of libvirt's implicit USB, balloon, and video devices. That narrower and less conventional device/firmware path provides no material benefit required by T20, so Q35 wins the tie-break. Cloud Hypervisor cannot be managed by the installed libvirt build and was excluded before boot.
 
-This is an owner-approved selection. Create the required new vault ADR before V02; do not treat this document as that ADR.
+This is an owner-approved selection. This document is implementation evidence, not a vault ADR. V02 was performed under the canonical Run authorization while the shared vault lock was held elsewhere; no vault aggregate state was inspected or changed.
 
 ## Fixture and host identity
 
@@ -47,28 +47,20 @@ The DHCP addresses above are historical evidence only. Both domains, their inter
 
 ## Reproduction values for V02 and V03
 
-These values describe the recommended configuration. They are intentionally **not yet executable**: a new ADR must precede V02, and values that can exist only after the V02 disposable guest and TCP probe are prepared are explicitly TBD rather than invented.
+These are the literal values observed and verified during V02:
 
 ```sh
 T20_URI='qemu:///system'
 T20_DOMAIN='t20-v02-q35'
-T20_GUEST='TBD before V02'
+T20_GUEST='t20eval@192.168.122.164'
 T20_EXPECTED_DOMAIN_TYPE='kvm'
 T20_EXPECTED_MACHINE='pc-q35-noble'
 T20_EXPECTED_EMULATOR='/usr/bin/qemu-system-x86_64'
-T20_PEER_HOST='TBD before V02'
-T20_PEER_PORT='TBD before V02'
+T20_PEER_HOST='192.168.122.1'
+T20_PEER_PORT='18767'
 ```
 
-Before V02:
-
-1. add the separate machine-type ADR;
-2. create a new disposable `t20-v02-q35` by requesting `q35` through `qemu:///system` (do not recreate or reuse either V01 domain);
-3. set `T20_GUEST` to that guest's actual `user@address`;
-4. select and start the operator-owned same-libvirt-network TCP peer, then replace both peer TBD values; and
-5. re-read domain XML. If the host package set has changed and `q35` no longer resolves to `pc-q35-noble`, update the expected observed value through review rather than forcing the old resolved alias.
-
-V03 uses the same `T20_URI`, `T20_DOMAIN`, and `T20_GUEST`. Resource sizing, autostart, crash restart, production image lifecycle, and production provisioning remain outside V01.
+V03 uses the same `T20_URI`, `T20_DOMAIN`, and currently observed `T20_GUEST`; because the address is a dynamic lease, V03 must re-read it before use. The TCP peer was V02-only and no longer exists. Continue requesting stable alias `q35`; if the host package set changes and it resolves differently, review the new live value rather than forcing `pc-q35-noble`. Resource sizing, autostart, crash restart, production image lifecycle, and production provisioning remain outside V01/V02.
 
 ## Live command evidence
 
@@ -362,3 +354,123 @@ cleanup_failed=0
 - [x] Operational maturity and compatibility are applied as the approved tie-break.
 - [x] Disposable resources were prefixed `t20-`, did not reuse an existing name/path, had autostart disabled, and were removed.
 - [x] Final owner approval of the QEMU/KVM Q35 recommendation is recorded from the canonical source above.
+
+## V02 Q35 implementation and verifier evidence
+
+The canonical Run had already accepted baseline-red evidence that `t20-v02-q35` was absent at `2026-07-26T17:02:44Z`. A fresh read-only preflight at `2026-07-26T17:23:04Z` reconfirmed that exact domain and `t20-v02-pool` were absent (`virsh dominfo` and `pool-info` each exited 1), the three planned paths were absent, and `ss -H -ltnp 'sport = :18767'` returned no socket. No unrelated domain, network, pool, file, service, firewall rule, or STT Worker VM was modified.
+
+### Guest creation
+
+The operator was `avirus`; non-interactive system-libvirt access required no `sudo`. With `umask 077`, the following native V01-style flow ran from `2026-07-26T17:23:24Z` through `17:23:58Z`. The grouped shell exited 0; `set -eu` made every displayed creation step gating.
+
+```console
+$ mkdir -p /home/avirus/.local/state/t20-v02-q35 /var/tmp/t20-v02-work /var/tmp/t20-v02-pool
+$ chmod 700 /home/avirus/.local/state/t20-v02-q35 /var/tmp/t20-v02-work
+$ chmod 755 /var/tmp/t20-v02-pool
+$ ssh-keygen -q -t ed25519 -N '' -C t20-v02-q35 -f /home/avirus/.local/state/t20-v02-q35/id_ed25519
+$ chmod 600 /home/avirus/.local/state/t20-v02-q35/id_ed25519
+[private key contents omitted; each command exited 0]
+
+$ curl -fL --retry 3 https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img -o /var/tmp/t20-v02-work/noble-server-cloudimg-amd64.img
+$ printf '%s  %s\n' d1940f7d69d343355e183dff1e08a59852d32e7309baa7a4bad8365b11b005ac /var/tmp/t20-v02-work/noble-server-cloudimg-amd64.img | sha256sum --check
+/var/tmp/t20-v02-work/noble-server-cloudimg-amd64.img: OK
+$ qemu-img convert -p -O qcow2 /var/tmp/t20-v02-work/noble-server-cloudimg-amd64.img /var/tmp/t20-v02-pool/t20-v02-q35.qcow2
+$ qemu-img resize /var/tmp/t20-v02-pool/t20-v02-q35.qcow2 8G
+Image resized.
+[each command exited 0]
+```
+
+`cloud-localds` created `/var/tmp/t20-v02-pool/t20-v02-q35-seed.img` from operator-owned metadata and cloud-config for locked-password user `t20eval`, inserting only the generated public key (omitted here), disabling SSH passwords/root, and enabling root growth. The source download was then removed. Pool setup and creation were:
+
+```console
+$ virsh -c qemu:///system pool-define-as t20-v02-pool dir --target /var/tmp/t20-v02-pool
+$ virsh -c qemu:///system pool-start t20-v02-pool
+$ virsh -c qemu:///system pool-refresh t20-v02-pool
+[each command exited 0]
+
+$ virt-install --connect qemu:///system --name t20-v02-q35 --memory 2048 --vcpus 2 --cpu host-passthrough --machine q35 --boot uefi --osinfo ubuntu24.04 --import --disk path=/var/tmp/t20-v02-pool/t20-v02-q35.qcow2,format=qcow2,bus=virtio --disk path=/var/tmp/t20-v02-pool/t20-v02-q35-seed.img,format=raw,bus=virtio --network network=default,model=virtio --graphics none --console pty,target.type=serial --noautoconsole
+Domain creation completed.
+[exit 0 at 2026-07-26T17:23:58Z]
+```
+
+The resulting domain was running and persistent with autostart disabled. The pool was active and persistent with autostart `no`. Its first DHCP lease was `192.168.122.164`; SSH and `cloud-init status --wait` passed on the first poll at `2026-07-26T17:24:14Z`.
+
+### Approved temporary listener and complete verifier
+
+No Tailscale or firewall command was run. The approved peer was bound only to the existing libvirt bridge address. After correcting a non-listening Python quoting error (exit 1, owned PID/log files removed, no socket created), this exact stdlib listener started:
+
+```sh
+nohup python3 -c 'import socket; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); s.bind(("192.168.122.1",18767)); s.listen(1); s.settimeout(180); c,a=s.accept(); data=c.recv(64); print("peer=%s token=%s" % (a[0],data.decode("ascii","replace").strip()),flush=True); c.sendall(b"T20-V02-ACK\n"); c.close(); s.close()' </dev/null >/var/tmp/t20-v02-work/listener.log 2>&1 &
+echo $! >/var/tmp/t20-v02-work/listener.pid
+```
+
+At `2026-07-26T17:24:51Z`, PID `2697195` was owned by `avirus`, and `ss` showed only `192.168.122.1:18767`, process `python3`, PID `2697195`, as the matching listener. The listener accepted one connection and then closed itself, with a 180-second accept timeout as its outer bound.
+
+The host's `virsh dumpxml` defaults to live XML for a running domain and does not support `--live`. One preliminary invocation with that unsupported option stopped before guest checks and exited 1 at `17:25:19Z`; it changed no state. The corrected complete verifier below ran at `2026-07-26T17:25:37Z–17:25:38Z` and exited 0:
+
+```sh
+T20_URI='qemu:///system'
+T20_DOMAIN='t20-v02-q35'
+T20_GUEST='t20eval@192.168.122.164'
+T20_EXPECTED_DOMAIN_TYPE='kvm'
+T20_EXPECTED_MACHINE='pc-q35-noble'
+T20_EXPECTED_EMULATOR='/usr/bin/qemu-system-x86_64'
+T20_PEER_HOST='192.168.122.1'
+T20_PEER_PORT='18767'
+T20_KEY='/home/avirus/.local/state/t20-v02-q35/id_ed25519'
+T20_KNOWN_HOSTS='/home/avirus/.local/state/t20-v02-q35/known_hosts'
+
+state=$(virsh -c "$T20_URI" domstate "$T20_DOMAIN")
+test "$state" = running
+virsh -c "$T20_URI" dumpxml "$T20_DOMAIN" >/var/tmp/t20-v02-work/live.xml
+python3 -c 'import sys,xml.etree.ElementTree as E; r=E.parse(sys.argv[1]).getroot(); got=(r.get("type"),r.find("./os/type").get("machine"),r.findtext("./devices/emulator")); exp=tuple(sys.argv[2:]); print("domain_type=%s\nmachine=%s\nemulator=%s" % got); raise SystemExit(0 if got == exp else 1)' /var/tmp/t20-v02-work/live.xml "$T20_EXPECTED_DOMAIN_TYPE" "$T20_EXPECTED_MACHINE" "$T20_EXPECTED_EMULATOR"
+timeout 60 ssh -i "$T20_KEY" -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$T20_KNOWN_HOSTS" "$T20_GUEST" "T20_PEER_HOST=$T20_PEER_HOST T20_PEER_PORT=$T20_PEER_PORT bash -s" <<'GUEST'
+set -eu
+cloud-init status --wait
+virt=$(systemd-detect-virt)
+test "$virt" = kvm
+printf 'guest_virtualization=%s\n' "$virt"
+systemd-run --user --wait --collect --quiet /usr/bin/true
+printf 'systemd_user_transient=pass\n'
+test -n "$HOME" && test -d "$HOME" && test -w "$HOME"
+printf 'guest_home=%s writable=yes\n' "$HOME"
+exec 3<>"/dev/tcp/$T20_PEER_HOST/$T20_PEER_PORT"
+printf 'T20-V02-PROBE\n' >&3
+IFS= read -r ack <&3
+test "$ack" = T20-V02-ACK
+exec 3<&-; exec 3>&-
+printf 'tcp_peer=%s:%s connected=yes ack=%s\n' "$T20_PEER_HOST" "$T20_PEER_PORT" "$ack"
+GUEST
+```
+
+Relevant unredacted output contained no secrets:
+
+```text
+domain_state=running
+domain_type=kvm
+machine=pc-q35-noble
+emulator=/usr/bin/qemu-system-x86_64
+status: done
+guest_virtualization=kvm
+systemd_user_transient=pass
+guest_home=/home/t20eval writable=yes
+tcp_peer=192.168.122.1:18767 connected=yes ack=T20-V02-ACK
+V02_VERIFIER=PASS
+[exit 0]
+```
+
+The listener log independently recorded `peer=192.168.122.164 token=T20-V02-PROBE`.
+
+### Listener cleanup and V03-owned residual resources
+
+At `2026-07-26T17:26:05Z`, `kill -0 2697195` failed because the one-shot listener had already exited. `ss -H -ltnp 'sport = :18767'` returned no socket. The owned listener PID/log, XML snapshot, cloud-init source, and `/var/tmp/t20-v02-work` were removed. A second socket-absence check at `17:26:33Z` passed. No listener, PID file, or temporary work directory remains.
+
+The following resources are intentionally retained exclusively for immediate V03:
+
+- running persistent domain `t20-v02-q35` through `qemu:///system`, autostart `disable`;
+- active persistent directory pool `t20-v02-pool`, autostart `no`;
+- `/var/tmp/t20-v02-pool/t20-v02-q35.qcow2` (owner `libvirt-qemu:kvm`, mode 644) and attached seed `/var/tmp/t20-v02-pool/t20-v02-q35-seed.img` (same owner/mode);
+- libvirt-managed UEFI NVRAM `/var/lib/libvirt/qemu/nvram/t20-v02-q35_VARS.fd` (owner `libvirt-qemu:kvm`, mode 600);
+- SSH state directory `/home/avirus/.local/state/t20-v02-q35` (owner `avirus:avirus`, mode 700), containing private key `id_ed25519` (mode 600), its public key, and `known_hosts`. The exact private-key path is `/home/avirus/.local/state/t20-v02-q35/id_ed25519`; its contents were never printed or committed.
+
+V03 owns final teardown: gracefully stop `t20-v02-q35`, undefine it with its NVRAM, destroy/undefine `t20-v02-pool`, and remove `/var/tmp/t20-v02-pool` plus `/home/avirus/.local/state/t20-v02-q35`. Any ordinary dynamic DHCP record should be left for normal expiry rather than changing the shared `default` network. V02 did not execute V03 lifecycle checks or teardown. Unrelated host state, including the existing network, firewall, Tailscale state, services, other domains/pools/files, and the STT Worker VM, was left untouched.

--- a/ops/pi-user-vm/machine-type-evaluation.md
+++ b/ops/pi-user-vm/machine-type-evaluation.md
@@ -1,0 +1,364 @@
+# T20 V01 machine-type evaluation
+
+**Evaluation host:** `homelab` (Linux/KVM)
+**Evidence collected:** 2026-07-26 15:42:14Z–15:55:28Z
+**Status:** recommendation complete; **final owner approval is pending** at the parent/user checkpoint. No production VM was provisioned and no vault ADR was changed.
+
+## Recommendation
+
+Recommend **QEMU/KVM Q35**, managed by libvirt's QEMU driver at `qemu:///system`, using the requested stable alias `q35`. On this host libvirt resolved that request to `pc-q35-noble` in domain XML.
+
+Both Q35 and a carefully minimized `microvm` booted the approved Ubuntu fixture and passed the same block, network, console, and cold-lifecycle probes. The approved tie-break is operational maturity and compatibility first. Q35 worked through the ordinary `virt-install` path with Ubuntu 24.04 OS metadata and UEFI. `microvm` first failed with `No PCI buses available` and required hand-authored XML, explicit `virtio-mmio` addresses, and explicit suppression of libvirt's implicit USB, balloon, and video devices. That narrower and less conventional device/firmware path provides no material benefit required by T20, so Q35 wins the tie-break. Cloud Hypervisor cannot be managed by the installed libvirt build and was excluded before boot.
+
+This is a recommendation, not an owner-approved selection. After owner approval, create the required new vault ADR before V02; do not treat this document as that ADR.
+
+## Fixture and host identity
+
+- Host kernel: `Linux homelab 7.0.0-28-generic ... x86_64 GNU/Linux`.
+- Libvirt URI/driver: `qemu:///system`, QEMU driver (`Using API: QEMU 10.0.0`).
+- Acceleration/hypervisor: domain type `kvm`; QEMU 8.2.2 at `/usr/bin/qemu-system-x86_64`.
+- Libvirt: client, API, and daemon 10.0.0.
+- Network: existing libvirt network `default`, active, persistent, bridge `virbr0`. Its definition, active/autostart state, and firewall were not altered. The two evaluated guests obtained ordinary dynamic DHCP leases.
+- Representative image: Ubuntu 24.04 LTS Canonical cloud image, `noble-server-cloudimg-amd64.img`.
+- Canonical source: `https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img`.
+- Canonical checksum source: `https://cloud-images.ubuntu.com/noble/current/SHA256SUMS`.
+- SHA-256 observed in Canonical metadata and verified after download: `d1940f7d69d343355e183dff1e08a59852d32e7309baa7a4bad8365b11b005ac`.
+- Image metadata: qcow2, virtual size 3.5 GiB (3,758,096,384 bytes), downloaded file size 624,105,472 bytes. The guest console identified itself as Ubuntu 24.04.4 LTS; guest kernel was `6.8.0-136-generic`.
+
+The image was downloaded only to `/var/tmp/t20-v01-work`, copied into the disposable `t20-v01-pool`, and removed during cleanup.
+
+## Comparative disposition
+
+| Criterion | QEMU/KVM Q35 | QEMU/KVM `microvm` | Cloud Hypervisor |
+|---|---|---|---|
+| Native libvirt manageability on `homelab` | **Pass.** QEMU driver, `qemu:///system`; ordinary `virt-install` completed. | **Pass with material caveat.** QEMU driver accepted hand-authored `microvm` XML only after implicit PCI-dependent devices were suppressed and virtio devices were explicitly addressed as `virtio-mmio`. | **Unavailable.** `ch:///system` returned `no connection driver available`; no `cloud-hypervisor` executable was installed. Excluded before boot under the V01 rule. |
+| KVM acceleration | **Pass.** Live domain XML had `type="kvm"`; guest reported `systemd-detect-virt=kvm`. | **Pass.** Same observations. | **Not testable:** required native libvirt driver is unavailable. |
+| Requested / observed machine | `q35` / `pc-q35-noble` | `microvm` / `microvm` | No domain could be defined. |
+| Ubuntu 24.04 representative boot | **Pass.** Cloud-init `status: done`; SSH ready; systemd user transient unit passed; writable home. | **Pass after custom XML.** Same guest checks passed. | Not run because native management is unavailable. |
+| Persistent block device | **Pass.** qcow2 root was `/dev/vda1` ext4; marker survived graceful shutdown and cold start. | **Pass.** Same result. | Not testable because native management is unavailable. |
+| Libvirt-network connectivity | **Pass.** `network=default`, virtio NIC, DHCP address `192.168.122.116`; SSH from host and ping to `192.168.122.1` passed. | **Pass.** `network=default`, virtio-mmio NIC, DHCP address `192.168.122.190`; the same probes passed. | Not testable because native management is unavailable. |
+| Headless diagnostics / console | **Pass.** No graphics, PTY serial console, active guest `serial-getty@ttyS0`; `virsh console` attached and displayed the Ubuntu login prompt. | **Pass.** No graphics, PTY serial console, active guest serial getty; `virsh console` attached. | Not testable because native management is unavailable. |
+| Graceful stop/start | **Pass.** `virsh shutdown` reached `shut off` on poll 2; start succeeded; SSH returned on poll 3. | **Pass.** Same result. | Not testable because native management is unavailable. |
+| Stable alias / version pin | **Recommend stable alias `q35`.** Record resolved `pc-q35-noble` as V02's expected XML value on this host; do not request the downstream resolved name as a production pin. | If selected, request stable `microvm`; no versioned alternative was reported. Rejected. | Not applicable. |
+| Material limitations | Larger, conventional PC/PCI device surface; host-specific alias resolution means V02 must compare against the live observed value recorded below. | Default Ubuntu `virt-install` XML was incompatible; no automatic x86 EFI firmware was advertised for `microvm`; reduced PCI/USB/video/balloon support; requires specialized XML and virtio-mmio devices. | Installed libvirt has no `ch` connection driver, and the hypervisor executable is absent. |
+| Disposition / rejection reason | **Recommended, owner approval pending.** Best maturity and compatibility. | **Rejected by tie-break**, despite functional probes: materially more specialized integration for no required benefit. | **Rejected/unavailable:** no native libvirt management on the target host. |
+
+The DHCP addresses above are historical evidence only. Both domains, their interfaces, storage, and scratch data were removed; no evaluated guest is currently reachable at either value. Any DHCP lease-record expiry remains owned by the unchanged existing network.
+
+## Reproduction values for V02 and V03
+
+These values describe the recommended configuration. They are intentionally **not yet executable**: owner approval and a new ADR must precede V02, and values that can exist only after the V02 disposable guest and TCP probe are prepared are explicitly TBD rather than invented.
+
+```sh
+T20_URI='qemu:///system'
+T20_DOMAIN='t20-v02-q35'
+T20_GUEST='TBD before V02'
+T20_EXPECTED_DOMAIN_TYPE='kvm'
+T20_EXPECTED_MACHINE='pc-q35-noble'
+T20_EXPECTED_EMULATOR='/usr/bin/qemu-system-x86_64'
+T20_PEER_HOST='TBD before V02'
+T20_PEER_PORT='TBD before V02'
+```
+
+Before V02:
+
+1. obtain owner approval and add the separate machine-type ADR;
+2. create a new disposable `t20-v02-q35` by requesting `q35` through `qemu:///system` (do not recreate or reuse either V01 domain);
+3. set `T20_GUEST` to that guest's actual `user@address`;
+4. select and start the operator-owned same-libvirt-network TCP peer, then replace both peer TBD values; and
+5. re-read domain XML. If the host package set has changed and `q35` no longer resolves to `pc-q35-noble`, update the expected observed value through review rather than forcing the old resolved alias.
+
+V03 uses the same `T20_URI`, `T20_DOMAIN`, and `T20_GUEST`. Resource sizing, autostart, crash restart, production image lifecycle, and production provisioning remain outside V01.
+
+## Live command evidence
+
+Outputs below are limited to candidate-relevant fields. SSH keys, credentials, tokens, unrelated domains, and unrelated host data were neither printed nor recorded. Bracketed exit statuses are from the target host unless identified as the local SSH wrapper.
+
+### Host, driver, capabilities, and image
+
+At `2026-07-26T15:42:14Z`:
+
+```console
+$ virsh -c qemu:///system uri
+qemu:///system
+[exit 0]
+
+$ virsh -c qemu:///system version --daemon
+Compiled against library: libvirt 10.0.0
+Using library: libvirt 10.0.0
+Using API: QEMU 10.0.0
+Running hypervisor: QEMU 8.2.2
+Running against daemon: 10.0.0
+[exit 0]
+
+$ qemu-system-x86_64 --version
+QEMU emulator version 8.2.2 (Debian 1:8.2.2+ds-0ubuntu1.17)
+[exit 0]
+
+$ virsh -c qemu:///system domcapabilities --virttype kvm --arch x86_64 --machine q35
+<domainCapabilities>
+  <path>/usr/bin/qemu-system-x86_64</path>
+  <domain>kvm</domain>
+  <machine>pc-q35-noble</machine>
+  ...
+</domainCapabilities>
+[exit 0]
+
+$ virsh -c qemu:///system domcapabilities --virttype kvm --arch x86_64 --machine microvm
+<domainCapabilities>
+  <path>/usr/bin/qemu-system-x86_64</path>
+  <domain>kvm</domain>
+  <machine>microvm</machine>
+  ...
+  <os supported='yes'>
+    <enum name='firmware'/>
+    ...
+  </os>
+  ...
+</domainCapabilities>
+[exit 0]
+```
+
+At `2026-07-26T15:43:15Z`, the existing network was read without `sudo`:
+
+```console
+$ virsh -c qemu:///system net-info default
+Name:           default
+UUID:           [omitted]
+Active:         yes
+Persistent:     yes
+Autostart:      yes
+Bridge:         virbr0
+[exit 0]
+```
+
+The operator account is in `libvirt` and `kvm`. Non-interactive `sudo -n true` exited 1 (`sudo: a password is required`), but no privileged operation was needed: all evaluation lifecycle and storage-pool operations succeeded through the system libvirt API as the operator. No authentication blocker remained.
+
+At `2026-07-26T15:43:15Z` and `15:44:34Z`:
+
+```console
+$ sh -c "curl -fsSL https://cloud-images.ubuntu.com/noble/current/SHA256SUMS | awk '$2 == \"noble-server-cloudimg-amd64.img\" || $2 == \"*noble-server-cloudimg-amd64.img\" {print; found=1} END {exit !found}'"
+d1940f7d69d343355e183dff1e08a59852d32e7309baa7a4bad8365b11b005ac *noble-server-cloudimg-amd64.img
+[exit 0]
+
+$ curl -fL https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img -o /var/tmp/t20-v01-work/noble-server-cloudimg-amd64.img
+[exit 0]
+
+$ printf '%s  %s\n' d1940f7d69d343355e183dff1e08a59852d32e7309baa7a4bad8365b11b005ac /var/tmp/t20-v01-work/noble-server-cloudimg-amd64.img | sha256sum --check
+/var/tmp/t20-v01-work/noble-server-cloudimg-amd64.img: OK
+[exit 0]
+```
+
+### Cloud Hypervisor exclusion
+
+This is the exact local capability test supporting pre-boot exclusion, collected at `2026-07-26T15:42:14Z`:
+
+```console
+$ virsh -c ch:///system capabilities
+error: failed to connect to the hypervisor
+error: no connection driver available for ch:///system
+[exit 1]
+
+$ command -v cloud-hypervisor
+[no output]
+[exit 1]
+```
+
+`ch:///system` is the native libvirt Cloud Hypervisor URI. Because the local libvirt installation reports that it has no connection driver for that URI, it cannot define, boot, attach storage/network/console, or perform lifecycle operations for a Cloud Hypervisor domain. Per V01, no substitute direct-hypervisor test was performed.
+
+### Q35 creation, identity, guest, and lifecycle
+
+The creation command completed at `2026-07-26T15:45:05Z`:
+
+```console
+$ virt-install --connect qemu:///system --name t20-v01-q35 --memory 2048 --vcpus 2 --cpu host-passthrough --machine q35 --boot uefi --osinfo ubuntu24.04 --import --disk path=/var/tmp/t20-v01-pool/t20-v01-q35.qcow2,format=qcow2,bus=virtio --disk path=/var/tmp/t20-v01-pool/t20-v01-q35-seed.img,format=raw,bus=virtio --network network=default,model=virtio --graphics none --console pty,target.type=serial --noautoconsole
+Domain creation completed.
+[exit 0]
+```
+
+Relevant `virsh -c qemu:///system dumpxml t20-v01-q35` fields at `2026-07-26T15:45:31Z`:
+
+```text
+domain_type=kvm
+machine=pc-q35-noble
+emulator=/usr/bin/qemu-system-x86_64
+disk_targets=disk/vda/virtio,disk/vdb/virtio
+interfaces=network/default/virtio/mac=[omitted]
+consoles=pty/serial
+graphics_count=0
+```
+
+The exact guest probe body was run over batch SSH to `t20eval@192.168.122.116` at `2026-07-26T15:46:11Z`:
+
+```sh
+set -eu
+cloud-init status --wait
+echo "virt=$(systemd-detect-virt)"
+echo "kernel=$(uname -r)"
+echo "boot_id_present=$(test -s /proc/sys/kernel/random/boot_id && echo yes)"
+echo "root_source=$(findmnt -n -o SOURCE /)"
+echo "root_fstype=$(findmnt -n -o FSTYPE /)"
+echo "home_writable=$(test -w "$HOME" && echo yes)"
+systemd-run --user --wait --collect --quiet /usr/bin/true
+echo "systemd_user_transient=pass"
+gateway=$(ip -4 route show default | awk '{print $3; exit}')
+test -n "$gateway"
+ping -c 1 -W 2 "$gateway" >/dev/null
+echo "default_gateway=$gateway ping=pass"
+echo "serial_getty=$(systemctl is-active serial-getty@ttyS0.service || true)"
+printf 'T20-Q35-PERSIST-%s\n' "$(date -u +%s)" >"$HOME/.t20-v01-persistence"
+sync
+cat "$HOME/.t20-v01-persistence"
+```
+
+```text
+status: done
+virt=kvm
+kernel=6.8.0-136-generic
+boot_id_present=
+root_source=/dev/vda1
+root_fstype=ext4
+home_writable=yes
+systemd_user_transient=pass
+default_gateway=192.168.122.1 ping=pass
+serial_getty=active
+T20-Q35-PERSIST-1785080771
+[exit 0]
+```
+
+`boot_id_present` was an informational print with an empty value and was not used as a pass criterion; cloud-init completion, successful SSH, the running guest probes, and the console provide the boot result.
+
+At `2026-07-26T15:46:11Z`, a bounded controlling-TTY `virsh console` capture attached and displayed the `Ubuntu 24.04.4 LTS t20-v01-q35 ttyS0` login prompt. At `15:46:28Z`, `timeout 5 script -q -c "virsh -c qemu:///system console t20-v01-q35 --force" /dev/null < /dev/null` independently attached again. Exit 124 was expected because each observation was deliberately bounded by `timeout`.
+
+Cold lifecycle at `2026-07-26T15:46:55Z–15:47:09Z`:
+
+```console
+$ virsh -c qemu:///system shutdown t20-v01-q35
+Domain 't20-v01-q35' is being shutdown
+[exit 0]
+$ # poll: virsh domstate t20-v01-q35, up to 60 times with 2s delay
+stopped=true state=shut off attempts=2
+[exit 0]
+$ virsh -c qemu:///system start t20-v01-q35
+Domain 't20-v01-q35' started
+[exit 0]
+$ # batch-SSH poll, up to 60 times with 3s delay
+reachable=true attempts=3
+[exit 0]
+$ ssh ... 'cat "$HOME/.t20-v01-persistence"; systemd-run --user --wait --collect --quiet /usr/bin/true'
+T20-Q35-PERSIST-1785080771
+post_start_systemd_user=pass
+[exit 0]
+```
+
+### `microvm` creation, identity, guest, and lifecycle
+
+The ordinary Ubuntu path failed at `2026-07-26T15:47:28Z`:
+
+```console
+$ virt-install --connect qemu:///system --name t20-v01-microvm --memory 2048 --vcpus 2 --cpu host-passthrough --machine microvm --osinfo ubuntu24.04 --import --disk path=/var/tmp/t20-v01-pool/t20-v01-microvm.qcow2,format=qcow2,bus=virtio --disk path=/var/tmp/t20-v01-pool/t20-v01-microvm-seed.img,format=raw,bus=virtio --network network=default,model=virtio --graphics none --console pty,target.type=serial --noautoconsole
+ERROR    XML error: No PCI buses available
+[exit 1]
+```
+
+A minimal domain with the same memory, CPU, disks, NIC, and serial console was then defined with these candidate-significant XML fields:
+
+```xml
+<domain type='kvm'>
+  <name>t20-v01-microvm</name>
+  <memory unit='MiB'>2048</memory><vcpu>2</vcpu>
+  <os><type arch='x86_64' machine='microvm'>hvm</type><boot dev='hd'/></os>
+  <features><acpi/><apic/></features>
+  <cpu mode='host-passthrough'/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <controller type='usb' model='none'/>
+    <memballoon model='none'/><video><model type='none'/></video>
+    <disk type='file' device='disk'><driver name='qemu' type='qcow2'/><source file='/var/tmp/t20-v01-pool/t20-v01-microvm.qcow2'/><target dev='vda' bus='virtio'/><address type='virtio-mmio'/></disk>
+    <disk type='file' device='disk'><driver name='qemu' type='raw'/><source file='/var/tmp/t20-v01-pool/t20-v01-microvm-seed.img'/><target dev='vdb' bus='virtio'/><address type='virtio-mmio'/></disk>
+    <interface type='network'><source network='default'/><model type='virtio'/><address type='virtio-mmio'/></interface>
+    <serial type='pty'><target type='isa-serial' port='0'/></serial>
+    <console type='pty'><target type='serial' port='0'/></console>
+  </devices>
+</domain>
+```
+
+At `2026-07-26T15:49:29Z`, `virsh -c qemu:///system define ...` and `virsh -c qemu:///system start t20-v01-microvm` both exited 0. Relevant live XML at `15:49:49Z` was:
+
+```text
+domain_type=kvm
+machine=microvm
+emulator=/usr/bin/qemu-system-x86_64
+disk=disk/vda/virtio/address=virtio-mmio
+disk=disk/vdb/virtio/address=virtio-mmio
+interface=network/default/virtio/mac=[omitted]/address=virtio-mmio
+graphics_count=0
+video=none
+consoles=pty/serial
+controllers=usb/none
+balloon=none
+```
+
+An equivalent guest probe body ran at `2026-07-26T15:50:04Z` against the observed address `t20eval@192.168.122.190`; it omitted Q35's non-gating informational boot-ID print and changed the marker prefix:
+
+```text
+status: done
+virt=kvm
+kernel=6.8.0-136-generic
+root_source=/dev/vda1
+root_fstype=ext4
+home_writable=yes
+systemd_user_transient=pass
+default_gateway=192.168.122.1 ping=pass
+serial_getty=active
+T20-MICROVM-PERSIST-1785081005
+[exit 0]
+```
+
+At `2026-07-26T15:50:10Z`, the same bounded `virsh console` command attached successfully; exit 124 was the expected five-second observation timeout.
+
+Cold lifecycle at `2026-07-26T15:50:35Z–15:50:47Z`:
+
+```text
+virsh shutdown: exit 0
+stopped=true state=shut off attempts=2
+virsh start: exit 0
+post-start SSH reachable=true attempts=3
+persisted marker=T20-MICROVM-PERSIST-1785081005
+post_start_systemd_user=pass
+[combined exit 0]
+```
+
+## Cleanup and safety result
+
+The operator-managed resources created were `t20-v01-q35`, `t20-v01-microvm`, `t20-v01-pool`, `/var/tmp/t20-v01-work`, and `/var/tmp/t20-v01-pool`; libvirt generated only their transient child state (domain interfaces, Q35 NVRAM, and dynamic DHCP leases). Neither domain was marked for autostart. No hardware was rebound; no host service, firewall, existing domain or pool, existing network configuration/state, or STT Worker VM was changed; the host was not rebooted.
+
+Cleanup ran at `2026-07-26T15:51:20Z–15:51:25Z`:
+
+```text
+virsh shutdown t20-v01-q35: exit 0; shut off on poll 2
+virsh shutdown t20-v01-microvm: exit 0; shut off on poll 2
+virsh undefine t20-v01-q35 --nvram: exit 0
+virsh undefine t20-v01-microvm: exit 0
+virsh pool-destroy t20-v01-pool: exit 0
+virsh pool-undefine t20-v01-pool: exit 0
+rm -rf -- /var/tmp/t20-v01-work /var/tmp/t20-v01-pool: exit 0
+dominfo t20-v01-q35: exit 1 (expected absent)
+dominfo t20-v01-microvm: exit 1 (expected absent)
+pool-info t20-v01-pool: exit 1 (expected absent)
+both path-absence tests: exit 0
+cleanup_failed=0
+```
+
+**Owned live resources remaining: none.** A read-only check at `2026-07-26T15:55:28Z` showed that the unchanged `default` network still retained its ordinary time-bounded DHCP lease records for the now-absent `t20-v01-q35` and `t20-v01-microvm` clients. These are passive network records, not live domains/interfaces or reusable owned resources; they were left for normal expiry rather than editing or restarting the existing network.
+
+## V01 self-audit
+
+- [x] Q35, `microvm`, and Cloud Hypervisor are each dispositioned.
+- [x] Every candidate records native manageability, KVM status, guest boot, persistent block, libvirt network, headless console, graceful lifecycle, limitations, and rejection reason where rejected; unavailable Cloud Hypervisor fields are explicitly not testable.
+- [x] Cloud Hypervisor's pre-boot exclusion includes the exact local capability command, output, and status.
+- [x] URI/driver, hypervisor, requested and observed machine, emulator, alias policy, image source/checksum, rationale, and all V02/V03 field names are recorded.
+- [x] Unknown guest/TCP-peer values are `TBD before V02`, not invented.
+- [x] Operational maturity and compatibility are applied as the approved tie-break.
+- [x] Disposable resources were prefixed `t20-`, did not reuse an existing name/path, had autostart disabled, and were removed.
+- [ ] Final owner approval is deliberately pending. This is the one V01 contract item not yet satisfiable by the implementation writer; the exact required human decision is to approve or reject the QEMU/KVM Q35 recommendation at the parent/user checkpoint.

--- a/ops/pi-user-vm/machine-type-evaluation.md
+++ b/ops/pi-user-vm/machine-type-evaluation.md
@@ -1,8 +1,8 @@
-# T20 Q35 machine-type evaluation and V02 evidence
+# T20 Q35 machine-type evaluation and V01–V03 evidence
 
 **Evaluation host:** `homelab` (Linux/KVM)
-**Evidence collected:** V01: 2026-07-26 15:42:14Z–15:55:28Z; V02: 2026-07-26 17:23:04Z–17:26:33Z
-**Status:** V01 recommendation complete and **owner approved**; V02 verifier **passed**. Canonical V01 approval source: Vault Hunter Run `vh-T20-1785077639159`, Run observation `T20.V01.q35-selection.approved.2026-07-26` at Registry revision 12. The V02 host-local endpoint was separately approved in Run observation `T20.V02.host-local-probe.approved.2026-07-26`. No production VM was provisioned and no vault path was inspected or changed during V02.
+**Evidence collected:** V01: 2026-07-26 15:42:14Z–15:55:28Z; V02: 2026-07-26 17:23:04Z–17:26:33Z; V03: 2026-07-26 17:39:09Z–17:41:46Z; accepted review hardening and postchecks: 2026-07-26 18:02:05Z–18:04:50Z
+**Status:** V01 recommendation **owner approved**; V02 and V03 verifiers **passed**; accepted review hardening **passed** with the V03 resources retained. Canonical V01 approval source: Vault Hunter Run `vh-T20-1785077639159`, Run observation `T20.V01.q35-selection.approved.2026-07-26` at Registry revision 12. The V02 host-local endpoint was separately approved in Run observation `T20.V02.host-local-probe.approved.2026-07-26`. This is not a claim of canonical vault completion or cleanup: no vault path was inspected or changed, and retained-resource teardown remains a checkpoint-two obligation.
 
 ## Recommendation
 
@@ -47,12 +47,14 @@ The DHCP addresses above are historical evidence only. Both domains, their inter
 
 ## Reproduction values for V02 and V03
 
-These are the literal values observed and verified during V02:
+These are the literal values observed and verified during V02. `T20_GUEST` records that observation, not a static address:
 
 ```sh
 T20_URI='qemu:///system'
 T20_DOMAIN='t20-v02-q35'
 T20_GUEST='t20eval@192.168.122.164'
+T20_KEY='/home/avirus/.local/state/t20-v02-q35/id_ed25519'
+T20_KNOWN_HOSTS='/home/avirus/.local/state/t20-v02-q35/known_hosts'
 T20_EXPECTED_DOMAIN_TYPE='kvm'
 T20_EXPECTED_MACHINE='pc-q35-noble'
 T20_EXPECTED_EMULATOR='/usr/bin/qemu-system-x86_64'
@@ -60,7 +62,19 @@ T20_PEER_HOST='192.168.122.1'
 T20_PEER_PORT='18767'
 ```
 
-V03 uses the same `T20_URI`, `T20_DOMAIN`, and currently observed `T20_GUEST`; because the address is a dynamic lease, V03 must re-read it before use. The TCP peer was V02-only and no longer exists. Continue requesting stable alias `q35`; if the host package set changes and it resolves differently, review the new live value rather than forcing `pc-q35-noble`. Resource sizing, autostart, crash restart, production image lifecycle, and production provisioning remain outside V01/V02.
+V03 and later retained-state checks use the same `T20_URI` and `T20_DOMAIN`, but must re-read the dynamic lease and construct `T20_GUEST` immediately before use. The successful checked SSH mechanism was:
+
+```sh
+T20_IP=$(virsh -c "$T20_URI" domifaddr "$T20_DOMAIN" --source lease | awk '$3 == "ipv4" {sub(/\/.*/, "", $4); print $4; exit}')
+test -n "$T20_IP"
+T20_GUEST="t20eval@$T20_IP"
+timeout 60 ssh -n -i "$T20_KEY" \
+  -o BatchMode=yes -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=yes -o UserKnownHostsFile="$T20_KNOWN_HOSTS" \
+  -o ConnectTimeout=2 "$T20_GUEST" /usr/bin/true
+```
+
+Any canonical command abbreviated as plain `ssh "$T20_GUEST" ...` requires these equivalent checked identity, batch, host-key, known-hosts, and timeout options either on the command line or in effective SSH configuration; unchecked default plain SSH is not the reproduced mechanism. The TCP peer was V02-only and no longer exists. Continue requesting stable alias `q35`; if the host package set changes and it resolves differently, review the new live value rather than forcing `pc-q35-noble`. Resource sizing, autostart, crash restart, production image lifecycle, and production provisioning remain outside V01/V02.
 
 ## Live command evidence
 
@@ -672,6 +686,41 @@ local_ssh_wrapper_exit=0
 
 ### Retained state and later cleanup obligation
 
-V03 deliberately performed no final cleanup. Domain `t20-v02-q35` remains running and persistent with autostart disabled; pool `t20-v02-pool` remains active and persistent with autostart `no`. The qcow2 disk, seed image, libvirt-managed NVRAM, and complete SSH state remain at the V02 paths and ownership/modes shown above. The V03 marker was removed, and listener port 18767 remains absent. V03 did not run the V02 listener and did not inspect or alter Tailscale, networking, the firewall, unrelated resources, or the STT Worker VM.
+V03 deliberately performed no final cleanup. At V03 completion, domain `t20-v02-q35` was running and persistent with autostart disabled; pool `t20-v02-pool` was active and persistent with autostart `no`; and the qcow2 disk, seed image, libvirt-managed NVRAM, and complete SSH state remained at the V02 paths and ownership/modes shown above. The V03 marker was removed, and listener port 18767 remained absent. V03 did not run the V02 listener and did not inspect or alter Tailscale, networking, the firewall, unrelated resources, or the STT Worker VM.
 
 A later authorized cleanup still must gracefully stop `t20-v02-q35`, undefine it with its NVRAM, destroy and undefine `t20-v02-pool`, and remove `/var/tmp/t20-v02-pool` and `/home/avirus/.local/state/t20-v02-q35`. Leave any dynamic DHCP record for normal expiry; do not alter the shared `default` network.
+
+## Accepted review hardening and retained-state postcheck
+
+At `2026-07-26T17:59:58Z`, exact ownership validation bound the domain's `vda` and `vdb`, its NVRAM, and the pool target to the retained paths before any mode change. Immediately before hardening at `18:02:05Z`, the exact modes were:
+
+```text
+/var/tmp/t20-v02-pool                                  avirus:avirus     755
+/var/tmp/t20-v02-pool/t20-v02-q35.qcow2               libvirt-qemu:kvm  644
+/var/tmp/t20-v02-pool/t20-v02-q35-seed.img             libvirt-qemu:kvm  644
+/var/lib/libvirt/qemu/nvram/t20-v02-q35_VARS.fd         libvirt-qemu:kvm  600
+/home/avirus/.local/state/t20-v02-q35/id_ed25519        avirus:avirus     600
+```
+
+Because `avirus` owned the directory but not the two libvirt-owned files, a direct non-interactive `sudo -n chmod 0640` made no change and exited 1 (`sudo: a password is required`). The domain was then gracefully stopped (`shut off` on poll 2). With both source inodes held open, only the two validated paths were replaced byte-for-byte under `umask 0027`, grouped to `kvm`, and set to `0640`; the directory was grouped to `kvm` and set to `0750`:
+
+```sh
+exec 3<"$QCOW2"; exec 4<"$SEED"
+rm -- "$QCOW2" "$SEED"
+(umask 0027; cp --sparse=always /proc/self/fd/3 "$QCOW2"; cp --sparse=always /proc/self/fd/4 "$SEED")
+exec 3<&-; exec 4<&-
+chgrp kvm "$QCOW2" "$SEED"; chmod 0640 "$QCOW2" "$SEED"
+chgrp kvm "$POOL_PATH"; chmod 0750 "$POOL_PATH"
+```
+
+The before/after SHA-256 values matched exactly: qcow2 `ab6c0e8c43119c17a6c363f697e7f6a32b7a42a418b2fc4d0e4e50a5d7e925ef`; seed `8e177a96172a62148aed2b5a60103193b1f5f9c8f98465815869677c02893205`. Starting the domain restored the two files' libvirt ownership while retaining the hardened modes. The accepted postcheck at `2026-07-26T18:03:04Z` recorded:
+
+```text
+/var/tmp/t20-v02-pool                                  avirus:kvm        750
+/var/tmp/t20-v02-pool/t20-v02-q35.qcow2               libvirt-qemu:kvm  640
+/var/tmp/t20-v02-pool/t20-v02-q35-seed.img             libvirt-qemu:kvm  640
+/var/lib/libvirt/qemu/nvram/t20-v02-q35_VARS.fd         libvirt-qemu:kvm  600
+/home/avirus/.local/state/t20-v02-q35/id_ed25519        avirus:avirus     600
+```
+
+The postcheck re-read dynamic address `192.168.122.164`, used the checked SSH command above successfully (exit 0), and passed with domain `running`/autostart `disable`, pool `running`/autostart `no`, and listener 18767 absent; a final read-only validation at `18:04:50Z` reconfirmed every result. NVRAM and private-key modes were only verified as existing `0600`; they were not changed. All retained resources and the later cleanup obligation remain in place; this hardening is not final cleanup or canonical vault completion.

--- a/ops/pi-user-vm/t20-verifier-explainer.html
+++ b/ops/pi-user-vm/t20-verifier-explainer.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>T20 · Verifier Explainer</title>
+  <meta name="description" content="Three terminal-style SVG diagrams explaining the T20 libvirt machine-type verifiers.">
+  <style>
+    :root {
+      --bg: #282828;
+      --raised: #32302f;
+      --user: #3c3836;
+      --selected: #45403d;
+      --text: #ebdbb2;
+      --bright: #fbf1c7;
+      --orange: #f28534;
+      --yellow: #fabd2f;
+      --gold: #e9b143;
+      --green: #b8bb26;
+      --green2: #b0b846;
+      --blue: #80aa9e;
+      --sage: #89b482;
+      --purple: #d3869b;
+      --red: #ea6962;
+      --muted: #928374;
+      --dim: #665c54;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    html { background: var(--bg); scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 88% 4%, rgba(128,170,158,.09), transparent 26rem),
+        radial-gradient(circle at 8% 28%, rgba(242,133,52,.08), transparent 24rem),
+        var(--bg);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    }
+    :where(p,h1,h2,h3,li,code,span) { overflow-wrap: anywhere; }
+    .t20-page { width: min(1120px, calc(100% - 2rem)); margin: 0 auto; padding: 2rem 0 5rem; }
+    .t20-topbar {
+      display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+      padding: .72rem 1rem; border: 1px solid var(--selected); border-bottom: 0;
+      border-radius: 13px 13px 0 0; background: var(--raised); color: var(--text); font-size: .74rem;
+    }
+    .t20-dots { display: flex; gap: .42rem; }
+    .t20-dot { width: .62rem; height: .62rem; border-radius: 50%; }
+    .t20-dot:nth-child(1) { background: var(--red); }
+    .t20-dot:nth-child(2) { background: var(--yellow); }
+    .t20-dot:nth-child(3) { background: var(--green); }
+    .t20-hero {
+      border: 1px solid var(--selected); border-radius: 0 0 13px 13px; background: rgba(50,48,47,.92);
+      padding: clamp(1.35rem, 4vw, 3rem); box-shadow: 0 24px 70px rgba(0,0,0,.3);
+    }
+    .t20-kicker { color: var(--orange); font-size: .72rem; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+    h1 { margin: .7rem 0 1rem; max-width: 900px; color: var(--bright); font-size: clamp(2.2rem, 7vw, 5rem); line-height: .95; letter-spacing: -.06em; }
+    .t20-lede { max-width: 820px; margin: 0; color: var(--text); font-size: clamp(.94rem, 2vw, 1.08rem); line-height: 1.65; }
+    .t20-command { margin-top: 1.4rem; padding: .8rem 1rem; border-left: 3px solid var(--green); background: var(--bg); color: var(--text); font-size: .8rem; }
+    .t20-command b { color: var(--green); }
+    .t20-card {
+      margin-top: 2.2rem; border: 1px solid var(--selected); border-radius: 14px;
+      overflow: hidden; background: rgba(50,48,47,.92); box-shadow: 0 16px 48px rgba(0,0,0,.18);
+    }
+    .t20-card-head { display: grid; grid-template-columns: auto 1fr auto; gap: .9rem; align-items: center; padding: 1rem 1.2rem; border-bottom: 1px solid var(--selected); }
+    .t20-id { color: var(--bg); background: var(--orange); border-radius: 6px; padding: .38rem .5rem; font-weight: 900; }
+    .t20-card h2 { margin: 0; color: var(--bright); font-size: clamp(1rem, 3vw, 1.45rem); letter-spacing: -.025em; }
+    .t20-pass { color: var(--green); border: 1px solid rgba(184,187,38,.45); border-radius: 999px; padding: .3rem .55rem; font-size: .7rem; white-space: nowrap; }
+    .t20-diagram { padding: clamp(.6rem, 2vw, 1.2rem); overflow-x: auto; background: var(--bg); }
+    .t20-diagram svg { display: block; width: 100%; min-width: 900px; height: auto; }
+    .t20-copy { padding: 1.15rem 1.25rem 1.3rem; display: grid; grid-template-columns: 1.1fr .9fr; gap: 1.2rem; }
+    .t20-copy h3 { margin: 0 0 .5rem; color: var(--gold); font-size: .78rem; text-transform: uppercase; letter-spacing: .1em; }
+    .t20-copy p, .t20-copy li { color: var(--text); font-size: .82rem; line-height: 1.58; }
+    .t20-copy p { margin: 0; }
+    .t20-copy ul { margin: 0; padding-left: 1.15rem; }
+    .t20-copy li + li { margin-top: .35rem; }
+    .t20-evidence { border-left: 1px solid var(--selected); padding-left: 1.2rem; }
+    .t20-evidence code { color: var(--purple); }
+    .t20-footer { margin-top: 2.6rem; display: flex; justify-content: space-between; flex-wrap: wrap; gap: .8rem; color: var(--text); font-size: .7rem; }
+    .t20-svg-bg { fill: #282828; }
+    .t20-svg-panel { fill: #32302f; stroke: #45403d; stroke-width: 2; }
+    .t20-svg-panel-hot { fill: #353d25; stroke: #b8bb26; stroke-width: 2; }
+    .t20-svg-panel-warn { fill: #3c3836; stroke: #fabd2f; stroke-width: 2; }
+    .t20-svg-panel-off { fill: #3d1f1f; stroke: #f2594b; stroke-width: 2; }
+    .t20-svg-title { fill: #fbf1c7; font: 700 18px ui-monospace, monospace; }
+    .t20-svg-text { fill: #ebdbb2; font: 14px ui-monospace, monospace; }
+    .t20-svg-small { fill: #ebdbb2; font: 12px ui-monospace, monospace; }
+    .t20-svg-green { fill: #b8bb26; font: 700 13px ui-monospace, monospace; }
+    .t20-svg-yellow { fill: #fabd2f; font: 700 13px ui-monospace, monospace; }
+    .t20-svg-red { fill: #ea6962; font: 700 13px ui-monospace, monospace; }
+    .t20-svg-blue { fill: #80aa9e; font: 700 13px ui-monospace, monospace; }
+    .t20-svg-purple { fill: #d3869b; font: 13px ui-monospace, monospace; }
+    .t20-svg-line { stroke: #665c54; stroke-width: 2; fill: none; }
+    .t20-svg-line-green { stroke: #b8bb26; stroke-width: 3; fill: none; }
+    .t20-svg-line-blue { stroke: #80aa9e; stroke-width: 3; fill: none; }
+    .t20-svg-line-yellow { stroke: #fabd2f; stroke-width: 3; fill: none; }
+    .t20-svg-terminal { fill: #3c3836; stroke: #45403d; stroke-width: 1.5; }
+    .t20-svg-prompt { fill: #b8bb26; font: 700 12px ui-monospace, monospace; }
+    .t20-svg-command { fill: #ebdbb2; font: 12px ui-monospace, monospace; }
+    @media (max-width: 760px) {
+      .t20-page { width: min(100% - 1rem, 1120px); padding-top: .5rem; }
+      .t20-copy { grid-template-columns: 1fr; }
+      .t20-evidence { border-left: 0; border-top: 1px solid var(--selected); padding: 1rem 0 0; }
+      .t20-card-head { grid-template-columns: auto 1fr; }
+      .t20-pass { grid-column: 1 / -1; justify-self: start; }
+      h1 { letter-spacing: -.045em; }
+    }
+    @media print {
+      body { background: white; }
+      .t20-card, .t20-hero { break-inside: avoid; box-shadow: none; }
+    }
+  </style>
+</head>
+<body>
+  <main class="t20-page">
+    <div class="t20-topbar">
+      <div class="t20-dots" aria-hidden="true"><span class="t20-dot"></span><span class="t20-dot"></span><span class="t20-dot"></span></div>
+      <span>t20-verifiers — 112×34</span>
+      <span>ansi / gruvbox-material</span>
+    </div>
+    <header class="t20-hero">
+      <div class="t20-kicker">Multi-VM GPU Host · T20</div>
+      <h1>Three proofs. One tested VM choice.</h1>
+      <p class="t20-lede">The evidence moves from architecture choice to a working guest, then proves that the guest survives a real cold lifecycle. Each verifier answers one question and deliberately leaves downstream policy alone.</p>
+      <div class="t20-command"><b>$</b> verify T20 --ordered <span style="color:var(--orange)">V01</span> → <span style="color:var(--blue)">V02</span> → <span style="color:var(--purple)">V03</span> <span style="color:var(--green)">[PASS]</span></div>
+    </header>
+
+    <article class="t20-card" id="v01">
+      <div class="t20-card-head"><span class="t20-id">V01</span><h2>Which libvirt machine type should user VMs use?</h2><span class="t20-pass">● PASS</span></div>
+      <div class="t20-diagram">
+        <svg viewBox="0 0 1000 330" role="img" aria-labelledby="v01-title v01-desc">
+          <title id="v01-title">V01 candidate selection diagram</title>
+          <desc id="v01-desc">Q35 and microvm pass live probes, Cloud Hypervisor is unavailable, and Q35 wins the maturity and compatibility tie-break.</desc>
+          <defs><marker id="v01-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10Z" fill="#b8bb26"/></marker></defs>
+          <rect class="t20-svg-bg" width="1000" height="330" rx="10"/>
+          <text class="t20-svg-small" x="25" y="28">candidate matrix / live homelab evidence</text>
+          <rect class="t20-svg-panel-hot" x="25" y="50" width="285" height="150" rx="10"/>
+          <text class="t20-svg-title" x="47" y="82">QEMU/KVM Q35</text>
+          <text class="t20-svg-green" x="47" y="110">[PASS] standard path</text>
+          <text class="t20-svg-small" x="47" y="139">virt-install · UEFI · PCI</text>
+          <text class="t20-svg-small" x="47" y="162">boot · disk · net · console</text>
+          <text class="t20-svg-small" x="47" y="185">cold lifecycle</text>
+          <rect class="t20-svg-panel-warn" x="357" y="50" width="285" height="150" rx="10"/>
+          <text class="t20-svg-title" x="379" y="82">QEMU microvm</text>
+          <text class="t20-svg-yellow" x="379" y="110">[PASS] specialized</text>
+          <text class="t20-svg-small" x="379" y="139">hand-authored XML</text>
+          <text class="t20-svg-small" x="379" y="162">virtio-mmio · fewer devices</text>
+          <text class="t20-svg-small" x="379" y="185">no required benefit</text>
+          <rect class="t20-svg-panel-off" x="689" y="50" width="285" height="150" rx="10"/>
+          <text class="t20-svg-title" x="711" y="82">Cloud Hypervisor</text>
+          <text class="t20-svg-red" x="711" y="110">[UNAVAILABLE]</text>
+          <text class="t20-svg-small" x="711" y="139">ch:///system</text>
+          <text class="t20-svg-small" x="711" y="162">no connection driver</text>
+          <text class="t20-svg-small" x="711" y="185">excluded before boot</text>
+          <path class="t20-svg-line-green" d="M168 210 L168 252 L440 252" marker-end="url(#v01-arrow)"/>
+          <path class="t20-svg-line" d="M500 210 L500 236"/>
+          <path class="t20-svg-line" d="M832 210 L832 236"/>
+          <rect class="t20-svg-terminal" x="440" y="225" width="430" height="82" rx="8"/>
+          <text class="t20-svg-prompt" x="462" y="254">$</text>
+          <text class="t20-svg-command" x="482" y="254">select --priority maturity,compatibility</text>
+          <text class="t20-svg-green" x="462" y="282">→ q35 / qemu:///system / owner approved</text>
+        </svg>
+      </div>
+      <div class="t20-copy">
+        <div><h3>What it proves</h3><p>Three candidates receive a real disposition. Q35 and <code>microvm</code> both booted Ubuntu and passed storage, networking, console, and lifecycle probes. Q35 wins because it uses the ordinary supported path; Cloud Hypervisor cannot be managed by this host's installed libvirt build.</p></div>
+        <div class="t20-evidence"><h3>What it does not decide</h3><ul><li>Production image lifecycle</li><li>VM resources or restart policy</li><li>Credentials or user migration</li></ul></div>
+      </div>
+    </article>
+
+    <article class="t20-card" id="v02">
+      <div class="t20-card-head"><span class="t20-id">V02</span><h2>Does the selected guest have the minimum usable boundary?</h2><span class="t20-pass">● PASS</span></div>
+      <div class="t20-diagram">
+        <svg viewBox="0 0 1000 350" role="img" aria-labelledby="v02-title v02-desc">
+          <title id="v02-title">V02 guest identity and connectivity diagram</title>
+          <desc id="v02-desc">A Q35 guest is managed by libvirt, passes guest capability checks, and reaches a temporary listener through the tested libvirt bridge path; Tailscale and public routing are outside this verifier.</desc>
+          <defs><marker id="v02-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#80aa9e"/></marker></defs>
+          <rect class="t20-svg-bg" width="1000" height="350" rx="10"/>
+          <text class="t20-svg-small" x="25" y="28">selected path / identity + guest + network</text>
+          <rect class="t20-svg-panel" x="25" y="72" width="260" height="170" rx="10"/>
+          <text class="t20-svg-title" x="47" y="104">libvirt</text>
+          <text class="t20-svg-blue" x="47" y="132">qemu:///system</text>
+          <text class="t20-svg-small" x="47" y="160">type = kvm</text>
+          <text class="t20-svg-small" x="47" y="183">machine = pc-q35-noble</text>
+          <text class="t20-svg-small" x="47" y="206">emulator = qemu-system-x86_64</text>
+          <path class="t20-svg-line-blue" d="M285 157 L368 157" marker-end="url(#v02-arrow)"/>
+          <rect class="t20-svg-panel-hot" x="380" y="52" width="285" height="210" rx="10"/>
+          <text class="t20-svg-title" x="402" y="84">Ubuntu 24.04 guest</text>
+          <text class="t20-svg-green" x="402" y="114">[RUNNING]</text>
+          <text class="t20-svg-text" x="402" y="148">✓ systemd user manager</text>
+          <text class="t20-svg-text" x="402" y="176">✓ writable $HOME</text>
+          <text class="t20-svg-text" x="402" y="204">✓ strict SSH identity</text>
+          <text class="t20-svg-text" x="402" y="232">✓ virt = kvm</text>
+          <path class="t20-svg-line-blue" d="M665 157 L748 157" marker-end="url(#v02-arrow)"/>
+          <rect class="t20-svg-panel" x="760" y="72" width="215" height="170" rx="10"/>
+          <text class="t20-svg-title" x="782" y="104">libvirt bridge</text>
+          <text class="t20-svg-blue" x="782" y="134">192.168.122.1</text>
+          <text class="t20-svg-small" x="782" y="164">temporary :18767</text>
+          <text class="t20-svg-green" x="782" y="194">TCP [PASS]</text>
+          <text class="t20-svg-small" x="782" y="219">listener removed</text>
+          <rect class="t20-svg-terminal" x="222" y="286" width="556" height="42" rx="7"/>
+          <text class="t20-svg-prompt" x="244" y="312">$</text>
+          <text class="t20-svg-command" x="264" y="312">path=libvirt-bridge  listener=:18767  temporary=true</text>
+        </svg>
+      </div>
+      <div class="t20-copy">
+        <div><h3>What it proves</h3><p>The approved Q35 identity appears in live domain XML, and the guest is usable for a Pi-style workload: virtualization is real, user services work, home is writable, and TCP crosses the tested libvirt bridge path. Strict SSH key and host-key checks were used. The listener is temporary and removed after each observation.</p></div>
+        <div class="t20-evidence"><h3>What it does not decide</h3><ul><li>Tailscale state was not inspected or altered.</li><li>No Tailscale enrollment was performed.</li><li>No exit node was required.</li><li>Public routing was not evaluated.</li></ul></div>
+      </div>
+    </article>
+
+    <article class="t20-card" id="v03">
+      <div class="t20-card-head"><span class="t20-id">V03</span><h2>Does guest state survive a real libvirt cold lifecycle?</h2><span class="t20-pass">● PASS</span></div>
+      <div class="t20-diagram">
+        <svg viewBox="0 0 1000 345" role="img" aria-labelledby="v03-title v03-desc">
+          <title id="v03-title">V03 cold lifecycle state diagram</title>
+          <desc id="v03-desc">A marker is written and synced, the domain shuts off and restarts, SSH returns, and the exact marker persists before cleanup.</desc>
+          <defs><marker id="v03-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#d3869b"/></marker></defs>
+          <rect class="t20-svg-bg" width="1000" height="345" rx="10"/>
+          <text class="t20-svg-small" x="25" y="28">state machine / marker must survive the cold boundary</text>
+          <rect class="t20-svg-panel-hot" x="24" y="82" width="165" height="118" rx="9"/>
+          <text class="t20-svg-title" x="45" y="114">RUNNING</text>
+          <text class="t20-svg-small" x="45" y="145">write marker</text>
+          <text class="t20-svg-green" x="45" y="174">sync ✓</text>
+          <path class="t20-svg-line-yellow" d="M189 141 L252 141" marker-end="url(#v03-arrow)"/>
+          <rect class="t20-svg-panel-warn" x="264" y="82" width="165" height="118" rx="9"/>
+          <text class="t20-svg-title" x="285" y="114">SHUTDOWN</text>
+          <text class="t20-svg-small" x="285" y="145">virsh shutdown</text>
+          <text class="t20-svg-yellow" x="285" y="174">shut off ✓</text>
+          <path class="t20-svg-line" d="M429 141 L492 141" marker-end="url(#v03-arrow)"/>
+          <rect class="t20-svg-panel" x="504" y="82" width="165" height="118" rx="9"/>
+          <text class="t20-svg-title" x="525" y="114">START</text>
+          <text class="t20-svg-small" x="525" y="145">virsh start</text>
+          <text class="t20-svg-blue" x="525" y="174">SSH returns ✓</text>
+          <path class="t20-svg-line-blue" d="M669 141 L732 141" marker-end="url(#v03-arrow)"/>
+          <rect class="t20-svg-panel-hot" x="744" y="82" width="232" height="118" rx="9"/>
+          <text class="t20-svg-title" x="765" y="114">VERIFY</text>
+          <text class="t20-svg-small" x="765" y="145">exact marker matches</text>
+          <text class="t20-svg-green" x="765" y="174">user systemd ✓</text>
+          <rect class="t20-svg-terminal" x="185" y="252" width="630" height="62" rx="8"/>
+          <text class="t20-svg-prompt" x="207" y="280">$</text>
+          <text class="t20-svg-command" x="227" y="280">cat ~/.t20-persistence == $marker</text>
+          <text class="t20-svg-green" x="207" y="301">[PASS] persistent disk + lifecycle + recovery</text>
+        </svg>
+      </div>
+      <div class="t20-copy">
+        <div><h3>What it proves</h3><p>The marker is durable, not merely cached in a running guest. Libvirt reaches <code>shut off</code>, starts the same persistent domain, SSH recovers, and the exact marker plus user service behavior survive the boundary.</p></div>
+        <div class="t20-evidence"><h3>Still outside T20</h3><ul><li>Crash-restart and autostart policy</li><li>Production backups and image recovery</li><li>Long-running Pi process migration</li></ul></div>
+      </div>
+    </article>
+
+    <footer class="t20-footer"><span>source · T20 accepted verifier evidence</span><span>style · ANSI states / Gruvbox Material / terminal-first</span></footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Verifiers

### V01 — candidate selection and owner approval

**Contract.** Compare QEMU/KVM Q35, QEMU/KVM `microvm`, and Cloud Hypervisor for native libvirt manageability, KVM identity, representative Ubuntu boot, persistent block storage, libvirt networking, headless console, graceful cold lifecycle, material limitations, and rejection rationale; select only after owner approval.

**Exact command/manual observation.** The host-side capability observations included:

```sh
virsh -c qemu:///system domcapabilities --virttype kvm --arch x86_64 --machine q35
virsh -c qemu:///system domcapabilities --virttype kvm --arch x86_64 --machine microvm
virsh -c ch:///system capabilities
command -v cloud-hypervisor
```

The two QEMU candidates were then booted and checked with `virsh -c qemu:///system`, checked batch SSH, bounded `virsh console`, marker persistence, `virsh shutdown`, a poll to `shut off`, `virsh start`, and post-start SSH. Q35 worked through ordinary `virt-install`; `microvm` required hand-authored `virtio-mmio` XML; `ch:///system capabilities` reported `no connection driver available` and `cloud-hypervisor` was absent. The owner approved Q35 in canonical Vault Hunter Run `vh-T20-1785077639159`, observation `T20.V01.q35-selection.approved.2026-07-26`, Registry revision 12.

**Result: PASS.** Q35 is the approved maturity/compatibility choice. Reviewed commit `033baac5667444f4ebdc75e74715f81bc2e5115a`; tree `b8fcfd59a510fdb888a62a9cb7e991940f28482a`. Machine evaluation SHA-256 `97ca61ab78038b1413aa87d2955574e43364d943ed66a9c8ee27c5a746ab3194`; final-check transcript SHA-256 `b10c830bb25f5fed6a8d814f46af0a80254ef6acd1d25e323ee02043ebf9bd5c`.

### V02 — selected Q35 identity and guest/peer capability

**Contract.** A persistent running domain must report `kvm`, `pc-q35-noble`, and `/usr/bin/qemu-system-x86_64`; cloud-init, guest KVM identity, user systemd, writable home, strict batch SSH, and one approved temporary host-local TCP exchange must succeed, after which the listener must be absent.

**Exact command/observation.** The corrected complete verifier used the live XML default for the running domain and strict SSH:

```sh
test "$(virsh -c qemu:///system domstate t20-v02-q35)" = running
virsh -c qemu:///system dumpxml t20-v02-q35

timeout 60 ssh -i /home/avirus/.local/state/t20-v02-q35/id_ed25519 \
  -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
  -o UserKnownHostsFile=/home/avirus/.local/state/t20-v02-q35/known_hosts \
  t20eval@192.168.122.164 'cloud-init status --wait; systemd-detect-virt; systemd-run --user --wait --collect --quiet /usr/bin/true; test -w "$HOME"'
```

The same checked guest session opened `/dev/tcp/192.168.122.1/18767`, sent `T20-V02-PROBE`, and required `T20-V02-ACK`; the one-shot listener independently recorded the peer/token and then exited. The identity comparison returned exactly `kvm`, `pc-q35-noble`, and `/usr/bin/qemu-system-x86_64`; the final socket-absence check passed.

**Result: PASS.** Reviewed commit `033baac5667444f4ebdc75e74715f81bc2e5115a`; tree `b8fcfd59a510fdb888a62a9cb7e991940f28482a`. Final-check transcript SHA-256 `b10c830bb25f5fed6a8d814f46af0a80254ef6acd1d25e323ee02043ebf9bd5c`; machine evaluation SHA-256 `97ca61ab78038b1413aa87d2955574e43364d943ed66a9c8ee27c5a746ab3194`.

### V03 — graceful cold lifecycle and persistence

**Contract.** Create and sync a unique guest marker, request graceful shutdown and observe `shut off`, cold-start the same persistent domain, recover through checked batch SSH, compare the exact marker, recover user systemd, remove the marker, and retain only the authorized resources with autostart disabled.

**Exact command/observation.** The accepted verifier freshly read the dynamic lease, used strict checked SSH to write and `sync` the marker, and executed:

```sh
virsh -c qemu:///system shutdown t20-v02-q35
# bounded poll: virsh -c qemu:///system domstate t20-v02-q35 until exactly "shut off"
virsh -c qemu:///system start t20-v02-q35
# bounded checked-SSH poll using ssh -n, BatchMode, IdentitiesOnly, strict host-key checking, and ConnectTimeout=2
# checked guest assertions: exact marker comparison, then
systemd-run --user --wait --collect --quiet /usr/bin/true
```

The domain reached `shut off` on poll 2, started successfully, and strict batch SSH returned on poll 3. The synced marker matched byte-for-byte, user systemd passed, and the marker was removed. Postchecks found the domain running with autostart disabled, the pool running with autostart off, retained disk/seed/NVRAM/SSH state present, and listener port 18767 absent.

**Result: PASS.** Reviewed commit `033baac5667444f4ebdc75e74715f81bc2e5115a`; tree `b8fcfd59a510fdb888a62a9cb7e991940f28482a`. Final-check transcript SHA-256 `b10c830bb25f5fed6a8d814f46af0a80254ef6acd1d25e323ee02043ebf9bd5c`; machine evaluation SHA-256 `97ca61ab78038b1413aa87d2955574e43364d943ed66a9c8ee27c5a746ab3194`.

## Evidence

- **Problem/verifier explainer:** [t20-verifier-explainer.html](https://github.com/aviralmansingka/dotfiles/blob/033baac5667444f4ebdc75e74715f81bc2e5115a/ops/pi-user-vm/t20-verifier-explainer.html) — commit-pinned presentation mapped to V01 candidate choice, V02 guest boundary, and V03 cold lifecycle; SHA-256 `870c9f5465ad1231ca8cca2d326fa9b7b84558b08e42da55360e2f141482868e`.
- **Machine evaluation:** [machine-type-evaluation.md](https://github.com/aviralmansingka/dotfiles/blob/033baac5667444f4ebdc75e74715f81bc2e5115a/ops/pi-user-vm/machine-type-evaluation.md) — commit-pinned commands, observations, outputs, limitations, approval provenance, cleanup history, and V01–V03 mapping; SHA-256 `97ca61ab78038b1413aa87d2955574e43364d943ed66a9c8ee27c5a746ab3194`.

The generated explainer teaches the verifier surface and the relationship among V01–V03. It is presentation material, not a substitute for the exact behavioral commands, observations, and outputs in the machine evaluation and sealed final-check transcript.

```text
FINAL_CHECKS=V01,V02,V03
FINAL_CHECK_EXIT=0
FINAL_CHECK_TRANSCRIPT_SHA256=b10c830bb25f5fed6a8d814f46af0a80254ef6acd1d25e323ee02043ebf9bd5c
EVALUATION_SHA256=97ca61ab78038b1413aa87d2955574e43364d943ed66a9c8ee27c5a746ab3194
EXPLAINER_SHA256=870c9f5465ad1231ca8cca2d326fa9b7b84558b08e42da55360e2f141482868e
REVIEWED_COMMIT=033baac5667444f4ebdc75e74715f81bc2e5115a
REVIEWED_TREE=b8fcfd59a510fdb888a62a9cb7e991940f28482a
WORKTREE_CLEAN=true
```

## Retained resources and cleanup

Retained owned resources are the running persistent `t20-v02-q35` domain (autostart disabled), active persistent `t20-v02-pool` (autostart off), its qcow2 and seed, libvirt-managed NVRAM, and operator SSH state. Private-key contents were never printed or committed.

Mandatory post-merge cleanup remains a separately authorized checkpoint: gracefully stop the domain, undefine it with NVRAM, destroy and undefine the pool, remove the owned pool storage and SSH state, and leave any shared-network DHCP record to expire normally. This PR update performs no cleanup and changes no host/libvirt state.

Accepted ADR decisions are tracked in the vault; no machine-local vault path is linked here.

## Boundaries

No production VM; no Tailscale or exit-node guest enrollment; no STT Worker change; no restart, image, credential, resource-sizing, crash-restart, or production provisioning policy work.

