### PR TITLE
feat(pi): show No Mistakes pipeline timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ cd ~/.pi/agent/npm
 npm install
 ```
 
+Pi's read-only No Mistakes timeline polls `no-mistakes axi status` and displays the nine AXI phases below the editor when the current repository has a run. Use `/no-mistakes-timeline` to toggle it, or pass `on`, `off`, or `refresh`; the widget stays hidden when no run exists.
+
 For Pi over WhatsApp, copy `~/.config/pi-whatsapp.env.example` to `~/.config/pi-whatsapp.env`, fill in the allowed chat IDs, then enable the user services:
 
 ```sh

--- a/pi/.pi/agent/extensions/no-mistakes-timeline.ts
+++ b/pi/.pi/agent/extensions/no-mistakes-timeline.ts
@@ -113,14 +113,14 @@ function glyph(status: string): { symbol: string; color: "success" | "warning" |
     case "completed":
     case "passed":
     case "checks-passed":
-      return { symbol: "✓", color: "success" };
+      return { symbol: "●", color: "success" };
     case "running":
     case "fixing":
     case "awaiting":
       return { symbol: "⟳", color: "warning" };
     case "failed":
     case "cancelled":
-      return { symbol: "✗", color: "error" };
+      return { symbol: "×", color: "error" };
     case "skipped":
       return { symbol: "–", color: "dim" };
     default:
@@ -146,7 +146,7 @@ export function renderNoMistakesTimeline(snapshot: Snapshot, theme: Theme, width
       step.activity,
     ].filter(Boolean).join(" · ");
     lines.push(truncateToWidth(
-      `${theme.fg("dim", `  ${connector}`)} ${theme.fg(stepGlyph.color, stepGlyph.symbol)} ${theme.fg("text", theme.bold(step.name))}${details ? theme.fg("dim", ` · ${details}`) : ""}`,
+      `${theme.fg("borderMuted", `  ${connector}`)} ${theme.fg(stepGlyph.color, stepGlyph.symbol)} ${theme.fg("text", theme.bold(step.name))}${details ? theme.fg("dim", ` · ${details}`) : ""}`,
       width,
       "…",
     ));

--- a/pi/.pi/agent/extensions/no-mistakes-timeline.ts
+++ b/pi/.pi/agent/extensions/no-mistakes-timeline.ts
@@ -158,6 +158,8 @@ export default function noMistakesTimeline(pi: ExtensionAPI) {
   let timer: ReturnType<typeof setInterval> | undefined;
   let enabled = true;
   let polling = false;
+  let generation = 0;
+  let pollController: AbortController | undefined;
   let snapshot: Snapshot | undefined;
 
   const display = (ctx: ExtensionContext) => {
@@ -178,31 +180,44 @@ export default function noMistakesTimeline(pi: ExtensionAPI) {
     ctx.ui.setStatus(WIDGET_ID, themeStatus(ctx, state.symbol, snapshot.status, state.color));
   };
 
-  const refresh = async (ctx: ExtensionContext) => {
-    if (polling || !enabled || ctx.mode !== "tui") return;
+  const refresh = async (ctx: ExtensionContext, expectedGeneration = generation) => {
+    if (polling || !enabled || ctx.mode !== "tui" || expectedGeneration !== generation) return;
+    const controller = new AbortController();
+    pollController = controller;
     polling = true;
     try {
       const result = await pi.exec("no-mistakes", ["axi", "status"], {
         cwd: ctx.cwd,
+        signal: controller.signal,
         timeout: 5000,
       });
+      if (controller.signal.aborted || expectedGeneration !== generation) return;
       snapshot = result.code === 0 ? parseNoMistakesStatus(result.stdout) : undefined;
     } catch {
+      if (controller.signal.aborted || expectedGeneration !== generation) return;
       snapshot = undefined;
     } finally {
-      polling = false;
-      display(ctx);
+      if (pollController === controller) {
+        pollController = undefined;
+        polling = false;
+      }
+      if (!controller.signal.aborted && expectedGeneration === generation) display(ctx);
     }
   };
 
   pi.on("session_start", (_event, ctx) => {
     if (ctx.mode !== "tui") return;
-    void refresh(ctx);
-    timer = setInterval(() => void refresh(ctx), POLL_MS);
+    const sessionGeneration = ++generation;
+    void refresh(ctx, sessionGeneration);
+    timer = setInterval(() => void refresh(ctx, sessionGeneration), POLL_MS);
     timer.unref?.();
   });
 
   pi.on("session_shutdown", (_event, ctx) => {
+    generation++;
+    pollController?.abort();
+    pollController = undefined;
+    polling = false;
     if (timer) clearInterval(timer);
     timer = undefined;
     ctx.ui.setWidget(WIDGET_ID, undefined);
@@ -217,9 +232,12 @@ export default function noMistakesTimeline(pi: ExtensionAPI) {
       else if (action === "on") enabled = true;
       else if (action === "refresh") enabled = true;
       else enabled = !enabled;
-      if (enabled) await refresh(ctx);
+      const commandGeneration = generation;
+      if (enabled) await refresh(ctx, commandGeneration);
       else display(ctx);
-      ctx.ui.notify(`No Mistakes timeline ${enabled ? "on" : "off"}`, "info");
+      if (commandGeneration === generation) {
+        ctx.ui.notify(`No Mistakes timeline ${enabled ? "on" : "off"}`, "info");
+      }
     },
   });
 }

--- a/pi/.pi/agent/extensions/no-mistakes-timeline.ts
+++ b/pi/.pi/agent/extensions/no-mistakes-timeline.ts
@@ -1,0 +1,234 @@
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+
+const WIDGET_ID = "no-mistakes-timeline";
+const POLL_MS = 1000;
+
+type Step = {
+  name: string;
+  status: string;
+  findings?: number;
+  durationMs?: number;
+  activity?: string;
+};
+
+type Snapshot = {
+  id?: string;
+  branch?: string;
+  head?: string;
+  status: string;
+  steps: Step[];
+};
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      return JSON.parse(trimmed) as string;
+    } catch {}
+  }
+  return trimmed;
+}
+
+function splitRow(row: string): string[] {
+  const values: string[] = [];
+  let value = "";
+  let quoted = false;
+  for (let index = 0; index < row.length; index++) {
+    const character = row[index]!;
+    if (character === '"') {
+      if (quoted && row[index + 1] === '"') {
+        value += '"';
+        index++;
+      } else {
+        quoted = !quoted;
+      }
+    } else if (character === "," && !quoted) {
+      values.push(value.trim());
+      value = "";
+    } else {
+      value += character;
+    }
+  }
+  values.push(value.trim());
+  return values.map(unquote);
+}
+
+function scalar(output: string, key: string): string | undefined {
+  const match = output.match(new RegExp(`^\\s{0,2}${key}:\\s*(.+)$`, "m"));
+  return match ? unquote(match[1]!) : undefined;
+}
+
+function table(output: string, name: string): Array<Record<string, string>> {
+  const lines = output.split("\n");
+  const headerIndex = lines.findIndex((line) =>
+    new RegExp(`^${name}\\[\\d+\\]\\{([^}]+)\\}:$`).test(line.trim()),
+  );
+  if (headerIndex < 0) return [];
+  const header = lines[headerIndex]!.trim().match(/\{([^}]+)\}/)?.[1]?.split(",") ?? [];
+  const rows: Array<Record<string, string>> = [];
+  for (const line of lines.slice(headerIndex + 1)) {
+    if (!/^\s{2,}\S/.test(line)) break;
+    const values = splitRow(line.trim());
+    if (values.length !== header.length) continue;
+    rows.push(Object.fromEntries(header.map((column, index) => [column, values[index] ?? ""])));
+  }
+  return rows;
+}
+
+export function parseNoMistakesStatus(output: string): Snapshot | undefined {
+  if (/^runs:\s*0 runs yet/m.test(output)) return undefined;
+  const active = new Map(table(output, "active_steps").map((row) => [row.step, row]));
+  const steps = table(output, "steps").map((row): Step => {
+    const live = active.get(row.step);
+    const findings = Number(row.findings);
+    const durationMs = Number(row.duration_ms);
+    return {
+      name: row.step || "step",
+      status: row.status || "pending",
+      findings: Number.isFinite(findings) ? findings : undefined,
+      durationMs: Number.isFinite(durationMs) ? durationMs : undefined,
+      activity: [live?.round, live?.active_for, live?.last_activity].filter(Boolean).join(" · ") || undefined,
+    };
+  });
+  if (steps.length === 0) return undefined;
+  return {
+    id: scalar(output, "id"),
+    branch: scalar(output, "branch"),
+    head: scalar(output, "head"),
+    status: scalar(output, "outcome") ?? scalar(output, "status") ?? scalar(output, "gate") ?? "running",
+    steps,
+  };
+}
+
+function duration(milliseconds?: number): string | undefined {
+  if (!milliseconds || milliseconds < 1) return undefined;
+  if (milliseconds < 1000) return `${milliseconds}ms`;
+  if (milliseconds < 60000) return `${(milliseconds / 1000).toFixed(1)}s`;
+  return `${Math.floor(milliseconds / 60000)}m${Math.floor((milliseconds % 60000) / 1000)}s`;
+}
+
+function glyph(status: string): { symbol: string; color: "success" | "warning" | "error" | "dim" } {
+  switch (status) {
+    case "completed":
+    case "passed":
+    case "checks-passed":
+      return { symbol: "✓", color: "success" };
+    case "running":
+    case "fixing":
+    case "awaiting":
+      return { symbol: "⟳", color: "warning" };
+    case "failed":
+    case "cancelled":
+      return { symbol: "✗", color: "error" };
+    case "skipped":
+      return { symbol: "–", color: "dim" };
+    default:
+      return { symbol: "○", color: "dim" };
+  }
+}
+
+export function renderNoMistakesTimeline(snapshot: Snapshot, theme: Theme, width: number): string[] {
+  const statusGlyph = glyph(snapshot.status);
+  const title = [
+    theme.fg("accent", theme.bold("No Mistakes")),
+    snapshot.branch ? theme.fg("text", snapshot.branch) : undefined,
+    theme.fg(statusGlyph.color, `${statusGlyph.symbol} ${snapshot.status}`),
+  ].filter(Boolean).join(theme.fg("dim", " · "));
+  const lines = [truncateToWidth(title, width, "…")];
+  snapshot.steps.forEach((step, index) => {
+    const stepGlyph = glyph(step.status);
+    const connector = index === snapshot.steps.length - 1 ? "└─" : "├─";
+    const details = [
+      step.status,
+      duration(step.durationMs),
+      step.findings ? `${step.findings} findings` : undefined,
+      step.activity,
+    ].filter(Boolean).join(" · ");
+    lines.push(truncateToWidth(
+      `${theme.fg("dim", `  ${connector}`)} ${theme.fg(stepGlyph.color, stepGlyph.symbol)} ${theme.fg("text", theme.bold(step.name))}${details ? theme.fg("dim", ` · ${details}`) : ""}`,
+      width,
+      "…",
+    ));
+  });
+  return lines;
+}
+
+export default function noMistakesTimeline(pi: ExtensionAPI) {
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let enabled = true;
+  let polling = false;
+  let snapshot: Snapshot | undefined;
+
+  const display = (ctx: ExtensionContext) => {
+    if (!enabled || !snapshot || ctx.mode !== "tui") {
+      ctx.ui.setWidget(WIDGET_ID, undefined);
+      ctx.ui.setStatus(WIDGET_ID, undefined);
+      return;
+    }
+    ctx.ui.setWidget(
+      WIDGET_ID,
+      (_tui, theme) => ({
+        render: (width: number) => renderNoMistakesTimeline(snapshot!, theme, width),
+        invalidate() {},
+      }),
+      { placement: "belowEditor" },
+    );
+    const state = glyph(snapshot.status);
+    ctx.ui.setStatus(WIDGET_ID, themeStatus(ctx, state.symbol, snapshot.status, state.color));
+  };
+
+  const refresh = async (ctx: ExtensionContext) => {
+    if (polling || !enabled || ctx.mode !== "tui") return;
+    polling = true;
+    try {
+      const result = await pi.exec("no-mistakes", ["axi", "status"], {
+        cwd: ctx.cwd,
+        timeout: 5000,
+      });
+      snapshot = result.code === 0 ? parseNoMistakesStatus(result.stdout) : undefined;
+    } catch {
+      snapshot = undefined;
+    } finally {
+      polling = false;
+      display(ctx);
+    }
+  };
+
+  pi.on("session_start", (_event, ctx) => {
+    if (ctx.mode !== "tui") return;
+    void refresh(ctx);
+    timer = setInterval(() => void refresh(ctx), POLL_MS);
+    timer.unref?.();
+  });
+
+  pi.on("session_shutdown", (_event, ctx) => {
+    if (timer) clearInterval(timer);
+    timer = undefined;
+    ctx.ui.setWidget(WIDGET_ID, undefined);
+    ctx.ui.setStatus(WIDGET_ID, undefined);
+  });
+
+  pi.registerCommand("no-mistakes-timeline", {
+    description: "Toggle or refresh the No Mistakes pipeline timeline",
+    handler: async (args, ctx) => {
+      const action = args.trim().toLowerCase();
+      if (action === "off") enabled = false;
+      else if (action === "on") enabled = true;
+      else if (action === "refresh") enabled = true;
+      else enabled = !enabled;
+      if (enabled) await refresh(ctx);
+      else display(ctx);
+      ctx.ui.notify(`No Mistakes timeline ${enabled ? "on" : "off"}`, "info");
+    },
+  });
+}
+
+function themeStatus(
+  ctx: ExtensionContext,
+  symbol: string,
+  status: string,
+  color: "success" | "warning" | "error" | "dim",
+): string {
+  return `${ctx.ui.theme.fg(color, symbol)}${ctx.ui.theme.fg("dim", ` NM ${status}`)}`;
+}

--- a/pi/.pi/agent/extensions/no-mistakes-timeline.ts
+++ b/pi/.pi/agent/extensions/no-mistakes-timeline.ts
@@ -1,4 +1,8 @@
-import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  Theme,
+} from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 
 const WIDGET_ID = "no-mistakes-timeline";
@@ -65,20 +69,29 @@ function table(output: string, name: string): Array<Record<string, string>> {
     new RegExp(`^${name}\\[\\d+\\]\\{([^}]+)\\}:$`).test(line.trim()),
   );
   if (headerIndex < 0) return [];
-  const header = lines[headerIndex]!.trim().match(/\{([^}]+)\}/)?.[1]?.split(",") ?? [];
+  const header =
+    lines[headerIndex]!.trim()
+      .match(/\{([^}]+)\}/)?.[1]
+      ?.split(",") ?? [];
   const rows: Array<Record<string, string>> = [];
   for (const line of lines.slice(headerIndex + 1)) {
     if (!/^\s{2,}\S/.test(line)) break;
     const values = splitRow(line.trim());
     if (values.length !== header.length) continue;
-    rows.push(Object.fromEntries(header.map((column, index) => [column, values[index] ?? ""])));
+    rows.push(
+      Object.fromEntries(
+        header.map((column, index) => [column, values[index] ?? ""]),
+      ),
+    );
   }
   return rows;
 }
 
 export function parseNoMistakesStatus(output: string): Snapshot | undefined {
   if (/^runs:\s*0 runs yet/m.test(output)) return undefined;
-  const active = new Map(table(output, "active_steps").map((row) => [row.step, row]));
+  const active = new Map(
+    table(output, "active_steps").map((row) => [row.step, row]),
+  );
   const steps = table(output, "steps").map((row): Step => {
     const live = active.get(row.step);
     const findings = Number(row.findings);
@@ -88,7 +101,10 @@ export function parseNoMistakesStatus(output: string): Snapshot | undefined {
       status: row.status || "pending",
       findings: Number.isFinite(findings) ? findings : undefined,
       durationMs: Number.isFinite(durationMs) ? durationMs : undefined,
-      activity: [live?.round, live?.active_for, live?.last_activity].filter(Boolean).join(" · ") || undefined,
+      activity:
+        [live?.round, live?.active_for, live?.last_activity]
+          .filter(Boolean)
+          .join(" · ") || undefined,
     };
   });
   if (steps.length === 0) return undefined;
@@ -96,7 +112,11 @@ export function parseNoMistakesStatus(output: string): Snapshot | undefined {
     id: scalar(output, "id"),
     branch: scalar(output, "branch"),
     head: scalar(output, "head"),
-    status: scalar(output, "outcome") ?? scalar(output, "status") ?? scalar(output, "gate") ?? "running",
+    status:
+      scalar(output, "outcome") ??
+      scalar(output, "status") ??
+      scalar(output, "gate") ??
+      "running",
     steps,
   };
 }
@@ -108,7 +128,10 @@ function duration(milliseconds?: number): string | undefined {
   return `${Math.floor(milliseconds / 60000)}m${Math.floor((milliseconds % 60000) / 1000)}s`;
 }
 
-function glyph(status: string): { symbol: string; color: "success" | "warning" | "error" | "dim" } {
+function glyph(status: string): {
+  symbol: string;
+  color: "success" | "warning" | "error" | "dim";
+} {
   switch (status) {
     case "completed":
     case "passed":
@@ -128,13 +151,19 @@ function glyph(status: string): { symbol: string; color: "success" | "warning" |
   }
 }
 
-export function renderNoMistakesTimeline(snapshot: Snapshot, theme: Theme, width: number): string[] {
+export function renderNoMistakesTimeline(
+  snapshot: Snapshot,
+  theme: Theme,
+  width: number,
+): string[] {
   const statusGlyph = glyph(snapshot.status);
   const title = [
     theme.fg("accent", theme.bold("No Mistakes")),
     snapshot.branch ? theme.fg("text", snapshot.branch) : undefined,
     theme.fg(statusGlyph.color, `${statusGlyph.symbol} ${snapshot.status}`),
-  ].filter(Boolean).join(theme.fg("dim", " · "));
+  ]
+    .filter(Boolean)
+    .join(theme.fg("dim", " · "));
   const lines = [truncateToWidth(title, width, "…")];
   snapshot.steps.forEach((step, index) => {
     const stepGlyph = glyph(step.status);
@@ -144,12 +173,16 @@ export function renderNoMistakesTimeline(snapshot: Snapshot, theme: Theme, width
       duration(step.durationMs),
       step.findings ? `${step.findings} findings` : undefined,
       step.activity,
-    ].filter(Boolean).join(" · ");
-    lines.push(truncateToWidth(
-      `${theme.fg("borderMuted", `  ${connector}`)} ${theme.fg(stepGlyph.color, stepGlyph.symbol)} ${theme.fg("text", theme.bold(step.name))}${details ? theme.fg("dim", ` · ${details}`) : ""}`,
-      width,
-      "…",
-    ));
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    lines.push(
+      truncateToWidth(
+        `${theme.fg("borderMuted", `  ${connector}`)} ${theme.fg(stepGlyph.color, stepGlyph.symbol)} ${theme.fg("text", theme.bold(step.name))}${details ? theme.fg("dim", ` · ${details}`) : ""}`,
+        width,
+        "…",
+      ),
+    );
   });
   return lines;
 }
@@ -171,17 +204,30 @@ export default function noMistakesTimeline(pi: ExtensionAPI) {
     ctx.ui.setWidget(
       WIDGET_ID,
       (_tui, theme) => ({
-        render: (width: number) => renderNoMistakesTimeline(snapshot!, theme, width),
+        render: (width: number) =>
+          renderNoMistakesTimeline(snapshot!, theme, width),
         invalidate() {},
       }),
       { placement: "belowEditor" },
     );
     const state = glyph(snapshot.status);
-    ctx.ui.setStatus(WIDGET_ID, themeStatus(ctx, state.symbol, snapshot.status, state.color));
+    ctx.ui.setStatus(
+      WIDGET_ID,
+      themeStatus(ctx, state.symbol, snapshot.status, state.color),
+    );
   };
 
-  const refresh = async (ctx: ExtensionContext, expectedGeneration = generation) => {
-    if (polling || !enabled || ctx.mode !== "tui" || expectedGeneration !== generation) return;
+  const refresh = async (
+    ctx: ExtensionContext,
+    expectedGeneration = generation,
+  ) => {
+    if (
+      polling ||
+      !enabled ||
+      ctx.mode !== "tui" ||
+      expectedGeneration !== generation
+    )
+      return;
     const controller = new AbortController();
     pollController = controller;
     polling = true;
@@ -191,17 +237,21 @@ export default function noMistakesTimeline(pi: ExtensionAPI) {
         signal: controller.signal,
         timeout: 5000,
       });
-      if (controller.signal.aborted || expectedGeneration !== generation) return;
-      snapshot = result.code === 0 ? parseNoMistakesStatus(result.stdout) : undefined;
+      if (controller.signal.aborted || expectedGeneration !== generation)
+        return;
+      snapshot =
+        result.code === 0 ? parseNoMistakesStatus(result.stdout) : undefined;
     } catch {
-      if (controller.signal.aborted || expectedGeneration !== generation) return;
+      if (controller.signal.aborted || expectedGeneration !== generation)
+        return;
       snapshot = undefined;
     } finally {
       if (pollController === controller) {
         pollController = undefined;
         polling = false;
       }
-      if (!controller.signal.aborted && expectedGeneration === generation) display(ctx);
+      if (!controller.signal.aborted && expectedGeneration === generation)
+        display(ctx);
     }
   };
 

--- a/scripts/verify-pi-no-mistakes-timeline
+++ b/scripts/verify-pi-no-mistakes-timeline
@@ -37,8 +37,11 @@ printf '%s\n' '{"theme":"gruvbox-material"}' > "$verify_dir/agent/settings.json"
 
 raw="$verify_dir/timeline.raw"
 plain="$verify_dir/timeline.txt"
+off_raw="$verify_dir/timeline-off.raw"
+off_plain="$verify_dir/timeline-off.txt"
 export PI_NM_AGENT_DIR="$verify_dir/agent"
 export PI_NM_RAW="$raw"
+export PI_NM_OFF_RAW="$off_raw"
 export PI_NM_PATH="$verify_dir/bin:$PATH"
 export PI_NM_THEME="$repo_root/pi/.pi/agent/themes/gruvbox-material.json"
 export PI_NM_SESSION="$verify_dir/session.jsonl"
@@ -54,12 +57,18 @@ expect "review"
 expect "round 1"
 send -- "/no-mistakes-timeline off\r"
 expect "No Mistakes timeline off"
+log_file
+log_file -a -noappend $env(PI_NM_OFF_RAW)
+send -- "\014"
+after 500
 send -- "/quit\r"
 expect eof
 EXPECT
 
 perl -pe 's/\e\][^\a]*(?:\a|\e\\)//g; s/\e\[[0-?]*[ -\/]*[@-~]//g; s/\r//g' \
   "$raw" > "$plain"
+perl -pe 's/\e\][^\a]*(?:\a|\e\\)//g; s/\e\[[0-?]*[ -\/]*[@-~]//g; s/\r//g' \
+  "$off_raw" > "$off_plain"
 for expected in \
   'No Mistakes' \
   'feature/no-mistakes-timeline' \
@@ -74,6 +83,12 @@ for expected in \
     exit 1
   }
 done
+
+if grep -F '✓ intent' "$off_plain" >/dev/null; then
+  printf 'timeline remained visible after toggling off\n' >&2
+  tail -120 "$off_plain" >&2
+  exit 1
+fi
 
 printf 'ok: No Mistakes TOON status renders in the Pi timeline rail\n'
 printf 'ok: completed, running, and pending phases use timeline status glyphs\n'

--- a/scripts/verify-pi-no-mistakes-timeline
+++ b/scripts/verify-pi-no-mistakes-timeline
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verify_dir="$(mktemp -d)"
+cleanup() { rm -rf -- "$verify_dir"; }
+trap cleanup EXIT
+
+mkdir -p "$verify_dir/bin" "$verify_dir/agent/extensions"
+cat > "$verify_dir/bin/no-mistakes" <<'FAKE'
+#!/bin/sh
+cat <<'TOON'
+run:
+  id: "01TESTTIMELINE"
+  branch: feature/no-mistakes-timeline
+  status: running
+  head: abc12345
+  findings: none
+  active_steps[1]{step,active_for,last_activity,agent_pid,round}:
+    review,12s,"quiet 2s",4242,"round 1"
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,210
+    review,running,0,12000
+    test,pending,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+TOON
+FAKE
+chmod +x "$verify_dir/bin/no-mistakes"
+ln -s "$repo_root/pi/.pi/agent/extensions/no-mistakes-timeline.ts" \
+  "$verify_dir/agent/extensions/no-mistakes-timeline.ts"
+printf '%s\n' '{"theme":"gruvbox-material"}' > "$verify_dir/agent/settings.json"
+
+raw="$verify_dir/timeline.raw"
+plain="$verify_dir/timeline.txt"
+export PI_NM_AGENT_DIR="$verify_dir/agent"
+export PI_NM_RAW="$raw"
+export PI_NM_PATH="$verify_dir/bin:$PATH"
+export PI_NM_THEME="$repo_root/pi/.pi/agent/themes/gruvbox-material.json"
+export PI_NM_SESSION="$verify_dir/session.jsonl"
+
+expect <<'EXPECT'
+set timeout 20
+log_user 0
+log_file -a -noappend $env(PI_NM_RAW)
+spawn env PATH=$env(PI_NM_PATH) PI_CODING_AGENT_DIR=$env(PI_NM_AGENT_DIR) pi --offline --approve --no-context-files --no-skills --theme $env(PI_NM_THEME) --session $env(PI_NM_SESSION)
+expect "No Mistakes"
+expect "feature/no-mistakes-timeline"
+expect "review"
+expect "round 1"
+send -- "/no-mistakes-timeline off\r"
+expect "No Mistakes timeline off"
+send -- "/quit\r"
+expect eof
+EXPECT
+
+perl -pe 's/\e\][^\a]*(?:\a|\e\\)//g; s/\e\[[0-?]*[ -\/]*[@-~]//g; s/\r//g' \
+  "$raw" > "$plain"
+for expected in \
+  'No Mistakes' \
+  'feature/no-mistakes-timeline' \
+  '✓ intent' \
+  '⟳ review' \
+  'round 1' \
+  '○ ci' \
+  'No Mistakes timeline off'; do
+  grep -F "$expected" "$plain" >/dev/null || {
+    printf 'missing timeline text: %s\n' "$expected" >&2
+    tail -120 "$plain" >&2
+    exit 1
+  }
+done
+
+printf 'ok: No Mistakes TOON status renders in the Pi timeline rail\n'
+printf 'ok: completed, running, and pending phases use timeline status glyphs\n'
+printf 'ok: /no-mistakes-timeline toggles the live widget\n'

--- a/scripts/verify-pi-no-mistakes-timeline
+++ b/scripts/verify-pi-no-mistakes-timeline
@@ -24,7 +24,7 @@ run:
     review,running,0,12000
     test,pending,0,0
     document,pending,0,0
-    lint,pending,0,0
+    lint,failed,1,0
     push,pending,0,0
     pr,pending,0,0
     ci,pending,0,0
@@ -72,9 +72,10 @@ perl -pe 's/\e\][^\a]*(?:\a|\e\\)//g; s/\e\[[0-?]*[ -\/]*[@-~]//g; s/\r//g' \
 for expected in \
   'No Mistakes' \
   'feature/no-mistakes-timeline' \
-  '✓ intent' \
+  '● intent' \
   '⟳ review' \
   'round 1' \
+  '× lint' \
   '○ ci' \
   'No Mistakes timeline off'; do
   grep -F "$expected" "$plain" >/dev/null || {
@@ -84,7 +85,7 @@ for expected in \
   }
 done
 
-if grep -F '✓ intent' "$off_plain" >/dev/null; then
+if grep -F '● intent' "$off_plain" >/dev/null; then
   printf 'timeline remained visible after toggling off\n' >&2
   tail -120 "$off_plain" >&2
   exit 1


### PR DESCRIPTION
## Intent

Integrate a native Pi extension that visualizes No Mistakes pipeline progress using Aviral's existing connected timeline UI. Keep the integration read-only: poll runs: 0 runs yet in this repository
help[1]: "Run no-mistakes axi run --intent \"the user's goal\" --yes to validate the current branch", render the nine AXI phases as a compact themed timeline below the editor with matching rail/glyph semantics, expose a toggle/refresh command, hide cleanly when no run exists, and stop polling on session shutdown. Reuse Pi's built-in extension and TUI APIs without adding dependencies or transferring pipeline control into the visualizer. Include a deterministic terminal verifier for parsing, live phase rendering, and toggling.

## What Changed

- Add a read-only Pi extension that polls No Mistakes status and renders the nine AXI phases as a themed timeline below the editor.
- Add toggle and refresh commands, hide the timeline when no run exists, and cancel polling during session shutdown.
- Document timeline usage and add a deterministic terminal verifier for rendering, parsing, and toggling behavior.

## Risk Assessment

✅ Low: The change is well-bounded and the source satisfies the required read-only polling, timeline rendering, toggle/refresh, no-run hiding, and shutdown cleanup behavior.

## Testing

After correcting temporary evidence-harness path and startup synchronization issues, the deterministic terminal verifier passed end-to-end: all nine themed phases rendered with live activity and rail glyphs, toggle and refresh worked, the no-run state stayed hidden, and polling stopped at session shutdown; reviewer-visible HTML, terminal captures, and lifecycle logs were collected.

<details>
<summary>Evidence: Rendered Gruvbox timeline evidence</summary>

```text
<!doctype html>
<meta charset="utf-8">
<title>No Mistakes Pi timeline evidence</title>
<style>
  body { margin: 0; padding: 32px; background: #282828; color: #ebdbb2; font: 15px/1.45 "JetBrains Mono", Menlo, monospace; }
  .terminal { width: 820px; padding: 22px 24px; background: #32302f; border: 1px solid #504945; border-radius: 10px; box-shadow: 0 12px 32px #0008; }
  .muted { color: #928374; } .dim { color: #665c54; } .accent { color: #f28534; font-weight: 700; }
  .ok { color: #b8bb26; } .warn { color: #fabd2f; } .bad { color: #f2594b; }
  .rail { color: #665c54; } .footer { margin-top: 10px; color: #89b482; }
  .note { margin-top: 18px; color: #928374; font: 13px/1.4 system-ui, sans-serif; }
</style>
<div class="terminal" role="img" aria-label="Captured Pi terminal showing No Mistakes pipeline timeline">
  <div class="dim">────────────────────────────────────────────────────────────────────────────────</div>
  <div><span class="accent">No Mistakes</span><span class="muted"> · </span>feature/no-mistakes-timeline<span class="muted"> · </span><span class="warn">⟳ running</span></div>
  <div><span class="rail">  ├─</span> <span class="ok">●</span> <b>intent</b><span class="muted"> · completed</span></div>
  <div><span class="rail">  ├─</span> <span class="ok">●</span> <b>rebase</b><span class="muted"> · completed · 210ms</span></div>
  <div><span class="rail">  ├─</span> <span class="warn">⟳</span> <b>review</b><span class="muted"> · running · 12.0s · round 1 · 12s · quiet 2s</span></div>
  <div><span class="rail">  ├─</span> <span class="dim">○</span> <b>test</b><span class="muted"> · pending</span></div>
  <div><span class="rail">  ├─</span> <span class="dim">○</span> <b>document</b><span class="muted"> · pending</span></div>
  <div><span class="rail">  ├─</span> <span class="bad">×</span> <b>lint</b><span class="muted"> · failed · 1 findings</span></div>
  <div><span class="rail">  ├─</span> <span class="dim">○</span> <b>push</b><span class="muted"> · pending</span></div>
  <div><span class="rail">  ├─</span> <span class="dim">○</span> <b>pr</b><span class="muted"> · pending</span></div>
  <div><span class="rail">  └─</span> <span class="dim">○</span> <b>ci</b><span class="muted"> · pending</span></div>
  <div class="footer">⟳ NM running</div>
</div>
<div class="note">Faithful HTML rendering of the text and Gruvbox status semantics captured from the real Pi TUI by scripts/verify-pi-no-mistakes-timeline. Raw ANSI and stripped terminal captures are stored beside this artifact.</div>
```
</details>
<details>
<summary>Evidence: Captured Pi timeline transcript</summary>

```text
--- rendered timeline excerpts ---
────────────────────────────────────────────────────────────────────────────────
~/.no-mistakes/worktrees/cbcfef4f5cf6/01KYK2V8CV5T49F2A00V4XNDGN (detached)
0.0%/0 (auto)                                                            unknownNo Mistakes · feature/no-mistakes-timeline · ⟳ running
  ├─ ● intent · completed
  ├─ ● rebase · completed · 210ms
  ├─ ⟳ review · running · 12.0s · round 1 · 12s · quiet 2s
  ├─ ○ test · pending
  ├─ ○ document · pending
  ├─ × lint · failed · 1 findings
  ├─ ○ push · pending
  ├─ ○ pr · pending
  └─ ○ ci · pending
~/.no-mistakes/worktrees/cbcfef4f5cf6/01KYK2V8CV5T49F2A00V4XNDGN (detached)
0.0%/0 (auto)                                                            unknown
⟳ NM running No Mistakes timeline off                                                       

────────────────────────────────────[38;2;
--- after toggle off ---
```
</details>
<details>
<summary>Evidence: Empty-state and shutdown polling evidence</summary>

```text
Empty-state UI: hidden (no timeline title rendered)
Polling calls before shutdown: 3
Polling calls two seconds after shutdown: 3
Result: polling stopped with the Pi session
```
</details>
<details>
<summary>Evidence: Explicit refresh command evidence</summary>

```text
Explicit refresh command: acknowledged as timeline on
Empty status after refresh: timeline remained hidden
```
</details>
<details>
<summary>Evidence: Deterministic verifier transcript</summary>

```text
ok: No Mistakes TOON status renders in the Pi timeline rail
ok: completed, running, and pending phases use timeline status glyphs
ok: /no-mistakes-timeline toggles the live widget
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `pi/.pi/agent/extensions/no-mistakes-timeline.ts:194` - The required “stop polling on session shutdown” invariant is violated by an in-flight refresh. Sequence: polling starts, session_shutdown clears only the interval, pi.exec resolves afterward, and finally calls display using the torn-down session context. Abort the active execution during shutdown and guard post-await updates with a shutdown generation or flag.
- 🚨 `scripts/verify-pi-no-mistakes-timeline:55` - The required deterministic verifier for “toggling” only waits for the off notification; its later grep finds timeline text rendered before the command. A handler that never removes the widget would still pass. Assert the post-toggle widget/status is absent, or toggle it back on and verify a fresh render.

🔧 Fix: Cancel shutdown polls and verify hidden timeline
1 error still open:
- 🚨 `pi/.pi/agent/extensions/no-mistakes-timeline.ts:116` - The required “matching rail/glyph semantics” diverges from Aviral&#39;s existing connected timeline: this hunk renders completed/failed as `✓`/`✗` and rails with `dim`, while `tool-call-renderer.ts` uses `●`/`×` and `borderMuted`. Confirm this visual divergence or align the new timeline with the canonical semantics.

🔧 Fix: Align timeline glyphs and rail theming
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./scripts/verify-pi-no-mistakes-timeline`
- <code>Pi TUI with a fake nine-phase `no-mistakes axi status`, including `/no-mistakes-timeline off`</code>
- <code>Pi TUI with `runs: 0 runs yet in this repository`, asserting no timeline rendered</code>
- <code>`/no-mistakes-timeline refresh`, asserting acknowledgement while the empty timeline remained hidden</code>
- <code>Polling call-count comparison immediately and two seconds after `/quit`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
