### PR TITLE
Default Vault Hunter to visible Pi agents

### DIFF
--- a/.agents/skills/vault-hunter-worker/SKILL.md
+++ b/.agents/skills/vault-hunter-worker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vault-hunter-worker
-description: Run and monitor one bounded Vault Hunter or Vault Scout Codex worker in an exact one-pane Herdr tab, capture its opaque ownership tuple, return its handoff, and close or preserve only that worker as directed. Use only when Vault Hunter or Vault Scout delegates an interactive worker lifecycle.
+description: Run and monitor one bounded Vault Hunter or Vault Scout Pi worker in an exact one-pane Herdr tab, capture its opaque ownership tuple, return its handoff, and close or preserve only that worker as directed. Use only when Vault Hunter or Vault Scout delegates a visible worker lifecycle.
 ---
 
 # Vault Hunter Worker
@@ -42,10 +42,12 @@ The prompt may explicitly permit narrow follow-up reads. Otherwise its path allo
 3. Use `herdr tab create` with the supplied workspace, cwd, label, `--no-focus`, and
    `SIDEKICK_NAMED_SESSION=<feature-slug>-<run-key>-<role>`. Capture its returned tab and root-pane IDs. Do not split
    beside another pane.
-4. Use `herdr pane run` on that root pane to start
-   `codex --dangerously-bypass-approvals-and-sandbox <prompt>` with the prompt-file contents.
+4. Use `herdr pane run` on that root pane to start the Pi coding agent as
+   `pi --name <feature-slug>-<run-key>-<role> <prompt>` with the prompt-file contents supplied as the initial message.
+   Do not substitute another agent runtime unless the delegating parent records an explicit user request or a required
+   capability exception, such as Codex computer use.
 5. Wait for that pane's agent detection, then use `herdr agent rename` to name it
-   `codex-<feature-slug>-<run-key>-<role>`. Failure to detect the agent is a failed launch.
+   `pi-<feature-slug>-<run-key>-<role>`. Failure to detect the agent is a failed launch.
 6. Return one JSON object containing the exact workspace, tab, pane, terminal, agent, session, cwd, branch, and
    `pane_count`. Accept the launch only when the tuple matches and `pane_count=1`.
 7. Delete the prompt file after confirmed launch. If validation fails, close only the returned malformed tab, verify

--- a/.agents/skills/vault-hunter/SKILL.md
+++ b/.agents/skills/vault-hunter/SKILL.md
@@ -41,8 +41,10 @@ If any item is missing, invoke `$vault-scout` on the source Issue or supplied te
    `vault_hunter_run`, and `vault_hunter_record` as compatibility tools until generic Registry operations replace them.
 3. Bind the exact driver, repository, branch, worktree, and Herdr identity when present. A non-Pi or headless Run uses
    the same domain contract without inventing Herdr identity.
-4. The parent creates or reuses the Task-owned implementation worktree and any Herdr workspace required for interactive
-   workers; `$vault-hunter-worker` receives those exact resources and never provisions a route itself.
+4. The parent creates or reuses the Task-owned implementation worktree and a Herdr workspace for implementation,
+   review, verification, and delivery workers; `$vault-hunter-worker` receives those exact resources and never
+   provisions a route itself. Use a headless route only when the user explicitly requests it or Herdr cannot represent
+   the work, and record that exception before launch.
 5. Mark only this Task and Feature checklist item in progress, add one weekly backlog timeline, and use
    `$vault-hunter-checkpoint` for serialized vault commits.
 
@@ -68,12 +70,16 @@ certify a verifier or update canonical Goal, Task, or Feature state.
 
 ## Agent routing
 
-- Use the cheapest capable bounded worker for mechanical discovery, implementation, checks, and release work.
+- Default every delegated worker to the Pi coding agent (`pi`). Do not substitute Codex, Claude, or another runtime
+  unless the user explicitly requests it or the task requires a capability Pi cannot provide, such as Codex computer
+  use; record the reason before launch.
+- Launch implementation, review, verification, and delivery workers as visible, Herdr-tracked `$vault-hunter-worker`
+  sessions by default. Headless subagents are the exception for tiny read-only work where visibility adds no value, or
+  when the user explicitly requests them; never use a headless writer by default.
 - Give every child one Goal, exact inputs, an allowlist, validations, output shape, and stop conditions.
-- Use a fresh read-only agent for independent diff review. Pin base, head, tree, and Task contract; require findings with
-  severity and path/line, or an explicit clean verdict.
-- Use Herdr-visible `$vault-hunter-worker` only for interactive prototypes, manual UI validation, or work that genuinely
-  benefits from steering and resumption. Name it `<runtime>-<feature-slug>-<run-key>-<role>`.
+- Use a fresh read-only Pi agent for independent diff review. Pin base, head, tree, and Task contract; require findings
+  with severity and path/line, or an explicit clean verdict.
+- Name visible sessions `pi-<feature-slug>-<run-key>-<role>`.
 - Never run parallel writers in one worktree. Children may produce repository changes and evidence, but not vault
   status, acceptance, or completion decisions.
 


### PR DESCRIPTION
## Summary
- default Vault Hunter workers to the Pi coding agent
- make Herdr-visible sessions the implementation/review/verification/delivery default
- reserve headless and alternate runtimes for explicit exceptions

## No Mistakes
The installed No Mistakes skill now mirrors this policy, and `~/.no-mistakes/config.yaml` remains explicitly `agent: pi`.