### PR TITLE
Align Pi extensions with visible Vault Hunter workers

### DIFF
--- a/.agents/skills/wayfinder/SKILL.md
+++ b/.agents/skills/wayfinder/SKILL.md
@@ -102,7 +102,7 @@ Ruling something out of scope is a scoping act, not a step on the route. When a 
 
 ## Pi / Herdr / Codex sub-agents
 
-When running in Pi and the `wayfinder_subagents` tool is available, use it for AFK `wayfinder:research` and AFK `wayfinder:task` tickets that should run in parallel. Each task prompt must include the map name/link, ticket name/link, exact question, tracker-specific claim/report/close instructions, and a clear stop condition. The tool launches full interactive Codex TUIs as visible `codex-wf-*` sessions through Herdr that also fit the Neovim Sidekick named-session flow; do not launch them with non-interactive `codex exec`.
+When running in Pi and the `wayfinder_subagents` tool is available, use it for AFK `wayfinder:research` and AFK `wayfinder:task` tickets that should run in parallel. Each task prompt must include the map name/link, ticket name/link, exact question, tracker-specific claim/report/close instructions, and a clear stop condition. The tool launches full interactive Pi coding-agent TUIs as visible `pi-wf-*` sessions through Herdr that also fit the Neovim Sidekick named-session flow; use another runtime only when the user explicitly requests it or Pi lacks a required capability.
 
 The launcher monitors every session after startup:
 

--- a/pi/.pi/agent/extensions/subagent.ts
+++ b/pi/.pi/agent/extensions/subagent.ts
@@ -1,8 +1,8 @@
 /**
- * Minimal subagents extension.
+ * Minimal headless subagents extension.
  *
- * Registers a single `subagent` tool with three agents: scout, researcher, worker.
- * Supports single and parallel execution. Output is verbal only (no file handoff).
+ * Registers one configurable `subagent` tool for bounded read-only work.
+ * Write-capable agent configurations are rejected in favor of visible Herdr Pi sessions.
  */
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
@@ -1442,7 +1442,7 @@ export default function (pi: ExtensionAPI) {
 		promptSnippet: "Run subagents for delegated tasks",
 		promptGuidelines: [
 			"Parallel tool calls are your primary parallelism mechanism — put multiple independent read/fetch/search calls in one function_calls block. Don't use subagents to parallelize simple I/O.",
-			"Use subagent to delegate *reasoning and decisions*: codebase exploration (scout), web research (researcher), or isolated code changes (worker)",
+			"Use subagent only for bounded read-only reasoning or research. Launch implementation, verification, review, and delivery work as visible Herdr-tracked Pi sessions unless the user explicitly authorizes a headless exception.",
 			"For multiple independent subagent tasks, emit multiple `subagent` tool calls in the same turn — they run in parallel automatically.",
 			"Subagents run in the background; continue the driving conversation instead of waiting or polling for them.",
 			"Subagent completion is delivered back into the driving conversation automatically.",
@@ -1465,6 +1465,9 @@ export default function (pi: ExtensionAPI) {
 			if (!agent) {
 				const available = agents.map((a) => a.name).join(", ") || "none";
 				throw new Error(`Unknown agent: ${params.agent}. Available agents: ${available}`);
+			}
+			if (agent.tools.some((tool) => tool === "write" || tool === "edit")) {
+				throw new Error(`Headless writer ${params.agent} is disabled. Launch a visible Herdr-tracked Pi session instead.`);
 			}
 
 			const [provider, modelId] = (agent.model || "").split("/");

--- a/pi/.pi/agent/extensions/vault-hunter-agents.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-agents.ts
@@ -38,15 +38,6 @@ const agents: Agent[] = [
     filePath,
   },
   {
-    name: "worker",
-    description: "Implement one bounded change in the supplied worktree.",
-    tools: ["read", "write", "edit", "bash", "grep", "find", "ls"],
-    model: "openai-codex/gpt-5.6-sol",
-    thinking: "high",
-    systemPrompt: "Implement only the bounded task in the supplied worktree. Follow repository instructions, preserve unrelated state, run the requested checks, and report changed paths, commands, exit statuses, commit/tree, and remaining risks.",
-    filePath,
-  },
-  {
     name: "reviewer",
     description: "Independently review a bounded change without editing it.",
     tools: readOnlyTools,
@@ -68,7 +59,7 @@ export default function (pi: ExtensionAPI) {
       installed = true;
     }
     return {
-      systemPrompt: `${event.systemPrompt}\n\nThe only configured subagents are delegate, context-builder, worker, and reviewer. Use only those exact names.`,
+      systemPrompt: `${event.systemPrompt}\n\nThe only configured headless subagents are delegate, context-builder, and reviewer, and they are read-only. Use visible Herdr-tracked Pi sessions for implementation, verification, review, and delivery unless the user explicitly authorizes a headless exception.`,
     };
   });
 }

--- a/pi/.pi/agent/extensions/vault-hunter-run.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-run.ts
@@ -75,24 +75,6 @@ type DriverPlacement = {
   herdr: { workspaceId: string; tabId: string; paneId: string; terminalId: string };
   agentSession: { source: string; kind: string; value: string };
 };
-type PendingSubagent = {
-  runId: string;
-  startedAt: string;
-  agent: string;
-  taskSha256: string;
-  cwd: string;
-  observationKey: string;
-  parentSessionId: string;
-};
-type SubagentResult = {
-  agent?: string;
-  output?: string;
-  exitCode?: number;
-  model?: string;
-  usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; cost?: number; turns?: number };
-  progress?: { durationMs?: number; toolCount?: number; error?: string };
-};
-
 function now(): string { return new Date().toISOString(); }
 function slug(value: string): string { return value.replace(/[^A-Za-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "run"; }
 function sha256(value: string): string { return createHash("sha256").update(value).digest("hex"); }
@@ -104,10 +86,6 @@ function restoredRunId(ctx: ExtensionContext): string | undefined {
     if (typeof runId === "string" && runId) return runId;
   }
   return undefined;
-}
-function subagentResult(details: unknown): SubagentResult | undefined {
-  const results = (details as { results?: unknown } | undefined)?.results;
-  return Array.isArray(results) ? results[0] as SubagentResult | undefined : undefined;
 }
 function parentUsage(ctx: ExtensionContext) {
   const totals = { input: 0, output: 0, cache_read: 0, cache_write: 0, total_tokens: 0, cost: 0, requests: 0 };
@@ -266,7 +244,6 @@ function registry(input: Record<string, unknown>, signal?: AbortSignal): Promise
 export default function (pi: ExtensionAPI) {
   let activeRunId: string | undefined;
   let registrationQueue = Promise.resolve();
-  const pendingSubagents = new Map<string, PendingSubagent>();
 
   async function observe(input: Record<string, unknown>, ctx: ExtensionContext): Promise<void> {
     try { await registry(input); }
@@ -287,50 +264,12 @@ export default function (pi: ExtensionAPI) {
     }, ctx);
   }
 
-  async function reconcileInterrupted(runId: string, ctx: ExtensionContext): Promise<void> {
-    let run: any;
-    try { run = await registry({ action: "get", root: REGISTRY_ROOT, run_id: runId }); }
-    catch { return; }
-    const parentSessionId = ctx.sessionManager.getSessionId();
-    const terminal = new Set((run.lifecycle ?? []).map((item: any) => item.observation_id));
-    for (const item of run.lifecycle ?? []) {
-      if (item.kind !== "subagent/started") continue;
-      let detail: any;
-      try { detail = JSON.parse(item.detail); } catch { continue; }
-      if (detail?.parent_session_id !== parentSessionId) continue;
-      const match = String(item.observation_id).match(/^subagent-(.+)-started$/);
-      if (!match || terminal.has(`subagent-${match[1]}-finished`) || terminal.has(`subagent-${match[1]}-interrupted`)) continue;
-      const observedAt = now();
-      await observe({
-        action: "append", root: REGISTRY_ROOT, run_id: runId, updated_at: observedAt,
-        lifecycle: {
-          observation_id: `subagent-${match[1]}-interrupted`, observed_at: observedAt, kind: "subagent/interrupted",
-          goal_id: item.goal_id, state: "interrupted",
-          detail: JSON.stringify({ schema: "vault-hunter-subagent/v1", tool_call_id: detail.tool_call_id, parent_session_id: parentSessionId, started_at: item.observed_at, ended_at: observedAt, reason: "session-recovery" }),
-        },
-      }, ctx);
-    }
-  }
-
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", (_event, ctx) => {
     activeRunId = restoredRunId(ctx);
-    if (activeRunId) await reconcileInterrupted(activeRunId, ctx);
   });
 
   pi.on("session_shutdown", async (event, ctx) => {
     if (!activeRunId) return;
-    for (const [toolCallId, pending] of pendingSubagents) {
-      const observedAt = now();
-      await observe({
-        action: "append", root: REGISTRY_ROOT, run_id: pending.runId, updated_at: observedAt,
-        lifecycle: {
-          observation_id: `subagent-${pending.observationKey}-interrupted`, observed_at: observedAt, kind: "subagent/interrupted",
-          goal_id: `subagent/${pending.agent}`, state: "interrupted",
-          detail: JSON.stringify({ schema: "vault-hunter-subagent/v1", tool_call_id: toolCallId, parent_session_id: pending.parentSessionId, started_at: pending.startedAt, ended_at: observedAt, reason: `session-${event.reason}` }),
-        },
-      }, ctx);
-    }
-    pendingSubagents.clear();
     const key = sha256(`${ctx.sessionManager.getSessionId()}:${event.reason}:${ctx.sessionManager.getLeafId() ?? "root"}`).slice(0, 20);
     await recordParentUsage(activeRunId, `session/${event.reason}`, key, ctx);
   });
@@ -353,10 +292,9 @@ export default function (pi: ExtensionAPI) {
     parameters: Type.Object({}),
     async execute(_id, _params, signal, _update, ctx) {
       const placement = await driverPlacement(pi, ctx, signal);
-      if (!pi.getActiveTools().includes("subagent")) throw new Error("The required synchronous subagent tool is not active.");
       return text("Vault Hunter driver preflight passed.", {
         sessionId: ctx.sessionManager.getSessionId(), sessionFile: ctx.sessionManager.getSessionFile(),
-        cwd: ctx.cwd, herdr: placement?.herdr, subagent: "active",
+        cwd: ctx.cwd, herdr: placement?.herdr, workerRuntime: "visible-herdr-pi",
       });
     },
   });
@@ -410,65 +348,6 @@ export default function (pi: ExtensionAPI) {
         });
       });
     },
-  });
-
-  pi.on("tool_call", async (event, ctx) => {
-    if (event.toolName !== "subagent" || !activeRunId) return;
-    const agent = typeof event.input.agent === "string" ? event.input.agent : "unknown";
-    const task = typeof event.input.task === "string" ? event.input.task : "";
-    const startedAt = now();
-    const parentSessionId = ctx.sessionManager.getSessionId();
-    const observationKey = sha256(`${parentSessionId}:${event.toolCallId}`).slice(0, 20);
-    const pending = {
-      runId: activeRunId, startedAt, agent, taskSha256: sha256(task),
-      cwd: typeof event.input.cwd === "string" ? event.input.cwd : ctx.cwd,
-      observationKey, parentSessionId,
-    };
-    pendingSubagents.set(event.toolCallId, pending);
-    await observe({
-      action: "append", root: REGISTRY_ROOT, run_id: pending.runId, updated_at: startedAt,
-      participant: {
-        participant_id: `headless-${observationKey}`, observed_at: startedAt, role: agent, goal_id: `subagent/${agent}`,
-        herdr: null, agent_session: { source: "pi-subagents", kind: "tool-call", value: event.toolCallId },
-      },
-      lifecycle: {
-        observation_id: `subagent-${observationKey}-started`, observed_at: startedAt, kind: "subagent/started",
-        goal_id: `subagent/${agent}`, state: "running",
-        detail: JSON.stringify({ schema: "vault-hunter-subagent/v1", tool_call_id: event.toolCallId, parent_session_id: parentSessionId, agent, task_sha256: pending.taskSha256, cwd: pending.cwd }),
-      },
-    }, ctx);
-  });
-
-  pi.on("tool_result", async (event, ctx) => {
-    if (event.toolName !== "subagent") return;
-    const pending = pendingSubagents.get(event.toolCallId);
-    if (!pending) return;
-    pendingSubagents.delete(event.toolCallId);
-    const endedAt = now();
-    const result = subagentResult(event.details);
-    const usage = result?.usage;
-    const output = result?.output ?? event.content.filter((item) => item.type === "text").map((item) => item.text).join("\n");
-    const failed = event.isError || result?.exitCode !== undefined && result.exitCode !== 0 || !!result?.progress?.error;
-    await observe({
-      action: "append", root: REGISTRY_ROOT, run_id: pending.runId, updated_at: endedAt,
-      lifecycle: {
-        observation_id: `subagent-${pending.observationKey}-finished`, observed_at: endedAt, kind: "subagent/finished",
-        goal_id: `subagent/${pending.agent}`, state: failed ? "failed" : "completed",
-        detail: JSON.stringify({
-          schema: "vault-hunter-subagent/v1", tool_call_id: event.toolCallId, parent_session_id: pending.parentSessionId,
-          agent: pending.agent, model: result?.model ?? "", task_sha256: pending.taskSha256, result_sha256: sha256(output),
-          cwd: pending.cwd, started_at: pending.startedAt, ended_at: endedAt,
-          duration_ms: result?.progress?.durationMs ?? Date.parse(endedAt) - Date.parse(pending.startedAt),
-          exit_status: result?.exitCode ?? (failed ? 1 : 0), tool_count: result?.progress?.toolCount ?? 0,
-          usage: {
-            input: usage?.input ?? 0, output: usage?.output ?? 0, cache_read: usage?.cacheRead ?? 0,
-            cache_write: usage?.cacheWrite ?? 0, total_tokens: (usage?.input ?? 0) + (usage?.output ?? 0) + (usage?.cacheRead ?? 0) + (usage?.cacheWrite ?? 0),
-            cost: usage?.cost ?? 0, turns: usage?.turns ?? 0,
-          },
-          error: result?.progress?.error ?? "",
-        }),
-      },
-    }, ctx);
   });
 
   pi.on("tool_result", async (event, ctx) => {

--- a/pi/.pi/agent/extensions/wayfinder-subagents.ts
+++ b/pi/.pi/agent/extensions/wayfinder-subagents.ts
@@ -20,7 +20,7 @@ const TaskSchema = Type.Object({
   title: Type.String({ description: "Human-readable Wayfinder ticket title." }),
   prompt: Type.String({ description: "Complete prompt for the sub-agent" }),
   cwd: Type.Optional(Type.String({ description: "Working directory for this sub-agent. Defaults to current cwd." })),
-  model: Type.Optional(Type.String({ description: "Optional Codex model ID." })),
+  model: Type.Optional(Type.String({ description: "Optional Pi model ID." })),
 });
 
 const ParamsSchema = Type.Object({
@@ -98,13 +98,13 @@ function names(map: Params["map"], task: Params["tasks"][number]) {
     workspaceLabel: `Wayfinder · ${map.title}`,
     tabLabel: `${typeLabel} · ${task.ticketId} · ${shorten(task.title)}`,
     slug,
-    agentName: `codex-${slug}`,
+    agentName: `pi-${slug}`,
   };
 }
 
 function makePrompt(map: Params["map"], task: Params["tasks"][number]): string {
   return [
-    "You are a Wayfinder sub-agent running in your own Codex session.",
+    "You are a Wayfinder sub-agent running in your own visible Pi coding-agent session.",
     "Resolve exactly the task below. Do not broaden scope.",
     "If this is a Wayfinder research ticket, record findings on the ticket/map exactly as the Wayfinder skill requires.",
     "If blocked, keep the ticket and session open and begin your final response with `BLOCKED:` followed by the reason.",
@@ -266,13 +266,13 @@ export default function (pi: ExtensionAPI) {
     name: "wayfinder_subagents",
     label: "Wayfinder Subagents",
     description: [
-      "Launch Wayfinder sub-agent Codex sessions with the full interactive TUI through Herdr.",
+      "Launch Wayfinder sub-agent Pi coding-agent sessions with the full interactive TUI through Herdr.",
       "Use this after creating Wayfinder research/task tickets that can run AFK in parallel.",
       "Each map gets a dedicated Herdr workspace and each ticket gets its own tab.",
-      "Sessions use deterministic codex-wf-<map>-<type>-<ticket>-<title> names for Neovim Sidekick.",
+      "Sessions use deterministic pi-wf-<map>-<type>-<ticket>-<title> names for Neovim Sidekick.",
       "Completed sessions are terminated after evidence capture; blocked sessions remain open and the parent receives a summary.",
     ].join(" "),
-    promptSnippet: "Launch AFK Wayfinder research/task sub-agents as full interactive Herdr Codex sessions.",
+    promptSnippet: "Launch AFK Wayfinder research/task sub-agents as full interactive Herdr Pi sessions.",
     promptGuidelines: [
       "Use wayfinder_subagents only for AFK Wayfinder research/task tickets; do not use it for HITL grilling/prototype tickets.",
       "When using wayfinder_subagents, pass the map title plus each ticket's type and tracker ID as structured fields.",
@@ -297,7 +297,7 @@ export default function (pi: ExtensionAPI) {
         const identity = names(params.map, task);
         const cwd = task.cwd ?? ctx.cwd;
         const placement = await preparePlacement(identity.workspaceLabel, identity.tabLabel, cwd, signal);
-        const command = ["codex", "--dangerously-bypass-approvals-and-sandbox"];
+        const command = ["pi", "--name", identity.slug];
         if (task.model) command.push("--model", task.model);
         command.push(makePrompt(params.map, task));
 


### PR DESCRIPTION
## Summary
- reject write-capable headless subagents and remove Vault Hunter’s headless worker registration
- remove stale generic-subagent lifecycle inference from the Run adapter
- launch Wayfinder AFK sessions as visible Herdr-tracked Pi agents
- update Wayfinder skill text to match

## Verification
- all changed extensions load together through Pi in offline mode
- diff check passes
- static audit finds no stale Codex-launch or inferred subagent-lifecycle paths