### PR TITLE
feat(nvim): render ANSI Markdown fences

### DIFF
--- a/nvim/.config/nvim/lua/helpers/markdown_ansi.lua
+++ b/nvim/.config/nvim/lua/helpers/markdown_ansi.lua
@@ -1,0 +1,295 @@
+local M = {}
+
+local groups = {}
+local definitions = {}
+local group_count = 0
+
+local basic_colors = {
+  "#000000",
+  "#800000",
+  "#008000",
+  "#808000",
+  "#000080",
+  "#800080",
+  "#008080",
+  "#c0c0c0",
+  "#808080",
+  "#ff0000",
+  "#00ff00",
+  "#ffff00",
+  "#0000ff",
+  "#ff00ff",
+  "#00ffff",
+  "#ffffff",
+}
+
+local function indexed_color(index)
+  if index < 16 then
+    return vim.g["terminal_color_" .. index] or basic_colors[index + 1]
+  end
+  if index < 232 then
+    local value = index - 16
+    local levels = { 0, 95, 135, 175, 215, 255 }
+    local red = math.floor(value / 36)
+    local green = math.floor(value % 36 / 6)
+    local blue = value % 6
+    return ("#%02x%02x%02x"):format(levels[red + 1], levels[green + 1], levels[blue + 1])
+  end
+  local gray = 8 + (index - 232) * 10
+  return ("#%02x%02x%02x"):format(gray, gray, gray)
+end
+
+local function color(index)
+  return index and { index = index } or nil
+end
+
+local function copy(state)
+  return vim.deepcopy(state)
+end
+
+local function reset(state)
+  for key in pairs(state) do
+    state[key] = nil
+  end
+end
+
+local function apply_sgr(state, params)
+  local next_state = copy(state)
+  local values = {}
+  if params == "" then
+    values[1] = 0
+  else
+    if
+      not params:match("^[%d;]+$")
+      or params:sub(1, 1) == ";"
+      or params:sub(-1) == ";"
+      or params:find(";;", 1, true)
+    then
+      return false
+    end
+    for value in params:gmatch("[^;]+") do
+      values[#values + 1] = tonumber(value)
+    end
+    if #values == 0 then
+      return false
+    end
+  end
+
+  local i = 1
+  while i <= #values do
+    local value = values[i]
+    if value == 0 then
+      reset(next_state)
+    elseif value == 1 then
+      next_state.bold = true
+    elseif value == 3 then
+      next_state.italic = true
+    elseif value == 4 then
+      next_state.underline = true
+    elseif value == 7 then
+      next_state.reverse = true
+    elseif value == 9 then
+      next_state.strikethrough = true
+    elseif value == 22 then
+      next_state.bold = nil
+    elseif value == 23 then
+      next_state.italic = nil
+    elseif value == 24 then
+      next_state.underline = nil
+    elseif value == 27 then
+      next_state.reverse = nil
+    elseif value == 29 then
+      next_state.strikethrough = nil
+    elseif value >= 30 and value <= 37 then
+      next_state.fg = color(value - 30)
+    elseif value >= 40 and value <= 47 then
+      next_state.bg = color(value - 40)
+    elseif value >= 90 and value <= 97 then
+      next_state.fg = color(value - 90 + 8)
+    elseif value >= 100 and value <= 107 then
+      next_state.bg = color(value - 100 + 8)
+    elseif value == 39 then
+      next_state.fg = nil
+    elseif value == 49 then
+      next_state.bg = nil
+    elseif value == 38 or value == 48 then
+      local target = value == 38 and "fg" or "bg"
+      local mode = values[i + 1]
+      if mode == 5 and values[i + 2] and values[i + 2] >= 0 and values[i + 2] <= 255 then
+        next_state[target] = color(values[i + 2])
+        i = i + 2
+      elseif
+        mode == 2
+        and values[i + 2]
+        and values[i + 3]
+        and values[i + 4]
+        and values[i + 2] >= 0
+        and values[i + 2] <= 255
+        and values[i + 3] >= 0
+        and values[i + 3] <= 255
+        and values[i + 4] >= 0
+        and values[i + 4] <= 255
+      then
+        next_state[target] = {
+          gui = ("#%02x%02x%02x"):format(values[i + 2], values[i + 3], values[i + 4]),
+        }
+        i = i + 4
+      else
+        return false
+      end
+    else
+      return false
+    end
+    i = i + 1
+  end
+
+  reset(state)
+  for key, value in pairs(next_state) do
+    state[key] = value
+  end
+  return true
+end
+
+local function highlight_attributes(state)
+  local attrs = {
+    bold = state.bold,
+    italic = state.italic,
+    underline = state.underline,
+    reverse = state.reverse,
+    strikethrough = state.strikethrough,
+  }
+  if state.fg then
+    attrs.fg = state.fg.gui or indexed_color(state.fg.index)
+    attrs.ctermfg = state.fg.index
+  end
+  if state.bg then
+    attrs.bg = state.bg.gui or indexed_color(state.bg.index)
+    attrs.ctermbg = state.bg.index
+  end
+  return attrs
+end
+
+local function group_for(state)
+  if not next(state) then
+    return nil
+  end
+
+  local key = vim.inspect(state)
+  if groups[key] then
+    return groups[key]
+  end
+
+  group_count = group_count + 1
+  local name = "RenderMarkdownAnsi" .. group_count
+  local attrs = highlight_attributes(state)
+  vim.api.nvim_set_hl(0, name, attrs)
+  groups[key] = name
+  definitions[name] = copy(state)
+  return name
+end
+
+local function add_highlight(marks, row, start_col, end_col, state)
+  local group = group_for(state)
+  if group and start_col < end_col then
+    marks[#marks + 1] = {
+      conceal = false,
+      start_row = row,
+      start_col = start_col,
+      opts = {
+        end_col = end_col,
+        hl_group = group,
+        hl_mode = "combine",
+        priority = 200,
+      },
+    }
+  end
+end
+
+local function parse_line(marks, row, line, start_col, end_col, state)
+  local cursor = start_col + 1
+  local limit = end_col or #line
+  while cursor <= limit do
+    local sgr_start, sgr_end, params = line:find("\27%[([0-9;]*)m", cursor)
+    if not sgr_start or sgr_start > limit then
+      break
+    end
+    add_highlight(marks, row, cursor - 1, sgr_start - 1, state)
+    if apply_sgr(state, params) then
+      marks[#marks + 1] = {
+        conceal = false,
+        start_row = row,
+        start_col = sgr_start - 1,
+        opts = {
+          end_col = sgr_end,
+          conceal = "",
+          priority = 201,
+        },
+      }
+    else
+      add_highlight(marks, row, sgr_start - 1, sgr_end, state)
+    end
+    cursor = sgr_end + 1
+  end
+  add_highlight(marks, row, cursor - 1, limit, state)
+end
+
+local function content_node(node)
+  for child in node:iter_children() do
+    if child:type() == "code_fence_content" then
+      return child
+    end
+  end
+end
+
+local function language(node, buf)
+  for child in node:iter_children() do
+    if child:type() == "info_string" then
+      return vim.trim(vim.treesitter.get_node_text(child, buf))
+    end
+  end
+end
+
+local function visit(node, buf, marks)
+  if node:type() == "fenced_code_block" and language(node, buf) == "ansi" then
+    local content = content_node(node)
+    if not content then
+      return
+    end
+    local start_row, start_col, end_row, end_col = content:range()
+    local lines = vim.api.nvim_buf_get_lines(buf, start_row, end_row + (end_col > 0 and 1 or 0), false)
+    local state = {}
+    for offset, line in ipairs(lines) do
+      local row = start_row + offset - 1
+      local first_col = row == start_row and start_col or 0
+      local last_col = row == end_row and end_col or #line
+      parse_line(marks, row, line, first_col, last_col, state)
+    end
+    return
+  end
+
+  for child in node:iter_children() do
+    visit(child, buf, marks)
+  end
+end
+
+function M.parse(ctx)
+  if vim.bo[ctx.buf].filetype ~= "markdown" then
+    return {}
+  end
+  local marks = {}
+  visit(ctx.root, ctx.buf, marks)
+  return marks
+end
+
+function M.setup()
+  vim.api.nvim_create_autocmd("ColorScheme", {
+    group = vim.api.nvim_create_augroup("RenderMarkdownAnsiColors", { clear = true }),
+    callback = function()
+      for name, state in pairs(definitions) do
+        vim.api.nvim_set_hl(0, name, highlight_attributes(state))
+      end
+    end,
+  })
+end
+
+return M

--- a/nvim/.config/nvim/lua/plugins/markdown.lua
+++ b/nvim/.config/nvim/lua/plugins/markdown.lua
@@ -128,6 +128,9 @@ return {
     "MeanderingProgrammer/render-markdown.nvim",
     dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-tree/nvim-web-devicons" }, -- if you use the mini.nvim suite
     ft = { "markdown", "octo" },
+    init = function()
+      require("helpers.markdown_ansi").setup()
+    end,
     keys = {
       {
         "<leader>ft",
@@ -530,6 +533,12 @@ return {
     ---@type render.md.UserConfig
     opts = {
       render_modes = true,
+      custom_handlers = {
+        markdown = {
+          extends = true,
+          parse = require("helpers.markdown_ansi").parse,
+        },
+      },
       -- Override render-markdown's default win_options.concealcursor (set to "")
       -- so links stay concealed when the cursor is on a link line. Pairs with
       -- helpers/markdown_links.lua setting conceallevel=3 + concealcursor=nvic.

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -4419,10 +4419,151 @@ local function validate_markdown_formatting()
   vim.api.nvim_buf_delete(buf, { force = true })
 end
 
+local function validate_markdown_ansi()
+  local config_lua = vim.fn.getcwd() .. "/nvim/.config/nvim/lua"
+  package.path = config_lua .. "/?.lua;" .. config_lua .. "/?/init.lua;" .. package.path
+  package.loaded["helpers.markdown_ansi"] = nil
+
+  local ansi = require("helpers.markdown_ansi")
+  ansi.setup()
+  local esc = "\27"
+  local lines = {
+    "```ansi",
+    esc .. "[1;38;2;146;131;116mtruecolor",
+    "carried " .. esc .. "[0mplain",
+    esc .. "[91;44mclassic" .. esc .. "[39;49m defaults",
+    esc .. "[38;5;196;48;5;17mindexed " .. esc .. "[2munsupported",
+    "```",
+    "```text",
+    esc .. "[31mnot ansi" .. esc .. "[0m",
+    "```",
+  }
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].filetype = "markdown"
+  local parser = vim.treesitter.get_parser(buf, "markdown")
+  local marks = ansi.parse({ buf = buf, root = parser:parse()[1]:root(), last = true })
+
+  local concealed = 0
+  local highlighted = {}
+  for _, mark in ipairs(marks) do
+    if mark.conceal ~= false then
+      fail("ANSI marks must remain rendered under the cursor and in visual mode")
+    end
+    if mark.opts.conceal == "" then
+      concealed = concealed + 1
+    elseif mark.opts.hl_group then
+      highlighted[#highlighted + 1] = {
+        row = mark.start_row,
+        start_col = mark.start_col,
+        end_col = mark.opts.end_col,
+        group = mark.opts.hl_group,
+        attrs = vim.api.nvim_get_hl(0, { name = mark.opts.hl_group, link = false }),
+      }
+    end
+  end
+
+  if concealed ~= 5 then
+    fail("expected five supported SGR sequences to be concealed, got " .. concealed)
+  end
+  if not vim.deep_equal(vim.api.nvim_buf_get_lines(buf, 0, -1, false), lines) then
+    fail("ANSI rendering must not alter the Markdown source bytes")
+  end
+  vim.api.nvim_win_set_buf(0, buf)
+  vim.api.nvim_win_set_cursor(0, { 2, 0 })
+  vim.cmd("normal! yy")
+  if vim.fn.getreg('"') ~= lines[2] .. "\n" then
+    fail("linewise yank should copy the complete underlying ANSI bytes")
+  end
+
+  local function has_highlight(row, predicate)
+    for _, item in ipairs(highlighted) do
+      if item.row == row and predicate(item) then
+        return true
+      end
+    end
+    return false
+  end
+
+  if
+    not has_highlight(1, function(item)
+      return item.attrs.bold and item.attrs.fg == 0x928374
+    end)
+  then
+    fail("truecolor foreground and bold should render")
+  end
+  if
+    not has_highlight(2, function(item)
+      return item.start_col == 0 and item.attrs.bold and item.attrs.fg == 0x928374
+    end)
+  then
+    fail("SGR style should carry across lines until reset")
+  end
+  if
+    not has_highlight(3, function(item)
+      local fg = tonumber(vim.g.terminal_color_9:sub(2), 16)
+      local bg = tonumber(vim.g.terminal_color_4:sub(2), 16)
+      return item.attrs.fg == fg and item.attrs.bg == bg
+    end)
+  then
+    fail("classic 16-color foreground and background should render")
+  end
+  local classic_group
+  for _, item in ipairs(highlighted) do
+    if item.row == 3 then
+      classic_group = item.group
+      break
+    end
+  end
+  local original_red = vim.g.terminal_color_9
+  vim.g.terminal_color_9 = "#123456"
+  vim.api.nvim_exec_autocmds("ColorScheme", { pattern = "verify-markdown-ansi" })
+  local reloaded = vim.api.nvim_get_hl(0, { name = classic_group, link = false })
+  vim.g.terminal_color_9 = original_red
+  vim.api.nvim_exec_autocmds("ColorScheme", { pattern = "verify-markdown-ansi" })
+  if reloaded.fg ~= 0x123456 then
+    fail("classic ANSI colors should refresh from the active terminal palette")
+  end
+  if
+    not has_highlight(4, function(item)
+      return item.attrs.fg == 0xff0000 and item.attrs.bg == 0x00005f
+    end)
+  then
+    fail("indexed 256-color foreground and background should render")
+  end
+
+  local unsupported = lines[5]:find(esc .. "[2m", 1, true) - 1
+  for _, mark in ipairs(marks) do
+    if mark.start_row == 4 and mark.opts.conceal == "" and mark.start_col == unsupported then
+      fail("unsupported SGR should remain visible")
+    end
+    if mark.start_row == 7 then
+      fail("ANSI outside an ansi fence should not render")
+    end
+  end
+
+  local specs = dofile("nvim/.config/nvim/lua/plugins/markdown.lua")
+  local configured = false
+  for _, spec in ipairs(specs) do
+    if spec[1] == "MeanderingProgrammer/render-markdown.nvim" then
+      configured = spec.opts.custom_handlers.markdown.extends
+        and spec.opts.custom_handlers.markdown.parse == ansi.parse
+        and spec.opts.render_modes == true
+    end
+  end
+  if not configured then
+    fail("render-markdown should install the ANSI handler in every mode")
+  end
+
+  vim.api.nvim_buf_delete(buf, { force = true })
+end
+
 local cases = {
   ["agent-keymaps"] = validate_agent_keymaps,
   ["weekly-backlog"] = validate_weekly_backlog,
   ["markdown-formatting"] = validate_markdown_formatting,
+  ["markdown-ansi"] = validate_markdown_ansi,
   ["inline-ask-edit"] = validate_inline_ask_edit,
   ["sidekick-pi"] = validate_sidekick_pi,
   ["sidekick-herdr"] = validate_sidekick_herdr,
@@ -4437,7 +4578,7 @@ if not fn then
   fail(
     "unknown VERIFY_NVIM_CASE "
       .. vim.inspect(case)
-      .. "; expected one of: agent-keymaps, weekly-backlog, markdown-formatting, inline-ask-edit, sidekick-pi, sidekick-herdr, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
+      .. "; expected one of: agent-keymaps, weekly-backlog, markdown-formatting, markdown-ansi, inline-ask-edit, sidekick-pi, sidekick-herdr, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
   )
 end
 


### PR DESCRIPTION
## Summary
- render SGR styling inside Markdown `ansi` fences without altering buffer bytes
- keep rendering active under cursor, insert, and visual modes while yanks preserve raw ANSI
- support classic, 256-color, and truecolor foreground/background plus common attributes and resets

## Verification
- `./scripts/verify-nvim markdown-ansi`
- `./scripts/verify-nvim markdown-formatting`
- headless integration against the motivating Pi Agent note: 35 concealed SGR spans and 22 ANSI highlight spans