### PR TITLE
feat(nvim): route Atlas to dedicated picker pane

### DIFF
--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -363,11 +363,16 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - `<C-.>` toggles the last picker-selected Sidekick session, falling back to the cwd session picker.
 - `<C-;>` opens the local session picker.
 - `<C-r>` renames the selected session in the picker.
+- `<C-x>` confirms before closing the selected agent from the local session picker.
 - `<leader>at` sends the current context/object through Sidekick's native `{this}` placeholder.
 - `<leader>ap` opens prompt selection.
 - Sidekick supports sending context, prompting, toggling float/split, opening local sessions, and creating named sessions.
 - Sidekick keymaps include ask/edit/apply/reject/yank, context/prompt sending, the local picker, and named-session creation.
-- Sidekick cwd session picker includes previews.
+- Sidekick cwd session picker keeps the ordinary conversation preview full-width above its input, with Workspaces,
+  Agents, and Atlas Preview panes across the bottom.
+- For an exactly registered participant, the bottom-right pane shows the compact read-only Atlas projection without
+  replacing the ordinary conversation preview; incomplete or unmatched identity leaves the Atlas pane empty.
+- Ordinary preview polling and full-history scrolling continue while Atlas lookup is pending or displayed.
 - Sidekick global named-session picker includes previews.
 - Sidekick session pickers support killing sessions.
 - Sidekick can search captured named-session pane contents with ripgrep.

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1093,7 +1093,12 @@ function M.open(opts)
     local item = current_preview_item()
     if preview_loading
       or not item
-      or item.status ~= "working"
+      or (
+        item.status ~= "working"
+        and not vim.iter(items):any(function(candidate)
+          return candidate.agent_name == item.agent_name and candidate.status == "working"
+        end)
+      )
       or item == expanded_preview_item
     then
       return

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -622,10 +622,12 @@ function M.open(opts)
   local groups = workspace_groups(local_workspace_id, metric_cache)
   local workspace_matcher = require("snacks.picker.core.matcher").new({ sort = false })
   if #items == 0 then
-    items = { {
-      text = workspace_id and "(no named sessions in workspace)" or "(no named sessions in cwd)",
-      _empty = true,
-    } }
+    items = {
+      {
+        text = workspace_id and "(no named sessions in workspace)" or "(no named sessions in cwd)",
+        _empty = true,
+      },
+    }
   end
 
   local workspace_rows = {}
@@ -914,7 +916,8 @@ function M.open(opts)
   end
 
   local function swap_preview_buffer(buf, staging_win, item, rendered, generation, on_swap, previous_tick)
-    if generation ~= preview_generation
+    if
+      generation ~= preview_generation
       or item ~= preview_selection
       or not picker
       or picker.closed
@@ -957,7 +960,8 @@ function M.open(opts)
   end
 
   local function swap_atlas_buffer(buf, staging_win, item, generation, previous_tick)
-    if generation ~= preview_generation
+    if
+      generation ~= preview_generation
       or item ~= preview_selection
       or not picker
       or picker.closed
@@ -996,7 +1000,9 @@ function M.open(opts)
     local preview = {
       win = {
         win = atlas_win.win,
-        win_valid = function() return atlas_win:valid() end,
+        win_valid = function()
+          return atlas_win:valid()
+        end,
       },
     }
     local buf, staging_win = prepare_preview_buffer(frame, nil, preview)
@@ -1030,8 +1036,7 @@ function M.open(opts)
       return
     end
     atlas_attempted = true
-    local lookup_win = atlas_win and atlas_win:valid() and atlas_win.win
-      or (preview_window(preview) or {}).win
+    local lookup_win = atlas_win and atlas_win:valid() and atlas_win.win or (preview_window(preview) or {}).win
     if not lookup_win then
       return
     end
@@ -1040,7 +1045,8 @@ function M.open(opts)
     local height = vim.api.nvim_win_get_height(lookup_win)
     local lookup = opts.atlas_lookup or atlas_lookup
     atlas_process = lookup(item, width, height, function(result)
-      if generation ~= preview_generation
+      if
+        generation ~= preview_generation
         or item ~= preview_selection
         or not picker
         or picker.closed
@@ -1059,7 +1065,8 @@ function M.open(opts)
       restage_atlas_preview(item, generation)
     end)
     vim.defer_fn(function()
-      if generation ~= preview_generation
+      if
+        generation ~= preview_generation
         or item ~= preview_selection
         or not picker
         or picker.closed
@@ -1091,14 +1098,12 @@ function M.open(opts)
 
   local function refresh_preview()
     local item = current_preview_item()
-    if preview_loading
+    if
+      preview_loading
       or not item
-      or (
-        item.status ~= "working"
-        and not vim.iter(items):any(function(candidate)
-          return candidate.agent_name == item.agent_name and candidate.status == "working"
-        end)
-      )
+      or (item.status ~= "working" and not vim.iter(items):any(function(candidate)
+        return candidate.agent_name == item.agent_name and candidate.status == "working"
+      end))
       or item == expanded_preview_item
     then
       return
@@ -1171,11 +1176,7 @@ function M.open(opts)
       if generation ~= preview_generation or item ~= preview_selection then
         return
       end
-      if not picker
-        or picker.closed
-        or item ~= current_preview_item()
-        or item ~= expanded_preview_item
-      then
+      if not picker or picker.closed or item ~= current_preview_item() or item ~= expanded_preview_item then
         return
       end
       output = scrub_preview_output(item, output)
@@ -1317,8 +1318,12 @@ function M.open(opts)
       ["<c-w>"] = focus_input,
       ["<c-u>"] = clear_input,
       ["<c-x>"] = workspace_delete,
-      ["<c-b>"] = function() scroll_preview(true) end,
-      ["<c-f>"] = function() scroll_preview(false) end,
+      ["<c-b>"] = function()
+        scroll_preview(true)
+      end,
+      ["<c-f>"] = function()
+        scroll_preview(false)
+      end,
       ["<esc>"] = focus_input,
     },
   })
@@ -1336,10 +1341,14 @@ function M.open(opts)
   local agent_float = require("sidekick.config").cli.win.float
   -- Sidekick sizes the float's content first; its rounded border then adds one
   -- cell on every side. The borderless picker root must include those cells.
-  local picker_width =
-    math.max(agent_float.width <= 1 and math.floor(vim.o.columns * agent_float.width) or agent_float.width, 80) + 2
-  local picker_height =
-    math.max(agent_float.height <= 1 and math.floor(vim.o.lines * agent_float.height) or agent_float.height, 10) + 2
+  local picker_width = math.max(
+    agent_float.width <= 1 and math.floor(vim.o.columns * agent_float.width) or agent_float.width,
+    80
+  ) + 2
+  local picker_height = math.max(
+    agent_float.height <= 1 and math.floor(vim.o.lines * agent_float.height) or agent_float.height,
+    10
+  ) + 2
   local winhl = "Normal:SidekickPickerTransparent"
     .. ",NormalFloat:SidekickPickerTransparent"
     .. ",NormalNC:SidekickPickerTransparent"
@@ -1435,17 +1444,21 @@ function M.open(opts)
       focus_input()
       if has_working then
         spinner_timer = vim.uv.new_timer()
-        spinner_timer:start(spinner_refresh_ms, spinner_refresh_ms, vim.schedule_wrap(function()
-          if picker.closed then
-            stop_spinner()
-          else
-            picker.list:update({ force = true })
-            if has_workspace_working then
-              render_workspace()
+        spinner_timer:start(
+          spinner_refresh_ms,
+          spinner_refresh_ms,
+          vim.schedule_wrap(function()
+            if picker.closed then
+              stop_spinner()
+            else
+              picker.list:update({ force = true })
+              if has_workspace_working then
+                render_workspace()
+              end
+              refresh_preview()
             end
-            refresh_preview()
-          end
-        end))
+          end)
+        )
       end
     end,
     on_close = function(active_picker)

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -633,6 +633,7 @@ function M.open(opts)
   local picker
   local spinner_timer
   local workspace_win
+  local atlas_win
   local rendered_workspace_item
   local pending_workspace_item
   local workspace_active = false
@@ -884,6 +885,18 @@ function M.open(opts)
     end
   end
 
+  local function clear_atlas_preview()
+    if not atlas_win or not atlas_win:valid() then
+      return
+    end
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[buf].buftype = "nofile"
+    vim.bo[buf].bufhidden = "wipe"
+    vim.bo[buf].modifiable = false
+    atlas_win.buf = buf
+    vim.api.nvim_win_set_buf(atlas_win.win, buf)
+  end
+
   local function invalidate_preview()
     preview_generation = preview_generation + 1
     stop_atlas_lookup()
@@ -891,6 +904,7 @@ function M.open(opts)
     atlas_phase = nil
     atlas_frame = nil
     atlas_attempted = false
+    clear_atlas_preview()
   end
 
   transition_preview = function()
@@ -936,29 +950,60 @@ function M.open(opts)
     if generation ~= preview_generation or item ~= preview_selection then
       return
     end
-    local atlas_fallback = atlas_attempted
-    atlas_phase = atlas_fallback and "fallback-staging" or nil
-    atlas_frame = nil
     local output, err = preview_text(item, preview_line_limit(preview))
     local rendered = output or err
     local buf, staging_win = prepare_preview_buffer(output, err, preview)
     vim.schedule(function()
-      swap_preview_buffer(buf, staging_win, item, rendered, generation, function()
-        if atlas_fallback then
-          atlas_phase = nil
-        end
-      end)
+      swap_preview_buffer(buf, staging_win, item, rendered, generation)
     end)
   end
 
-  local function restage_atlas_preview(item, preview, generation)
+  local function swap_atlas_buffer(buf, staging_win, item, generation, previous_tick)
+    if generation ~= preview_generation
+      or item ~= preview_selection
+      or not picker
+      or picker.closed
+      or item ~= current_preview_item()
+      or atlas_phase ~= "staging"
+      or not atlas_win
+      or not atlas_win:valid()
+    then
+      discard_preview_buffer(buf, staging_win)
+      return
+    end
+    local ready, tick = preview_buffer_ready(buf, previous_tick)
+    if not ready then
+      vim.defer_fn(function()
+        swap_atlas_buffer(buf, staging_win, item, generation, tick)
+      end, preview_settle_ms)
+      return
+    end
+    atlas_win.buf = buf
+    vim.api.nvim_win_set_buf(atlas_win.win, buf)
+    staging_buffers[buf] = nil
+    if staging_win and vim.api.nvim_win_is_valid(staging_win) then
+      vim.api.nvim_win_close(staging_win, true)
+    end
+    atlas_phase = "active"
+  end
+
+  local function restage_atlas_preview(item, generation)
+    if not atlas_frame or not atlas_win or not atlas_win:valid() then
+      atlas_phase = nil
+      atlas_frame = nil
+      return
+    end
     atlas_phase = "staging"
     local frame = atlas_frame
+    local preview = {
+      win = {
+        win = atlas_win.win,
+        win_valid = function() return atlas_win:valid() end,
+      },
+    }
     local buf, staging_win = prepare_preview_buffer(frame, nil, preview)
     vim.schedule(function()
-      swap_preview_buffer(buf, staging_win, item, frame, generation, function()
-        atlas_phase = "active"
-      end)
+      swap_atlas_buffer(buf, staging_win, item, generation)
     end)
   end
 
@@ -972,56 +1017,59 @@ function M.open(opts)
     elseif item == displayed_preview_item and item == expanded_preview_item then
       return
     elseif atlas_phase == "active" and atlas_frame then
-      restage_atlas_preview(item, preview, preview_generation)
+      restage_atlas_preview(item, preview_generation)
       return
-    elseif atlas_attempted and atlas_phase == nil then
+    elseif atlas_phase == "pending" or atlas_phase == "staging" then
+      return
+    elseif atlas_attempted then
       render_default_preview(item, preview, preview_generation)
       return
     end
     local generation = preview_generation
-    if complete_atlas_identity(item) then
-      if atlas_attempted then
-        return
-      end
-      atlas_attempted = true
-      atlas_phase = "pending"
-      local win = preview_window(preview)
-      local width = win and vim.api.nvim_win_get_width(win.win) or vim.o.columns
-      local height = win and vim.api.nvim_win_get_height(win.win) or math.max(vim.o.lines, 2)
-      local lookup = opts.atlas_lookup or atlas_lookup
-      atlas_process = lookup(item, width, height, function(result)
-        if generation ~= preview_generation
-          or item ~= preview_selection
-          or not picker
-          or picker.closed
-          or atlas_phase ~= "pending"
-        then
-          return
-        end
-        atlas_process = nil
-        local frame = atlas_result_frame(result)
-        if not frame then
-          render_default_preview(item, preview, generation)
-          return
-        end
-        atlas_frame = frame
-        restage_atlas_preview(item, preview, generation)
-      end)
-      vim.defer_fn(function()
-        if generation ~= preview_generation
-          or item ~= preview_selection
-          or not picker
-          or picker.closed
-          or atlas_phase ~= "pending"
-        then
-          return
-        end
-        stop_atlas_lookup()
-        render_default_preview(item, preview, generation)
-      end, atlas_lookup_timeout_ms)
+    render_default_preview(item, preview, generation)
+    if not complete_atlas_identity(item) then
       return
     end
-    render_default_preview(item, preview, generation)
+    atlas_attempted = true
+    if not atlas_win or not atlas_win:valid() then
+      return
+    end
+    atlas_phase = "pending"
+    local width = vim.api.nvim_win_get_width(atlas_win.win)
+    local height = vim.api.nvim_win_get_height(atlas_win.win)
+    local lookup = opts.atlas_lookup or atlas_lookup
+    atlas_process = lookup(item, width, height, function(result)
+      if generation ~= preview_generation
+        or item ~= preview_selection
+        or not picker
+        or picker.closed
+        or atlas_phase ~= "pending"
+      then
+        return
+      end
+      atlas_process = nil
+      local frame = atlas_result_frame(result)
+      if not frame then
+        atlas_phase = nil
+        clear_atlas_preview()
+        return
+      end
+      atlas_frame = frame
+      restage_atlas_preview(item, generation)
+    end)
+    vim.defer_fn(function()
+      if generation ~= preview_generation
+        or item ~= preview_selection
+        or not picker
+        or picker.closed
+        or atlas_phase ~= "pending"
+      then
+        return
+      end
+      stop_atlas_lookup()
+      atlas_phase = nil
+      clear_atlas_preview()
+    end, atlas_lookup_timeout_ms)
   end
 
   local function move_workspace_selection(step)
@@ -1043,8 +1091,7 @@ function M.open(opts)
 
   local function refresh_preview()
     local item = current_preview_item()
-    if atlas_phase
-      or preview_loading
+    if preview_loading
       or not item
       or item.status ~= "working"
       or item == expanded_preview_item
@@ -1059,7 +1106,7 @@ function M.open(opts)
       if generation ~= preview_generation or item ~= preview_selection then
         return
       end
-      if atlas_phase or not picker or picker.closed or item ~= current_preview_item() then
+      if not picker or picker.closed or item ~= current_preview_item() then
         return
       end
       if item == expanded_preview_item then
@@ -1097,7 +1144,7 @@ function M.open(opts)
 
   local function scroll_preview(up)
     local item = current_preview_item()
-    if atlas_phase or not item or item._empty or item._workspace then
+    if not item or item._empty or item._workspace then
       return
     end
     if item == expanded_preview_item and item ~= loading_full_preview_item then
@@ -1119,8 +1166,7 @@ function M.open(opts)
       if generation ~= preview_generation or item ~= preview_selection then
         return
       end
-      if atlas_phase
-        or not picker
+      if not picker
         or picker.closed
         or item ~= current_preview_item()
         or item ~= expanded_preview_item
@@ -1268,6 +1314,16 @@ function M.open(opts)
       ["<esc>"] = focus_input,
     },
   })
+  atlas_win = Snacks.win({
+    show = false,
+    focusable = false,
+    bo = { buftype = "nofile", bufhidden = "wipe", modifiable = false },
+    wo = {
+      winhighlight = "Normal:SidekickPickerTransparent,NormalNC:SidekickPickerTransparent",
+      wrap = true,
+      linebreak = true,
+    },
+  })
 
   local agent_float = require("sidekick.config").cli.win.float
   -- Sidekick sizes the float's content first; its rounded border then adds one
@@ -1289,7 +1345,7 @@ function M.open(opts)
     layout = {
       reverse = false,
       preview = true,
-      wins = { workspace = workspace_win },
+      wins = { workspace = workspace_win, atlas = atlas_win },
       layout = {
         box = "vertical",
         width = picker_width,
@@ -1302,7 +1358,7 @@ function M.open(opts)
           box = "horizontal",
           height = 14,
           {
-            width = 0.5,
+            width = 0.333,
             win = "workspace",
             height = 12,
             title = " Workspaces ",
@@ -1311,11 +1367,18 @@ function M.open(opts)
             border = "rounded",
           },
           {
+            width = 0.333,
             win = "list",
             height = 12,
-            title = " Local sessions ",
+            title = " Agents ",
             footer = " <C-w> Workspaces ",
             footer_pos = "center",
+            border = "rounded",
+          },
+          {
+            win = "atlas",
+            height = 12,
+            title = " Atlas Preview ",
             border = "rounded",
           },
         },

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1210,19 +1210,15 @@ function M.open(opts)
     internal.toggle_tool_session(target, true, item.terminal_id)
   end
 
-  local function kill_item(active_picker, item)
+  local function kill_item(_, item)
     if not item or item._empty or not item.pane_id then
       return
     end
-    if herdr.close(item.pane_id) then
-      if opts.on_kill then
-        opts.on_kill(item)
-      end
-      reopening = true
-      active_picker:close()
-      vim.schedule(function()
-        M.open(opts)
-      end)
+    if vim.fn.confirm("Kill agent " .. item.label .. "?", "&Yes\n&No", 2) ~= 1 then
+      return
+    end
+    if herdr.close(item.pane_id) and opts.on_kill then
+      opts.on_kill(item)
     end
   end
 

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1088,9 +1088,6 @@ function M.open(opts)
     pending_workspace_item = nil
     set_active_selector(true)
     show_preview(item)
-    if item._workspace then
-      clear_atlas_preview()
-    end
   end
 
   local function refresh_preview()

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1088,6 +1088,9 @@ function M.open(opts)
     pending_workspace_item = nil
     set_active_selector(true)
     show_preview(item)
+    if item._workspace then
+      clear_atlas_preview()
+    end
   end
 
   local function refresh_preview()

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1030,12 +1030,14 @@ function M.open(opts)
       return
     end
     atlas_attempted = true
-    if not atlas_win or not atlas_win:valid() then
+    local lookup_win = atlas_win and atlas_win:valid() and atlas_win.win
+      or (preview_window(preview) or {}).win
+    if not lookup_win then
       return
     end
     atlas_phase = "pending"
-    local width = vim.api.nvim_win_get_width(atlas_win.win)
-    local height = vim.api.nvim_win_get_height(atlas_win.win)
+    local width = vim.api.nvim_win_get_width(lookup_win)
+    local height = vim.api.nvim_win_get_height(lookup_win)
     local lookup = opts.atlas_lookup or atlas_lookup
     atlas_process = lookup(item, width, height, function(result)
       if generation ~= preview_generation

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -743,9 +743,7 @@ function M.open(opts)
       end
     end
     workspace_pattern = pattern
-    local filtered_item = workspace_rows[cursor_row]
-    filtered_item = filtered_item and not filtered_item._workspace and filtered_item or nil
-    if workspace_active and preview_selection ~= nil and filtered_item ~= preview_selection then
+    if workspace_active and preview_selection ~= nil and workspace_rows[cursor_row] ~= preview_selection then
       transition_preview()
       rendered_workspace_item = nil
       pending_workspace_item = nil

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1011,10 +1011,10 @@ function M.open(opts)
       transition_preview()
       preview_selection = item
       displayed_preview_item = item
-    elseif not atlas_eligible then
-      invalidate_preview()
     elseif item == displayed_preview_item and item == expanded_preview_item then
       return
+    elseif not atlas_eligible then
+      invalidate_preview()
     elseif atlas_phase == "active" and atlas_frame then
       restage_atlas_preview(item, preview_generation)
       return
@@ -1215,15 +1215,22 @@ function M.open(opts)
     internal.toggle_tool_session(target, true, item.terminal_id)
   end
 
-  local function kill_item(_, item)
+  local function kill_item(active_picker, item)
     if not item or item._empty or not item.pane_id then
       return
     end
     if vim.fn.confirm("Kill agent " .. item.label .. "?", "&Yes\n&No", 2) ~= 1 then
       return
     end
-    if herdr.close(item.pane_id) and opts.on_kill then
-      opts.on_kill(item)
+    if herdr.close(item.pane_id) then
+      if opts.on_kill then
+        opts.on_kill(item)
+      end
+      reopening = true
+      active_picker:close()
+      vim.schedule(function()
+        M.open(opts)
+      end)
     end
   end
 

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1082,7 +1082,6 @@ function M.open(opts)
     if not item then
       return
     end
-    transition_preview()
     vim.api.nvim_win_set_cursor(workspace_win.win, { row, 0 })
     rendered_workspace_item = item
     pending_workspace_item = nil

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1008,12 +1008,13 @@ function M.open(opts)
   end
 
   show_preview = function(item, preview)
+    local atlas_eligible = complete_atlas_identity(item)
     if item ~= preview_selection then
-      invalidate_preview()
+      transition_preview()
       preview_selection = item
       displayed_preview_item = item
-      expanded_preview_item = nil
-      pending_preview_scroll = nil
+    elseif not atlas_eligible then
+      invalidate_preview()
     elseif item == displayed_preview_item and item == expanded_preview_item then
       return
     elseif atlas_phase == "active" and atlas_frame then
@@ -1027,7 +1028,7 @@ function M.open(opts)
     end
     local generation = preview_generation
     render_default_preview(item, preview, generation)
-    if not complete_atlas_identity(item) then
+    if not atlas_eligible then
       return
     end
     atlas_attempted = true

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1518,11 +1518,7 @@ local function validate_sidekick_herdr()
       local previous_win = fake_picker.preview.win.win
       fake_picker.preview.win.win = preview_win
       read_result = "\27[32mT10 V01 ordinary Herdr preview\27[0m\r\nunchanged second line"
-      local expected_preview_buf = render_preview(done_item)
-      local expected_preview = table.concat(
-        vim.api.nvim_buf_get_lines(expected_preview_buf, 0, -1, false),
-        "\n"
-      )
+      local expected_preview
       local frame = table.concat({
         "Run atlas-rich-run · Goal 3/5 T10.V01",
         "Participant driver · Role verifier-steward",
@@ -1587,13 +1583,19 @@ local function validate_sidekick_herdr()
       atlas_item.status = "working"
 
       fake_picker.closed = false
-      current_fake_item = atlas_item
+      current_fake_item = done_item
       local workspace = atlas_picker_opts.layout.wins.workspace
       workspace:show()
       atlas_preview:show()
       vim.api.nvim_win_set_width(atlas_preview.win, math.max(math.floor(preview_width / 3) - 2, 1))
       vim.api.nvim_win_set_height(atlas_preview.win, math.min(12, host_height - 2))
       atlas_picker_opts.on_show(fake_picker)
+      local expected_preview_buf = render_preview(done_item)
+      expected_preview = table.concat(
+        vim.api.nvim_buf_get_lines(expected_preview_buf, 0, -1, false),
+        "\n"
+      )
+      current_fake_item = atlas_item
       input_pattern = "pblocked"
       input_changed()
       if vim.api.nvim_win_get_cursor(workspace.win)[1] ~= 2 then

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1648,10 +1648,15 @@ local function validate_sidekick_herdr()
       local top_rendered = table.concat(vim.api.nvim_buf_get_lines(top_buf, 0, -1, false), "\n")
       local atlas_buf = atlas_preview.buf
       local rendered = table.concat(vim.api.nvim_buf_get_lines(atlas_buf, 0, -1, false), "\n")
+      local rendered_fields = rendered:gsub("\n", "")
       if vim.bo[atlas_buf].buftype ~= "terminal"
-        or not rendered:find("Run atlas-rich-run · Goal 3/5 T10.V01", 1, true)
-        or not rendered:find("Participant driver · Role verifier-steward", 1, true)
-        or not rendered:find("Lifecycle verify · active", 1, true)
+        or not rendered_fields:find("Run atlas-rich-run", 1, true)
+        or not rendered_fields:find("Goal 3/5", 1, true)
+        or not rendered_fields:find("T10.V01", 1, true)
+        or not rendered_fields:find("Participant driver", 1, true)
+        or not rendered_fields:find("Role verifier-steward", 1, true)
+        or not rendered_fields:find("Lifecycle verify", 1, true)
+        or not rendered_fields:find("active", 1, true)
       then
         fail("T10 V01 bottom-right Atlas preview is incomplete at " .. size .. ": " .. vim.inspect(rendered))
       end
@@ -1683,10 +1688,13 @@ local function validate_sidekick_herdr()
         vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false),
         "\n"
       )
+      local layout_fields = layout_rendered:gsub("\n", "")
       if preview_swaps ~= layout_swaps
         or fake_picker.preview.win.buf ~= top_buf
         or atlas_preview.buf == blank_layout_buf
-        or not layout_rendered:find("Run atlas-rich-run · Goal 3/5 T10.V01", 1, true)
+        or not layout_fields:find("Run atlas-rich-run", 1, true)
+        or not layout_fields:find("Goal 3/5", 1, true)
+        or not layout_fields:find("T10.V01", 1, true)
         or #lookup_calls ~= 1
       then
         fail("T04 V01 same-selection layout callback should re-stage only active Atlas at " .. size)

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1506,7 +1506,7 @@ local function validate_sidekick_herdr()
       vim.o.lines = host_height
       local preview_width = host_width - 4
       local preview_height = math.max(host_height - 20, 2)
-      local atlas_win = vim.api.nvim_open_win(vim.api.nvim_create_buf(false, true), false, {
+      local preview_win = vim.api.nvim_open_win(vim.api.nvim_create_buf(false, true), false, {
         relative = "editor",
         row = 0,
         col = 0,
@@ -1515,9 +1515,18 @@ local function validate_sidekick_herdr()
         style = "minimal",
         hide = true,
       })
+      local previous_win = fake_picker.preview.win.win
+      fake_picker.preview.win.win = preview_win
+      read_result = "\27[32mT10 V01 ordinary Herdr preview\27[0m\r\nunchanged second line"
+      local expected_preview_buf = render_preview(done_item)
+      local expected_preview = table.concat(
+        vim.api.nvim_buf_get_lines(expected_preview_buf, 0, -1, false),
+        "\n"
+      )
       local frame = table.concat({
-        "Run atlas-rich-run · Goal 3/5 T02.V01",
-        "Role driver · implementer · verifier · active",
+        "Run atlas-rich-run · Goal 3/5 T10.V01",
+        "Participant driver · Role verifier-steward",
+        "Lifecycle verify · active",
       }, "\r\n")
       local lookup_calls = {}
       cwd_picker.open({
@@ -1534,6 +1543,37 @@ local function validate_sidekick_herdr()
         end,
       })
       local atlas_picker_opts = picker_opts
+      local size = string.format("%dx%d", host_width, host_height)
+      local layout = atlas_picker_opts.layout.layout
+      local bottom = layout[3]
+      local atlas_layout = bottom and bottom[3]
+      local atlas_preview = atlas_layout
+        and atlas_layout.win
+        and atlas_picker_opts.layout.wins[atlas_layout.win]
+      if layout.box ~= "vertical"
+        or layout[1].win ~= "preview"
+        or layout[1].title ~= " Preview "
+        or layout[1].width ~= nil
+        or layout[2].win ~= "input"
+        or layout[2].height ~= 1
+        or not bottom
+        or bottom.box ~= "horizontal"
+        or #bottom ~= 3
+        or bottom[1].win ~= "workspace"
+        or bottom[1].title ~= " Workspaces "
+        or bottom[2].win ~= "list"
+        or bottom[2].title ~= " Agents "
+        or not atlas_layout
+        or atlas_layout.title ~= " Atlas Preview "
+        or not atlas_preview
+      then
+        fail(
+          "T10 V01 picker layout at "
+            .. size
+            .. " should be full-width Preview, input, then Workspaces | Agents | Atlas Preview: "
+            .. vim.inspect(layout)
+        )
+      end
       local atlas_item
       for _, item in ipairs(atlas_picker_opts.items) do
         if item.label == "pi-blocked" then
@@ -1546,12 +1586,13 @@ local function validate_sidekick_herdr()
       end
       atlas_item.status = "working"
 
-      local previous_win = fake_picker.preview.win.win
-      fake_picker.preview.win.win = atlas_win
       fake_picker.closed = false
       current_fake_item = atlas_item
       local workspace = atlas_picker_opts.layout.wins.workspace
       workspace:show()
+      atlas_preview:show()
+      vim.api.nvim_win_set_width(atlas_preview.win, math.max(math.floor(preview_width / 3) - 2, 1))
+      vim.api.nvim_win_set_height(atlas_preview.win, math.min(12, host_height - 2))
       atlas_picker_opts.on_show(fake_picker)
       input_pattern = "pblocked"
       input_changed()
@@ -1571,13 +1612,15 @@ local function validate_sidekick_herdr()
       local swaps_before = preview_swaps
       move_down[1]()
       vim.wait(1000, function()
-        return #lookup_calls > 0 and preview_swaps > swaps_before
+        return #lookup_calls > 0
+          and preview_swaps > swaps_before
+          and table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
+            :find("Run atlas-rich-run", 1, true) ~= nil
       end, 10)
 
-      local size = string.format("%dx%d", host_width, host_height)
       if #lookup_calls ~= 1 then
         fail(
-          "T04 V01 exact participant at "
+          "T10 V01 exact participant at "
             .. size
             .. " should invoke Atlas lookup exactly once; got "
             .. #lookup_calls
@@ -1593,77 +1636,100 @@ local function validate_sidekick_herdr()
           kind = "id",
           value = "session-5",
         })
-        or lookup.width ~= preview_width
-        or lookup.height ~= preview_height
+        or lookup.width ~= vim.api.nvim_win_get_width(atlas_preview.win)
+        or lookup.height ~= vim.api.nvim_win_get_height(atlas_preview.win)
       then
-        fail("T04 V01 exact Atlas lookup identity/dimensions mismatch at " .. size .. ": " .. vim.inspect(lookup))
+        fail("T10 V01 exact Atlas lookup identity/inner-dimensions mismatch at " .. size .. ": " .. vim.inspect(lookup))
       end
       if preview_swaps ~= swaps_before + 1 then
-        fail("T04 V01 matched Atlas should swap exactly one staged preview at " .. size)
+        fail("T10 V01 matched selection should stage the ordinary top preview exactly once at " .. size)
       end
-      local atlas_buf = fake_picker.preview.win.buf
+      local top_buf = fake_picker.preview.win.buf
+      local top_rendered = table.concat(vim.api.nvim_buf_get_lines(top_buf, 0, -1, false), "\n")
+      local atlas_buf = atlas_preview.buf
       local rendered = table.concat(vim.api.nvim_buf_get_lines(atlas_buf, 0, -1, false), "\n")
       if vim.bo[atlas_buf].buftype ~= "terminal"
-        or not rendered:find("Run atlas-rich-run · Goal 3/5 T02.V01", 1, true)
-        or not rendered:find("Role driver · implementer · verifier · active", 1, true)
+        or not rendered:find("Run atlas-rich-run · Goal 3/5 T10.V01", 1, true)
+        or not rendered:find("Participant driver · Role verifier-steward", 1, true)
+        or not rendered:find("Lifecycle verify · active", 1, true)
       then
-        fail("T04 V01 matched Atlas native preview is incomplete at " .. size .. ": " .. vim.inspect(rendered))
+        fail("T10 V01 bottom-right Atlas preview is incomplete at " .. size .. ": " .. vim.inspect(rendered))
+      end
+      if top_rendered ~= expected_preview
+        or top_rendered:find("atlas-rich-run", 1, true)
+        or top_rendered:find("T10.V01", 1, true)
+        or top_rendered:find("verifier-steward", 1, true)
+        or top_rendered:find("Lifecycle verify", 1, true)
+      then
+        fail(
+          "T10 V01 matched Atlas changed or leaked into the ordinary top preview at "
+            .. size
+            .. ": "
+            .. vim.inspect(top_rendered)
+        )
       end
       export_t04_evidence("matched-" .. size, atlas_buf)
 
       local blank_layout_buf = vim.api.nvim_create_buf(false, true)
-      fake_picker.preview.win.buf = blank_layout_buf
+      atlas_preview.buf = blank_layout_buf
+      vim.api.nvim_win_set_buf(atlas_preview.win, blank_layout_buf)
       local layout_swaps = preview_swaps
       atlas_picker_opts.preview({ item = lookup.item, preview = fake_picker.preview })
-      vim.wait(1000, function() return preview_swaps > layout_swaps end, 10)
+      vim.wait(1000, function()
+        return table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
+          :find("Run atlas-rich-run", 1, true) ~= nil
+      end, 10)
       local layout_rendered = table.concat(
-        vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
+        vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false),
         "\n"
       )
-      if preview_swaps ~= layout_swaps + 1
-        or fake_picker.preview.win.buf == blank_layout_buf
-        or not layout_rendered:find("Run atlas-rich-run · Goal 3/5 T02.V01", 1, true)
+      if preview_swaps ~= layout_swaps
+        or fake_picker.preview.win.buf ~= top_buf
+        or atlas_preview.buf == blank_layout_buf
+        or not layout_rendered:find("Run atlas-rich-run · Goal 3/5 T10.V01", 1, true)
+        or #lookup_calls ~= 1
       then
-        fail("T04 V01 same-selection layout callback should re-stage active Atlas at " .. size)
+        fail("T04 V01 same-selection layout callback should re-stage only active Atlas at " .. size)
       end
-      atlas_buf = fake_picker.preview.win.buf
       if vim.api.nvim_buf_is_valid(blank_layout_buf) then
         vim.api.nvim_buf_delete(blank_layout_buf, { force = true })
       end
 
-      local reads_with_atlas = async_reads
-      local swaps_with_atlas = preview_swaps
       vim.wait(200)
       atlas_picker_opts.actions.sidekick_preview_scroll_down()
       vim.wait(200)
-      if async_reads ~= reads_with_atlas
-        or preview_swaps ~= swaps_with_atlas
-        or fake_picker.preview.win.buf ~= atlas_buf
+      if not table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
+          :find("Run atlas-rich-run", 1, true)
+        or #lookup_calls ~= 1
       then
-        fail("T04 V01 refresh/full-preview loading overwrote active Atlas at " .. size)
+        fail("T04 V01 refresh/full-preview loading overwrote or repeated active Atlas at " .. size)
       end
 
       local heading_swaps = preview_swaps
       move_up[1]()
-      vim.wait(1000, function() return preview_swaps > heading_swaps end, 10)
+      vim.wait(1000, function()
+        return preview_swaps > heading_swaps
+          and table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n") == ""
+      end, 10)
       local heading_bytes = table.concat(
         vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
         "\n"
       )
       if preview_swaps ~= heading_swaps + 1
-        or fake_picker.preview.win.buf == atlas_buf
         or heading_bytes ~= "(no session)"
+        or table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n") ~= ""
         or #lookup_calls ~= 1
       then
-        fail("T04 V01 real workspace-heading navigation did not replace active Atlas at " .. size)
+        fail("T04 V01 real workspace-heading navigation did not clear Atlas at " .. size)
       end
 
       input_pattern = ""
       fake_picker.closed = true
       atlas_picker_opts.on_close(fake_picker)
       workspace:close()
+      atlas_preview:close()
       fake_picker.preview.win.win = previous_win
-      vim.api.nvim_win_close(atlas_win, true)
+      vim.api.nvim_win_close(preview_win, true)
     end
 
     verify_atlas_preview(100, 30)

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -989,8 +989,10 @@ local function validate_sidekick_herdr()
   local original_read = herdr.read
   local original_read_async = herdr.read_async
   local original_focus = herdr.focus
+  local original_close = herdr.close
   local original_toggle = internal.toggle_tool_session
   local original_ui_input = vim.ui.input
+  local original_confirm = vim.fn.confirm
   local picker_opts
   local read_args
   local read_result = "\27[31mfirst logical line\27[0m"
@@ -1004,6 +1006,7 @@ local function validate_sidekick_herdr()
   local async_read_args = {}
   local focused = {}
   local toggles = {}
+  local closed_panes = {}
   Snacks.picker.pick = function(opts)
     picker_opts = opts
   end
@@ -1044,6 +1047,10 @@ local function validate_sidekick_herdr()
   end
   herdr.focus = function(name)
     focused[#focused + 1] = name
+    return true
+  end
+  herdr.close = function(pane_id)
+    closed_panes[#closed_panes + 1] = pane_id
     return true
   end
   internal.toggle_tool_session = function(name, focus, terminal_id)
@@ -1164,6 +1171,39 @@ local function validate_sidekick_herdr()
       or picker_opts == rename_picker_opts
     then
       fail("session rename should rename the selected Herdr agent and reopen the picker")
+    end
+
+    local kill_item
+    for _, item in ipairs(picker_opts.items) do
+      if item.label == "pi-done" then
+        kill_item = item
+        break
+      end
+    end
+    local kill_input = picker_opts.win.input.keys["<c-x>"]
+    local kill_list = picker_opts.win.list.keys["<c-x>"]
+    local kill_action = type(kill_input) == "table" and kill_input[1] or kill_input
+    local kill_list_action = type(kill_list) == "table" and kill_list[1] or kill_list
+    if not kill_item
+      or type(kill_action) ~= "string"
+      or kill_list_action ~= kill_action
+      or type(picker_opts.actions[kill_action]) ~= "function"
+    then
+      fail("cwd picker should expose one agent-kill action from input and list")
+    end
+    local kill_prompt
+    vim.fn.confirm = function(prompt)
+      kill_prompt = prompt
+      return 1
+    end
+    picker_opts.actions[kill_action]({ close = function() end }, kill_item)
+    vim.fn.confirm = original_confirm
+    if not kill_prompt
+      or not kill_prompt:find(kill_item.label, 1, true)
+      or #closed_panes ~= 1
+      or closed_panes[1] ~= kill_item.pane_id
+    then
+      fail("agent kill should confirm the selected agent and close its pane exactly once")
     end
 
     if type(picker_opts.on_show) ~= "function" or type(picker_opts.on_close) ~= "function" then
@@ -1705,14 +1745,47 @@ local function validate_sidekick_herdr()
         vim.api.nvim_buf_delete(blank_layout_buf, { force = true })
       end
 
-      vim.wait(200)
+      local active_atlas_buf = atlas_preview.buf
+      local active_atlas_bytes = table.concat(
+        vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false),
+        "\n"
+      )
+      local active_poll_swaps = preview_swaps
+      read_result = "\27[32mT10 V03 active poll refresh\27[0m"
+      vim.wait(1000, function()
+        return preview_swaps > active_poll_swaps
+          and table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
+            :find("T10 V03 active poll refresh", 1, true) ~= nil
+      end, 10)
+      if preview_swaps <= active_poll_swaps
+        or atlas_preview.buf ~= active_atlas_buf
+        or table.concat(vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false), "\n")
+          ~= active_atlas_bytes
+      then
+        fail("T10 V03 active Atlas should allow top Preview polling without changing its frame at " .. size)
+      end
+
+      local active_full_reads = async_reads
+      local active_full_swaps = preview_swaps
+      read_result = "\27[32mT10 V03 active full preview\27[0m"
       atlas_picker_opts.actions.sidekick_preview_scroll_down()
-      vim.wait(200)
-      if not table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
-          :find("Run atlas-rich-run", 1, true)
+      vim.wait(1000, function()
+        local last_read = async_read_args[#async_read_args]
+        return last_read
+          and last_read.lines == 2147483647
+          and preview_swaps > active_full_swaps
+          and table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
+            :find("T10 V03 active full preview", 1, true) ~= nil
+      end, 10)
+      atlas_picker_opts.actions.sidekick_preview_scroll_up()
+      if async_reads <= active_full_reads
+        or preview_swaps <= active_full_swaps
+        or atlas_preview.buf ~= active_atlas_buf
+        or table.concat(vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false), "\n")
+          ~= active_atlas_bytes
         or #lookup_calls ~= 1
       then
-        fail("T04 V01 refresh/full-preview loading overwrote or repeated active Atlas at " .. size)
+        fail("T10 V03 active full Preview should change without changing or repeating Atlas at " .. size)
       end
 
       local heading_swaps = preview_swaps
@@ -1752,6 +1825,10 @@ local function validate_sidekick_herdr()
     vim.list_extend(
       protected_paths,
       vim.fn.glob("scripts/fixtures/vault-hunter-atlas*/runs/*.json", false, true)
+    )
+    vim.list_extend(
+      protected_paths,
+      vim.fn.glob("scripts/fixtures/vault-hunter-atlas*/vault/**/*.md", false, true)
     )
     local protected_bytes = {}
     for _, path in ipairs(protected_paths) do
@@ -2116,6 +2193,9 @@ local function validate_sidekick_herdr()
 
     local selection_callbacks = {}
     local selection_cancels = {}
+    local late_selection = complete_v03_item("selection-late")
+    late_selection.status = "working"
+    current_fake_item = late_selection
     local selection_picker_opts, selection_workspace = open_v03_picker(function(item, _, _, callback)
       local label = item._atlas_v03_case
       selection_callbacks[label] = callback
@@ -2123,12 +2203,52 @@ local function validate_sidekick_herdr()
         selection_cancels[label] = (selection_cancels[label] or 0) + 1
       end
     end)
-    local late_selection = complete_v03_item("selection-late")
-    current_fake_item = late_selection
     selection_picker_opts.preview({ item = late_selection, preview = fake_picker.preview })
     if not selection_callbacks["selection-late"] then
       fail("T04 V03 selection-change fixture did not start its Atlas lookup")
     end
+    local selection_atlas = selection_picker_opts.layout.wins.atlas
+    local pending_atlas_buf = vim.api.nvim_win_get_buf(selection_atlas.win)
+    local pending_atlas_bytes = table.concat(
+      vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false),
+      "\n"
+    )
+    local pending_poll_swaps = preview_swaps
+    read_result = "\27[36mT10 V03 pending poll refresh\27[0m"
+    vim.wait(1000, function()
+      return preview_swaps > pending_poll_swaps
+        and preview_bytes():find("T10 V03 pending poll refresh", 1, true) ~= nil
+    end, 10)
+    if preview_swaps <= pending_poll_swaps
+      or pending_atlas_bytes ~= ""
+      or vim.api.nvim_win_get_buf(selection_atlas.win) ~= pending_atlas_buf
+      or table.concat(vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false), "\n")
+        ~= pending_atlas_bytes
+    then
+      fail("T10 V03 pending Atlas should allow top Preview polling while staying empty")
+    end
+
+    local pending_full_reads = async_reads
+    local pending_full_swaps = preview_swaps
+    read_result = "\27[36mT10 V03 pending full preview\27[0m"
+    selection_picker_opts.actions.sidekick_preview_scroll_down()
+    vim.wait(1000, function()
+      local last_read = async_read_args[#async_read_args]
+      return last_read
+        and last_read.lines == 2147483647
+        and preview_swaps > pending_full_swaps
+        and preview_bytes():find("T10 V03 pending full preview", 1, true) ~= nil
+    end, 10)
+    selection_picker_opts.actions.sidekick_preview_scroll_up()
+    if async_reads <= pending_full_reads
+      or preview_swaps <= pending_full_swaps
+      or vim.api.nvim_win_get_buf(selection_atlas.win) ~= pending_atlas_buf
+      or table.concat(vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false), "\n")
+        ~= pending_atlas_bytes
+    then
+      fail("T10 V03 pending full Preview should change while displayed Atlas stays empty")
+    end
+
     local selection_default = vim.deepcopy(complete_identity)
     selection_default.agent_session = nil
     selection_default._atlas_v03_case = "selection-default"
@@ -2137,7 +2257,6 @@ local function validate_sidekick_herdr()
     selection_picker_opts.preview({ item = selection_default, preview = fake_picker.preview })
     vim.wait(1000, function() return preview_swaps > selection_swaps end, 10)
     local selected_bytes = preview_bytes()
-    local selection_atlas = selection_picker_opts.layout.wins.atlas
     local selected_atlas_buf = vim.api.nvim_win_get_buf(selection_atlas.win)
     local selected_buffers = valid_buffer_set()
     local selected_swaps = preview_swaps
@@ -2297,9 +2416,11 @@ local function validate_sidekick_herdr()
   herdr.read = original_read
   herdr.read_async = original_read_async
   herdr.focus = original_focus
+  herdr.close = original_close
   herdr.call = original_herdr_call
   internal.toggle_tool_session = original_toggle
   vim.ui.input = original_ui_input
+  vim.fn.confirm = original_confirm
   pcall(vim.api.nvim_tabpage_del_var, current_tab, "herdr_workspace_id")
   pcall(vim.api.nvim_tabpage_del_var, current_tab, "herdr_workspace_label")
   if not picker_ok then

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1192,18 +1192,25 @@ local function validate_sidekick_herdr()
       fail("cwd picker should expose one agent-kill action from input and list")
     end
     local kill_prompt
+    local kill_picker_opts = picker_opts
+    local kill_picker_closed = false
     vim.fn.confirm = function(prompt)
       kill_prompt = prompt
       return 1
     end
-    picker_opts.actions[kill_action]({ close = function() end }, kill_item)
+    picker_opts.actions[kill_action]({ close = function() kill_picker_closed = true end }, kill_item)
     vim.fn.confirm = original_confirm
+    vim.wait(100, function() return picker_opts ~= kill_picker_opts end, 5)
+    local kill_picker_refreshed = picker_opts ~= kill_picker_opts
+    picker_opts = kill_picker_opts
     if not kill_prompt
       or not kill_prompt:find(kill_item.label, 1, true)
       or #closed_panes ~= 1
       or closed_panes[1] ~= kill_item.pane_id
+      or not kill_picker_closed
+      or not kill_picker_refreshed
     then
-      fail("agent kill should confirm the selected agent and close its pane exactly once")
+      fail("agent kill should confirm, close the selected pane, and refresh the picker")
     end
 
     if type(picker_opts.on_show) ~= "function" or type(picker_opts.on_close) ~= "function" then
@@ -2068,6 +2075,27 @@ local function validate_sidekick_herdr()
       fail("T04 V03 default control should render once without an Atlas lookup")
     end
     local v03_default_preview_bytes = preview_bytes()
+    local default_full_swaps = preview_swaps
+    local default_full_reads = async_reads
+    identity_picker_opts.actions.sidekick_preview_scroll_down()
+    vim.wait(1000, function()
+      local last_read = async_read_args[#async_read_args]
+      return last_read
+        and last_read.lines == 2147483647
+        and preview_swaps > default_full_swaps
+    end, 10)
+    local default_full_buf = fake_picker.preview.win.buf
+    local default_full_bytes = preview_bytes()
+    local default_layout_swaps = preview_swaps
+    identity_picker_opts.preview({ item = default_control, preview = fake_picker.preview })
+    vim.wait(200)
+    if async_reads <= default_full_reads
+      or preview_swaps ~= default_layout_swaps
+      or fake_picker.preview.win.buf ~= default_full_buf
+      or preview_bytes() ~= default_full_bytes
+    then
+      fail("T10 V03 ordinary full Preview should survive same-selection layout callbacks")
+    end
 
     local identity_cases = {
       {
@@ -2371,7 +2399,9 @@ local function validate_sidekick_herdr()
 
     local last_session = require("plugins.sidekick.last_session")
     last_session.label = nil
+    vim.api.nvim_tabpage_set_var(current_tab, "herdr_workspace_id", done_item.workspace_id)
     picker_opts.confirm({ close = function() end }, done_item)
+    pcall(vim.api.nvim_tabpage_del_var, current_tab, "herdr_workspace_id")
     if #toggles ~= 1 or toggles[1].name ~= "pi-done" or toggles[1].focus ~= true then
       fail("confirm should focus the selected done session exactly once: " .. vim.inspect(toggles))
     end

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1918,8 +1918,10 @@ local function validate_sidekick_herdr()
       cwd_picker.open({ atlas_lookup = lookup })
       local opts = picker_opts
       local workspace = opts.layout.wins.workspace
+      local atlas = opts.layout.wins.atlas
       fake_picker.closed = false
       workspace:show()
+      atlas:show()
       opts.on_show(fake_picker)
       opts.win.input.keys["<c-w>"][1]()
       return opts, workspace
@@ -1929,6 +1931,7 @@ local function validate_sidekick_herdr()
       fake_picker.closed = true
       opts.on_close(fake_picker)
       workspace:close()
+      opts.layout.wins.atlas:close()
     end
 
     local function preview_bytes()
@@ -2054,14 +2057,26 @@ local function validate_sidekick_herdr()
     control._atlas_v03_case = "complete"
     current_fake_item = control
     local control_swaps = preview_swaps
+    local control_atlas = identity_picker_opts.layout.wins.atlas
+    local control_atlas_buf = control_atlas.buf
     identity_picker_opts.preview({ item = control, preview = fake_picker.preview })
     identity_picker_opts.preview({ item = control, preview = fake_picker.preview })
-    vim.wait(1000, function() return preview_swaps > control_swaps end, 10)
+    vim.wait(1000, function()
+      return preview_swaps > control_swaps
+        and control_atlas.buf ~= control_atlas_buf
+        and table.concat(vim.api.nvim_buf_get_lines(control_atlas.buf, 0, -1, false), "\n")
+          :find("Run atlas-v03-complete", 1, true) ~= nil
+    end, 10)
     if (identity_calls.complete or 0) ~= 1 or not identity_callbacks.complete then
       fail("T04 V03 complete identity control should perform exactly one Atlas lookup")
     end
-    if preview_swaps ~= control_swaps + 1 or not preview_bytes():find("Run atlas%-v03%-complete", 1, false) then
-      fail("T04 V03 complete identity control should swap one matched Atlas preview")
+    if preview_swaps ~= control_swaps + 1
+      or preview_bytes() ~= v03_default_preview_bytes
+      or control_atlas.buf == control_atlas_buf
+      or not table.concat(vim.api.nvim_buf_get_lines(control_atlas.buf, 0, -1, false), "\n")
+        :find("Run atlas-v03-complete", 1, true)
+    then
+      fail("T04 V03 complete identity control should swap one matched dedicated Atlas preview")
     end
     close_v03_picker(identity_picker_opts, identity_workspace)
 

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1801,8 +1801,10 @@ local function validate_sidekick_herdr()
     current_fake_item = baseline_item
     fake_picker.closed = false
     local fallback_workspace = fallback_picker_opts.layout.wins.workspace
+    local fallback_atlas = fallback_picker_opts.layout.wins.atlas
     local baseline_swaps = preview_swaps
     fallback_workspace:show()
+    fallback_atlas:show()
     fallback_picker_opts.on_show(fake_picker)
     fallback_picker_opts.win.input.keys["<c-w>"][1]()
     vim.wait(1000, function() return preview_swaps > baseline_swaps end, 10)
@@ -1859,6 +1861,10 @@ local function validate_sidekick_herdr()
           fallback_failures[#fallback_failures + 1] = fallback_case .. " changed the default preview bytes"
         end
       end
+      local fallback_atlas_buf = vim.api.nvim_win_get_buf(fallback_atlas.win)
+      if table.concat(vim.api.nvim_buf_get_lines(fallback_atlas_buf, 0, -1, false), "\n") ~= "" then
+        fallback_failures[#fallback_failures + 1] = fallback_case .. " populated the Atlas pane"
+      end
     end
     local fallback_layout_item = vim.deepcopy(fallback_item)
     fallback_layout_item._atlas_fallback_case = "unregistered"
@@ -1894,6 +1900,7 @@ local function validate_sidekick_herdr()
     fake_picker.closed = true
     fallback_picker_opts.on_close(fake_picker)
     fallback_workspace:close()
+    fallback_atlas:close()
     if #fallback_failures > 0 then
       fail("T04 V02 Atlas fallback regressions: " .. table.concat(fallback_failures, "; "))
     end
@@ -2078,6 +2085,27 @@ local function validate_sidekick_herdr()
     then
       fail("T04 V03 complete identity control should swap one matched dedicated Atlas preview")
     end
+    local ordinary = vim.deepcopy(complete_identity)
+    ordinary.agent_session = nil
+    ordinary._atlas_v03_case = "matched-to-ordinary"
+    current_fake_item = ordinary
+    local ordinary_swaps = preview_swaps
+    identity_picker_opts.preview({ item = ordinary, preview = fake_picker.preview })
+    local ordinary_atlas_buf = vim.api.nvim_win_get_buf(control_atlas.win)
+    if table.concat(vim.api.nvim_buf_get_lines(ordinary_atlas_buf, 0, -1, false), "\n") ~= "" then
+      fail("T10 V02 matched-to-ordinary selection should clear Atlas immediately")
+    end
+    vim.wait(1000, function() return preview_swaps > ordinary_swaps end, 10)
+    if (identity_calls["matched-to-ordinary"] or 0) ~= 0
+      or preview_swaps ~= ordinary_swaps + 1
+      or preview_bytes() ~= v03_default_preview_bytes
+      or table.concat(
+        vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(control_atlas.win), 0, -1, false),
+        "\n"
+      ) ~= ""
+    then
+      fail("T10 V02 matched-to-ordinary selection should preserve ordinary top preview and empty Atlas")
+    end
     close_v03_picker(identity_picker_opts, identity_workspace)
 
     local function complete_v03_item(label)
@@ -2109,6 +2137,8 @@ local function validate_sidekick_herdr()
     selection_picker_opts.preview({ item = selection_default, preview = fake_picker.preview })
     vim.wait(1000, function() return preview_swaps > selection_swaps end, 10)
     local selected_bytes = preview_bytes()
+    local selection_atlas = selection_picker_opts.layout.wins.atlas
+    local selected_atlas_buf = vim.api.nvim_win_get_buf(selection_atlas.win)
     local selected_buffers = valid_buffer_set()
     local selected_swaps = preview_swaps
     selection_callbacks["selection-late"](v03_result("selection-late"))
@@ -2116,6 +2146,8 @@ local function validate_sidekick_herdr()
     if (selection_cancels["selection-late"] or 0) ~= 1
       or preview_swaps ~= selected_swaps
       or preview_bytes() ~= selected_bytes
+      or vim.api.nvim_win_get_buf(selection_atlas.win) ~= selected_atlas_buf
+      or table.concat(vim.api.nvim_buf_get_lines(selected_atlas_buf, 0, -1, false), "\n") ~= ""
       or #new_valid_buffers(selected_buffers) ~= 0
     then
       fail("T04 V03 selection change should discard a late Atlas result")
@@ -2144,6 +2176,10 @@ local function validate_sidekick_herdr()
     if preview_swaps ~= selection_swaps + 1 or preview_bytes():find("selection%-staging") then
       fail("T04 V03 selection change should not swap an obsolete Atlas staging buffer")
     end
+    local selection_displayed_atlas_buf = vim.api.nvim_win_get_buf(selection_atlas.win)
+    if table.concat(vim.api.nvim_buf_get_lines(selection_displayed_atlas_buf, 0, -1, false), "\n") ~= "" then
+      fail("T10 V02 selection change should not repopulate Atlas from obsolete staging")
+    end
     close_v03_picker(selection_picker_opts, selection_workspace)
 
     local close_callbacks = {}
@@ -2159,12 +2195,16 @@ local function validate_sidekick_herdr()
     current_fake_item = late_close
     close_picker_opts.preview({ item = late_close, preview = fake_picker.preview })
     local close_swaps = preview_swaps
+    local close_bytes = preview_bytes()
     local close_buffers = valid_buffer_set()
+    local close_atlas = close_picker_opts.layout.wins.atlas
     close_v03_picker(close_picker_opts, close_workspace)
     close_callbacks["close-late"](v03_result("close-late"))
     vim.wait(100)
     if (close_cancels["close-late"] or 0) ~= 1
       or preview_swaps ~= close_swaps
+      or preview_bytes() ~= close_bytes
+      or close_atlas:valid()
       or #new_valid_buffers(close_buffers) ~= 0
     then
       fail("T04 V03 picker close should discard a late Atlas result")
@@ -2185,6 +2225,8 @@ local function validate_sidekick_herdr()
       fail("T04 V03 picker-close staging fixture did not create a staging buffer")
     end
     close_swaps = preview_swaps
+    close_bytes = preview_bytes()
+    local staged_close_atlas = staged_close_picker_opts.layout.wins.atlas
     close_v03_picker(staged_close_picker_opts, staged_close_workspace)
     vim.wait(100)
     for _, buf in ipairs(close_staging_buffers) do
@@ -2192,7 +2234,10 @@ local function validate_sidekick_herdr()
         fail("T04 V03 picker close should delete an obsolete Atlas staging buffer")
       end
     end
-    if preview_swaps ~= close_swaps then
+    if preview_swaps ~= close_swaps
+      or preview_bytes() ~= close_bytes
+      or staged_close_atlas:valid()
+    then
       fail("T04 V03 picker close should not swap an obsolete Atlas staging buffer")
     end
 

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1066,7 +1066,8 @@ local function validate_sidekick_herdr()
       fail("unbound cwd picker title should retain cwd scope: " .. vim.inspect(picker_opts.title))
     end
     local layout = picker_opts.layout.layout
-    if layout.box ~= "vertical"
+    if
+      layout.box ~= "vertical"
       or layout[1].win ~= "preview"
       or layout[2].win ~= "input"
       or layout[2].height ~= 1
@@ -1159,9 +1160,15 @@ local function validate_sidekick_herdr()
       end
       callback("Renamed Session")
     end
-    picker_opts.actions.sidekick_rename_session({ close = function() rename_closed = true end }, rename_item)
+    picker_opts.actions.sidekick_rename_session({
+      close = function()
+        rename_closed = true
+      end,
+    }, rename_item)
     vim.ui.input = original_ui_input
-    vim.wait(100, function() return picker_opts ~= rename_picker_opts end, 5)
+    vim.wait(100, function()
+      return picker_opts ~= rename_picker_opts
+    end, 5)
     if
       not rename_closed
       or not vim.deep_equal(
@@ -1184,7 +1191,8 @@ local function validate_sidekick_herdr()
     local kill_list = picker_opts.win.list.keys["<c-x>"]
     local kill_action = type(kill_input) == "table" and kill_input[1] or kill_input
     local kill_list_action = type(kill_list) == "table" and kill_list[1] or kill_list
-    if not kill_item
+    if
+      not kill_item
       or type(kill_action) ~= "string"
       or kill_list_action ~= kill_action
       or type(picker_opts.actions[kill_action]) ~= "function"
@@ -1198,12 +1206,19 @@ local function validate_sidekick_herdr()
       kill_prompt = prompt
       return 1
     end
-    picker_opts.actions[kill_action]({ close = function() kill_picker_closed = true end }, kill_item)
+    picker_opts.actions[kill_action]({
+      close = function()
+        kill_picker_closed = true
+      end,
+    }, kill_item)
     vim.fn.confirm = original_confirm
-    vim.wait(100, function() return picker_opts ~= kill_picker_opts end, 5)
+    vim.wait(100, function()
+      return picker_opts ~= kill_picker_opts
+    end, 5)
     local kill_picker_refreshed = picker_opts ~= kill_picker_opts
     picker_opts = kill_picker_opts
-    if not kill_prompt
+    if
+      not kill_prompt
       or not kill_prompt:find(kill_item.label, 1, true)
       or #closed_panes ~= 1
       or closed_panes[1] ~= kill_item.pane_id
@@ -1250,7 +1265,9 @@ local function validate_sidekick_herdr()
           win = vim.api.nvim_get_current_win(),
           map = function() end,
           on = function() end,
-          win_valid = function() return true end,
+          win_valid = function()
+            return true
+          end,
         },
         set_buf = function(self, buf)
           local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
@@ -1268,7 +1285,9 @@ local function validate_sidekick_herdr()
       },
       list = {
         win = {
-          valid = function() return false end,
+          valid = function()
+            return false
+          end,
           on = function() end,
         },
         move = function(_, step)
@@ -1299,7 +1318,8 @@ local function validate_sidekick_herdr()
       fail("agent picker should keep keyboard focus in its input")
     end
     local workspace_two_row = vim.fn.index(global_lines, "▾ Workspace Two · ● 0")
-    if not vim.startswith(global_lines[1], "▾ Workspace One · ")
+    if
+      not vim.startswith(global_lines[1], "▾ Workspace One · ")
       or workspace_two_row < 1
       or global_lines[workspace_two_row + 2] ~= "  └─ · pi-other-workspace · 42.5%"
     then
@@ -1320,11 +1340,15 @@ local function validate_sidekick_herdr()
     input_pattern = "pother"
     input_changed()
     global_lines = vim.api.nvim_buf_get_lines(global_win.buf, 0, -1, false)
-    if global_lines[1] ~= "▾ Workspace Two · ● 0"
+    if
+      global_lines[1] ~= "▾ Workspace Two · ● 0"
       or global_lines[2] ~= "  └─ · pi-other-workspace · 42.5%"
       or vim.api.nvim_win_get_cursor(global_win.win)[1] ~= 2
     then
-      fail("workspace fuzzy search should select the agent while retaining its workspace parent: " .. vim.inspect(global_lines))
+      fail(
+        "workspace fuzzy search should select the agent while retaining its workspace parent: "
+          .. vim.inspect(global_lines)
+      )
     end
     input_pattern = ""
     input_changed()
@@ -1385,7 +1409,8 @@ local function validate_sidekick_herdr()
       return last_read and last_read.lines == 2147483647
     end, 10)
     local full_read = async_read_args[#async_read_args]
-    if not full_read
+    if
+      not full_read
       or full_read.target ~= "codex-full-preview"
       or full_read.source ~= "recent-unwrapped"
       or full_read.lines ~= 2147483647
@@ -1404,11 +1429,7 @@ local function validate_sidekick_herdr()
     local stopped_reads = async_reads
     local stopped_preview_swaps = preview_swaps
     vim.wait(250)
-    if
-      spinner_updates ~= stopped_updates
-      or async_reads ~= stopped_reads
-      or preview_swaps ~= stopped_preview_swaps
-    then
+    if spinner_updates ~= stopped_updates or async_reads ~= stopped_reads or preview_swaps ~= stopped_preview_swaps then
       fail("closing the cwd picker should stop spinner and preview redraws")
     end
 
@@ -1428,7 +1449,9 @@ local function validate_sidekick_herdr()
       if fake_picker.preview.win.buf ~= previous_buf then
         fail("hover preview should keep the current buffer visible while its replacement renders")
       end
-      vim.wait(1000, function() return preview_swaps > previous_swaps end, 10)
+      vim.wait(1000, function()
+        return preview_swaps > previous_swaps
+      end, 10)
       if preview_swaps ~= previous_swaps + 1 then
         fail("hover preview should swap its completed staging buffer exactly once")
       end
@@ -1436,7 +1459,8 @@ local function validate_sidekick_herdr()
     end
 
     local buf = render_preview(done_item)
-    if not read_args
+    if
+      not read_args
       or read_args.target ~= "pi-done"
       or read_args.source ~= "recent-unwrapped"
       or read_args.lines ~= vim.api.nvim_win_get_height(fake_picker.preview.win.win) * 2
@@ -1475,7 +1499,9 @@ local function validate_sidekick_herdr()
     local sized_buf = render_preview(sized_item, {
       win = {
         win = sized_win,
-        win_valid = function() return true end,
+        win_valid = function()
+          return true
+        end,
       },
     })
     local sized_lines = vim.api.nvim_buf_get_lines(sized_buf, 0, 2, false)
@@ -1530,7 +1556,8 @@ local function validate_sidekick_herdr()
     }, "\r\n")
     local pi_scrub_buf = render_preview(done_item)
     local pi_scrubbed = table.concat(vim.api.nvim_buf_get_lines(pi_scrub_buf, 0, -1, false), "\n")
-    if pi_scrubbed:find("Working", 1, true)
+    if
+      pi_scrubbed:find("Working", 1, true)
       or pi_scrubbed:find("~/vault", 1, true)
       or pi_scrubbed:find("MCP:", 1, true)
     then
@@ -1590,10 +1617,9 @@ local function validate_sidekick_herdr()
       local layout = atlas_picker_opts.layout.layout
       local bottom = layout[3]
       local atlas_layout = bottom and bottom[3]
-      local atlas_preview = atlas_layout
-        and atlas_layout.win
-        and atlas_picker_opts.layout.wins[atlas_layout.win]
-      if layout.box ~= "vertical"
+      local atlas_preview = atlas_layout and atlas_layout.win and atlas_picker_opts.layout.wins[atlas_layout.win]
+      if
+        layout.box ~= "vertical"
         or layout[1].win ~= "preview"
         or layout[1].title ~= " Preview "
         or layout[1].width ~= nil
@@ -1638,10 +1664,7 @@ local function validate_sidekick_herdr()
       vim.api.nvim_win_set_height(atlas_preview.win, math.min(12, host_height - 2))
       atlas_picker_opts.on_show(fake_picker)
       local expected_preview_buf = render_preview(done_item)
-      expected_preview = table.concat(
-        vim.api.nvim_buf_get_lines(expected_preview_buf, 0, -1, false),
-        "\n"
-      )
+      expected_preview = table.concat(vim.api.nvim_buf_get_lines(expected_preview_buf, 0, -1, false), "\n")
       current_fake_item = atlas_item
       input_pattern = "pblocked"
       input_changed()
@@ -1652,8 +1675,11 @@ local function validate_sidekick_herdr()
       local move_down = atlas_picker_opts.win.input.keys["<Down>"]
       local heading_setup_swaps = preview_swaps
       move_up[1]()
-      vim.wait(1000, function() return preview_swaps > heading_setup_swaps end, 10)
-      if preview_swaps ~= heading_setup_swaps + 1
+      vim.wait(1000, function()
+        return preview_swaps > heading_setup_swaps
+      end, 10)
+      if
+        preview_swaps ~= heading_setup_swaps + 1
         or table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n") ~= "(no session)"
       then
         fail("T04 V01 workspace heading should render its empty default preview")
@@ -1663,20 +1689,20 @@ local function validate_sidekick_herdr()
       vim.wait(1000, function()
         return #lookup_calls > 0
           and preview_swaps > swaps_before
-          and table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
-            :find("Run atlas-rich-run", 1, true) ~= nil
+          and table
+              .concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
+              :find("Run atlas-rich-run", 1, true)
+            ~= nil
       end, 10)
 
       if #lookup_calls ~= 1 then
         fail(
-          "T10 V01 exact participant at "
-            .. size
-            .. " should invoke Atlas lookup exactly once; got "
-            .. #lookup_calls
+          "T10 V01 exact participant at " .. size .. " should invoke Atlas lookup exactly once; got " .. #lookup_calls
         )
       end
       local lookup = lookup_calls[1]
-      if lookup.item.workspace_id ~= "w1"
+      if
+        lookup.item.workspace_id ~= "w1"
         or lookup.item.tab_id ~= "w1:t5"
         or lookup.item.pane_id ~= "w1:p5"
         or lookup.item.terminal_id ~= "term-5"
@@ -1698,7 +1724,8 @@ local function validate_sidekick_herdr()
       local atlas_buf = atlas_preview.buf
       local rendered = table.concat(vim.api.nvim_buf_get_lines(atlas_buf, 0, -1, false), "\n")
       local rendered_fields = rendered:gsub("\n", "")
-      if vim.bo[atlas_buf].buftype ~= "terminal"
+      if
+        vim.bo[atlas_buf].buftype ~= "terminal"
         or not rendered_fields:find("Run atlas-rich-run", 1, true)
         or not rendered_fields:find("Goal 3/5", 1, true)
         or not rendered_fields:find("T10.V01", 1, true)
@@ -1709,7 +1736,8 @@ local function validate_sidekick_herdr()
       then
         fail("T10 V01 bottom-right Atlas preview is incomplete at " .. size .. ": " .. vim.inspect(rendered))
       end
-      if top_rendered ~= expected_preview
+      if
+        top_rendered ~= expected_preview
         or top_rendered:find("atlas-rich-run", 1, true)
         or top_rendered:find("T10.V01", 1, true)
         or top_rendered:find("verifier-steward", 1, true)
@@ -1730,15 +1758,14 @@ local function validate_sidekick_herdr()
       local layout_swaps = preview_swaps
       atlas_picker_opts.preview({ item = lookup.item, preview = fake_picker.preview })
       vim.wait(1000, function()
-        return table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
+        return table
+          .concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
           :find("Run atlas-rich-run", 1, true) ~= nil
       end, 10)
-      local layout_rendered = table.concat(
-        vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false),
-        "\n"
-      )
+      local layout_rendered = table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n")
       local layout_fields = layout_rendered:gsub("\n", "")
-      if preview_swaps ~= layout_swaps
+      if
+        preview_swaps ~= layout_swaps
         or fake_picker.preview.win.buf ~= top_buf
         or atlas_preview.buf == blank_layout_buf
         or not layout_fields:find("Run atlas-rich-run", 1, true)
@@ -1753,21 +1780,20 @@ local function validate_sidekick_herdr()
       end
 
       local active_atlas_buf = atlas_preview.buf
-      local active_atlas_bytes = table.concat(
-        vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false),
-        "\n"
-      )
+      local active_atlas_bytes = table.concat(vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false), "\n")
       local active_poll_swaps = preview_swaps
       read_result = "\27[32mT10 V03 active poll refresh\27[0m"
       vim.wait(1000, function()
         return preview_swaps > active_poll_swaps
-          and table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
-            :find("T10 V03 active poll refresh", 1, true) ~= nil
+          and table
+              .concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
+              :find("T10 V03 active poll refresh", 1, true)
+            ~= nil
       end, 10)
-      if preview_swaps <= active_poll_swaps
+      if
+        preview_swaps <= active_poll_swaps
         or atlas_preview.buf ~= active_atlas_buf
-        or table.concat(vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false), "\n")
-          ~= active_atlas_bytes
+        or table.concat(vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false), "\n") ~= active_atlas_bytes
       then
         fail("T10 V03 active Atlas should allow top Preview polling without changing its frame at " .. size)
       end
@@ -1781,15 +1807,17 @@ local function validate_sidekick_herdr()
         return last_read
           and last_read.lines == 2147483647
           and preview_swaps > active_full_swaps
-          and table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
-            :find("T10 V03 active full preview", 1, true) ~= nil
+          and table
+              .concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
+              :find("T10 V03 active full preview", 1, true)
+            ~= nil
       end, 10)
       atlas_picker_opts.actions.sidekick_preview_scroll_up()
-      if async_reads <= active_full_reads
+      if
+        async_reads <= active_full_reads
         or preview_swaps <= active_full_swaps
         or atlas_preview.buf ~= active_atlas_buf
-        or table.concat(vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false), "\n")
-          ~= active_atlas_bytes
+        or table.concat(vim.api.nvim_buf_get_lines(active_atlas_buf, 0, -1, false), "\n") ~= active_atlas_bytes
         or #lookup_calls ~= 1
       then
         fail("T10 V03 active full Preview should change without changing or repeating Atlas at " .. size)
@@ -1801,11 +1829,9 @@ local function validate_sidekick_herdr()
         return preview_swaps > heading_swaps
           and table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n") == ""
       end, 10)
-      local heading_bytes = table.concat(
-        vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
-        "\n"
-      )
-      if preview_swaps ~= heading_swaps + 1
+      local heading_bytes = table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
+      if
+        preview_swaps ~= heading_swaps + 1
         or heading_bytes ~= "(no session)"
         or table.concat(vim.api.nvim_buf_get_lines(atlas_preview.buf, 0, -1, false), "\n") ~= ""
         or #lookup_calls ~= 1
@@ -1829,14 +1855,8 @@ local function validate_sidekick_herdr()
     local protected_paths = {
       "nvim/.config/nvim/lua/plugins/sidekick/registry.lua",
     }
-    vim.list_extend(
-      protected_paths,
-      vim.fn.glob("scripts/fixtures/vault-hunter-atlas*/runs/*.json", false, true)
-    )
-    vim.list_extend(
-      protected_paths,
-      vim.fn.glob("scripts/fixtures/vault-hunter-atlas*/vault/**/*.md", false, true)
-    )
+    vim.list_extend(protected_paths, vim.fn.glob("scripts/fixtures/vault-hunter-atlas*/runs/*.json", false, true))
+    vim.list_extend(protected_paths, vim.fn.glob("scripts/fixtures/vault-hunter-atlas*/vault/**/*.md", false, true))
     local protected_bytes = {}
     for _, path in ipairs(protected_paths) do
       protected_bytes[path] = table.concat(vim.fn.readfile(path, "b"), "\n")
@@ -1891,14 +1911,14 @@ local function validate_sidekick_herdr()
     fallback_atlas:show()
     fallback_picker_opts.on_show(fake_picker)
     fallback_picker_opts.win.input.keys["<c-w>"][1]()
-    vim.wait(1000, function() return preview_swaps > baseline_swaps end, 10)
+    vim.wait(1000, function()
+      return preview_swaps > baseline_swaps
+    end, 10)
     if preview_swaps ~= baseline_swaps + 1 then
       fail("T04 V02 could not capture the unchanged default preview")
     end
-    local default_preview_bytes = table.concat(
-      vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
-      "\n"
-    )
+    local default_preview_bytes =
+      table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
 
     local fallback_cases = {
       "unregistered",
@@ -1924,23 +1944,14 @@ local function validate_sidekick_herdr()
         return preview_swaps > swaps_before
       end, 10)
       if fallback_calls[fallback_case] ~= 1 then
-        fallback_failures[#fallback_failures + 1] = string.format(
-          "%s invoked Atlas %d times",
-          fallback_case,
-          fallback_calls[fallback_case] or 0
-        )
+        fallback_failures[#fallback_failures + 1] =
+          string.format("%s invoked Atlas %d times", fallback_case, fallback_calls[fallback_case] or 0)
       end
       if preview_swaps ~= swaps_before + 1 then
-        fallback_failures[#fallback_failures + 1] = string.format(
-          "%s swapped the default preview %d times",
-          fallback_case,
-          preview_swaps - swaps_before
-        )
+        fallback_failures[#fallback_failures + 1] =
+          string.format("%s swapped the default preview %d times", fallback_case, preview_swaps - swaps_before)
       else
-        local actual = table.concat(
-          vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
-          "\n"
-        )
+        local actual = table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
         if actual ~= default_preview_bytes then
           fallback_failures[#fallback_failures + 1] = fallback_case .. " changed the default preview bytes"
         end
@@ -1956,14 +1967,17 @@ local function validate_sidekick_herdr()
     local fallback_layout_calls = fallback_calls.unregistered
     local fallback_layout_swaps = preview_swaps
     fallback_picker_opts.preview({ item = fallback_layout_item, preview = fake_picker.preview })
-    vim.wait(1000, function() return preview_swaps > fallback_layout_swaps end, 10)
+    vim.wait(1000, function()
+      return preview_swaps > fallback_layout_swaps
+    end, 10)
     fallback_picker_opts.preview({ item = fallback_layout_item, preview = fake_picker.preview })
-    vim.wait(1000, function() return preview_swaps > fallback_layout_swaps + 1 end, 10)
-    local fallback_layout_bytes = table.concat(
-      vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false),
-      "\n"
-    )
-    if fallback_calls.unregistered ~= fallback_layout_calls + 1
+    vim.wait(1000, function()
+      return preview_swaps > fallback_layout_swaps + 1
+    end, 10)
+    local fallback_layout_bytes =
+      table.concat(vim.api.nvim_buf_get_lines(fake_picker.preview.win.buf, 0, -1, false), "\n")
+    if
+      fallback_calls.unregistered ~= fallback_layout_calls + 1
       or preview_swaps ~= fallback_layout_swaps + 2
       or fallback_layout_bytes ~= default_preview_bytes
     then
@@ -2070,7 +2084,9 @@ local function validate_sidekick_herdr()
     current_fake_item = default_control
     local default_control_swaps = preview_swaps
     identity_picker_opts.preview({ item = default_control, preview = fake_picker.preview })
-    vim.wait(1000, function() return preview_swaps > default_control_swaps end, 10)
+    vim.wait(1000, function()
+      return preview_swaps > default_control_swaps
+    end, 10)
     if (identity_calls["default-control"] or 0) ~= 0 or preview_swaps ~= default_control_swaps + 1 then
       fail("T04 V03 default control should render once without an Atlas lookup")
     end
@@ -2080,16 +2096,15 @@ local function validate_sidekick_herdr()
     identity_picker_opts.actions.sidekick_preview_scroll_down()
     vim.wait(1000, function()
       local last_read = async_read_args[#async_read_args]
-      return last_read
-        and last_read.lines == 2147483647
-        and preview_swaps > default_full_swaps
+      return last_read and last_read.lines == 2147483647 and preview_swaps > default_full_swaps
     end, 10)
     local default_full_buf = fake_picker.preview.win.buf
     local default_full_bytes = preview_bytes()
     local default_layout_swaps = preview_swaps
     identity_picker_opts.preview({ item = default_control, preview = fake_picker.preview })
     vim.wait(200)
-    if async_reads <= default_full_reads
+    if
+      async_reads <= default_full_reads
       or preview_swaps ~= default_layout_swaps
       or fake_picker.preview.win.buf ~= default_full_buf
       or preview_bytes() ~= default_full_bytes
@@ -2100,44 +2115,64 @@ local function validate_sidekick_herdr()
     local identity_cases = {
       {
         label = "empty",
-        mutate = function(item) item._empty = true end,
+        mutate = function(item)
+          item._empty = true
+        end,
         expected = "(no session)",
       },
       {
         label = "workspace",
-        mutate = function(item) item._workspace = true end,
+        mutate = function(item)
+          item._workspace = true
+        end,
       },
       {
         label = "missing-workspace-id",
-        mutate = function(item) item.workspace_id = nil end,
+        mutate = function(item)
+          item.workspace_id = nil
+        end,
       },
       {
         label = "missing-tab-id",
-        mutate = function(item) item.tab_id = nil end,
+        mutate = function(item)
+          item.tab_id = nil
+        end,
       },
       {
         label = "missing-pane-id",
-        mutate = function(item) item.pane_id = nil end,
+        mutate = function(item)
+          item.pane_id = nil
+        end,
       },
       {
         label = "missing-terminal-id",
-        mutate = function(item) item.terminal_id = nil end,
+        mutate = function(item)
+          item.terminal_id = nil
+        end,
       },
       {
         label = "missing-session",
-        mutate = function(item) item.agent_session = nil end,
+        mutate = function(item)
+          item.agent_session = nil
+        end,
       },
       {
         label = "missing-session-source",
-        mutate = function(item) item.agent_session.source = nil end,
+        mutate = function(item)
+          item.agent_session.source = nil
+        end,
       },
       {
         label = "missing-session-kind",
-        mutate = function(item) item.agent_session.kind = nil end,
+        mutate = function(item)
+          item.agent_session.kind = nil
+        end,
       },
       {
         label = "missing-session-value",
-        mutate = function(item) item.agent_session.value = nil end,
+        mutate = function(item)
+          item.agent_session.value = nil
+        end,
       },
     }
     for _, identity_case in ipairs(identity_cases) do
@@ -2147,7 +2182,9 @@ local function validate_sidekick_herdr()
       current_fake_item = item
       local swaps_before = preview_swaps
       identity_picker_opts.preview({ item = item, preview = fake_picker.preview })
-      vim.wait(1000, function() return preview_swaps > swaps_before end, 10)
+      vim.wait(1000, function()
+        return preview_swaps > swaps_before
+      end, 10)
       if (identity_calls[identity_case.label] or 0) ~= 0 then
         fail("T04 V03 " .. identity_case.label .. " identity should perform zero Atlas lookups")
       end
@@ -2157,10 +2194,7 @@ local function validate_sidekick_herdr()
       local expected = identity_case.expected or v03_default_preview_bytes
       if preview_bytes() ~= expected then
         fail(
-          "T04 V03 "
-            .. identity_case.label
-            .. " identity changed the default preview: "
-            .. vim.inspect(preview_bytes())
+          "T04 V03 " .. identity_case.label .. " identity changed the default preview: " .. vim.inspect(preview_bytes())
         )
       end
     end
@@ -2176,16 +2210,20 @@ local function validate_sidekick_herdr()
     vim.wait(1000, function()
       return preview_swaps > control_swaps
         and control_atlas.buf ~= control_atlas_buf
-        and table.concat(vim.api.nvim_buf_get_lines(control_atlas.buf, 0, -1, false), "\n")
-          :find("Run atlas-v03-complete", 1, true) ~= nil
+        and table
+            .concat(vim.api.nvim_buf_get_lines(control_atlas.buf, 0, -1, false), "\n")
+            :find("Run atlas-v03-complete", 1, true)
+          ~= nil
     end, 10)
     if (identity_calls.complete or 0) ~= 1 or not identity_callbacks.complete then
       fail("T04 V03 complete identity control should perform exactly one Atlas lookup")
     end
-    if preview_swaps ~= control_swaps + 1
+    if
+      preview_swaps ~= control_swaps + 1
       or preview_bytes() ~= v03_default_preview_bytes
       or control_atlas.buf == control_atlas_buf
-      or not table.concat(vim.api.nvim_buf_get_lines(control_atlas.buf, 0, -1, false), "\n")
+      or not table
+        .concat(vim.api.nvim_buf_get_lines(control_atlas.buf, 0, -1, false), "\n")
         :find("Run atlas-v03-complete", 1, true)
     then
       fail("T04 V03 complete identity control should swap one matched dedicated Atlas preview")
@@ -2200,14 +2238,15 @@ local function validate_sidekick_herdr()
     if table.concat(vim.api.nvim_buf_get_lines(ordinary_atlas_buf, 0, -1, false), "\n") ~= "" then
       fail("T10 V02 matched-to-ordinary selection should clear Atlas immediately")
     end
-    vim.wait(1000, function() return preview_swaps > ordinary_swaps end, 10)
-    if (identity_calls["matched-to-ordinary"] or 0) ~= 0
+    vim.wait(1000, function()
+      return preview_swaps > ordinary_swaps
+    end, 10)
+    if
+      (identity_calls["matched-to-ordinary"] or 0) ~= 0
       or preview_swaps ~= ordinary_swaps + 1
       or preview_bytes() ~= v03_default_preview_bytes
-      or table.concat(
-        vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(control_atlas.win), 0, -1, false),
-        "\n"
-      ) ~= ""
+      or table.concat(vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(control_atlas.win), 0, -1, false), "\n")
+        ~= ""
     then
       fail("T10 V02 matched-to-ordinary selection should preserve ordinary top preview and empty Atlas")
     end
@@ -2237,21 +2276,17 @@ local function validate_sidekick_herdr()
     end
     local selection_atlas = selection_picker_opts.layout.wins.atlas
     local pending_atlas_buf = vim.api.nvim_win_get_buf(selection_atlas.win)
-    local pending_atlas_bytes = table.concat(
-      vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false),
-      "\n"
-    )
+    local pending_atlas_bytes = table.concat(vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false), "\n")
     local pending_poll_swaps = preview_swaps
     read_result = "\27[36mT10 V03 pending poll refresh\27[0m"
     vim.wait(1000, function()
-      return preview_swaps > pending_poll_swaps
-        and preview_bytes():find("T10 V03 pending poll refresh", 1, true) ~= nil
+      return preview_swaps > pending_poll_swaps and preview_bytes():find("T10 V03 pending poll refresh", 1, true) ~= nil
     end, 10)
-    if preview_swaps <= pending_poll_swaps
+    if
+      preview_swaps <= pending_poll_swaps
       or pending_atlas_bytes ~= ""
       or vim.api.nvim_win_get_buf(selection_atlas.win) ~= pending_atlas_buf
-      or table.concat(vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false), "\n")
-        ~= pending_atlas_bytes
+      or table.concat(vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false), "\n") ~= pending_atlas_bytes
     then
       fail("T10 V03 pending Atlas should allow top Preview polling while staying empty")
     end
@@ -2268,11 +2303,11 @@ local function validate_sidekick_herdr()
         and preview_bytes():find("T10 V03 pending full preview", 1, true) ~= nil
     end, 10)
     selection_picker_opts.actions.sidekick_preview_scroll_up()
-    if async_reads <= pending_full_reads
+    if
+      async_reads <= pending_full_reads
       or preview_swaps <= pending_full_swaps
       or vim.api.nvim_win_get_buf(selection_atlas.win) ~= pending_atlas_buf
-      or table.concat(vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false), "\n")
-        ~= pending_atlas_bytes
+      or table.concat(vim.api.nvim_buf_get_lines(pending_atlas_buf, 0, -1, false), "\n") ~= pending_atlas_bytes
     then
       fail("T10 V03 pending full Preview should change while displayed Atlas stays empty")
     end
@@ -2283,14 +2318,17 @@ local function validate_sidekick_herdr()
     current_fake_item = selection_default
     local selection_swaps = preview_swaps
     selection_picker_opts.preview({ item = selection_default, preview = fake_picker.preview })
-    vim.wait(1000, function() return preview_swaps > selection_swaps end, 10)
+    vim.wait(1000, function()
+      return preview_swaps > selection_swaps
+    end, 10)
     local selected_bytes = preview_bytes()
     local selected_atlas_buf = vim.api.nvim_win_get_buf(selection_atlas.win)
     local selected_buffers = valid_buffer_set()
     local selected_swaps = preview_swaps
     selection_callbacks["selection-late"](v03_result("selection-late"))
     vim.wait(100)
-    if (selection_cancels["selection-late"] or 0) ~= 1
+    if
+      (selection_cancels["selection-late"] or 0) ~= 1
       or preview_swaps ~= selected_swaps
       or preview_bytes() ~= selected_bytes
       or vim.api.nvim_win_get_buf(selection_atlas.win) ~= selected_atlas_buf
@@ -2314,7 +2352,9 @@ local function validate_sidekick_herdr()
     current_fake_item = after_stage_default
     selection_swaps = preview_swaps
     selection_picker_opts.preview({ item = after_stage_default, preview = fake_picker.preview })
-    vim.wait(1000, function() return preview_swaps > selection_swaps end, 10)
+    vim.wait(1000, function()
+      return preview_swaps > selection_swaps
+    end, 10)
     for _, buf in ipairs(selection_staging_buffers) do
       if vim.api.nvim_buf_is_valid(buf) then
         fail("T04 V03 selection change should delete an obsolete Atlas staging buffer")
@@ -2348,7 +2388,8 @@ local function validate_sidekick_herdr()
     close_v03_picker(close_picker_opts, close_workspace)
     close_callbacks["close-late"](v03_result("close-late"))
     vim.wait(100)
-    if (close_cancels["close-late"] or 0) ~= 1
+    if
+      (close_cancels["close-late"] or 0) ~= 1
       or preview_swaps ~= close_swaps
       or preview_bytes() ~= close_bytes
       or close_atlas:valid()
@@ -2381,10 +2422,7 @@ local function validate_sidekick_herdr()
         fail("T04 V03 picker close should delete an obsolete Atlas staging buffer")
       end
     end
-    if preview_swaps ~= close_swaps
-      or preview_bytes() ~= close_bytes
-      or staged_close_atlas:valid()
-    then
+    if preview_swaps ~= close_swaps or preview_bytes() ~= close_bytes or staged_close_atlas:valid() then
       fail("T04 V03 picker close should not swap an obsolete Atlas staging buffer")
     end
 
@@ -2431,7 +2469,8 @@ local function validate_sidekick_herdr()
     vim.api.nvim_tabpage_set_var(current_tab, "herdr_workspace_id", "missing")
     vim.api.nvim_tabpage_set_var(current_tab, "herdr_workspace_label", "Empty Workspace")
     cwd_picker.open()
-    if picker_opts.title ~= "Sidekick Sessions in Workspace: Empty Workspace"
+    if
+      picker_opts.title ~= "Sidekick Sessions in Workspace: Empty Workspace"
       or not picker_opts.items[1]
       or picker_opts.items[1].text ~= "(no named sessions in workspace)"
     then


### PR DESCRIPTION
## Intent

Complete and safely deliver Atlas T10 bottom-right Sidekick pane routing, including V03 polling and scrolling continuity, preserving V01/V02 lookup, fallback, navigation, kill, and read-only behavior, opening/updating the PR, and reaching CI-ready state without changing unrelated work.

## What Changed

- Add a bottom-right Atlas pane while retaining the full-width conversation preview.
- Preserve preview polling, scrolling, lookup fallback, navigation, and confirmed agent-kill behavior.
- Expand the Neovim verification harness and documentation for Atlas routing and continuity.

## Risk Assessment

✅ Low: The changes are well-bounded, preserve the required picker behaviors, and address the prior kill-refresh and expanded-preview continuity findings without introducing a substantiated source risk.

## Testing

The focused headless Neovim Sidekick harness exercised T10 bottom-right Atlas routing at two viewport sizes, V03 polling and scrolling continuity, and preserved lookup, fallback, navigation, kill, close, and read-only behavior; it completed successfully and produced rendered reviewer evidence. A native screenshot was unavailable because the deterministic harness runs Neovim headlessly, so actual terminal-buffer captures were rendered to HTML instead.

<details>
<summary>Evidence: Atlas T10 picker pane evidence</summary>

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8"><title>Atlas T10 Sidekick picker evidence</title>
<style>
:root { color-scheme: dark; } body { margin: 0; padding: 32px; background: #282828; color: #ebdbb2; font-family: ui-sans-serif, system-ui; }
h1 { color: #f28534; margin: 0 0 8px; } p { color: #bdae93; max-width: 900px; } .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:20px; margin-top:24px; }
figure { margin:0; background:#32302f; border:1px solid #665c54; border-radius:10px; overflow:hidden; } figcaption { padding:10px 14px; color:#e9b143; border-bottom:1px solid #665c54; font-weight:700; }
pre { margin:0; padding:16px; min-height:190px; color:#fbf1c7; background:#1d2021; font:15px/1.35 'JetBrains Mono',Menlo,monospace; white-space:pre; overflow:auto; }
.ok { color:#b8bb26; font-weight:700; } code {color:#80aa9e;}
</style></head><body>
<h1>Atlas T10 — bottom-right Sidekick pane</h1>
<p class="ok">Focused Neovim verifier passed.</p>
<p>These are rendered captures of the actual native terminal buffers produced by the Sidekick picker verification path. The harness also asserts the full-width ordinary Preview remains unchanged above the bottom row, Atlas uses the bottom-right pane's inner dimensions, polling and full-preview scrolling continue, fallbacks stay in ordinary Preview, stale callbacks are discarded, and navigation/close cleanup remains safe.</p>
<div class="grid">
<figure><figcaption>Atlas Preview — 100×30 host</figcaption><pre>Run atlas-rich-run · Goal 3/5 
T10.V01
Participant driver · Role veri
fier-steward
Lifecycle verify · active</pre></figure>
<figure><figcaption>Atlas Preview — 80×24 host</figcaption><pre>Run atlas-rich-run · Go
al 3/5 T10.V01
Participant driver · Ro
le verifier-steward
Lifecycle verify · acti
ve</pre></figure>
<figure><figcaption>Fallback — ordinary Preview restored</figcaption><pre>T04 V02 default preview bytes
second unchanged line</pre></figure>
</div>
<p>Generated from <code>T04_EVIDENCE_DIR=… scripts/verify-nvim sidekick-herdr</code>. A native screenshot was unavailable because the deterministic product harness runs Neovim headlessly; this rendered HTML preserves the captured user-facing terminal text and wrapping.</p>
</body></html>
```
</details>
<details>
<summary>Evidence: Matched Atlas pane at 100x30</summary>

```text
[1;36mRun atlas-rich-run · Goal 3/5 [0m
T10.V01
Participant driver · Role veri
fier-steward
Lifecycle verify · active
```
</details>
<details>
<summary>Evidence: Matched Atlas pane at 80x24</summary>

```text
[1;36mRun atlas-rich-run · Go[0m
al 3/5 T10.V01
Participant driver · Ro
le verifier-steward
Lifecycle verify · acti
ve
```
</details>
<details>
<summary>Evidence: Ordinary preview fallback restored</summary>

```text
[1;36mT04 V02 default preview bytes[0m
second unchanged line
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua:1222` - The required criterion says to preserve &#34;kill ... behavior&#34;, but this hunk adds a confirmation and removes the prior close-and-reopen refresh. After a successful kill, the static items/groups still show the dead agent and subsequent preview or activation targets it. Confirm whether this behavior change is intentional; otherwise restore the successful-kill refresh while retaining the selected pane ID.
- 🚨 `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua:1014` - A same-selection preview callback for an ordinary or incomplete-identity agent calls invalidate_preview() and then stages the bounded default preview even when expanded_preview_item is still selected. After full-preview scrolling, any layout/redraw callback therefore replaces the full buffer while leaving it marked expanded, breaking required scrolling continuity. Check the expanded-item guard before this invalidation, or clear only Atlas state without restaging the top preview.

🔧 Fix: Preserve kill refresh and expanded preview continuity
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `T04_EVIDENCE_DIR=/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/no-mistakes-evidence/01KYK3SMT8Y2KTD3NDRCSEW1DB scripts/verify-nvim sidekick-herdr`
- `Reviewed rendered 100x30 and 80x24 Atlas pane captures plus the ordinary-preview fallback capture.`
- `Confirmed polling, full-preview scrolling, lookup identity, fallback, navigation, kill confirmation, stale-result cleanup, close behavior, and read-only protected-file assertions in the focused harness.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
