### PR TITLE
Add deterministic Pi skill validation flow

### DIFF
--- a/scripts/verify-pi-skill
+++ b/scripts/verify-pi-skill
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+	echo "Usage: scripts/verify-pi-skill <skill-path>" >&2
+	exit 2
+fi
+
+pi_executable="$(command -v pi)" || {
+	echo "pi executable not found" >&2
+	exit 1
+}
+
+node --input-type=module - "$pi_executable" "$1" <<'NODE'
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, basename, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [piExecutable, suppliedPath] = process.argv.slice(2);
+const apiPath = join(dirname(realpathSync(piExecutable)), "index.js");
+const { loadSkills, parseFrontmatter } = await import(pathToFileURL(apiPath));
+const inputPath = resolve(suppliedPath);
+const result = loadSkills({
+	cwd: process.cwd(),
+	agentDir: process.cwd(),
+	skillPaths: [inputPath],
+	includeDefaults: false,
+});
+const errors = result.diagnostics.map(({ type, message, path }) =>
+	`${type}: ${path ? `${path}: ` : ""}${message}`,
+);
+
+let skillFile;
+try {
+	const inputStat = statSync(inputPath);
+	if (inputStat.isFile()) {
+		if (basename(inputPath) !== "SKILL.md") errors.push("error: input file must be named SKILL.md");
+		skillFile = inputPath;
+	} else if (inputStat.isDirectory()) {
+		const directSkillFile = join(inputPath, "SKILL.md");
+		skillFile = existsSync(directSkillFile) ? directSkillFile : result.skills[0]?.filePath;
+	}
+} catch {
+	// The Pi loader reports unreadable and missing paths.
+}
+
+if (skillFile) {
+	try {
+		const { frontmatter } = parseFrontmatter(readFileSync(skillFile, "utf8"));
+		if (typeof frontmatter.name !== "string" || !frontmatter.name.trim())
+			errors.push("error: name is required");
+		if (
+			(typeof frontmatter.description !== "string" || !frontmatter.description.trim()) &&
+			!errors.some((error) => error.endsWith("description is required"))
+		)
+			errors.push("error: description is required");
+	} catch {
+		// The Pi loader reports parser diagnostics.
+	}
+}
+
+if (result.skills.length !== 1)
+	errors.push(`error: expected exactly one loaded skill, got ${result.skills.length}`);
+
+if (errors.length) {
+	console.error(errors.join("\n"));
+	process.exit(1);
+}
+
+console.log(`Pi skill validation passed: ${result.skills[0].filePath}`);
+console.log("This check does not run the skill or its helper scripts.");
+console.log("A realistic request in an isolated Pi invocation with output inspection remains required.");
+NODE

--- a/scripts/verify-pi-skill
+++ b/scripts/verify-pi-skill
@@ -12,7 +12,7 @@ pi_executable="$(command -v pi)" || {
 }
 
 node --input-type=module - "$pi_executable" "$1" <<'NODE'
-import { readFileSync, realpathSync, statSync } from "node:fs";
+import { lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { dirname, basename, join, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -20,10 +20,8 @@ const [piExecutable, suppliedPath] = process.argv.slice(2);
 const inputPath = resolve(suppliedPath);
 const isUnderPath = (target, root) => target === root || target.startsWith(`${root}${sep}`);
 const homePath = process.env.HOME && resolve(process.env.HOME);
-if (
-	homePath &&
-	[resolve(homePath, ".agents"), resolve(homePath, ".pi")].some((root) => isUnderPath(inputPath, root))
-) {
+const deployedRoots = homePath ? [resolve(homePath, ".agents"), resolve(homePath, ".pi")] : [];
+if (deployedRoots.some((root) => isUnderPath(inputPath, root))) {
 	console.error("error: deployed skill paths under $HOME/.agents or $HOME/.pi are not allowed");
 	process.exit(1);
 }
@@ -45,6 +43,18 @@ try {
 	}
 } catch {
 	console.error("error: input must be a SKILL.md file or a directory containing direct SKILL.md");
+	process.exit(1);
+}
+
+const canonicalSkillFile = realpathSync(skillFile);
+if (
+	deployedRoots.some((root) =>
+		lstatSync(root, { throwIfNoEntry: false })
+			? isUnderPath(canonicalSkillFile, realpathSync(root))
+			: false,
+	)
+) {
+	console.error("error: deployed skill paths under $HOME/.agents or $HOME/.pi are not allowed");
 	process.exit(1);
 }
 

--- a/scripts/verify-pi-skill
+++ b/scripts/verify-pi-skill
@@ -12,37 +12,53 @@ pi_executable="$(command -v pi)" || {
 }
 
 node --input-type=module - "$pi_executable" "$1" <<'NODE'
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
-import { dirname, basename, join, resolve } from "node:path";
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, basename, join, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const [piExecutable, suppliedPath] = process.argv.slice(2);
-const apiPath = join(dirname(realpathSync(piExecutable)), "index.js");
-const { loadSkills, parseFrontmatter } = await import(pathToFileURL(apiPath));
 const inputPath = resolve(suppliedPath);
-const result = loadSkills({
-	cwd: process.cwd(),
-	agentDir: process.cwd(),
-	skillPaths: [inputPath],
-	includeDefaults: false,
-});
-const errors = result.diagnostics.map(({ type, message, path }) =>
-	`${type}: ${path ? `${path}: ` : ""}${message}`,
-);
+const isUnderPath = (target, root) => target === root || target.startsWith(`${root}${sep}`);
+const homePath = process.env.HOME && resolve(process.env.HOME);
+if (
+	homePath &&
+	[resolve(homePath, ".agents"), resolve(homePath, ".pi")].some((root) => isUnderPath(inputPath, root))
+) {
+	console.error("error: deployed skill paths under $HOME/.agents or $HOME/.pi are not allowed");
+	process.exit(1);
+}
 
 let skillFile;
 try {
 	const inputStat = statSync(inputPath);
 	if (inputStat.isFile()) {
-		if (basename(inputPath) !== "SKILL.md") errors.push("error: input file must be named SKILL.md");
+		if (basename(inputPath) !== "SKILL.md") {
+			console.error("error: input file must be named SKILL.md");
+			process.exit(1);
+		}
 		skillFile = inputPath;
 	} else if (inputStat.isDirectory()) {
-		const directSkillFile = join(inputPath, "SKILL.md");
-		skillFile = existsSync(directSkillFile) ? directSkillFile : result.skills[0]?.filePath;
+		skillFile = join(inputPath, "SKILL.md");
+		if (!statSync(skillFile).isFile()) throw new Error();
+	} else {
+		throw new Error();
 	}
 } catch {
-	// The Pi loader reports unreadable and missing paths.
+	console.error("error: input must be a SKILL.md file or a directory containing direct SKILL.md");
+	process.exit(1);
 }
+
+const apiPath = join(dirname(realpathSync(piExecutable)), "index.js");
+const { loadSkills, parseFrontmatter } = await import(pathToFileURL(apiPath));
+const result = loadSkills({
+	cwd: process.cwd(),
+	agentDir: process.cwd(),
+	skillPaths: [skillFile],
+	includeDefaults: false,
+});
+const errors = result.diagnostics.map(({ type, message, path }) =>
+	`${type}: ${path ? `${path}: ` : ""}${message}`,
+);
 
 if (skillFile) {
 	try {
@@ -59,8 +75,11 @@ if (skillFile) {
 	}
 }
 
-if (result.skills.length !== 1)
+if (result.skills.length !== 1) {
 	errors.push(`error: expected exactly one loaded skill, got ${result.skills.length}`);
+} else if (realpathSync(result.skills[0].filePath) !== realpathSync(skillFile)) {
+	errors.push("error: loaded skill does not match the supplied SKILL.md");
+}
 
 if (errors.length) {
 	console.error(errors.join("\n"));


### PR DESCRIPTION
## Summary

- Add `scripts/verify-pi-skill <skill-path>` as the repository entry point for validating one explicit source skill with Pi's own parser and loader.
- Reject indirect/non-`SKILL.md` inputs, required-metadata/diagnostic failures, and lexical or canonical paths under deployed `$HOME/.agents` / `$HOME/.pi` roots.
- Keep static validation model-free and explicitly hand semantic behavior to a realistic isolated Pi invocation.

## Verifiers

### V01 — Deterministic Source Validation

- **Observable contract:** accepts a valid explicit repository source skill; rejects a containing directory, a non-`SKILL.md` file, invalid or missing required metadata, Pi diagnostics, and lexical/canonical/symlink paths into active deployed roots; prints the required realistic-invocation handoff without invoking a model.
- **Exact command reference:** canonical Task `## Verifiers` → `### V01: Deterministic Source Validation` → `**Command:**`; the identical accepted `bash -c` command and complete output are captured in the revision-pinned V01 transcript and JSON manifest below.
- **Result:** exit `0`.
- **Implementation pin:** commit `be5ed63963114c205174f162fac0ab8ed652631b`; tree `208539bacd03cead754b4fff3e287d8c4ebdd5a0`.
- **Transcript SHA-256:** `47200e5cbd4737f395af1105180b11b4164c956378f833207d018350131dcace`.

### V02 — Realistic Isolated Pi Invocation

- **Observable contract:** explicitly loads the source `agent-issue-triage` skill against a disposable weekly fixture with other skills, extensions, sessions, and context disabled; returns the six expected entries in order, includes the deferred issue, excludes `Already Closed`, identifies the review as read-only, leaves fixture hashes unchanged, hashes the output artifact, and removes the disposable directory.
- **Exact manual-observation reference:** canonical Task `## Verifiers` → `### V02: Realistic Isolated Pi Invocation` → `**Manual observation:**`; the identical accepted shell sequence, output, and inspected observations are captured in the revision-pinned V02 transcript and JSON manifest below.
- **Result:** exit `0`; fixture comparison exit `0` and unchanged.
- **Implementation pin:** commit `be5ed63963114c205174f162fac0ab8ed652631b`; tree `208539bacd03cead754b4fff3e287d8c4ebdd5a0`.
- **Transcript SHA-256:** `e843bf33a17323b5f0e530e14efcd39c72748c39fdcc45e1abfab4517a40a330`.
- **Pi output SHA-256:** `87b67b22b32eb770d52d5d750ac5285a7570c371c456cb019739d4ad1de1873c`.

## Test plan

- [x] V01 canonical deterministic source-validation command — exit `0`.
- [x] V02 canonical realistic isolated Pi observation — exit `0`, expected ordered read-only output, unchanged fixture, output artifact hashed, disposable directory removed.

## Evidence

The immutable gist revision is canonical; the homelab alias is convenience-only.

- **V01 + V02 — immutable evidence revision:** https://gist.github.com/aviralmansingka/da7625a08e61348c3d1f35b46fc3e149/0204cd8c8ad322504da142723695245fb9bc95f3
- **V01 + V02 — raw terminal-first verifier explainer:** https://gist.githubusercontent.com/aviralmansingka/da7625a08e61348c3d1f35b46fc3e149/raw/0204cd8c8ad322504da142723695245fb9bc95f3/05-define-a-validation-flow-for-new-or-edited-pi-skills.html
- **V01 — raw transcript:** https://gist.githubusercontent.com/aviralmansingka/da7625a08e61348c3d1f35b46fc3e149/raw/0204cd8c8ad322504da142723695245fb9bc95f3/T05.V01.EX01.log
- **V01 — raw JSON manifest:** https://gist.githubusercontent.com/aviralmansingka/da7625a08e61348c3d1f35b46fc3e149/raw/0204cd8c8ad322504da142723695245fb9bc95f3/T05.V01.EX01.json
- **V02 — raw transcript:** https://gist.githubusercontent.com/aviralmansingka/da7625a08e61348c3d1f35b46fc3e149/raw/0204cd8c8ad322504da142723695245fb9bc95f3/T05.V02.EX01.log
- **V02 — raw JSON manifest:** https://gist.githubusercontent.com/aviralmansingka/da7625a08e61348c3d1f35b46fc3e149/raw/0204cd8c8ad322504da142723695245fb9bc95f3/T05.V02.EX01.json
- **V01 + V02 — convenience-only homelab alias:** https://homelab.tail1b3b66.ts.net/05-define-a-validation-flow-for-new-or-edited-pi-skills

Screenshots and video are not applicable because this is a non-visual CLI validator. The terminal-first explainer plus exact transcripts and manifests are the behavioral evidence.
