### PR TITLE
feat(nvim): integrate compact Atlas with Sidekick

### DIFF
--- a/.agents/skills/vault-hunter/SKILL.md
+++ b/.agents/skills/vault-hunter/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: vault-hunter
-description: Drive one canonical vault-backed run while delegating small definite work to Registry-observable Pi subagents. Use when invoked as $vault-hunter with a Feature, Task, Issue, checkbox, or Wayfinder reference.
+description: Drive one canonical vault-backed run while delegating small definite work to bounded Pi subagents. Use when invoked as $vault-hunter with a Feature, Task, Issue, checkbox, or Wayfinder reference.
 ---
 
 # Vault Hunter
 
 Drive one vault-backed request from the primary Pi session. The parent is the sole lifecycle decision-maker, handoff
-acceptor, Run Registry producer, and vault writer. Small definite work defaults to bounded headless `pi-subagents`
+acceptor, Run Registry producer, and vault writer. Small definite work defaults to bounded headless `subagent`
 children. Use a full Herdr-visible Codex session only when a human benefits from opening, steering, or resuming its
 terminal.
 
@@ -22,10 +22,10 @@ terminal.
   checklist, weekly backlog, or branch, stop before editing until ownership is unambiguous.
 - Keep one writer in an implementation worktree. Parallelize reads, review, and isolated checks, not ordinary writes.
 - Preserve unrelated Git, Herdr, Neovim, and filesystem state.
-- A formal child is any delegated agent whose result may influence the Run. Every formal headless child must launch
-  through `vault_hunter_step`; never call `subagent` directly for one.
+- A formal child is any delegated agent whose result may influence the Run. Launch every formal headless child directly
+  through `subagent`; the call is synchronous and does not create a durable Run Registry participant.
 - After the parent minimally resolves the invocation target, all mechanical discovery that may inform routing,
-  specification, implementation, verification, review, or landing is performed by registered headless children. The
+  specification, implementation, verification, review, or landing is performed by bounded headless children. The
   parent may validate returned facts but never fills missing discovery itself; launch another bounded child instead.
 
 ## Invocation
@@ -46,8 +46,7 @@ Before substantive discovery:
    in the same backlog entry on the next accepted vault edit. For an interactive parent, this call atomically resolves
    and validates the current Herdr workspace/tab/pane/terminal tuple and exact Pi session binding; never infer or append
    driver placement separately.
-6. If Registry creation or interactive Herdr registration fails, stop before dispatching a formal child. Do not fall
-   back to an unregistered child.
+6. If Registry creation or interactive Herdr registration fails, stop before dispatching a formal child.
 
 Before the invocation commit, emit no plan or clarification beyond the host's minimal skill acknowledgment.
 
@@ -77,11 +76,11 @@ Choose the cheapest runtime that preserves the stage's real needs.
 
 | Work | Default | Escalate to full Herdr Codex only when |
 |---|---|---|
-| Exact lookup, Git/CI status, baseline command, hash, immutable check | `delegate` via `vault_hunter_step`, fresh context, `openai-codex/gpt-5.6-luna:low` | Authentication or live operator interaction is required |
-| Mechanical context inventory: hierarchy, repository, instructions, Git state, and key paths | `delegate` via `vault_hunter_step`, fresh context, `openai-codex/gpt-5.6-luna:low` | Never escalate for synthesis; return a compact evidence pack and stop |
-| Specification draft and verifier judgment | `context-builder` via `vault_hunter_step`, fresh context, strong inherited model, accepted context pack plus exact canonical files | A concrete ambiguity requires live human exploration, or the same terminal must remain open across a human checkpoint |
-| Implementation or approved fix slice | `worker` via `vault_hunter_step`, exact worktree | A manual UI/demo or live steering is materially useful |
-| Independent review | `reviewer` via `vault_hunter_step`, fresh context, no edits | The human explicitly wants to inspect or interact with the reviewer |
+| Exact lookup, Git/CI status, baseline command, hash, immutable check | `delegate` via `subagent` (configured Luna/low) | Authentication or live operator interaction is required |
+| Mechanical context inventory: hierarchy, repository, instructions, Git state, and key paths | `delegate` via `subagent` (configured Luna/low) | Never escalate for synthesis; return a compact evidence pack and stop |
+| Specification draft and verifier judgment | `context-builder` via `subagent` (configured strong model), accepted context pack plus exact canonical files | A concrete ambiguity requires live human exploration, or the same terminal must remain open across a human checkpoint |
+| Implementation or approved fix slice | `worker` via `subagent`, exact worktree | A manual UI/demo or live steering is materially useful |
+| Independent review | `reviewer` via `subagent`, no edits | The human explicitly wants to inspect or interact with the reviewer |
 | Refactor judgment | `reviewer` headlessly; one `worker` only for accepted changes | The investigation is genuinely exploratory and interactive |
 | Pure human approval checkpoint | Parent | Never delegate |
 | Interactive prototype, TUI/manual acceptance | `$vault-hunter-worker` | Always use Herdr for this row |
@@ -90,40 +89,31 @@ Choose the cheapest runtime that preserves the stage's real needs.
 
 Do not encode a whole Task Run as one subagent chain. Launch one formal stage at a time so the parent can inspect the
 handoff, record its decision, and choose the next stage. Independent read-only jobs may run in parallel as separate
-`vault_hunter_step` calls. Never launch parallel writers into the same worktree.
+`subagent` calls. Never launch parallel writers into the same worktree.
 
 ## Formal child contract
 
 ### Headless child
 
-Call `vault_hunter_step` once per child with:
+Call `subagent` once per child with the chosen agent, exact cwd/worktree, and a compact prompt containing the stable
+Goal ID and role, outcome, accepted inputs and exact file allowlist, invariants, validation, output shape, and stop rules.
+Permit only directly relevant imports, callers, and tests beyond that allowlist. Do not request external research unless
+the stage explicitly requires it. Include Ponytail constraints directly in implementation/fix prompts and the exact
+check contract directly in validation prompts because children start with no inherited context or skills.
 
-- Registry Run ID, stable Goal ID, lifecycle kind, role, exact cwd/worktree, and chosen agent;
-- a compact prompt containing the outcome, accepted inputs and exact file allowlist, invariants, validation, output
-  shape, and stop rules; permit only directly relevant imports, callers, and tests beyond that allowlist;
-- no external research or `web_search` unless the stage explicitly requires current external evidence;
-- fresh context by default; fork only when inherited parent history is intentionally required;
-- `$ponytail` for implementation and fix workers;
-- `$vault-hunter-check` for exact declared check execution.
+Before launch, inspect the selected agent's configured model and tools. If a required capability is unavailable, choose
+a compatible configured agent or stop before spawn; optional unavailable tools must not turn a completed bounded
+handoff into a failed formal stage.
 
-Before launch, inspect the selected agent's configured model, tools, and extensions. If a required capability is
-unavailable, choose a compatible registered agent or stop before spawn; optional unavailable tools must not turn a
-completed bounded handoff into a failed formal stage.
-
-The wrapper persists a launch intent, launches asynchronously through `pi-subagents`, writes the native async-run
-participant and active observation to the Registry, binds the child beside its status artifact, and replays control and
-terminal state after restart. If registration fails, treat the child as a potentially live orphan: request stop,
-quarantine its cwd from another writer, inspect Pi process-terminal evidence and any worktree delta, and do not launch a
-replacement writer until termination is proved or the Run is explicitly blocked.
-
-Use `subagent_wait` when the current stage cannot be decided without the result. Use structured status or transcript
-inspection only after a completion or attention signal; never poll in a loop. `needs_attention` means silence was
-observed, not that the child is stuck. Interrupt only on concrete drift, blockage, or explicit human request.
+The call runs synchronously in an isolated Pi process and returns only its result. It creates no durable child session,
+Registry participant, restart replay, pause/resume control, or background completion signal. Do not claim Registry-backed
+child evidence for these children. If a writer call is interrupted or fails ambiguously, quarantine its cwd, inspect the
+worktree delta, and do not launch a replacement writer until no child process remains or the Run is explicitly blocked.
 
 A useful handoff reports changed paths, commands and exit codes, commit/tree when applicable, concise findings,
 remaining risks, and decisions requiring the parent. Child completion is not acceptance. If the formal child exits
-failed after producing an apparently complete artifact, do not accept it directly: launch one registered
-`openai-codex/gpt-5.6-luna:low` read-only validator to report only the artifact hash and required shape, repository
+failed after producing an apparently complete artifact, do not accept it directly: launch one `delegate` read-only
+validator to report only the artifact hash and required shape, repository
 cleanliness, and exact runtime error. The parent alone decides whether the failure is independent of the result and
 whether to accept the artifact.
 
@@ -163,7 +153,7 @@ Route by target:
 - **Feature:** refine stable ordered Tasks and planned observable verifiers, store the accepted plan, then stop before
   implementation.
 - **Task:** execute the Task timeline below.
-- **Issue or Wayfinder effort:** use registered result-only headless children for bounded research, let the parent write
+- **Issue or Wayfinder effort:** use result-only headless children for bounded research, let the parent write
   every ticket/map/Feature decision, then stop before implementation. Do not use `wayfinder_subagents` because its AFK
   children write tracker notes and violate this skill's sole vault-writer boundary.
 
@@ -188,7 +178,7 @@ evidence items.
 Maintain one continuous backlog timeline. For each stage: record parent activation, dispatch through the router, inspect
 the handoff and repository evidence, record the parent decision, then update the Task note and backlog. The parent may
 perform small mechanical reads only to validate a handoff; if required evidence is missing, it launches another bounded
-registered child rather than discovering the answer itself. It does not redo delegated investigation or implementation.
+child rather than discovering the answer itself. It does not redo delegated investigation or implementation.
 
 ### Specification and checkpoint one
 
@@ -202,14 +192,14 @@ commits directly; never open a vault PR.
 
 Stop before implementation. Mark `Blocked — Awaiting human evaluation`, report the Task link, verifier ledger,
 checkpoint commits, and exact decision requested. A pure approval is handled by the parent. When feedback requires more
-specification work, launch a new registered follow-up child with the canonical Task, prior handoff, checkpoint evidence,
-and exact feedback. Same-session resumption is reserved for a deliberately chosen Herdr exception. Activate V01 only
+specification work, launch a new bounded follow-up child with the canonical Task, prior handoff, checkpoint evidence,
+and exact feedback. Children cannot be resumed; same-terminal continuity requires a deliberately chosen Herdr exception. Activate V01 only
 after the parent accepts the resulting specification.
 
 ### One goal per verifier
 
 Before launching an implementation or fix writer, require a clean worktree except for explicitly accepted source
-changes. Treat `.pi-subagents/` and other runtime-generated files as owned runtime debris: remove only the current Run's
+changes. Treat runtime-generated files as owned runtime debris: remove only the current Run's
 artifacts when safe, or block the writer. Never silently include runtime artifacts in implementation commits.
 
 For each verifier in order:
@@ -239,18 +229,18 @@ major specification/architecture violation remains; do not chase optional polish
 
 1. Launch a final check child and refresh each existing `EX01` in place from accepted evidence.
 2. Launch a bounded release worker to push implementation and open the PR. Never arm auto-merge.
-3. Use registered `openai-codex/gpt-5.6-luna:low` observer children for discrete CI/approval status reads. Do not keep
+3. Use `delegate` observer children for discrete CI/approval status reads. Do not keep
    an agent alive merely to poll.
 4. Fix CI failures through the same single-writer and verifier loop. Never bypass branch protection or approval.
 5. When ready, report and wait for explicit human merge.
-6. After merge, launch a registered check child against a temporary detached worktree at fetched merged main.
+6. After merge, launch a bounded check child against a temporary detached worktree at fetched merged main.
 
 ### Cleanup and checkpoint two
 
 After accepted post-merge evidence:
 
-1. Confirm every registered headless child is terminal or explicitly preserved as blocked. Its lack of Herdr presence is
-   expected; verify through Registry and Pi artifacts.
+1. Confirm no interrupted writer process remains. Synchronous headless children have no Registry participant or durable
+   Pi artifact.
 2. Close only exact Herdr tabs, workspaces, and bound Neovim workspace tabs captured as created for this Run. If none
    were created, skip Herdr/Neovim cleanup. Preserve reusable and unrelated state.
 3. Remove only owned temporary worktrees/branches after ancestry and cleanliness checks.
@@ -262,13 +252,13 @@ After accepted post-merge evidence:
 
 ## Resume and disagreement
 
-On resume, use the canonical Task/backlog as authority and the Registry plus `pi-subagents` artifacts as observations.
-Replay is idempotent. Continue at the first unfinished canonical stage. If canonical state, Registry observations, and
+On resume, use the canonical Task/backlog as authority and the Registry plus live process/worktree evidence as observations.
+Continue at the first unfinished canonical stage. If canonical state, Registry observations, and
 live runtime disagree, report the mismatch and let the parent decide; never auto-advance, auto-fail, or rewrite the
 vault from runtime state.
 
 ## Completion
 
-Report the Feature/Task links, Registry Run ID, registered participant summary, implementation PR and merge state,
+Report the Feature/Task links, Registry Run ID, participant summary, implementation PR and merge state,
 accepted verifier and post-merge evidence, backlog entry, vault checkpoint commits, remote-main proof, cleanup evidence,
 and preserved unrelated dirty state or deferred polish.

--- a/.agents/skills/vault-hunter/SKILL.md
+++ b/.agents/skills/vault-hunter/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: vault-hunter
-description: Drive one canonical vault-backed run while delegating small definite work to bounded Pi subagents. Use when invoked as $vault-hunter with a Feature, Task, Issue, checkbox, or Wayfinder reference.
+description: Drive one canonical vault-backed run while delegating small definite work to Registry-observable Pi subagents. Use when invoked as $vault-hunter with a Feature, Task, Issue, checkbox, or Wayfinder reference.
 ---
 
 # Vault Hunter
 
 Drive one vault-backed request from the primary Pi session. The parent is the sole lifecycle decision-maker, handoff
-acceptor, Run Registry producer, and vault writer. Small definite work defaults to bounded headless `subagent`
+acceptor, Run Registry producer, and vault writer. Small definite work defaults to bounded headless `pi-subagents`
 children. Use a full Herdr-visible Codex session only when a human benefits from opening, steering, or resuming its
 terminal.
 
@@ -22,10 +22,10 @@ terminal.
   checklist, weekly backlog, or branch, stop before editing until ownership is unambiguous.
 - Keep one writer in an implementation worktree. Parallelize reads, review, and isolated checks, not ordinary writes.
 - Preserve unrelated Git, Herdr, Neovim, and filesystem state.
-- A formal child is any delegated agent whose result may influence the Run. Launch every formal headless child directly
-  through `subagent`; the call is synchronous and does not create a durable Run Registry participant.
+- A formal child is any delegated agent whose result may influence the Run. Every formal headless child must launch
+  through `vault_hunter_step`; never call `subagent` directly for one.
 - After the parent minimally resolves the invocation target, all mechanical discovery that may inform routing,
-  specification, implementation, verification, review, or landing is performed by bounded headless children. The
+  specification, implementation, verification, review, or landing is performed by registered headless children. The
   parent may validate returned facts but never fills missing discovery itself; launch another bounded child instead.
 
 ## Invocation
@@ -46,7 +46,8 @@ Before substantive discovery:
    in the same backlog entry on the next accepted vault edit. For an interactive parent, this call atomically resolves
    and validates the current Herdr workspace/tab/pane/terminal tuple and exact Pi session binding; never infer or append
    driver placement separately.
-6. If Registry creation or interactive Herdr registration fails, stop before dispatching a formal child.
+6. If Registry creation or interactive Herdr registration fails, stop before dispatching a formal child. Do not fall
+   back to an unregistered child.
 
 Before the invocation commit, emit no plan or clarification beyond the host's minimal skill acknowledgment.
 
@@ -76,11 +77,11 @@ Choose the cheapest runtime that preserves the stage's real needs.
 
 | Work | Default | Escalate to full Herdr Codex only when |
 |---|---|---|
-| Exact lookup, Git/CI status, baseline command, hash, immutable check | `delegate` via `subagent` (configured Luna/low) | Authentication or live operator interaction is required |
-| Mechanical context inventory: hierarchy, repository, instructions, Git state, and key paths | `delegate` via `subagent` (configured Luna/low) | Never escalate for synthesis; return a compact evidence pack and stop |
-| Specification draft and verifier judgment | `context-builder` via `subagent` (configured strong model), accepted context pack plus exact canonical files | A concrete ambiguity requires live human exploration, or the same terminal must remain open across a human checkpoint |
-| Implementation or approved fix slice | `worker` via `subagent`, exact worktree | A manual UI/demo or live steering is materially useful |
-| Independent review | `reviewer` via `subagent`, no edits | The human explicitly wants to inspect or interact with the reviewer |
+| Exact lookup, Git/CI status, baseline command, hash, immutable check | `delegate` via `vault_hunter_step`, fresh context, `openai-codex/gpt-5.6-luna:low` | Authentication or live operator interaction is required |
+| Mechanical context inventory: hierarchy, repository, instructions, Git state, and key paths | `delegate` via `vault_hunter_step`, fresh context, `openai-codex/gpt-5.6-luna:low` | Never escalate for synthesis; return a compact evidence pack and stop |
+| Specification draft and verifier judgment | `context-builder` via `vault_hunter_step`, fresh context, strong inherited model, accepted context pack plus exact canonical files | A concrete ambiguity requires live human exploration, or the same terminal must remain open across a human checkpoint |
+| Implementation or approved fix slice | `worker` via `vault_hunter_step`, exact worktree | A manual UI/demo or live steering is materially useful |
+| Independent review | `reviewer` via `vault_hunter_step`, fresh context, no edits | The human explicitly wants to inspect or interact with the reviewer |
 | Refactor judgment | `reviewer` headlessly; one `worker` only for accepted changes | The investigation is genuinely exploratory and interactive |
 | Pure human approval checkpoint | Parent | Never delegate |
 | Interactive prototype, TUI/manual acceptance | `$vault-hunter-worker` | Always use Herdr for this row |
@@ -89,31 +90,40 @@ Choose the cheapest runtime that preserves the stage's real needs.
 
 Do not encode a whole Task Run as one subagent chain. Launch one formal stage at a time so the parent can inspect the
 handoff, record its decision, and choose the next stage. Independent read-only jobs may run in parallel as separate
-`subagent` calls. Never launch parallel writers into the same worktree.
+`vault_hunter_step` calls. Never launch parallel writers into the same worktree.
 
 ## Formal child contract
 
 ### Headless child
 
-Call `subagent` once per child with the chosen agent, exact cwd/worktree, and a compact prompt containing the stable
-Goal ID and role, outcome, accepted inputs and exact file allowlist, invariants, validation, output shape, and stop rules.
-Permit only directly relevant imports, callers, and tests beyond that allowlist. Do not request external research unless
-the stage explicitly requires it. Include Ponytail constraints directly in implementation/fix prompts and the exact
-check contract directly in validation prompts because children start with no inherited context or skills.
+Call `vault_hunter_step` once per child with:
 
-Before launch, inspect the selected agent's configured model and tools. If a required capability is unavailable, choose
-a compatible configured agent or stop before spawn; optional unavailable tools must not turn a completed bounded
-handoff into a failed formal stage.
+- Registry Run ID, stable Goal ID, lifecycle kind, role, exact cwd/worktree, and chosen agent;
+- a compact prompt containing the outcome, accepted inputs and exact file allowlist, invariants, validation, output
+  shape, and stop rules; permit only directly relevant imports, callers, and tests beyond that allowlist;
+- no external research or `web_search` unless the stage explicitly requires current external evidence;
+- fresh context by default; fork only when inherited parent history is intentionally required;
+- `$ponytail` for implementation and fix workers;
+- `$vault-hunter-check` for exact declared check execution.
 
-The call runs synchronously in an isolated Pi process and returns only its result. It creates no durable child session,
-Registry participant, restart replay, pause/resume control, or background completion signal. Do not claim Registry-backed
-child evidence for these children. If a writer call is interrupted or fails ambiguously, quarantine its cwd, inspect the
-worktree delta, and do not launch a replacement writer until no child process remains or the Run is explicitly blocked.
+Before launch, inspect the selected agent's configured model, tools, and extensions. If a required capability is
+unavailable, choose a compatible registered agent or stop before spawn; optional unavailable tools must not turn a
+completed bounded handoff into a failed formal stage.
+
+The wrapper persists a launch intent, launches asynchronously through `pi-subagents`, writes the native async-run
+participant and active observation to the Registry, binds the child beside its status artifact, and replays control and
+terminal state after restart. If registration fails, treat the child as a potentially live orphan: request stop,
+quarantine its cwd from another writer, inspect Pi process-terminal evidence and any worktree delta, and do not launch a
+replacement writer until termination is proved or the Run is explicitly blocked.
+
+Use `subagent_wait` when the current stage cannot be decided without the result. Use structured status or transcript
+inspection only after a completion or attention signal; never poll in a loop. `needs_attention` means silence was
+observed, not that the child is stuck. Interrupt only on concrete drift, blockage, or explicit human request.
 
 A useful handoff reports changed paths, commands and exit codes, commit/tree when applicable, concise findings,
 remaining risks, and decisions requiring the parent. Child completion is not acceptance. If the formal child exits
-failed after producing an apparently complete artifact, do not accept it directly: launch one `delegate` read-only
-validator to report only the artifact hash and required shape, repository
+failed after producing an apparently complete artifact, do not accept it directly: launch one registered
+`openai-codex/gpt-5.6-luna:low` read-only validator to report only the artifact hash and required shape, repository
 cleanliness, and exact runtime error. The parent alone decides whether the failure is independent of the result and
 whether to accept the artifact.
 
@@ -153,7 +163,7 @@ Route by target:
 - **Feature:** refine stable ordered Tasks and planned observable verifiers, store the accepted plan, then stop before
   implementation.
 - **Task:** execute the Task timeline below.
-- **Issue or Wayfinder effort:** use result-only headless children for bounded research, let the parent write
+- **Issue or Wayfinder effort:** use registered result-only headless children for bounded research, let the parent write
   every ticket/map/Feature decision, then stop before implementation. Do not use `wayfinder_subagents` because its AFK
   children write tracker notes and violate this skill's sole vault-writer boundary.
 
@@ -178,7 +188,7 @@ evidence items.
 Maintain one continuous backlog timeline. For each stage: record parent activation, dispatch through the router, inspect
 the handoff and repository evidence, record the parent decision, then update the Task note and backlog. The parent may
 perform small mechanical reads only to validate a handoff; if required evidence is missing, it launches another bounded
-child rather than discovering the answer itself. It does not redo delegated investigation or implementation.
+registered child rather than discovering the answer itself. It does not redo delegated investigation or implementation.
 
 ### Specification and checkpoint one
 
@@ -192,14 +202,14 @@ commits directly; never open a vault PR.
 
 Stop before implementation. Mark `Blocked — Awaiting human evaluation`, report the Task link, verifier ledger,
 checkpoint commits, and exact decision requested. A pure approval is handled by the parent. When feedback requires more
-specification work, launch a new bounded follow-up child with the canonical Task, prior handoff, checkpoint evidence,
-and exact feedback. Children cannot be resumed; same-terminal continuity requires a deliberately chosen Herdr exception. Activate V01 only
+specification work, launch a new registered follow-up child with the canonical Task, prior handoff, checkpoint evidence,
+and exact feedback. Same-session resumption is reserved for a deliberately chosen Herdr exception. Activate V01 only
 after the parent accepts the resulting specification.
 
 ### One goal per verifier
 
 Before launching an implementation or fix writer, require a clean worktree except for explicitly accepted source
-changes. Treat runtime-generated files as owned runtime debris: remove only the current Run's
+changes. Treat `.pi-subagents/` and other runtime-generated files as owned runtime debris: remove only the current Run's
 artifacts when safe, or block the writer. Never silently include runtime artifacts in implementation commits.
 
 For each verifier in order:
@@ -229,18 +239,18 @@ major specification/architecture violation remains; do not chase optional polish
 
 1. Launch a final check child and refresh each existing `EX01` in place from accepted evidence.
 2. Launch a bounded release worker to push implementation and open the PR. Never arm auto-merge.
-3. Use `delegate` observer children for discrete CI/approval status reads. Do not keep
+3. Use registered `openai-codex/gpt-5.6-luna:low` observer children for discrete CI/approval status reads. Do not keep
    an agent alive merely to poll.
 4. Fix CI failures through the same single-writer and verifier loop. Never bypass branch protection or approval.
 5. When ready, report and wait for explicit human merge.
-6. After merge, launch a bounded check child against a temporary detached worktree at fetched merged main.
+6. After merge, launch a registered check child against a temporary detached worktree at fetched merged main.
 
 ### Cleanup and checkpoint two
 
 After accepted post-merge evidence:
 
-1. Confirm no interrupted writer process remains. Synchronous headless children have no Registry participant or durable
-   Pi artifact.
+1. Confirm every registered headless child is terminal or explicitly preserved as blocked. Its lack of Herdr presence is
+   expected; verify through Registry and Pi artifacts.
 2. Close only exact Herdr tabs, workspaces, and bound Neovim workspace tabs captured as created for this Run. If none
    were created, skip Herdr/Neovim cleanup. Preserve reusable and unrelated state.
 3. Remove only owned temporary worktrees/branches after ancestry and cleanliness checks.
@@ -252,13 +262,13 @@ After accepted post-merge evidence:
 
 ## Resume and disagreement
 
-On resume, use the canonical Task/backlog as authority and the Registry plus live process/worktree evidence as observations.
-Continue at the first unfinished canonical stage. If canonical state, Registry observations, and
+On resume, use the canonical Task/backlog as authority and the Registry plus `pi-subagents` artifacts as observations.
+Replay is idempotent. Continue at the first unfinished canonical stage. If canonical state, Registry observations, and
 live runtime disagree, report the mismatch and let the parent decide; never auto-advance, auto-fail, or rewrite the
 vault from runtime state.
 
 ## Completion
 
-Report the Feature/Task links, Registry Run ID, participant summary, implementation PR and merge state,
+Report the Feature/Task links, Registry Run ID, registered participant summary, implementation PR and merge state,
 accepted verifier and post-merge evidence, backlog entry, vault checkpoint commits, remote-main proof, cleanup evidence,
 and preserved unrelated dirty state or deferred polish.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For manual installation:
 ```sh
 brew bundle
 stow nvim tmux zsh ghostty git starship agents pi herdr launchd
+GOBIN="$HOME/.local/bin" go install ./cmd/vault-hunter-atlas
 ```
 
 On Linux (systemd) systems, deploy the user services with:

--- a/cmd/vault-hunter-atlas/main.go
+++ b/cmd/vault-hunter-atlas/main.go
@@ -15,11 +15,19 @@ import (
 )
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "companion" {
-		if err := companion(os.Args[2:]); err != nil {
-			fail(err)
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "companion":
+			if err := companion(os.Args[2:]); err != nil {
+				fail(err)
+			}
+			return
+		case "preview":
+			if err := preview(os.Args[2:]); err != nil {
+				fail(err)
+			}
+			return
 		}
-		return
 	}
 	render(os.Args[1:])
 }
@@ -68,6 +76,47 @@ func companion(args []string) error {
 	default:
 		return fmt.Errorf("unknown companion command %q", args[0])
 	}
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+
+func preview(args []string) error {
+	flags := flag.NewFlagSet("preview", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	workspaceID := flags.String("workspace-id", "", "Herdr workspace ID")
+	tabID := flags.String("tab-id", "", "Herdr tab ID")
+	paneID := flags.String("pane-id", "", "Herdr pane ID")
+	terminalID := flags.String("terminal-id", "", "Herdr terminal ID")
+	sessionSource := flags.String("agent-session-source", "", "agent-session source")
+	sessionKind := flags.String("agent-session-kind", "", "agent-session kind")
+	sessionValue := flags.String("agent-session-value", "", "agent-session value")
+	width := flags.Int("width", 0, "preview width")
+	height := flags.Int("height", 0, "preview height")
+	stateDir := flags.String("state-dir", "", "Vault Hunter state directory")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("unexpected preview arguments")
+	}
+	reader, err := vaultregistry.OpenReader(*stateDir)
+	if err != nil {
+		return err
+	}
+	selected := atlascompanion.Agent{
+		WorkspaceID: *workspaceID,
+		TabID:       *tabID,
+		PaneID:      *paneID,
+		TerminalID:  *terminalID,
+		AgentSession: &vaultregistry.AgentSession{
+			Source: *sessionSource,
+			Kind:   *sessionKind,
+			Value:  *sessionValue,
+		},
+	}
+	result, err := (atlascompanion.Client{Herdr: "herdr"}).Preview(reader, selected, *width, *height)
 	if err != nil {
 		return err
 	}

--- a/docs/evidence/vault-hunter-atlas-t04/.gitattributes
+++ b/docs/evidence/vault-hunter-atlas-t04/.gitattributes
@@ -1,0 +1,1 @@
+*.ansi binary

--- a/docs/evidence/vault-hunter-atlas-t04/README.md
+++ b/docs/evidence/vault-hunter-atlas-t04/README.md
@@ -1,0 +1,25 @@
+# Vault Hunter Atlas T04 ANSI evidence
+
+These artifacts were generated on **macOS 15.7.4** (24G517) by the real headless Neovim/Sidekick verifier harness in `scripts/verify-nvim.lua`. They capture the actual native terminal preview buffers exercised by T04 V01 and V02; no picker content was fabricated.
+
+The evidence was generated from the rebased implementation at commit `a7fbb100` and tree `3724f8d0` with:
+
+```sh
+T04_EVIDENCE_DIR=docs/evidence/vault-hunter-atlas-t04 scripts/verify-nvim sidekick-herdr
+```
+
+## Captures
+
+- `matched-100x30.ansi`: V01 matched Atlas preview on a 100x30 headless Neovim grid (96x10 preview window).
+- `matched-80x24.ansi`: V01 matched Atlas preview on an 80x24 headless Neovim grid (76x4 preview window).
+- `fallback-restored.ansi`: V02's actual restored default Sidekick preview buffer on the 80x24 headless grid after the Atlas fallback checks.
+
+Neovim's native terminal buffer interpreted and normalized the source SGR before buffer capture. As an explicit user-approved substitute for a screen capture, the opt-in exporter applies the deterministic renderer convention `SGR 1;36` (bold cyan) plus `SGR 0` only around captured heading lines when the captured buffer contains no SGR. All captured text, spacing, ordering, and trailing blank buffer lines are otherwise preserved verbatim. The ANSI wrappers add presentation only; they do not invent picker content. With `T04_EVIDENCE_DIR` absent, the verifier does not create or modify evidence files.
+
+## SHA-256
+
+```text
+d4d70b5d2872fbad1d951d2ef50b28fef92fba3fcb58833e66c2f01474d6e330  fallback-restored.ansi
+f6ba84198c92b818fc05d7aeed64e04caef08afcb29ca4ca5a197c30fd6209b7  matched-100x30.ansi
+7cc2b90511282c3ab9a44e2ee28be939c3f0779c98d2db03676eec040d812cde  matched-80x24.ansi
+```

--- a/docs/evidence/vault-hunter-atlas-t04/README.md
+++ b/docs/evidence/vault-hunter-atlas-t04/README.md
@@ -1,6 +1,6 @@
 # Vault Hunter Atlas T04 ANSI evidence
 
-These artifacts were generated on **macOS 15.7.4** (24G517) by the real headless Neovim/Sidekick verifier harness in `scripts/verify-nvim.lua`. They capture the actual native terminal preview buffers exercised by T04 V01 and V02; no picker content was fabricated.
+These artifacts were generated on **macOS 15.7.4** (24G517) by the headless Neovim/Sidekick verifier harness in `scripts/verify-nvim.lua`. They capture native terminal preview buffers produced by the real Sidekick preview rendering and lifecycle path exercised by T04 V01 and V02. The matched Atlas frames and fallback transcript text are deterministic fixtures supplied through mocked verifier hooks; this evidence run did not invoke the production `vault-hunter-atlas` lookup or Herdr read transport.
 
 The evidence was generated from the rebased implementation at commit `a7fbb100` and tree `3724f8d0` with:
 
@@ -14,7 +14,7 @@ T04_EVIDENCE_DIR=docs/evidence/vault-hunter-atlas-t04 scripts/verify-nvim sideki
 - `matched-80x24.ansi`: V01 matched Atlas preview on an 80x24 headless Neovim grid (76x4 preview window).
 - `fallback-restored.ansi`: V02's actual restored default Sidekick preview buffer on the 80x24 headless grid after the Atlas fallback checks.
 
-Neovim's native terminal buffer interpreted and normalized the source SGR before buffer capture. As an explicit user-approved substitute for a screen capture, the opt-in exporter applies the deterministic renderer convention `SGR 1;36` (bold cyan) plus `SGR 0` only around captured heading lines when the captured buffer contains no SGR. All captured text, spacing, ordering, and trailing blank buffer lines are otherwise preserved verbatim. The ANSI wrappers add presentation only; they do not invent picker content. With `T04_EVIDENCE_DIR` absent, the verifier does not create or modify evidence files.
+Neovim's native terminal buffer interpreted and normalized the source SGR before buffer capture. As an explicit user-approved substitute for a screen capture, the opt-in exporter applies the deterministic renderer convention `SGR 1;36` (bold cyan) plus `SGR 0` only around captured heading lines when the captured buffer contains no SGR. All captured text, spacing, ordering, and trailing blank buffer lines are otherwise preserved verbatim. The ANSI wrappers add presentation only. With `T04_EVIDENCE_DIR` absent, the verifier does not create or modify evidence files.
 
 ## SHA-256
 

--- a/docs/evidence/vault-hunter-atlas-t04/fallback-restored.ansi
+++ b/docs/evidence/vault-hunter-atlas-t04/fallback-restored.ansi
@@ -1,0 +1,22 @@
+[1;36mT04 V02 default preview bytes[0m
+second unchanged line
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/evidence/vault-hunter-atlas-t04/matched-100x30.ansi
+++ b/docs/evidence/vault-hunter-atlas-t04/matched-100x30.ansi
@@ -1,0 +1,9 @@
+[1;36mRun atlas-rich-run · Goal 3/5 T02.V01[0m
+Role driver · implementer · verifier · active
+
+
+
+
+
+
+

--- a/docs/evidence/vault-hunter-atlas-t04/matched-80x24.ansi
+++ b/docs/evidence/vault-hunter-atlas-t04/matched-80x24.ansi
@@ -1,0 +1,3 @@
+[1;36mRun atlas-rich-run · Goal 3/5 T02.V01[0m
+Role driver · implementer · verifier · active
+

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,12 @@ if ! command -v herdr >/dev/null 2>&1; then
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
+echo "==> Installing Vault Hunter Atlas"
+(
+    cd "$DOTFILES_DIR"
+    GOBIN="$HOME/.local/bin" go install ./cmd/vault-hunter-atlas
+)
+
 ####################
 #  3. Rust         #
 ####################

--- a/internal/atlas/compact_test.go
+++ b/internal/atlas/compact_test.go
@@ -1,0 +1,37 @@
+package atlas
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/aviral/dotfiles/internal/vaultregistry"
+)
+
+func TestCompactView(t *testing.T) {
+	run := vaultregistry.Run{
+		RunID: "run-compact",
+		Participants: []vaultregistry.Participant{{
+			ParticipantID: "worker", Role: "implementer",
+		}},
+		Lifecycle: []vaultregistry.Lifecycle{
+			{GoalID: "T04.V01", Kind: "verifier", State: "active", ObservedAt: "2026-07-26T12:00:00Z"},
+			{GoalID: "T04.V02", Kind: "verifier", State: "pending", ObservedAt: "2026-07-26T12:01:00Z"},
+		},
+	}
+
+	frame := CompactView(run, "worker", 76, 2)
+	want := strings.Join([]string{
+		"Run run-compact · Goal 1/2 T04.V01",
+		"Role worker · implementer · verifier · active",
+	}, "\n")
+	if frame != want {
+		t.Fatalf("CompactView = %q, want %q", frame, want)
+	}
+	for row, line := range strings.Split(frame, "\n") {
+		if width := lipgloss.Width(line); width > 76 {
+			t.Fatalf("row %d width = %d, want at most 76", row+1, width)
+		}
+	}
+}

--- a/internal/atlas/model.go
+++ b/internal/atlas/model.go
@@ -44,6 +44,62 @@ func NewModel(run vaultregistry.Run, width, height int) Model {
 	return m
 }
 
+// CompactView projects the same normalized goals and initial selection as the
+// standalone Atlas into the two rows available in Sidekick's preview.
+func CompactView(run vaultregistry.Run, participantID string, width, height int) string {
+	goals := normalize(run)
+	selected := initialSelection(goals)
+	goalID, kind, state := "?", "?", "?"
+	ordinal := "0/0"
+	if len(goals) != 0 {
+		goal := goals[selected]
+		goalID, kind, state = value(goal.id), value(goal.kind), value(goal.state)
+		ordinal = fmt.Sprintf("%d/%d", selected+1, len(goals))
+	}
+	role := "?"
+	for _, participant := range run.Participants {
+		if participant.ParticipantID == participantID {
+			role = value(participant.Role)
+		}
+	}
+	rows := []string{
+		boundedFields(width, []string{"Run ", " · Goal " + ordinal + " ", ""}, []string{value(run.RunID), goalID}),
+		boundedFields(width, []string{"Role ", " · ", " · ", " · ", ""}, []string{value(participantID), role, kind, state}),
+	}
+	if height < len(rows) {
+		rows = rows[:max(height, 0)]
+	}
+	return strings.Join(rows, "\n")
+}
+
+func boundedFields(width int, separators, fields []string) string {
+	var full strings.Builder
+	for i, field := range fields {
+		full.WriteString(separators[i])
+		full.WriteString(field)
+	}
+	full.WriteString(separators[len(separators)-1])
+	if lipgloss.Width(full.String()) <= width {
+		return full.String()
+	}
+	fixed := 0
+	for _, separator := range separators {
+		fixed += lipgloss.Width(separator)
+	}
+	available := max(width-fixed, 0)
+	var bounded strings.Builder
+	for i, field := range fields {
+		bounded.WriteString(separators[i])
+		remaining := len(fields) - i
+		limit := available / remaining
+		part := truncate(field, limit)
+		bounded.WriteString(part)
+		available -= lipgloss.Width(part)
+	}
+	bounded.WriteString(separators[len(separators)-1])
+	return truncate(bounded.String(), width)
+}
+
 type tickMsg struct{}
 
 func tick() tea.Cmd {

--- a/internal/atlascompanion/companion.go
+++ b/internal/atlascompanion/companion.go
@@ -119,23 +119,32 @@ func (c Client) correlate(run vaultregistry.Run, workspaceID string) ([]Correlat
 		return nil, nil, errors.New("workspace is not registered by a complete participant identity")
 	}
 
+	agents, err := c.listAgents()
+	if err != nil {
+		return nil, nil, err
+	}
+	correlations, liveOnly := correlate(run.Participants, agents)
+	return correlations, liveOnly, nil
+}
+
+func (c Client) listAgents() ([]Agent, error) {
 	var listed struct {
 		Type   string  `json:"type"`
 		Agents []Agent `json:"agents"`
 	}
 	if err := c.call(&listed, "agent", "list"); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if listed.Type != "agent_list" || listed.Agents == nil {
-		return nil, nil, errors.New("invalid Herdr agent list result")
+		return nil, errors.New("invalid Herdr agent list result")
 	}
 	for _, agent := range listed.Agents {
-		if agent.WorkspaceID == "" || agent.TabID == "" || agent.PaneID == "" || agent.TerminalID == "" {
-			return nil, nil, errors.New("invalid Herdr agent list result")
+		if agent.WorkspaceID == "" || agent.TabID == "" || agent.PaneID == "" || agent.TerminalID == "" ||
+			agent.AgentSession != nil && !completeSession(*agent.AgentSession) {
+			return nil, errors.New("invalid Herdr agent list result")
 		}
 	}
-	correlations, liveOnly := correlate(run.Participants, listed.Agents)
-	return correlations, liveOnly, nil
+	return listed.Agents, nil
 }
 
 func correlate(participants []vaultregistry.Participant, agents []Agent) ([]Correlation, []Agent) {
@@ -189,6 +198,10 @@ func completeHerdr(identity vaultregistry.HerdrIdentity) bool {
 
 func sameSession(recorded, live vaultregistry.AgentSession) bool {
 	return recorded.Source == live.Source && recorded.Kind == live.Kind && recorded.Value == live.Value
+}
+
+func completeSession(session vaultregistry.AgentSession) bool {
+	return session.Source != "" && session.Kind != "" && session.Value != ""
 }
 
 func (c Client) Attach(runID, workspaceID, stateDir string) (Tuple, error) {

--- a/internal/atlascompanion/preview.go
+++ b/internal/atlascompanion/preview.go
@@ -61,6 +61,14 @@ func (c Client) Preview(reader *vaultregistry.Reader, selected Agent, width, hei
 				continue
 			}
 			taskRecorded = true
+			if participant.AgentSession == nil {
+				stale = true
+				continue
+			}
+			if !sameSession(*participant.AgentSession, *selected.AgentSession) {
+				contradictory = true
+				continue
+			}
 			switch correlations[index].State {
 			case "matched":
 				matches = append(matches, candidate{run: run, participant: participant})

--- a/internal/atlascompanion/preview.go
+++ b/internal/atlascompanion/preview.go
@@ -61,14 +61,6 @@ func (c Client) Preview(reader *vaultregistry.Reader, selected Agent, width, hei
 				continue
 			}
 			taskRecorded = true
-			if participant.AgentSession == nil {
-				stale = true
-				continue
-			}
-			if !sameSession(*participant.AgentSession, *selected.AgentSession) {
-				contradictory = true
-				continue
-			}
 			switch correlations[index].State {
 			case "matched":
 				matches = append(matches, candidate{run: run, participant: participant})

--- a/internal/atlascompanion/preview.go
+++ b/internal/atlascompanion/preview.go
@@ -1,0 +1,113 @@
+package atlascompanion
+
+import (
+	"errors"
+
+	"github.com/aviral/dotfiles/internal/atlas"
+	"github.com/aviral/dotfiles/internal/vaultregistry"
+)
+
+// PreviewResult is the single read-only response consumed by Sidekick.
+type PreviewResult struct {
+	Outcome       string `json:"outcome"`
+	RunID         string `json:"run_id,omitempty"`
+	ParticipantID string `json:"participant_id,omitempty"`
+	Frame         string `json:"frame,omitempty"`
+}
+
+// Preview performs a read-only reverse lookup of one complete live identity.
+func (c Client) Preview(reader *vaultregistry.Reader, selected Agent, width, height int) (PreviewResult, error) {
+	if reader == nil || !completeAgent(selected) || selected.AgentSession == nil || !completeSession(*selected.AgentSession) || width <= 0 || height <= 0 {
+		return PreviewResult{}, errors.New("preview requires a complete identity and positive dimensions")
+	}
+	runs, err := reader.List()
+	if err != nil {
+		switch {
+		case errors.Is(err, vaultregistry.ErrUnsupportedVersion):
+			return PreviewResult{Outcome: "unsupported"}, nil
+		case errors.Is(err, vaultregistry.ErrMalformed), errors.Is(err, vaultregistry.ErrInvalidID):
+			return PreviewResult{Outcome: "malformed"}, nil
+		default:
+			return PreviewResult{}, err
+		}
+	}
+	agents, err := c.listAgents()
+	if err != nil {
+		return PreviewResult{}, err
+	}
+
+	liveMatches := make([]Agent, 0, 1)
+	for _, agent := range agents {
+		if sameAgentIdentity(selected, agent) {
+			liveMatches = append(liveMatches, agent)
+		}
+	}
+
+	type candidate struct {
+		run         vaultregistry.Run
+		participant vaultregistry.Participant
+	}
+	var matches []candidate
+	recorded, taskRecorded := false, false
+	stale, contradictory := false, false
+	for _, run := range runs {
+		correlations, _ := correlate(run.Participants, agents)
+		for index, participant := range run.Participants {
+			if participant.Herdr == nil || !sameRecordedIdentity(*participant.Herdr, selected) {
+				continue
+			}
+			recorded = true
+			if run.Task.Kind != "task" {
+				continue
+			}
+			taskRecorded = true
+			switch correlations[index].State {
+			case "matched":
+				matches = append(matches, candidate{run: run, participant: participant})
+			case "contradictory":
+				contradictory = true
+			default:
+				stale = true
+			}
+		}
+	}
+
+	switch {
+	case !recorded:
+		return PreviewResult{Outcome: "unregistered"}, nil
+	case !taskRecorded:
+		return PreviewResult{Outcome: "ineligible"}, nil
+	case len(liveMatches) > 1 || len(matches) > 1:
+		return PreviewResult{Outcome: "ambiguous"}, nil
+	case len(liveMatches) != 1 || liveMatches[0].AgentSession == nil || !sameSession(*selected.AgentSession, *liveMatches[0].AgentSession):
+		return PreviewResult{Outcome: "stale"}, nil
+	case contradictory:
+		return PreviewResult{Outcome: "contradictory"}, nil
+	case stale || len(matches) != 1:
+		return PreviewResult{Outcome: "stale"}, nil
+	}
+
+	match := matches[0]
+	return PreviewResult{
+		Outcome:       "matched",
+		RunID:         match.run.RunID,
+		ParticipantID: match.participant.ParticipantID,
+		Frame:         atlas.CompactView(match.run, match.participant.ParticipantID, width, height),
+	}, nil
+}
+
+func completeAgent(agent Agent) bool {
+	return agent.WorkspaceID != "" && agent.TabID != "" && agent.PaneID != "" && agent.TerminalID != ""
+}
+
+func sameAgentIdentity(left, right Agent) bool {
+	return completeAgent(left) && completeAgent(right) &&
+		left.WorkspaceID == right.WorkspaceID && left.TabID == right.TabID &&
+		left.PaneID == right.PaneID && left.TerminalID == right.TerminalID
+}
+
+func sameRecordedIdentity(recorded vaultregistry.HerdrIdentity, selected Agent) bool {
+	return completeHerdr(recorded) && completeAgent(selected) &&
+		recorded.WorkspaceID == selected.WorkspaceID && recorded.TabID == selected.TabID &&
+		recorded.PaneID == selected.PaneID && recorded.TerminalID == selected.TerminalID
+}

--- a/internal/atlascompanion/preview_test.go
+++ b/internal/atlascompanion/preview_test.go
@@ -1,6 +1,7 @@
 package atlascompanion
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,6 +77,260 @@ func TestPreviewUniqueMatch(t *testing.T) {
 	} {
 		if !strings.Contains(result.Frame, want) {
 			t.Fatalf("Preview frame missing %q: %q", want, result.Frame)
+		}
+	}
+}
+
+func TestPreviewOutcomesFailClosedAndReadOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name, outcome string
+		registry      []byte
+		configure     func(*testing.T, *vaultregistry.Producer, string, *vaultregistry.HerdrIdentity, *vaultregistry.AgentSession)
+		agents        func(*vaultregistry.HerdrIdentity, *vaultregistry.AgentSession) []Agent
+	}{
+		{
+			name: "malformed", outcome: "malformed", registry: []byte(`{"schema_version":`),
+		},
+		{
+			name: "unsupported", outcome: "unsupported", registry: []byte("{\"schema_version\":2}\n"),
+		},
+		{
+			name: "ambiguous", outcome: "ambiguous",
+			configure: func(t *testing.T, producer *vaultregistry.Producer, taskPath string, identity *vaultregistry.HerdrIdentity, session *vaultregistry.AgentSession) {
+				createPreviewRun(t, producer, previewRun("run-a", "task", taskPath, identity, session))
+				createPreviewRun(t, producer, previewRun("run-b", "task", taskPath, identity, session))
+			},
+			agents: selectedPreviewAgents,
+		},
+		{
+			name: "stale", outcome: "stale",
+			configure: func(t *testing.T, producer *vaultregistry.Producer, taskPath string, identity *vaultregistry.HerdrIdentity, session *vaultregistry.AgentSession) {
+				createPreviewRun(t, producer, previewRun("run-stale", "task", taskPath, identity, session))
+			},
+			agents: func(*vaultregistry.HerdrIdentity, *vaultregistry.AgentSession) []Agent { return []Agent{} },
+		},
+		{
+			name: "stale incomplete registration", outcome: "stale",
+			configure: func(t *testing.T, producer *vaultregistry.Producer, taskPath string, identity *vaultregistry.HerdrIdentity, _ *vaultregistry.AgentSession) {
+				createPreviewRun(t, producer, previewRun("run-incomplete", "task", taskPath, identity, nil))
+			},
+			agents: selectedPreviewAgents,
+		},
+		{
+			name: "contradictory", outcome: "contradictory",
+			configure: func(t *testing.T, producer *vaultregistry.Producer, taskPath string, identity *vaultregistry.HerdrIdentity, _ *vaultregistry.AgentSession) {
+				recorded := &vaultregistry.AgentSession{Source: "herdr:pi", Kind: "id", Value: "recorded-session"}
+				createPreviewRun(t, producer, previewRun("run-contradictory", "task", taskPath, identity, recorded))
+			},
+			agents: selectedPreviewAgents,
+		},
+		{
+			name: "unregistered", outcome: "unregistered",
+			configure: func(t *testing.T, producer *vaultregistry.Producer, taskPath string, _ *vaultregistry.HerdrIdentity, session *vaultregistry.AgentSession) {
+				other := &vaultregistry.HerdrIdentity{WorkspaceID: "other-workspace", TabID: "other-tab", PaneID: "other-pane", TerminalID: "other-terminal"}
+				createPreviewRun(t, producer, previewRun("run-unregistered", "task", taskPath, other, session))
+			},
+			agents: selectedPreviewAgents,
+		},
+		{
+			name: "ineligible", outcome: "ineligible",
+			configure: func(t *testing.T, producer *vaultregistry.Producer, taskPath string, identity *vaultregistry.HerdrIdentity, session *vaultregistry.AgentSession) {
+				createPreviewRun(t, producer, previewRun("run-feature", "feature", taskPath, identity, session))
+			},
+			agents: selectedPreviewAgents,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			vaultRoot := t.TempDir()
+			taskPath := filepath.Join(vaultRoot, "tasks", "04.md")
+			featurePath := filepath.Join(vaultRoot, "features", "atlas.md")
+			if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(featurePath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(taskPath, []byte("# exact vault task source\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(featurePath, []byte("# exact vault feature source\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			identity := &vaultregistry.HerdrIdentity{WorkspaceID: "workspace", TabID: "tab", PaneID: "pane", TerminalID: "terminal"}
+			session := &vaultregistry.AgentSession{Source: "herdr:pi", Kind: "id", Value: "live-session"}
+			producer, err := vaultregistry.OpenProducer(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.registry != nil {
+				if err := os.WriteFile(filepath.Join(root, "runs", tc.name+".json"), tc.registry, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				tc.configure(t, producer, taskPath, identity, session)
+			}
+			reader, err := vaultregistry.OpenReader(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			agents := []Agent{}
+			if tc.agents != nil {
+				agents = tc.agents(identity, session)
+			}
+			client, herdrLog := previewHerdr(t, herdrResponse(map[string]any{"type": "agent_list", "agents": agents}))
+			before := snapshotPreviewSources(t, root, taskPath, featurePath)
+			selected := Agent{WorkspaceID: identity.WorkspaceID, TabID: identity.TabID, PaneID: identity.PaneID, TerminalID: identity.TerminalID, AgentSession: session}
+
+			result, err := client.Preview(reader, selected, 76, 4)
+			if err != nil {
+				t.Fatalf("Preview error = %v", err)
+			}
+			if result != (PreviewResult{Outcome: tc.outcome}) {
+				t.Fatalf("Preview result = %#v, want outcome %q only", result, tc.outcome)
+			}
+			assertPreviewSources(t, before)
+			if tc.registry != nil {
+				log, err := os.ReadFile(herdrLog)
+				if err != nil && !os.IsNotExist(err) {
+					t.Fatal(err)
+				}
+				if len(log) != 0 {
+					t.Fatalf("%s Registry failure reached Herdr transport: %q", tc.name, log)
+				}
+			}
+		})
+	}
+}
+
+func TestPreviewRejectsMalformedHerdrTransportReadOnly(t *testing.T) {
+	root := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "task.md")
+	if err := os.WriteFile(vaultPath, []byte("# immutable vault source\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity := &vaultregistry.HerdrIdentity{WorkspaceID: "workspace", TabID: "tab", PaneID: "pane", TerminalID: "terminal"}
+	session := &vaultregistry.AgentSession{Source: "herdr:pi", Kind: "id", Value: "session"}
+	producer, err := vaultregistry.OpenProducer(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createPreviewRun(t, producer, previewRun("run", "task", vaultPath, identity, session))
+	reader, err := vaultregistry.OpenReader(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := herdrResponse(map[string]any{"type": "agent_list", "agents": selectedPreviewAgents(identity, session)})
+	for _, tc := range []struct {
+		name, response string
+	}{
+		{name: "multiple JSON documents", response: valid + "\n" + valid},
+		{name: "null envelope", response: "null"},
+		{name: "missing result", response: `{"id":"preview"}`},
+		{name: "scalar result", response: herdrResponse("agent_list")},
+		{name: "wrong result type", response: herdrResponse(map[string]any{"type": "tab_list", "agents": []Agent{}})},
+		{name: "null agents", response: herdrResponse(map[string]any{"type": "agent_list", "agents": nil})},
+		{name: "partial identity", response: herdrResponse(map[string]any{
+			"type": "agent_list", "agents": []any{map[string]any{"workspace_id": "workspace"}},
+		})},
+		{name: "partial session", response: herdrResponse(map[string]any{
+			"type": "agent_list",
+			"agents": []any{map[string]any{
+				"workspace_id": "workspace", "tab_id": "tab", "pane_id": "pane", "terminal_id": "terminal",
+				"agent_session": map[string]any{"source": "herdr:pi"},
+			}},
+		})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := previewHerdr(t, tc.response)
+			before := snapshotPreviewSources(t, root, vaultPath)
+			selected := Agent{WorkspaceID: identity.WorkspaceID, TabID: identity.TabID, PaneID: identity.PaneID, TerminalID: identity.TerminalID, AgentSession: session}
+			result, err := client.Preview(reader, selected, 76, 4)
+			if err == nil || result != (PreviewResult{}) {
+				t.Fatalf("Preview = %#v, %v; want fail-closed transport error", result, err)
+			}
+			assertPreviewSources(t, before)
+		})
+	}
+}
+
+func previewRun(runID, kind, taskPath string, identity *vaultregistry.HerdrIdentity, session *vaultregistry.AgentSession) vaultregistry.Run {
+	return vaultregistry.Run{
+		SchemaVersion: 1,
+		RunID:         runID,
+		InvokedAt:     "2026-07-26T12:00:00Z",
+		UpdatedAt:     "2026-07-26T12:00:00Z",
+		Task: vaultregistry.Task{
+			ID: "T04", Title: "Preview", Path: taskPath,
+			FeaturePath: filepath.Join(filepath.Dir(filepath.Dir(taskPath)), "features", "atlas.md"), Kind: kind,
+		},
+		Participants: []vaultregistry.Participant{{
+			ParticipantID: "worker", ObservedAt: "2026-07-26T12:00:01Z", Role: "implementer",
+			GoalID: "T04.V01", Herdr: identity, AgentSession: session,
+		}},
+	}
+}
+
+func createPreviewRun(t *testing.T, producer *vaultregistry.Producer, run vaultregistry.Run) {
+	t.Helper()
+	if _, err := producer.Create(run); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func selectedPreviewAgents(identity *vaultregistry.HerdrIdentity, session *vaultregistry.AgentSession) []Agent {
+	return []Agent{{
+		WorkspaceID: identity.WorkspaceID, TabID: identity.TabID,
+		PaneID: identity.PaneID, TerminalID: identity.TerminalID, AgentSession: session,
+	}}
+}
+
+func previewHerdr(t *testing.T, response string) (Client, string) {
+	t.Helper()
+	dir := t.TempDir()
+	log := filepath.Join(dir, "calls")
+	script := filepath.Join(dir, "herdr")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf 'called\\n' >>\"$PREVIEW_HERDR_LOG\"\nprintf '%s\\n' \"$PREVIEW_HERDR_RESPONSE\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PREVIEW_HERDR_LOG", log)
+	t.Setenv("PREVIEW_HERDR_RESPONSE", response)
+	return Client{Herdr: script}, log
+}
+
+func snapshotPreviewSources(t *testing.T, root string, vaultPaths ...string) map[string][]byte {
+	t.Helper()
+	paths := append([]string(nil), vaultPaths...)
+	entries, err := os.ReadDir(filepath.Join(root, "runs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			paths = append(paths, filepath.Join(root, "runs", entry.Name()))
+		}
+	}
+	before := make(map[string][]byte, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[path] = data
+	}
+	return before
+}
+
+func assertPreviewSources(t *testing.T, before map[string][]byte) {
+	t.Helper()
+	for path, want := range before {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("Preview changed Registry/vault source bytes at %s", path)
 		}
 	}
 }

--- a/internal/atlascompanion/preview_test.go
+++ b/internal/atlascompanion/preview_test.go
@@ -81,6 +81,36 @@ func TestPreviewUniqueMatch(t *testing.T) {
 	}
 }
 
+func TestPreviewOneSidedAgentSessionMatches(t *testing.T) {
+	root := t.TempDir()
+	identity := &vaultregistry.HerdrIdentity{WorkspaceID: "workspace", TabID: "tab", PaneID: "pane", TerminalID: "terminal"}
+	liveSession := &vaultregistry.AgentSession{Source: "herdr:pi", Kind: "id", Value: "live-session"}
+	producer, err := vaultregistry.OpenProducer(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createPreviewRun(t, producer, previewRun("run-one-sided", "task", "tasks/04.md", identity, nil))
+	reader, err := vaultregistry.OpenReader(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, _ := previewHerdr(t, herdrResponse(map[string]any{
+		"type": "agent_list", "agents": selectedPreviewAgents(identity, liveSession),
+	}))
+	selected := Agent{
+		WorkspaceID: identity.WorkspaceID, TabID: identity.TabID,
+		PaneID: identity.PaneID, TerminalID: identity.TerminalID, AgentSession: liveSession,
+	}
+
+	result, err := client.Preview(reader, selected, 76, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "matched" || result.RunID != "run-one-sided" || result.ParticipantID != "worker" || result.Frame == "" {
+		t.Fatalf("Preview result = %#v, want one-sided agent-session match", result)
+	}
+}
+
 func TestPreviewOutcomesFailClosedAndReadOnly(t *testing.T) {
 	for _, tc := range []struct {
 		name, outcome string
@@ -108,13 +138,6 @@ func TestPreviewOutcomesFailClosedAndReadOnly(t *testing.T) {
 				createPreviewRun(t, producer, previewRun("run-stale", "task", taskPath, identity, session))
 			},
 			agents: func(*vaultregistry.HerdrIdentity, *vaultregistry.AgentSession) []Agent { return []Agent{} },
-		},
-		{
-			name: "stale incomplete registration", outcome: "stale",
-			configure: func(t *testing.T, producer *vaultregistry.Producer, taskPath string, identity *vaultregistry.HerdrIdentity, _ *vaultregistry.AgentSession) {
-				createPreviewRun(t, producer, previewRun("run-incomplete", "task", taskPath, identity, nil))
-			},
-			agents: selectedPreviewAgents,
 		},
 		{
 			name: "contradictory", outcome: "contradictory",

--- a/internal/atlascompanion/preview_test.go
+++ b/internal/atlascompanion/preview_test.go
@@ -1,0 +1,81 @@
+package atlascompanion
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aviral/dotfiles/internal/vaultregistry"
+)
+
+func TestPreviewUniqueMatch(t *testing.T) {
+	root := t.TempDir()
+	producer, err := vaultregistry.OpenProducer(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := &vaultregistry.AgentSession{Source: "herdr:pi", Kind: "id", Value: "session-1"}
+	identity := &vaultregistry.HerdrIdentity{
+		WorkspaceID: "workspace-1", TabID: "tab-1", PaneID: "pane-1", TerminalID: "terminal-1",
+	}
+	run := vaultregistry.Run{
+		SchemaVersion: 1,
+		RunID:         "run-1",
+		InvokedAt:     "2026-07-26T12:00:00Z",
+		UpdatedAt:     "2026-07-26T12:00:00Z",
+		Task: vaultregistry.Task{
+			ID: "T04", Title: "Integrate compact Atlas", Path: "tasks/04.md",
+			FeaturePath: "features/vault-hunter-atlas.md", Kind: "task",
+		},
+		Participants: []vaultregistry.Participant{{
+			ParticipantID: "worker", ObservedAt: "2026-07-26T12:00:01Z", Role: "implementer",
+			GoalID: "T04.V01", Herdr: identity, AgentSession: session,
+		}},
+		Lifecycle: []vaultregistry.Lifecycle{{
+			ObservationID: "lifecycle-1", ObservedAt: "2026-07-26T12:00:02Z",
+			Kind: "verifier", GoalID: "T04.V01", State: "active",
+		}},
+	}
+	if _, err := producer.Create(run); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := vaultregistry.OpenReader(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	herdr := filepath.Join(t.TempDir(), "herdr")
+	if err := os.WriteFile(herdr, []byte("#!/bin/sh\nprintf '%s\\n' \"$PREVIEW_HERDR_RESPONSE\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PREVIEW_HERDR_RESPONSE", herdrResponse(map[string]any{
+		"type": "agent_list",
+		"agents": []any{map[string]any{
+			"workspace_id":  identity.WorkspaceID,
+			"tab_id":        identity.TabID,
+			"pane_id":       identity.PaneID,
+			"terminal_id":   identity.TerminalID,
+			"agent_session": session,
+		}},
+	}))
+	selected := Agent{
+		WorkspaceID: identity.WorkspaceID, TabID: identity.TabID,
+		PaneID: identity.PaneID, TerminalID: identity.TerminalID, AgentSession: session,
+	}
+	result, err := (Client{Herdr: herdr}).Preview(reader, selected, 76, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "matched" || result.RunID != run.RunID || result.ParticipantID != "worker" {
+		t.Fatalf("Preview result = %#v", result)
+	}
+	for _, want := range []string{
+		"Run run-1 · Goal 1/1 T04.V01",
+		"Role worker · implementer · verifier · active",
+	} {
+		if !strings.Contains(result.Frame, want) {
+			t.Fatalf("Preview frame missing %q: %q", want, result.Frame)
+		}
+	}
+}

--- a/internal/vaultregistry/storage_list_test.go
+++ b/internal/vaultregistry/storage_list_test.go
@@ -1,0 +1,28 @@
+package vaultregistry_test
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReaderList(t *testing.T) {
+	root := t.TempDir()
+	producer := mustProducer(t, root)
+	for _, id := range []string{"run-z", "run-a"} {
+		if _, err := producer.Create(baseRun(id)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runs, err := mustReader(t, root).List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, len(runs))
+	for i, run := range runs {
+		ids[i] = run.RunID
+	}
+	if want := []string{"run-a", "run-z"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("List Run IDs = %v, want %v", ids, want)
+	}
+}

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -648,8 +648,10 @@ function M.open(opts)
   local preview_selection
   local atlas_attempted = false
   local atlas_phase
+  local atlas_frame
   local atlas_process
   local staging_buffers = {}
+  local transition_preview
   local has_local_working = vim.iter(items):any(function(item)
     return item.status == "working"
   end)
@@ -740,6 +742,13 @@ function M.open(opts)
       end
     end
     workspace_pattern = pattern
+    local filtered_item = workspace_rows[cursor_row]
+    filtered_item = filtered_item and not filtered_item._workspace and filtered_item or nil
+    if workspace_active and preview_selection ~= nil and filtered_item ~= preview_selection then
+      transition_preview()
+      rendered_workspace_item = nil
+      pending_workspace_item = nil
+    end
     vim.bo[workspace_win.buf].modifiable = true
     vim.api.nvim_buf_set_lines(workspace_win.buf, 0, -1, false, lines)
     vim.bo[workspace_win.buf].modifiable = false
@@ -788,11 +797,16 @@ function M.open(opts)
     local item = workspace_rows[vim.api.nvim_win_get_cursor(workspace_win.win)[1]]
     if not item or item._workspace then
       pending_workspace_item = nil
+      if rendered_workspace_item or preview_selection then
+        transition_preview()
+        rendered_workspace_item = nil
+      end
       return
     end
     if item == rendered_workspace_item then
       pending_workspace_item = nil
     elseif item and item ~= pending_workspace_item then
+      transition_preview()
       pending_workspace_item = item
       render_workspace_preview()
     end
@@ -875,9 +889,16 @@ function M.open(opts)
     stop_atlas_lookup()
     discard_staging_buffers()
     atlas_phase = nil
+    atlas_frame = nil
     atlas_attempted = false
-    preview_loading = false
-    loading_full_preview_item = nil
+  end
+
+  transition_preview = function()
+    invalidate_preview()
+    preview_selection = nil
+    displayed_preview_item = nil
+    expanded_preview_item = nil
+    pending_preview_scroll = nil
   end
 
   local function swap_preview_buffer(buf, staging_win, item, rendered, generation, on_swap, previous_tick)
@@ -915,12 +936,29 @@ function M.open(opts)
     if generation ~= preview_generation or item ~= preview_selection then
       return
     end
-    atlas_phase = nil
+    local atlas_fallback = atlas_attempted
+    atlas_phase = atlas_fallback and "fallback-staging" or nil
+    atlas_frame = nil
     local output, err = preview_text(item, preview_line_limit(preview))
     local rendered = output or err
     local buf, staging_win = prepare_preview_buffer(output, err, preview)
     vim.schedule(function()
-      swap_preview_buffer(buf, staging_win, item, rendered, generation)
+      swap_preview_buffer(buf, staging_win, item, rendered, generation, function()
+        if atlas_fallback then
+          atlas_phase = nil
+        end
+      end)
+    end)
+  end
+
+  local function restage_atlas_preview(item, preview, generation)
+    atlas_phase = "staging"
+    local frame = atlas_frame
+    local buf, staging_win = prepare_preview_buffer(frame, nil, preview)
+    vim.schedule(function()
+      swap_preview_buffer(buf, staging_win, item, frame, generation, function()
+        atlas_phase = "active"
+      end)
     end)
   end
 
@@ -932,6 +970,12 @@ function M.open(opts)
       expanded_preview_item = nil
       pending_preview_scroll = nil
     elseif item == displayed_preview_item and item == expanded_preview_item then
+      return
+    elseif atlas_phase == "active" and atlas_frame then
+      restage_atlas_preview(item, preview, preview_generation)
+      return
+    elseif atlas_attempted and atlas_phase == nil then
+      render_default_preview(item, preview, preview_generation)
       return
     end
     local generation = preview_generation
@@ -960,13 +1004,8 @@ function M.open(opts)
           render_default_preview(item, preview, generation)
           return
         end
-        atlas_phase = "staging"
-        local buf, staging_win = prepare_preview_buffer(frame, nil, preview)
-        vim.schedule(function()
-          swap_preview_buffer(buf, staging_win, item, frame, generation, function()
-            atlas_phase = "active"
-          end)
-        end)
+        atlas_frame = frame
+        restage_atlas_preview(item, preview, generation)
       end)
       vim.defer_fn(function()
         if generation ~= preview_generation
@@ -994,6 +1033,7 @@ function M.open(opts)
     if not item then
       return
     end
+    transition_preview()
     vim.api.nvim_win_set_cursor(workspace_win.win, { row, 0 })
     rendered_workspace_item = item._workspace and nil or item
     pending_workspace_item = nil
@@ -1017,10 +1057,10 @@ function M.open(opts)
     local generation = preview_generation
     preview_loading = true
     herdr.read_async(item.agent_name, "recent-unwrapped", preview_line_limit(), true, function(output)
+      preview_loading = false
       if generation ~= preview_generation or item ~= preview_selection then
         return
       end
-      preview_loading = false
       if atlas_phase or not picker or picker.closed or item ~= current_preview_item() then
         return
       end
@@ -1075,11 +1115,11 @@ function M.open(opts)
     local generation = preview_generation
     loading_full_preview_item = item
     herdr.read_async(item.agent_name, "recent-unwrapped", full_preview_lines, true, function(output)
-      if generation ~= preview_generation or item ~= preview_selection then
-        return
-      end
       if loading_full_preview_item == item then
         loading_full_preview_item = nil
+      end
+      if generation ~= preview_generation or item ~= preview_selection then
+        return
       end
       if atlas_phase
         or not picker
@@ -1172,10 +1212,17 @@ function M.open(opts)
   end
 
   local function toggle_selector()
+    transition_preview()
     rendered_workspace_item = nil
     pending_workspace_item = nil
     set_active_selector(not workspace_active)
-    if not workspace_active then
+    if workspace_active then
+      local item = workspace_rows[vim.api.nvim_win_get_cursor(workspace_win.win)[1]]
+      if item and not item._workspace then
+        rendered_workspace_item = item
+        show_preview(item)
+      end
+    else
       show_preview(picker:current())
     end
     focus_input()
@@ -1289,18 +1336,27 @@ function M.open(opts)
     end,
     on_show = function(active_picker)
       picker = active_picker
+      if preview_selection then
+        transition_preview()
+      end
       render_workspace()
       set_active_selector(true)
       if opts.on_show then
         opts.on_show(picker)
       end
       workspace_win:on("WinEnter", function()
+        if not workspace_active then
+          transition_preview()
+        end
         set_active_selector(true)
         preview_workspace_cursor()
         vim.schedule(focus_input)
       end, { buf = true })
       picker.input.win:on({ "TextChangedI", "TextChanged" }, render_workspace, { buf = true })
       picker.list.win:on("WinEnter", function()
+        if workspace_active then
+          transition_preview()
+        end
         rendered_workspace_item = nil
         pending_workspace_item = nil
         set_active_selector(false)

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -795,7 +795,7 @@ function M.open(opts)
       return
     end
     local item = workspace_rows[vim.api.nvim_win_get_cursor(workspace_win.win)[1]]
-    if not item or item._workspace then
+    if not item then
       pending_workspace_item = nil
       if rendered_workspace_item or preview_selection then
         transition_preview()
@@ -1035,12 +1035,10 @@ function M.open(opts)
     end
     transition_preview()
     vim.api.nvim_win_set_cursor(workspace_win.win, { row, 0 })
-    rendered_workspace_item = item._workspace and nil or item
+    rendered_workspace_item = item
     pending_workspace_item = nil
     set_active_selector(true)
-    if not item._workspace then
-      show_preview(item)
-    end
+    show_preview(item)
   end
 
   local function refresh_preview()
@@ -1218,7 +1216,7 @@ function M.open(opts)
     set_active_selector(not workspace_active)
     if workspace_active then
       local item = workspace_rows[vim.api.nvim_win_get_cursor(workspace_win.win)[1]]
-      if item and not item._workspace then
+      if item then
         rendered_workspace_item = item
         show_preview(item)
       end

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -14,6 +14,7 @@ local session_paths = {}
 local spinner_refresh_ms = 80
 local preview_debounce_ms = 400
 local preview_settle_ms = 16
+local atlas_lookup_timeout_ms = 1000
 local full_preview_lines = 2147483647 -- Herdr clamps this to the available scrollback.
 local workspace_ns = vim.api.nvim_create_namespace("sidekick_workspace_picker")
 local status_rank = { working = 1, blocked = 2, done = 3, idle = 4 }
@@ -967,6 +968,18 @@ function M.open(opts)
           end)
         end)
       end)
+      vim.defer_fn(function()
+        if generation ~= preview_generation
+          or item ~= preview_selection
+          or not picker
+          or picker.closed
+          or atlas_phase ~= "pending"
+        then
+          return
+        end
+        stop_atlas_lookup()
+        render_default_preview(item, preview, generation)
+      end, atlas_lookup_timeout_ms)
       return
     end
     render_default_preview(item, preview, generation)

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -24,6 +24,66 @@ local status_display = {
   idle = { "·", "Comment" },
 }
 
+local function complete_atlas_identity(item)
+  local session = item and item.agent_session
+  return not not (item
+    and not item._empty
+    and not item._workspace
+    and type(item.workspace_id) == "string" and item.workspace_id ~= ""
+    and type(item.tab_id) == "string" and item.tab_id ~= ""
+    and type(item.pane_id) == "string" and item.pane_id ~= ""
+    and type(item.terminal_id) == "string" and item.terminal_id ~= ""
+    and session
+    and type(session.source) == "string" and session.source ~= ""
+    and type(session.kind) == "string" and session.kind ~= ""
+    and type(session.value) == "string" and session.value ~= "")
+end
+
+local function atlas_result_frame(result)
+  if type(result) ~= "table"
+    or result.outcome ~= "matched"
+    or type(result.run_id) ~= "string"
+    or result.run_id == ""
+    or type(result.participant_id) ~= "string"
+    or result.participant_id == ""
+    or type(result.frame) ~= "string"
+    or result.frame == ""
+  then
+    return nil
+  end
+  return result.frame
+end
+
+local function atlas_lookup(item, width, height, callback)
+  local executable = vim.fn.exepath("vault-hunter-atlas")
+  if executable == "" then
+    vim.schedule(function() callback(nil) end)
+    return
+  end
+  local session = item.agent_session
+  local command = {
+    executable,
+    "preview",
+    "--workspace-id", item.workspace_id,
+    "--tab-id", item.tab_id,
+    "--pane-id", item.pane_id,
+    "--terminal-id", item.terminal_id,
+    "--agent-session-source", session.source,
+    "--agent-session-kind", session.kind,
+    "--agent-session-value", session.value,
+    "--width", tostring(width),
+    "--height", tostring(height),
+  }
+  return vim.system(command, { text = true, timeout = 1000 }, vim.schedule_wrap(function(result)
+    if result.code ~= 0 then
+      callback(nil)
+      return
+    end
+    local ok, decoded = pcall(vim.json.decode, result.stdout or "")
+    callback(ok and decoded or nil)
+  end))
+end
+
 local function workspace_scope()
   local tab = vim.api.nvim_get_current_tabpage()
   local ok, workspace_id = pcall(vim.api.nvim_tabpage_get_var, tab, "herdr_workspace_id")
@@ -392,6 +452,7 @@ function M.list_items(metric_cache)
         tool = entry.tool,
         slug = entry.slug,
         pane_id = entry.pane_id,
+        tab_id = entry.tab_id,
         workspace_id = entry.workspace_id,
         terminal_id = entry.terminal_id,
         agent_name = entry.agent_name,
@@ -441,6 +502,7 @@ local function workspace_groups(first_workspace_id, metric_cache)
         toggle_name = parsed and parsed.label or tool,
         tool = tool,
         pane_id = agent.pane_id,
+        tab_id = agent.tab_id,
         workspace_id = workspace_id,
         terminal_id = agent.terminal_id,
         agent_name = agent.name,
@@ -581,6 +643,12 @@ function M.open(opts)
   local refreshed_preview_item
   local refreshed_preview_output
   local reopening = false
+  local preview_generation = 0
+  local preview_selection
+  local atlas_attempted = false
+  local atlas_phase
+  local atlas_process
+  local staging_buffers = {}
   local has_local_working = vim.iter(items):any(function(item)
     return item.status == "working"
   end)
@@ -762,6 +830,7 @@ function M.open(opts)
     else
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, { fallback or "(agent read failed)" })
     end
+    staging_buffers[buf] = staging_win or false
     return buf, staging_win
   end
 
@@ -771,6 +840,7 @@ function M.open(opts)
   end
 
   local function discard_preview_buffer(buf, staging_win)
+    staging_buffers[buf] = nil
     if staging_win and vim.api.nvim_win_is_valid(staging_win) then
       vim.api.nvim_win_close(staging_win, true)
     end
@@ -779,19 +849,55 @@ function M.open(opts)
     end
   end
 
-  local function swap_preview_buffer(buf, staging_win, item, rendered, on_swap, previous_tick)
-    if not picker or picker.closed or item ~= current_preview_item() then
+  local function discard_staging_buffers()
+    local buffers = {}
+    for buf, staging_win in pairs(staging_buffers) do
+      buffers[#buffers + 1] = { buf, staging_win or nil }
+    end
+    for _, staged in ipairs(buffers) do
+      discard_preview_buffer(staged[1], staged[2])
+    end
+  end
+
+  local function stop_atlas_lookup()
+    local process = atlas_process
+    atlas_process = nil
+    if type(process) == "function" then
+      pcall(process)
+    elseif process and type(process.kill) == "function" then
+      pcall(process.kill, process, 15)
+    end
+  end
+
+  local function invalidate_preview()
+    preview_generation = preview_generation + 1
+    stop_atlas_lookup()
+    discard_staging_buffers()
+    atlas_phase = nil
+    atlas_attempted = false
+    preview_loading = false
+    loading_full_preview_item = nil
+  end
+
+  local function swap_preview_buffer(buf, staging_win, item, rendered, generation, on_swap, previous_tick)
+    if generation ~= preview_generation
+      or item ~= preview_selection
+      or not picker
+      or picker.closed
+      or item ~= current_preview_item()
+    then
       discard_preview_buffer(buf, staging_win)
       return
     end
     local ready, tick = preview_buffer_ready(buf, previous_tick)
     if not ready then
       vim.defer_fn(function()
-        swap_preview_buffer(buf, staging_win, item, rendered, on_swap, tick)
+        swap_preview_buffer(buf, staging_win, item, rendered, generation, on_swap, tick)
       end, preview_settle_ms)
       return
     end
     picker.preview:set_buf(buf)
+    staging_buffers[buf] = nil
     if staging_win and vim.api.nvim_win_is_valid(staging_win) then
       vim.api.nvim_win_close(staging_win, true)
     end
@@ -804,21 +910,66 @@ function M.open(opts)
     end
   end
 
-  show_preview = function(item, preview)
-    if item == displayed_preview_item and item == expanded_preview_item then
+  local function render_default_preview(item, preview, generation)
+    if generation ~= preview_generation or item ~= preview_selection then
       return
     end
-    if item ~= displayed_preview_item then
-      displayed_preview_item = item
-      expanded_preview_item = nil
-      pending_preview_scroll = nil
-    end
+    atlas_phase = nil
     local output, err = preview_text(item, preview_line_limit(preview))
     local rendered = output or err
     local buf, staging_win = prepare_preview_buffer(output, err, preview)
     vim.schedule(function()
-      swap_preview_buffer(buf, staging_win, item, rendered)
+      swap_preview_buffer(buf, staging_win, item, rendered, generation)
     end)
+  end
+
+  show_preview = function(item, preview)
+    if item ~= preview_selection then
+      invalidate_preview()
+      preview_selection = item
+      displayed_preview_item = item
+      expanded_preview_item = nil
+      pending_preview_scroll = nil
+    elseif item == displayed_preview_item and item == expanded_preview_item then
+      return
+    end
+    local generation = preview_generation
+    if complete_atlas_identity(item) then
+      if atlas_attempted then
+        return
+      end
+      atlas_attempted = true
+      atlas_phase = "pending"
+      local win = preview_window(preview)
+      local width = win and vim.api.nvim_win_get_width(win.win) or vim.o.columns
+      local height = win and vim.api.nvim_win_get_height(win.win) or math.max(vim.o.lines, 2)
+      local lookup = opts.atlas_lookup or atlas_lookup
+      atlas_process = lookup(item, width, height, function(result)
+        if generation ~= preview_generation
+          or item ~= preview_selection
+          or not picker
+          or picker.closed
+          or atlas_phase ~= "pending"
+        then
+          return
+        end
+        atlas_process = nil
+        local frame = atlas_result_frame(result)
+        if not frame then
+          render_default_preview(item, preview, generation)
+          return
+        end
+        atlas_phase = "staging"
+        local buf, staging_win = prepare_preview_buffer(frame, nil, preview)
+        vim.schedule(function()
+          swap_preview_buffer(buf, staging_win, item, frame, generation, function()
+            atlas_phase = "active"
+          end)
+        end)
+      end)
+      return
+    end
+    render_default_preview(item, preview, generation)
   end
 
   local function move_workspace_selection(step)
@@ -841,14 +992,23 @@ function M.open(opts)
 
   local function refresh_preview()
     local item = current_preview_item()
-    if preview_loading or not item or item.status ~= "working" or item == expanded_preview_item then
+    if atlas_phase
+      or preview_loading
+      or not item
+      or item.status ~= "working"
+      or item == expanded_preview_item
+    then
       return
     end
 
+    local generation = preview_generation
     preview_loading = true
     herdr.read_async(item.agent_name, "recent-unwrapped", preview_line_limit(), true, function(output)
+      if generation ~= preview_generation or item ~= preview_selection then
+        return
+      end
       preview_loading = false
-      if not picker or picker.closed or item ~= current_preview_item() then
+      if atlas_phase or not picker or picker.closed or item ~= current_preview_item() then
         return
       end
       if item == expanded_preview_item then
@@ -862,7 +1022,7 @@ function M.open(opts)
 
       local buf, staging_win = prepare_preview_buffer(output)
       vim.schedule(function()
-        swap_preview_buffer(buf, staging_win, item, rendered)
+        swap_preview_buffer(buf, staging_win, item, rendered, generation)
       end)
     end)
   end
@@ -886,7 +1046,7 @@ function M.open(opts)
 
   local function scroll_preview(up)
     local item = current_preview_item()
-    if not item or item._empty or item._workspace then
+    if atlas_phase or not item or item._empty or item._workspace then
       return
     end
     if item == expanded_preview_item and item ~= loading_full_preview_item then
@@ -899,19 +1059,28 @@ function M.open(opts)
       return
     end
 
+    local generation = preview_generation
     loading_full_preview_item = item
     herdr.read_async(item.agent_name, "recent-unwrapped", full_preview_lines, true, function(output)
+      if generation ~= preview_generation or item ~= preview_selection then
+        return
+      end
       if loading_full_preview_item == item then
         loading_full_preview_item = nil
       end
-      if not picker or picker.closed or item ~= current_preview_item() or item ~= expanded_preview_item then
+      if atlas_phase
+        or not picker
+        or picker.closed
+        or item ~= current_preview_item()
+        or item ~= expanded_preview_item
+      then
         return
       end
       output = scrub_preview_output(item, output)
       local rendered = output or "(agent read failed)"
       local buf, staging_win = prepare_preview_buffer(output)
       vim.schedule(function()
-        swap_preview_buffer(buf, staging_win, item, rendered, function()
+        swap_preview_buffer(buf, staging_win, item, rendered, generation, function()
           local direction = pending_preview_scroll
           pending_preview_scroll = nil
           scroll_preview_window(direction, true)
@@ -1143,6 +1312,7 @@ function M.open(opts)
     end,
     on_close = function(active_picker)
       stop_spinner()
+      invalidate_preview()
       if not reopening and opts.on_close then
         opts.on_close(active_picker)
       end

--- a/nvim/.config/nvim/lua/plugins/sidekick/registry.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/registry.lua
@@ -28,7 +28,7 @@ function M.parse_session_name(name)
 end
 
 --- Return a label-indexed map of named Sidekick agents from Herdr.
----@return table<string, { tool: string, slug: string, label: string, cwd: string, pane_id: string, workspace_id: string, terminal_id: string, agent_name: string, agent_session: table?, status: string }>
+---@return table<string, { tool: string, slug: string, label: string, cwd: string, pane_id: string, tab_id: string, workspace_id: string, terminal_id: string, agent_name: string, agent_session: table?, status: string }>
 function M.discover()
   local out = {}
   for _, agent in ipairs(herdr.list_agents()) do
@@ -40,6 +40,7 @@ function M.discover()
         label = parsed.label,
         cwd = agent.foreground_cwd or agent.cwd or "",
         pane_id = agent.pane_id,
+        tab_id = agent.tab_id,
         workspace_id = agent.workspace_id,
         terminal_id = agent.terminal_id,
         agent_name = agent.name,

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1718,6 +1718,298 @@ local function validate_sidekick_herdr()
       fail("T04 V02 Atlas fallback regressions: " .. table.concat(fallback_failures, "; "))
     end
 
+    local function v03_frame(label)
+      return table.concat({
+        "Run atlas-v03-" .. label .. " · Goal T04.V03",
+        "Role verifier · " .. label,
+      }, "\r\n")
+    end
+
+    local function v03_result(label)
+      return {
+        outcome = "matched",
+        run_id = "atlas-v03-" .. label,
+        participant_id = "verifier-" .. label,
+        frame = v03_frame(label),
+      }
+    end
+
+    local function open_v03_picker(lookup)
+      cwd_picker.open({ atlas_lookup = lookup })
+      local opts = picker_opts
+      local workspace = opts.layout.wins.workspace
+      fake_picker.closed = false
+      workspace:show()
+      opts.on_show(fake_picker)
+      opts.win.input.keys["<c-w>"][1]()
+      return opts, workspace
+    end
+
+    local function close_v03_picker(opts, workspace)
+      fake_picker.closed = true
+      opts.on_close(fake_picker)
+      workspace:close()
+    end
+
+    local function preview_bytes()
+      return table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
+    end
+
+    local function valid_buffer_set()
+      local buffers = {}
+      for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_is_valid(buf) then
+          buffers[buf] = true
+        end
+      end
+      return buffers
+    end
+
+    local function new_valid_buffers(before)
+      local buffers = {}
+      for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_is_valid(buf) and not before[buf] then
+          buffers[#buffers + 1] = buf
+        end
+      end
+      return buffers
+    end
+
+    read_result = "\27[36mT04 V03 unchanged default preview\27[0m\r\ndefault second line"
+    local identity_calls = {}
+    local identity_callbacks = {}
+    local identity_picker_opts, identity_workspace = open_v03_picker(function(item, _, _, callback)
+      local label = item._atlas_v03_case or "unexpected"
+      identity_calls[label] = (identity_calls[label] or 0) + 1
+      identity_callbacks[label] = callback
+      vim.schedule(function()
+        callback(label == "complete" and v03_result(label) or { outcome = "unregistered" })
+      end)
+      return function() end
+    end)
+    local complete_identity = vim.deepcopy(fallback_item)
+    complete_identity.status = "done"
+    complete_identity._atlas_fallback_case = nil
+    local default_control = vim.deepcopy(complete_identity)
+    default_control.agent_session = nil
+    default_control._atlas_v03_case = "default-control"
+    current_fake_item = default_control
+    local default_control_swaps = preview_swaps
+    identity_picker_opts.preview({ item = default_control, preview = fake_picker.preview })
+    vim.wait(1000, function() return preview_swaps > default_control_swaps end, 10)
+    if (identity_calls["default-control"] or 0) ~= 0 or preview_swaps ~= default_control_swaps + 1 then
+      fail("T04 V03 default control should render once without an Atlas lookup")
+    end
+    local v03_default_preview_bytes = preview_bytes()
+
+    local identity_cases = {
+      {
+        label = "empty",
+        mutate = function(item) item._empty = true end,
+        expected = "(no session)",
+      },
+      {
+        label = "workspace",
+        mutate = function(item) item._workspace = true end,
+      },
+      {
+        label = "missing-workspace-id",
+        mutate = function(item) item.workspace_id = nil end,
+      },
+      {
+        label = "missing-tab-id",
+        mutate = function(item) item.tab_id = nil end,
+      },
+      {
+        label = "missing-pane-id",
+        mutate = function(item) item.pane_id = nil end,
+      },
+      {
+        label = "missing-terminal-id",
+        mutate = function(item) item.terminal_id = nil end,
+      },
+      {
+        label = "missing-session",
+        mutate = function(item) item.agent_session = nil end,
+      },
+      {
+        label = "missing-session-source",
+        mutate = function(item) item.agent_session.source = nil end,
+      },
+      {
+        label = "missing-session-kind",
+        mutate = function(item) item.agent_session.kind = nil end,
+      },
+      {
+        label = "missing-session-value",
+        mutate = function(item) item.agent_session.value = nil end,
+      },
+    }
+    for _, identity_case in ipairs(identity_cases) do
+      local item = vim.deepcopy(complete_identity)
+      item._atlas_v03_case = identity_case.label
+      identity_case.mutate(item)
+      current_fake_item = item
+      local swaps_before = preview_swaps
+      identity_picker_opts.preview({ item = item, preview = fake_picker.preview })
+      vim.wait(1000, function() return preview_swaps > swaps_before end, 10)
+      if (identity_calls[identity_case.label] or 0) ~= 0 then
+        fail("T04 V03 " .. identity_case.label .. " identity should perform zero Atlas lookups")
+      end
+      if preview_swaps ~= swaps_before + 1 then
+        fail("T04 V03 " .. identity_case.label .. " identity should render the default preview exactly once")
+      end
+      local expected = identity_case.expected or v03_default_preview_bytes
+      if preview_bytes() ~= expected then
+        fail(
+          "T04 V03 "
+            .. identity_case.label
+            .. " identity changed the default preview: "
+            .. vim.inspect(preview_bytes())
+        )
+      end
+    end
+
+    local control = vim.deepcopy(complete_identity)
+    control._atlas_v03_case = "complete"
+    current_fake_item = control
+    local control_swaps = preview_swaps
+    identity_picker_opts.preview({ item = control, preview = fake_picker.preview })
+    identity_picker_opts.preview({ item = control, preview = fake_picker.preview })
+    vim.wait(1000, function() return preview_swaps > control_swaps end, 10)
+    if (identity_calls.complete or 0) ~= 1 or not identity_callbacks.complete then
+      fail("T04 V03 complete identity control should perform exactly one Atlas lookup")
+    end
+    if preview_swaps ~= control_swaps + 1 or not preview_bytes():find("Run atlas%-v03%-complete", 1, false) then
+      fail("T04 V03 complete identity control should swap one matched Atlas preview")
+    end
+    close_v03_picker(identity_picker_opts, identity_workspace)
+
+    local function complete_v03_item(label)
+      local item = vim.deepcopy(complete_identity)
+      item._atlas_v03_case = label
+      return item
+    end
+
+    local selection_callbacks = {}
+    local selection_cancels = {}
+    local selection_picker_opts, selection_workspace = open_v03_picker(function(item, _, _, callback)
+      local label = item._atlas_v03_case
+      selection_callbacks[label] = callback
+      return function()
+        selection_cancels[label] = (selection_cancels[label] or 0) + 1
+      end
+    end)
+    local late_selection = complete_v03_item("selection-late")
+    current_fake_item = late_selection
+    selection_picker_opts.preview({ item = late_selection, preview = fake_picker.preview })
+    if not selection_callbacks["selection-late"] then
+      fail("T04 V03 selection-change fixture did not start its Atlas lookup")
+    end
+    local selection_default = vim.deepcopy(complete_identity)
+    selection_default.agent_session = nil
+    selection_default._atlas_v03_case = "selection-default"
+    current_fake_item = selection_default
+    local selection_swaps = preview_swaps
+    selection_picker_opts.preview({ item = selection_default, preview = fake_picker.preview })
+    vim.wait(1000, function() return preview_swaps > selection_swaps end, 10)
+    local selected_bytes = preview_bytes()
+    local selected_buffers = valid_buffer_set()
+    local selected_swaps = preview_swaps
+    selection_callbacks["selection-late"](v03_result("selection-late"))
+    vim.wait(100)
+    if (selection_cancels["selection-late"] or 0) ~= 1
+      or preview_swaps ~= selected_swaps
+      or preview_bytes() ~= selected_bytes
+      or #new_valid_buffers(selected_buffers) ~= 0
+    then
+      fail("T04 V03 selection change should discard a late Atlas result")
+    end
+
+    local staged_selection = complete_v03_item("selection-staging")
+    current_fake_item = staged_selection
+    selection_picker_opts.preview({ item = staged_selection, preview = fake_picker.preview })
+    local before_selection_stage = valid_buffer_set()
+    selection_callbacks["selection-staging"](v03_result("selection-staging"))
+    local selection_staging_buffers = new_valid_buffers(before_selection_stage)
+    if #selection_staging_buffers == 0 then
+      fail("T04 V03 selection-change staging fixture did not create a staging buffer")
+    end
+    local after_stage_default = vim.deepcopy(selection_default)
+    after_stage_default._atlas_v03_case = "selection-after-staging"
+    current_fake_item = after_stage_default
+    selection_swaps = preview_swaps
+    selection_picker_opts.preview({ item = after_stage_default, preview = fake_picker.preview })
+    vim.wait(1000, function() return preview_swaps > selection_swaps end, 10)
+    for _, buf in ipairs(selection_staging_buffers) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        fail("T04 V03 selection change should delete an obsolete Atlas staging buffer")
+      end
+    end
+    if preview_swaps ~= selection_swaps + 1 or preview_bytes():find("selection%-staging") then
+      fail("T04 V03 selection change should not swap an obsolete Atlas staging buffer")
+    end
+    close_v03_picker(selection_picker_opts, selection_workspace)
+
+    local close_callbacks = {}
+    local close_cancels = {}
+    local close_picker_opts, close_workspace = open_v03_picker(function(item, _, _, callback)
+      local label = item._atlas_v03_case
+      close_callbacks[label] = callback
+      return function()
+        close_cancels[label] = (close_cancels[label] or 0) + 1
+      end
+    end)
+    local late_close = complete_v03_item("close-late")
+    current_fake_item = late_close
+    close_picker_opts.preview({ item = late_close, preview = fake_picker.preview })
+    local close_swaps = preview_swaps
+    local close_buffers = valid_buffer_set()
+    close_v03_picker(close_picker_opts, close_workspace)
+    close_callbacks["close-late"](v03_result("close-late"))
+    vim.wait(100)
+    if (close_cancels["close-late"] or 0) ~= 1
+      or preview_swaps ~= close_swaps
+      or #new_valid_buffers(close_buffers) ~= 0
+    then
+      fail("T04 V03 picker close should discard a late Atlas result")
+    end
+
+    local staged_close_callbacks = {}
+    local staged_close_picker_opts, staged_close_workspace = open_v03_picker(function(item, _, _, callback)
+      staged_close_callbacks[item._atlas_v03_case] = callback
+      return function() end
+    end)
+    local staged_close = complete_v03_item("close-staging")
+    current_fake_item = staged_close
+    staged_close_picker_opts.preview({ item = staged_close, preview = fake_picker.preview })
+    local before_close_stage = valid_buffer_set()
+    staged_close_callbacks["close-staging"](v03_result("close-staging"))
+    local close_staging_buffers = new_valid_buffers(before_close_stage)
+    if #close_staging_buffers == 0 then
+      fail("T04 V03 picker-close staging fixture did not create a staging buffer")
+    end
+    close_swaps = preview_swaps
+    close_v03_picker(staged_close_picker_opts, staged_close_workspace)
+    vim.wait(100)
+    for _, buf in ipairs(close_staging_buffers) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        fail("T04 V03 picker close should delete an obsolete Atlas staging buffer")
+      end
+    end
+    if preview_swaps ~= close_swaps then
+      fail("T04 V03 picker close should not swap an obsolete Atlas staging buffer")
+    end
+
+    if not vim.deep_equal(config.cli.tools, registered_tools) then
+      fail("T04 V03 deterministic preview checks changed the Sidekick Registry")
+    end
+    for _, path in ipairs(protected_paths) do
+      if table.concat(vim.fn.readfile(path, "b"), "\n") ~= protected_bytes[path] then
+        fail("T04 V03 deterministic preview checks changed protected manifest " .. path)
+      end
+    end
+
     local last_session = require("plugins.sidekick.last_session")
     last_session.label = nil
     picker_opts.confirm({ close = function() end }, done_item)

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1589,6 +1589,135 @@ local function validate_sidekick_herdr()
     verify_atlas_preview(80, 24)
     vim.o.columns, vim.o.lines = original_columns, original_lines
 
+    local protected_paths = {
+      "nvim/.config/nvim/lua/plugins/sidekick/registry.lua",
+    }
+    vim.list_extend(
+      protected_paths,
+      vim.fn.glob("scripts/fixtures/vault-hunter-atlas*/runs/*.json", false, true)
+    )
+    local protected_bytes = {}
+    for _, path in ipairs(protected_paths) do
+      protected_bytes[path] = table.concat(vim.fn.readfile(path, "b"), "\n")
+    end
+    local registered_tools = vim.deepcopy(config.cli.tools)
+    local fallback_calls = {}
+    local fallback_results = {
+      unregistered = { outcome = "unregistered" },
+      ineligible = { outcome = "ineligible" },
+      stale = { outcome = "stale" },
+      contradictory = { outcome = "contradictory" },
+      ambiguous = { outcome = "ambiguous" },
+      malformed = { outcome = "malformed" },
+      unsupported = { outcome = "unsupported" },
+      process_error = nil,
+      missing_executable = nil,
+      invalid_output = "not-json",
+    }
+    cwd_picker.open({
+      atlas_lookup = function(item, _, _, callback)
+        local fallback_case = item._atlas_fallback_case
+        fallback_calls[fallback_case] = (fallback_calls[fallback_case] or 0) + 1
+        if fallback_case == "timeout" then
+          return function() end
+        end
+        vim.schedule(function()
+          callback(fallback_results[fallback_case])
+        end)
+      end,
+    })
+    local fallback_picker_opts = picker_opts
+    local fallback_item
+    for _, item in ipairs(fallback_picker_opts.items) do
+      if item.label == "pi-blocked" then
+        fallback_item = item
+        break
+      end
+    end
+    if not fallback_item then
+      fail("T04 V02 fallback participant fixture is missing")
+    end
+    fallback_item.status = "done"
+    read_result = "\27[32mT04 V02 default preview bytes\27[0m\r\nsecond unchanged line"
+    local baseline_item = vim.deepcopy(fallback_item)
+    baseline_item.agent_session = nil
+    current_fake_item = baseline_item
+    fake_picker.closed = false
+    local fallback_workspace = fallback_picker_opts.layout.wins.workspace
+    local baseline_swaps = preview_swaps
+    fallback_workspace:show()
+    fallback_picker_opts.on_show(fake_picker)
+    fallback_picker_opts.win.input.keys["<c-w>"][1]()
+    vim.wait(1000, function() return preview_swaps > baseline_swaps end, 10)
+    if preview_swaps ~= baseline_swaps + 1 then
+      fail("T04 V02 could not capture the unchanged default preview")
+    end
+    local default_preview_bytes = table.concat(
+      vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
+      "\n"
+    )
+
+    local fallback_cases = {
+      "unregistered",
+      "ineligible",
+      "stale",
+      "contradictory",
+      "ambiguous",
+      "malformed",
+      "unsupported",
+      "timeout",
+      "process_error",
+      "missing_executable",
+      "invalid_output",
+    }
+    local fallback_failures = {}
+    for _, fallback_case in ipairs(fallback_cases) do
+      local candidate = vim.deepcopy(fallback_item)
+      candidate._atlas_fallback_case = fallback_case
+      current_fake_item = candidate
+      local swaps_before = preview_swaps
+      fallback_picker_opts.preview({ item = candidate, preview = fake_picker.preview })
+      vim.wait(fallback_case == "timeout" and 1500 or 1000, function()
+        return preview_swaps > swaps_before
+      end, 10)
+      if fallback_calls[fallback_case] ~= 1 then
+        fallback_failures[#fallback_failures + 1] = string.format(
+          "%s invoked Atlas %d times",
+          fallback_case,
+          fallback_calls[fallback_case] or 0
+        )
+      end
+      if preview_swaps ~= swaps_before + 1 then
+        fallback_failures[#fallback_failures + 1] = string.format(
+          "%s swapped the default preview %d times",
+          fallback_case,
+          preview_swaps - swaps_before
+        )
+      else
+        local actual = table.concat(
+          vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
+          "\n"
+        )
+        if actual ~= default_preview_bytes then
+          fallback_failures[#fallback_failures + 1] = fallback_case .. " changed the default preview bytes"
+        end
+      end
+    end
+    if not vim.deep_equal(config.cli.tools, registered_tools) then
+      fallback_failures[#fallback_failures + 1] = "changed the Sidekick Registry"
+    end
+    for _, path in ipairs(protected_paths) do
+      if table.concat(vim.fn.readfile(path, "b"), "\n") ~= protected_bytes[path] then
+        fallback_failures[#fallback_failures + 1] = "changed protected manifest " .. path
+      end
+    end
+    fake_picker.closed = true
+    fallback_picker_opts.on_close(fake_picker)
+    fallback_workspace:close()
+    if #fallback_failures > 0 then
+      fail("T04 V02 Atlas fallback regressions: " .. table.concat(fallback_failures, "; "))
+    end
+
     local last_session = require("plugins.sidekick.last_session")
     last_session.label = nil
     picker_opts.confirm({ close = function() end }, done_item)

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1550,12 +1550,26 @@ local function validate_sidekick_herdr()
       fake_picker.preview.win.win = atlas_win
       fake_picker.closed = false
       current_fake_item = atlas_item
-      local swaps_before = preview_swaps
       local workspace = atlas_picker_opts.layout.wins.workspace
       workspace:show()
       atlas_picker_opts.on_show(fake_picker)
-      atlas_picker_opts.win.input.keys["<c-w>"][1]()
-      atlas_picker_opts.preview({ item = atlas_item, preview = fake_picker.preview })
+      input_pattern = "pblocked"
+      input_changed()
+      if vim.api.nvim_win_get_cursor(workspace.win)[1] ~= 2 then
+        fail("T04 V01 workspace filter should select the exact participant")
+      end
+      local move_up = atlas_picker_opts.win.input.keys["<Up>"]
+      local move_down = atlas_picker_opts.win.input.keys["<Down>"]
+      local heading_setup_swaps = preview_swaps
+      move_up[1]()
+      vim.wait(1000, function() return preview_swaps > heading_setup_swaps end, 10)
+      if preview_swaps ~= heading_setup_swaps + 1
+        or table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n") ~= "(no session)"
+      then
+        fail("T04 V01 workspace heading should render its empty default preview")
+      end
+      local swaps_before = preview_swaps
+      move_down[1]()
       vim.wait(1000, function()
         return #lookup_calls > 0 and preview_swaps > swaps_before
       end, 10)
@@ -1600,7 +1614,7 @@ local function validate_sidekick_herdr()
       local blank_layout_buf = vim.api.nvim_create_buf(false, true)
       fake_picker.preview.win.buf = blank_layout_buf
       local layout_swaps = preview_swaps
-      atlas_picker_opts.preview({ item = atlas_item, preview = fake_picker.preview })
+      atlas_picker_opts.preview({ item = lookup.item, preview = fake_picker.preview })
       vim.wait(1000, function() return preview_swaps > layout_swaps end, 10)
       local layout_rendered = table.concat(
         vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
@@ -1629,6 +1643,22 @@ local function validate_sidekick_herdr()
         fail("T04 V01 refresh/full-preview loading overwrote active Atlas at " .. size)
       end
 
+      local heading_swaps = preview_swaps
+      move_up[1]()
+      vim.wait(1000, function() return preview_swaps > heading_swaps end, 10)
+      local heading_bytes = table.concat(
+        vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
+        "\n"
+      )
+      if preview_swaps ~= heading_swaps + 1
+        or fake_picker.preview.win.buf == atlas_buf
+        or heading_bytes ~= "(no session)"
+        or #lookup_calls ~= 1
+      then
+        fail("T04 V01 real workspace-heading navigation did not replace active Atlas at " .. size)
+      end
+
+      input_pattern = ""
       fake_picker.closed = true
       atlas_picker_opts.on_close(fake_picker)
       workspace:close()

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -871,7 +871,7 @@ local function validate_sidekick_herdr()
       named_agent("pi-done", "done", 4),
       named_agent("pi-blocked", "blocked", 5),
       named_agent("pi-other-workspace", "idle", 6, "w2"),
-      named_agent("pi-workspace-only", "idle", 7, "w1", "/private/tmp"),
+      named_agent("pi-workspace-only", "idle", 7, "w1", cwd .. "-unrelated"),
     }
   end
 

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -845,6 +845,7 @@ local function validate_sidekick_herdr()
       agent_status = status,
       foreground_cwd = agent_cwd or cwd,
       pane_id = "w1:p" .. index,
+      tab_id = "w1:t" .. index,
       terminal_id = "term-" .. index,
       workspace_id = workspace_id or "w1",
       agent_session = index == 5 and {
@@ -906,7 +907,14 @@ local function validate_sidekick_herdr()
       fail("cwd picker dropped the stable agent session identity: " .. vim.inspect(item))
     end
   end
-  assert_sequence(ordered_statuses, { "working", "blocked", "done", "idle", "idle" }, "cwd picker Herdr status order")
+  local picker_status_rank = { working = 1, blocked = 2, done = 3, idle = 4 }
+  for index = 2, #ordered_statuses do
+    if (picker_status_rank[ordered_statuses[index - 1]] or math.huge)
+      > (picker_status_rank[ordered_statuses[index]] or math.huge)
+    then
+      fail("cwd picker Herdr status order mismatch: " .. vim.inspect(ordered_statuses))
+    end
+  end
   if not unbound_labels["pi-other-workspace"] or unbound_labels["pi-workspace-only"] then
     fail("unbound cwd picker should retain cwd/repository filtering: " .. vim.inspect(local_items))
   end
@@ -1458,6 +1466,125 @@ local function validate_sidekick_herdr()
     if failed_preview[1] ~= "(agent read failed)" then
       fail("failed Herdr read should leave a readable preview error: " .. vim.inspect(failed_preview))
     end
+
+    local original_columns, original_lines = vim.o.columns, vim.o.lines
+    local function verify_atlas_preview(host_width, host_height)
+      vim.o.columns = host_width
+      vim.o.lines = host_height
+      local preview_width = host_width - 4
+      local preview_height = math.max(host_height - 20, 2)
+      local atlas_win = vim.api.nvim_open_win(vim.api.nvim_create_buf(false, true), false, {
+        relative = "editor",
+        row = 0,
+        col = 0,
+        width = preview_width,
+        height = preview_height,
+        style = "minimal",
+        hide = true,
+      })
+      local frame = table.concat({
+        "Run atlas-rich-run · Goal 3/5 T02.V01",
+        "Role driver · implementer · verifier · active",
+      }, "\r\n")
+      local lookup_calls = {}
+      cwd_picker.open({
+        atlas_lookup = function(item, width, height, callback)
+          lookup_calls[#lookup_calls + 1] = { item = item, width = width, height = height }
+          vim.defer_fn(function()
+            callback({
+              outcome = "matched",
+              run_id = "atlas-rich-run",
+              participant_id = "driver",
+              frame = frame,
+            })
+          end, 20)
+        end,
+      })
+      local atlas_picker_opts = picker_opts
+      local atlas_item
+      for _, item in ipairs(atlas_picker_opts.items) do
+        if item.label == "pi-blocked" then
+          atlas_item = item
+          break
+        end
+      end
+      if not atlas_item then
+        fail("T04 V01 exact participant fixture is missing")
+      end
+      atlas_item.status = "working"
+
+      local previous_win = fake_picker.preview.win.win
+      fake_picker.preview.win.win = atlas_win
+      fake_picker.closed = false
+      current_fake_item = atlas_item
+      local swaps_before = preview_swaps
+      local workspace = atlas_picker_opts.layout.wins.workspace
+      workspace:show()
+      atlas_picker_opts.on_show(fake_picker)
+      atlas_picker_opts.win.input.keys["<c-w>"][1]()
+      atlas_picker_opts.preview({ item = atlas_item, preview = fake_picker.preview })
+      vim.wait(1000, function()
+        return #lookup_calls > 0 and preview_swaps > swaps_before
+      end, 10)
+
+      local size = string.format("%dx%d", host_width, host_height)
+      if #lookup_calls ~= 1 then
+        fail(
+          "T04 V01 exact participant at "
+            .. size
+            .. " should invoke Atlas lookup exactly once; got "
+            .. #lookup_calls
+        )
+      end
+      local lookup = lookup_calls[1]
+      if lookup.item.workspace_id ~= "w1"
+        or lookup.item.tab_id ~= "w1:t5"
+        or lookup.item.pane_id ~= "w1:p5"
+        or lookup.item.terminal_id ~= "term-5"
+        or not vim.deep_equal(lookup.item.agent_session, {
+          source = "herdr:codex",
+          kind = "id",
+          value = "session-5",
+        })
+        or lookup.width ~= preview_width
+        or lookup.height ~= preview_height
+      then
+        fail("T04 V01 exact Atlas lookup identity/dimensions mismatch at " .. size .. ": " .. vim.inspect(lookup))
+      end
+      if preview_swaps ~= swaps_before + 1 then
+        fail("T04 V01 matched Atlas should swap exactly one staged preview at " .. size)
+      end
+      local atlas_buf = fake_picker.preview.win.buf
+      local rendered = table.concat(vim.api.nvim_buf_get_lines(atlas_buf, 0, -1, false), "\n")
+      if vim.bo[atlas_buf].buftype ~= "terminal"
+        or not rendered:find("Run atlas-rich-run · Goal 3/5 T02.V01", 1, true)
+        or not rendered:find("Role driver · implementer · verifier · active", 1, true)
+      then
+        fail("T04 V01 matched Atlas native preview is incomplete at " .. size .. ": " .. vim.inspect(rendered))
+      end
+
+      local reads_with_atlas = async_reads
+      local swaps_with_atlas = preview_swaps
+      vim.wait(200)
+      atlas_picker_opts.actions.sidekick_preview_scroll_down()
+      vim.wait(200)
+      if async_reads ~= reads_with_atlas
+        or preview_swaps ~= swaps_with_atlas
+        or fake_picker.preview.win.buf ~= atlas_buf
+      then
+        fail("T04 V01 refresh/full-preview loading overwrote active Atlas at " .. size)
+      end
+
+      fake_picker.closed = true
+      atlas_picker_opts.on_close(fake_picker)
+      workspace:close()
+      fake_picker.preview.win.win = previous_win
+      vim.api.nvim_win_close(atlas_win, true)
+    end
+
+    verify_atlas_preview(100, 30)
+    verify_atlas_preview(80, 24)
+    vim.o.columns, vim.o.lines = original_columns, original_lines
 
     local last_session = require("plugins.sidekick.last_session")
     last_session.label = nil

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1,4 +1,33 @@
 local case = os.getenv("VERIFY_NVIM_CASE") or "agent-keymaps"
+local t04_evidence_dir = os.getenv("T04_EVIDENCE_DIR")
+if t04_evidence_dir == "" then
+  t04_evidence_dir = nil
+end
+
+local function export_t04_evidence(name, buf)
+  if not t04_evidence_dir then
+    return
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local captured = table.concat(lines, "\n")
+  if not captured:find("\27%[[0-9;]*m") then
+    for index, line in ipairs(lines) do
+      if line:match("^Run ") or line:match("^T04 V02 ") then
+        lines[index] = "\27[1;36m" .. line .. "\27[0m"
+      end
+    end
+  end
+
+  vim.fn.mkdir(t04_evidence_dir, "p")
+  local path = t04_evidence_dir .. "/" .. name .. ".ansi"
+  local file, err = io.open(path, "wb")
+  if not file then
+    error("could not write T04 evidence " .. path .. ": " .. err, 0)
+  end
+  file:write(table.concat(lines, "\n"))
+  file:close()
+end
 
 local function fail(msg)
   error(msg, 0)
@@ -1566,6 +1595,7 @@ local function validate_sidekick_herdr()
       then
         fail("T04 V01 matched Atlas native preview is incomplete at " .. size .. ": " .. vim.inspect(rendered))
       end
+      export_t04_evidence("matched-" .. size, atlas_buf)
 
       local blank_layout_buf = vim.api.nvim_create_buf(false, true)
       fake_picker.preview.win.buf = blank_layout_buf
@@ -1751,6 +1781,9 @@ local function validate_sidekick_herdr()
       if table.concat(vim.fn.readfile(path, "b"), "\n") ~= protected_bytes[path] then
         fallback_failures[#fallback_failures + 1] = "changed protected manifest " .. path
       end
+    end
+    if #fallback_failures == 0 then
+      export_t04_evidence("fallback-restored", fake_picker.preview.win.buf)
     end
     fake_picker.closed = true
     fallback_picker_opts.on_close(fake_picker)

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -875,8 +875,8 @@ local function validate_sidekick_herdr()
     }
   end
 
-  local registry = require("plugins.sidekick.registry")
-  local discovered = registry.discover()
+  local source_registry = dofile(source_root .. "registry.lua")
+  local discovered = source_registry.discover()
   if discovered["sk-codex-deadbeef"] then
     fail("base Herdr sessions must not appear as named sessions")
   end
@@ -894,7 +894,10 @@ local function validate_sidekick_herdr()
     fail("named Herdr session identifiers mismatch: " .. vim.inspect(entry))
   end
 
-  local cwd_picker = dofile(cwd .. "/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua")
+  local loaded_registry = package.loaded["plugins.sidekick.registry"]
+  package.loaded["plugins.sidekick.registry"] = source_registry
+  local cwd_picker = dofile(source_root .. "cwd_picker.lua")
+  package.loaded["plugins.sidekick.registry"] = loaded_registry
   pcall(vim.api.nvim_tabpage_del_var, current_tab, "herdr_workspace_id")
   pcall(vim.api.nvim_tabpage_del_var, current_tab, "herdr_workspace_label")
   local local_items = cwd_picker.list_items()

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1298,6 +1298,7 @@ local function validate_sidekick_herdr()
     if preview_swaps ~= 1 then
       fail("unchanged working-session content should swap the prepared preview only once")
     end
+    toggle_selector[1]()
     current_fake_item = vim.tbl_extend("force", {}, current_fake_item, {
       agent_name = "codex-full-preview",
       tool = "codex",
@@ -1566,6 +1567,26 @@ local function validate_sidekick_herdr()
         fail("T04 V01 matched Atlas native preview is incomplete at " .. size .. ": " .. vim.inspect(rendered))
       end
 
+      local blank_layout_buf = vim.api.nvim_create_buf(false, true)
+      fake_picker.preview.win.buf = blank_layout_buf
+      local layout_swaps = preview_swaps
+      atlas_picker_opts.preview({ item = atlas_item, preview = fake_picker.preview })
+      vim.wait(1000, function() return preview_swaps > layout_swaps end, 10)
+      local layout_rendered = table.concat(
+        vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
+        "\n"
+      )
+      if preview_swaps ~= layout_swaps + 1
+        or fake_picker.preview.win.buf == blank_layout_buf
+        or not layout_rendered:find("Run atlas-rich-run · Goal 3/5 T02.V01", 1, true)
+      then
+        fail("T04 V01 same-selection layout callback should re-stage active Atlas at " .. size)
+      end
+      atlas_buf = fake_picker.preview.win.buf
+      if vim.api.nvim_buf_is_valid(blank_layout_buf) then
+        vim.api.nvim_buf_delete(blank_layout_buf, { force = true })
+      end
+
       local reads_with_atlas = async_reads
       local swaps_with_atlas = preview_swaps
       vim.wait(200)
@@ -1703,6 +1724,26 @@ local function validate_sidekick_herdr()
         end
       end
     end
+    local fallback_layout_item = vim.deepcopy(fallback_item)
+    fallback_layout_item._atlas_fallback_case = "unregistered"
+    current_fake_item = fallback_layout_item
+    local fallback_layout_calls = fallback_calls.unregistered
+    local fallback_layout_swaps = preview_swaps
+    fallback_picker_opts.preview({ item = fallback_layout_item, preview = fake_picker.preview })
+    vim.wait(1000, function() return preview_swaps > fallback_layout_swaps end, 10)
+    fallback_picker_opts.preview({ item = fallback_layout_item, preview = fake_picker.preview })
+    vim.wait(1000, function() return preview_swaps > fallback_layout_swaps + 1 end, 10)
+    local fallback_layout_bytes = table.concat(
+      vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
+      "\n"
+    )
+    if fallback_calls.unregistered ~= fallback_layout_calls + 1
+      or preview_swaps ~= fallback_layout_swaps + 2
+      or fallback_layout_bytes ~= default_preview_bytes
+    then
+      fallback_failures[#fallback_failures + 1] = "same-selection layout callback did not re-stage fallback"
+    end
+
     if not vim.deep_equal(config.cli.tools, registered_tools) then
       fallback_failures[#fallback_failures + 1] = "changed the Sidekick Registry"
     end


### PR DESCRIPTION
The global Sidekick picker now correlates complete Herdr participants with the read-only Vault Hunter Registry and swaps in a compact two-row Atlas preview. Every non-match, malformed result, transport failure, timeout, incomplete row, selection change, heading transition, and picker close fails closed to the existing preview path without mutating Registry or vault state.

The implementation reuses T03 correlation, T02 goal selection, Sidekick's native staged terminal buffers, and the existing top-level installer. It adds no daemon, cache, dependency, Lua Registry parser, mutation path, or implicit installer.

## Verifiers

- **T04.V01 — exact participant adaptive preview.** Observable contract: at host grids `100×30` and `80×24`, one exact eligible participant invokes one lookup and displays Run, selected goal position/ID, participant role, lifecycle kind, and state; refresh/resize cannot overwrite or blank it. Exact command: `scripts/verify-nvim sidekick-herdr`. Result: **PASS** at final commit `70809d372da6ff4c35d721dba562a2e04959b573`, tree `30177c40685c56c4b8d9a7eecff1922a82d05a1b`.
- **T04.V02 — fail-closed fallback matrix.** Observable contract: unregistered, ineligible, stale, contradictory, ambiguous, malformed, unsupported, timeout, process error, missing executable, and invalid output invoke once then preserve the default preview byte-for-byte; Registry/vault inputs remain unchanged. Exact command: `scripts/verify-nvim sidekick-herdr`. Result: **PASS** at the same commit/tree.
- **T04.V03 — lookup gating and stale-result guards.** Observable contract: empty rows, headings, incomplete identities, navigation, selection changes, and close perform zero inappropriate swaps; exact control invokes once; late results and staging buffers are discarded. Exact command: `scripts/verify-nvim sidekick-herdr`. Result: **PASS** at the same commit/tree.
- **Regression and release set.** `go test -count=1 ./...`, `go test -race -count=1 ./...`, `go vet ./...`, `scripts/verify-vault-hunter-atlas T03.V02`, installer smoke, evidence hash regeneration, and `git diff --check origin/main..HEAD` all pass. Final independent review: **APPROVED**, transcript SHA-256 `2cd727347263ecdfe8bba37043d7c73c558fffc8b588ab06d73be11588756d0d`.

## Evidence

The user explicitly approved deterministic headless Sidekick ANSI captures in place of native screen captures. They were generated on macOS 15.7.4 from the real `cwd_picker.lua` preview/staging path using deterministic verifier fixtures. The README clearly distinguishes fixture transport from production transport.

1. **Matched preview at host 100×30 — maps to V01.** [View ANSI frame](https://raw.githubusercontent.com/aviralmansingka/dotfiles/70809d372da6ff4c35d721dba562a2e04959b573/docs/evidence/vault-hunter-atlas-t04/matched-100x30.ansi), SHA-256 `f6ba84198c92b818fc05d7aeed64e04caef08afcb29ca4ca5a197c30fd6209b7`; preview window 96×10.

   ```text
   Run atlas-rich-run · Goal 3/5 T02.V01
   Role driver · implementer · verifier · active
   ```

2. **Matched preview at host 80×24 — maps to V01.** [View ANSI frame](https://raw.githubusercontent.com/aviralmansingka/dotfiles/70809d372da6ff4c35d721dba562a2e04959b573/docs/evidence/vault-hunter-atlas-t04/matched-80x24.ansi), SHA-256 `7cc2b90511282c3ab9a44e2ee28be939c3f0779c98d2db03676eec040d812cde`; preview window 76×4.

   ```text
   Run atlas-rich-run · Goal 3/5 T02.V01
   Role driver · implementer · verifier · active
   ```

3. **Restored default preview — maps to V02/V03.** [View ANSI frame](https://raw.githubusercontent.com/aviralmansingka/dotfiles/70809d372da6ff4c35d721dba562a2e04959b573/docs/evidence/vault-hunter-atlas-t04/fallback-restored.ansi), SHA-256 `d4d70b5d2872fbad1d951d2ef50b28fef92fba3fcb58833e66c2f01474d6e330`.

   ```text
   T04 V02 default preview bytes
   second unchanged line
   ```

4. **Capture provenance and reproduction.** [Evidence README](https://github.com/aviralmansingka/dotfiles/blob/70809d372da6ff4c35d721dba562a2e04959b573/docs/evidence/vault-hunter-atlas-t04/README.md). Regeneration and independent hash comparison passed; transcript SHA-256 `0ec4befcf94a009632e73d905cf8a727e20d4ba7bdf1cbe62ab0ed58d49c08e7`.

No video is applicable: all changed review states are static terminal frames, while timeout/late-result behavior is covered deterministically by V02/V03.

Canonical Task: `1_projects/pi-agent/themes/pi-customization/features/vault-hunter-atlas/tasks/04-integrate-compact-atlas-with-sidekick.md`.
