### PR TITLE
feat(pi): add live Atlas evidence rail prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ cd ~/.pi/agent/npm
 npm install
 ```
 
+Use `/atlas-rail-prototype` in Pi's interactive TUI to open the disposable Atlas T02.V01 evidence-rail fixture. It
+uses the active theme, requires at least 80 columns, and never persists data or mutates the Run Registry. Navigate
+stages with `j`/`k` or the arrow keys, toggle details with Enter, and close with `q` or Escape.
+
 Pi's read-only No Mistakes timeline polls `no-mistakes axi status` and displays the nine AXI phases below the editor when the current repository has a run. Use `/no-mistakes-timeline` to toggle it, or pass `on`, `off`, or `refresh`; the widget stays hidden when no run exists.
 
 For Pi over WhatsApp, copy `~/.config/pi-whatsapp.env.example` to `~/.config/pi-whatsapp.env`, fill in the allowed chat IDs, then enable the user services:

--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ cd ~/.pi/agent/npm
 npm install
 ```
 
-Use `/atlas-rail-prototype` in Pi's interactive TUI to open the disposable Atlas T02.V01 evidence-rail fixture. It
-uses the active theme, requires at least 80 columns, and never persists data or mutates the Run Registry. Navigate
-stages with `j`/`k` or the arrow keys, toggle details with Enter, and close with `q` or Escape.
+Use `/atlas-rail-prototype` in Pi's interactive TUI to open the disposable Atlas evidence rail for the active Vault
+Hunter Run bound to the current Pi session. It uses the active theme, requires at least 80 columns, and reads without
+mutating the Run Registry. Navigate stages with `j`/`k` or the arrow keys, toggle details with Enter, toggle the latest
+eight versus all steps locally with Ctrl+V, and close with `q` or Escape.
 
 Pi's read-only No Mistakes timeline polls `no-mistakes axi status` and displays the nine AXI phases below the editor when the current repository has a run. Use `/no-mistakes-timeline` to toggle it, or pass `on`, `off`, or `refresh`; the widget stays hidden when no run exists.
 

--- a/README.md
+++ b/README.md
@@ -70,28 +70,28 @@ terraform -chdir=ops/devbox destroy \
 
 ## Stow Packages
 
-| Package | Description |
-|---------|-------------|
-| `aerospace` | AeroSpace tiling window manager |
-| `agents` | Shared agent skills |
-| `blinksh` | Blink Shell (iOS terminal) config |
-| `claude` | Claude AI context files |
-| `code` | Code snippets (Golang, Lua) |
-| `ghostty` | Ghostty terminal emulator |
-| `herdr` | Agent workspaces, notifications, and sound configuration |
-| `git` | Git configuration |
-| `kube` | Kubernetes configuration |
-| `launchd` | macOS user LaunchAgents (vault and dotfiles auto-sync) |
-| `neovide` | Neovide (Neovim GUI) config |
-| `nvim` | Neovim with LazyVim |
-| `ssh` | SSH configuration |
-| `starship` | Starship prompt |
-| `systemd` | User systemd units (vault/dotfiles auto-sync, Pi/WhatsApp/Telegram bridges) |
-| `pi` | Pi agent config, packages, themes, and messaging daemons |
-| `terminfo` | Custom terminfo entries |
-| `tmux` | Tmux configuration |
-| `tmuxinator` | Tmuxinator session templates |
-| `zsh` | Zsh shell configuration |
+| Package      | Description                                                                 |
+| ------------ | --------------------------------------------------------------------------- |
+| `aerospace`  | AeroSpace tiling window manager                                             |
+| `agents`     | Shared agent skills                                                         |
+| `blinksh`    | Blink Shell (iOS terminal) config                                           |
+| `claude`     | Claude AI context files                                                     |
+| `code`       | Code snippets (Golang, Lua)                                                 |
+| `ghostty`    | Ghostty terminal emulator                                                   |
+| `herdr`      | Agent workspaces, notifications, and sound configuration                    |
+| `git`        | Git configuration                                                           |
+| `kube`       | Kubernetes configuration                                                    |
+| `launchd`    | macOS user LaunchAgents (vault and dotfiles auto-sync)                      |
+| `neovide`    | Neovide (Neovim GUI) config                                                 |
+| `nvim`       | Neovim with LazyVim                                                         |
+| `ssh`        | SSH configuration                                                           |
+| `starship`   | Starship prompt                                                             |
+| `systemd`    | User systemd units (vault/dotfiles auto-sync, Pi/WhatsApp/Telegram bridges) |
+| `pi`         | Pi agent config, packages, themes, and messaging daemons                    |
+| `terminfo`   | Custom terminfo entries                                                     |
+| `tmux`       | Tmux configuration                                                          |
+| `tmuxinator` | Tmuxinator session templates                                                |
+| `zsh`        | Zsh shell configuration                                                     |
 
 ## Git auto-sync services
 

--- a/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
+++ b/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
@@ -124,10 +124,7 @@ class EvidenceRailPrototype {
 
     row(
       this.theme.fg("warning", this.theme.bold("Run timeline")),
-      this.theme.fg(
-        "warning",
-        this.theme.bold(`Selected · ${selected.label}`),
-      ),
+      this.theme.fg("warning", this.theme.bold(`Selected · ${selected.label}`)),
     );
     row(
       this.theme.fg("muted", "2 complete · 1 active · 2 pending"),
@@ -142,8 +139,14 @@ class EvidenceRailPrototype {
     STAGES.forEach((stage, index) => {
       const last = index === STAGES.length - 1;
       const connector = last ? " └─ " : " ├─ ";
-      const glyph = stage.state === "done" ? "✓" : stage.state === "active" ? "◉" : "○";
-      const color = stage.state === "done" ? "success" : stage.state === "active" ? "warning" : "muted";
+      const glyph =
+        stage.state === "done" ? "✓" : stage.state === "active" ? "◉" : "○";
+      const color =
+        stage.state === "done"
+          ? "success"
+          : stage.state === "active"
+            ? "warning"
+            : "muted";
       let stageText =
         this.theme.fg("dim", connector) +
         this.theme.fg(color, ` ${glyph} ${stage.label} `);
@@ -160,7 +163,10 @@ class EvidenceRailPrototype {
       const childConnector = last ? "     " : " │   ";
       row(
         this.theme.fg("dim", childConnector + "└─ ") +
-          this.theme.fg(index === this.selected ? "accent" : "muted", stage.summary),
+          this.theme.fg(
+            index === this.selected ? "accent" : "muted",
+            stage.summary,
+          ),
         rightRows[rightIndex++] ?? "",
       );
     });
@@ -172,7 +178,10 @@ class EvidenceRailPrototype {
     lines.push(rule());
     row(
       this.theme.fg("dim", "j/k select · Enter expand · q quit"),
-      this.theme.fg("dim", `recorded snapshot · ${frameWidth}×${lines.length + 2}`),
+      this.theme.fg(
+        "dim",
+        `recorded snapshot · ${frameWidth}×${lines.length + 2}`,
+      ),
     );
 
     return lines.map((line) => truncateToWidth(line, width, ""));
@@ -181,7 +190,9 @@ class EvidenceRailPrototype {
   private detailRows(stage: Stage): string[] {
     const th = this.theme;
     const rows = [
-      th.fg("muted", "12:01  ") + th.fg("syntaxNumber", " ○ ") + "verifier queued ",
+      th.fg("muted", "12:01  ") +
+        th.fg("syntaxNumber", " ○ ") +
+        "verifier queued ",
       th.fg("muted", "12:05  ") +
         th.bg("selectedBg", th.fg("warning", th.bold(" ◉ verifier active "))),
       th.fg("accent", "       Rendering deterministic snapshots"),
@@ -198,21 +209,38 @@ class EvidenceRailPrototype {
     if (stage.label !== "T02.V01") {
       return [
         th.fg("muted", "Recorded stage"),
-        th.bg("customMessageBg", th.fg("customMessageLabel", ` ${stage.label} `)),
-        th.fg("muted", " state       ") + th.fg(stage.state === "done" ? "success" : stage.state === "active" ? "warning" : "muted", stage.state),
+        th.bg(
+          "customMessageBg",
+          th.fg("customMessageLabel", ` ${stage.label} `),
+        ),
+        th.fg("muted", " state       ") +
+          th.fg(
+            stage.state === "done"
+              ? "success"
+              : stage.state === "active"
+                ? "warning"
+                : "muted",
+            stage.state,
+          ),
         th.fg("muted", " summary     ") + th.fg("text", stage.summary),
       ];
     }
 
     return [
       ...rows,
-      th.bg("customMessageBg", th.fg("customMessageLabel", th.bold(" Result capsule "))),
+      th.bg(
+        "customMessageBg",
+        th.fg("customMessageLabel", th.bold(" Result capsule ")),
+      ),
       th.fg("muted", " outcome     ") + th.fg("error", th.bold("failed")),
       th.fg("muted", " phase       ") + th.fg("syntaxNumber", "baseline"),
       th.fg("muted", " reproduce"),
       th.fg("mdLink", " scripts/verify-vault-hunter-atlas T02.V01"),
       th.fg("muted", " artifact    ") + th.fg("syntaxNumber", "aaaaaaaaaaaa…"),
-      th.bg("customMessageBg", th.fg("customMessageLabel", th.bold(" Ownership "))),
+      th.bg(
+        "customMessageBg",
+        th.fg("customMessageLabel", th.bold(" Ownership ")),
+      ),
       th.fg("muted", " driver      ") + "implementer",
       th.fg("muted", " review      ") + "reviewer",
       th.fg("muted", " authority   ") + th.fg("mdLink", "observation only"),
@@ -227,12 +255,16 @@ export default function atlasEvidenceRailPrototype(pi: ExtensionAPI) {
     description: "Open the disposable Atlas evidence-forward rail",
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
       if (ctx.mode !== "tui") {
-        ctx.ui.notify("The Atlas rail prototype requires interactive TUI mode.", "warning");
+        ctx.ui.notify(
+          "The Atlas rail prototype requires interactive TUI mode.",
+          "warning",
+        );
         return;
       }
 
-      await ctx.ui.custom<void>((tui, theme, _keybindings, done) =>
-        new EvidenceRailPrototype(theme, () => tui.requestRender(), done),
+      await ctx.ui.custom<void>(
+        (tui, theme, _keybindings, done) =>
+          new EvidenceRailPrototype(theme, () => tui.requestRender(), done),
       );
     },
   });

--- a/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
+++ b/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
@@ -1,0 +1,239 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  Theme,
+} from "@earendil-works/pi-coding-agent";
+import {
+  Key,
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
+
+type Stage = {
+  label: string;
+  state: "done" | "active" | "pending";
+  summary: string;
+};
+
+const STAGES: Stage[] = [
+  { label: "Admission", state: "done", summary: "Registry fixture loaded" },
+  {
+    label: "Checkpoint one",
+    state: "done",
+    summary: "Human approval recorded",
+  },
+  {
+    label: "T02.V01",
+    state: "active",
+    summary: "Snapshot verification running",
+  },
+  { label: "Review", state: "pending", summary: "Awaiting verification" },
+  { label: "Delivery", state: "pending", summary: "Not started" },
+];
+
+function pad(text: string, width: number): string {
+  const clipped = truncateToWidth(text, width, "…");
+  return clipped + " ".repeat(Math.max(0, width - visibleWidth(clipped)));
+}
+
+class EvidenceRailPrototype {
+  private selected = 2;
+  private expanded = true;
+
+  constructor(
+    private readonly theme: Theme,
+    private readonly requestRender: () => void,
+    private readonly done: () => void,
+  ) {}
+
+  handleInput(data: string): void {
+    if (
+      matchesKey(data, "q") ||
+      matchesKey(data, Key.escape) ||
+      matchesKey(data, Key.ctrl("c"))
+    ) {
+      this.done();
+      return;
+    }
+
+    if (
+      (matchesKey(data, "j") || matchesKey(data, Key.down)) &&
+      this.selected < STAGES.length - 1
+    ) {
+      this.selected += 1;
+      this.requestRender();
+      return;
+    }
+
+    if (
+      (matchesKey(data, "k") || matchesKey(data, Key.up)) &&
+      this.selected > 0
+    ) {
+      this.selected -= 1;
+      this.requestRender();
+      return;
+    }
+
+    if (matchesKey(data, Key.enter)) {
+      this.expanded = !this.expanded;
+      this.requestRender();
+    }
+  }
+
+  render(width: number): string[] {
+    if (width < 80) {
+      return [
+        this.theme.fg(
+          "warning",
+          truncateToWidth("Atlas rail prototype requires 80 columns", width),
+        ),
+      ];
+    }
+
+    const frameWidth = Math.min(width, 115);
+    const leftWidth = Math.max(30, Math.floor((frameWidth - 3) * 0.39));
+    const rightWidth = frameWidth - leftWidth - 3;
+    const selected = STAGES[this.selected]!;
+    const lines: string[] = [];
+
+    const row = (left = "", right = "") => {
+      lines.push(
+        pad(left, leftWidth) +
+          this.theme.fg("dim", " │ ") +
+          pad(right, rightWidth),
+      );
+    };
+
+    const rule = () =>
+      this.theme.fg(
+        "dim",
+        "─".repeat(leftWidth) + "─┼─" + "─".repeat(rightWidth),
+      );
+
+    const title =
+      this.theme.fg("accent", this.theme.bold("VAULT HUNTER")) +
+      "  " +
+      this.theme.fg("text", this.theme.bold("T02.V01")) +
+      this.theme.fg("muted", " · atlas-rich-run");
+    const activeBadge = this.theme.bg(
+      "toolSuccessBg",
+      this.theme.fg("success", this.theme.bold(" ACTIVE ")),
+    );
+    lines.push(pad(title, frameWidth - 8) + activeBadge);
+
+    row(
+      this.theme.fg("warning", this.theme.bold("Run timeline")),
+      this.theme.fg(
+        "warning",
+        this.theme.bold(`Selected · ${selected.label}`),
+      ),
+    );
+    row(
+      this.theme.fg("muted", "2 complete · 1 active · 2 pending"),
+      this.theme.fg("muted", selected.summary),
+    );
+    lines.push(rule());
+
+    const rightRows = this.detailRows(selected);
+    let rightIndex = 0;
+
+    row(this.theme.fg("dim", " │"), rightRows[rightIndex++] ?? "");
+    STAGES.forEach((stage, index) => {
+      const last = index === STAGES.length - 1;
+      const connector = last ? " └─ " : " ├─ ";
+      const glyph = stage.state === "done" ? "✓" : stage.state === "active" ? "◉" : "○";
+      const color = stage.state === "done" ? "success" : stage.state === "active" ? "warning" : "muted";
+      let stageText =
+        this.theme.fg("dim", connector) +
+        this.theme.fg(color, ` ${glyph} ${stage.label} `);
+      if (index === this.selected) {
+        stageText =
+          this.theme.fg("dim", connector) +
+          this.theme.bg(
+            "selectedBg",
+            this.theme.fg(color, this.theme.bold(` ${glyph} ${stage.label} `)),
+          );
+      }
+      row(stageText, rightRows[rightIndex++] ?? "");
+
+      const childConnector = last ? "     " : " │   ";
+      row(
+        this.theme.fg("dim", childConnector + "└─ ") +
+          this.theme.fg(index === this.selected ? "accent" : "muted", stage.summary),
+        rightRows[rightIndex++] ?? "",
+      );
+    });
+
+    while (rightIndex < rightRows.length) {
+      row("", rightRows[rightIndex++] ?? "");
+    }
+
+    lines.push(rule());
+    row(
+      this.theme.fg("dim", "j/k select · Enter expand · q quit"),
+      this.theme.fg("dim", `recorded snapshot · ${frameWidth}×${lines.length + 2}`),
+    );
+
+    return lines.map((line) => truncateToWidth(line, width, ""));
+  }
+
+  private detailRows(stage: Stage): string[] {
+    const th = this.theme;
+    const rows = [
+      th.fg("muted", "12:01  ") + th.fg("syntaxNumber", " ○ ") + "verifier queued ",
+      th.fg("muted", "12:05  ") +
+        th.bg("selectedBg", th.fg("warning", th.bold(" ◉ verifier active "))),
+      th.fg("accent", "       Rendering deterministic snapshots"),
+      th.fg("muted", "12:05  ") +
+        th.bg(
+          "toolErrorBg",
+          th.fg("error", th.bold(" ! baseline evidence · failed · exit 1 ")),
+        ),
+      th.fg("error", "       Expected baseline-red result"),
+    ];
+
+    if (!this.expanded) return rows;
+
+    if (stage.label !== "T02.V01") {
+      return [
+        th.fg("muted", "Recorded stage"),
+        th.bg("customMessageBg", th.fg("customMessageLabel", ` ${stage.label} `)),
+        th.fg("muted", " state       ") + th.fg(stage.state === "done" ? "success" : stage.state === "active" ? "warning" : "muted", stage.state),
+        th.fg("muted", " summary     ") + th.fg("text", stage.summary),
+      ];
+    }
+
+    return [
+      ...rows,
+      th.bg("customMessageBg", th.fg("customMessageLabel", th.bold(" Result capsule "))),
+      th.fg("muted", " outcome     ") + th.fg("error", th.bold("failed")),
+      th.fg("muted", " phase       ") + th.fg("syntaxNumber", "baseline"),
+      th.fg("muted", " reproduce"),
+      th.fg("mdLink", " scripts/verify-vault-hunter-atlas T02.V01"),
+      th.fg("muted", " artifact    ") + th.fg("syntaxNumber", "aaaaaaaaaaaa…"),
+      th.bg("customMessageBg", th.fg("customMessageLabel", th.bold(" Ownership "))),
+      th.fg("muted", " driver      ") + "implementer",
+      th.fg("muted", " review      ") + "reviewer",
+      th.fg("muted", " authority   ") + th.fg("mdLink", "observation only"),
+    ];
+  }
+
+  invalidate(): void {}
+}
+
+export default function atlasEvidenceRailPrototype(pi: ExtensionAPI) {
+  pi.registerCommand("atlas-rail-prototype", {
+    description: "Open the disposable Atlas evidence-forward rail",
+    handler: async (_args: string, ctx: ExtensionCommandContext) => {
+      if (ctx.mode !== "tui") {
+        ctx.ui.notify("The Atlas rail prototype requires interactive TUI mode.", "warning");
+        return;
+      }
+
+      await ctx.ui.custom<void>((tui, theme, _keybindings, done) =>
+        new EvidenceRailPrototype(theme, () => tui.requestRender(), done),
+      );
+    },
+  });
+}

--- a/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
+++ b/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
@@ -39,7 +39,10 @@ const POLL_MS = 1000;
 const VIRTUAL_STEP_LIMIT = 8;
 const REGISTRY_ROOT =
   process.env.VAULT_HUNTER_STATE_DIR ??
-  join(process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state"), "vault-hunter");
+  join(
+    process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state"),
+    "vault-hunter",
+  );
 
 const EMPTY_STAGES: Stage[] = [
   {
@@ -83,8 +86,11 @@ class EvidenceRailPrototype {
       const selectedStage = stages[this.selected];
       this.showAllSteps = !this.showAllSteps;
       const nextStages = this.stages();
-      const nextSelected = selectedStage ? nextStages.indexOf(selectedStage) : -1;
-      this.selected = nextSelected >= 0 ? nextSelected : Math.max(0, nextStages.length - 1);
+      const nextSelected = selectedStage
+        ? nextStages.indexOf(selectedStage)
+        : -1;
+      this.selected =
+        nextSelected >= 0 ? nextSelected : Math.max(0, nextStages.length - 1);
       this.requestRender();
       return;
     }
@@ -160,7 +166,10 @@ class EvidenceRailPrototype {
     const title =
       this.theme.fg("accent", this.theme.bold("VAULT HUNTER")) +
       "  " +
-      this.theme.fg("text", this.theme.bold(snapshot?.title ?? "No registered Run")) +
+      this.theme.fg(
+        "text",
+        this.theme.bold(snapshot?.title ?? "No registered Run"),
+      ) +
       this.theme.fg(
         "muted",
         ` · ${snapshot ? `${snapshot.runId} · r${snapshot.revision}` : "Registry unavailable"}`,
@@ -173,10 +182,7 @@ class EvidenceRailPrototype {
 
     row(
       this.theme.fg("warning", this.theme.bold("Run timeline")),
-      this.theme.fg(
-        "warning",
-        this.theme.bold(`Selected · ${selected.label}`),
-      ),
+      this.theme.fg("warning", this.theme.bold(`Selected · ${selected.label}`)),
     );
     row(
       this.theme.fg(
@@ -195,20 +201,38 @@ class EvidenceRailPrototype {
     row(this.theme.fg("dim", " │"), rightRows[rightIndex++] ?? "");
     if (hiddenSteps > 0) {
       row(
-        this.theme.fg("dim", ` ├─ …  ${hiddenSteps} earlier ${hiddenSteps === 1 ? "step" : "steps"} · expand with <c-v>`),
+        this.theme.fg(
+          "dim",
+          ` ├─ …  ${hiddenSteps} earlier ${hiddenSteps === 1 ? "step" : "steps"} · expand with <c-v>`,
+        ),
         "",
       );
     }
-    const stageLabelWidth = Math.max(...stages.map((stage) => visibleWidth(stage.label)));
+    const stageLabelWidth = Math.max(
+      ...stages.map((stage) => visibleWidth(stage.label)),
+    );
     stages.forEach((stage, index) => {
       const last = index === stages.length - 1;
       const connector = last ? " └─ " : " ├─ ";
-      const glyph = stage.state === "done" ? "✓" : stage.state === "active" ? "◉" : stage.state === "failed" ? "!" : "○";
-      const color = stage.state === "done" ? "success" : stage.state === "active" ? "warning" : stage.state === "failed" ? "error" : "muted";
+      const glyph =
+        stage.state === "done"
+          ? "✓"
+          : stage.state === "active"
+            ? "◉"
+            : stage.state === "failed"
+              ? "!"
+              : "○";
+      const color =
+        stage.state === "done"
+          ? "success"
+          : stage.state === "active"
+            ? "warning"
+            : stage.state === "failed"
+              ? "error"
+              : "muted";
       const badge = ` ${glyph} ${pad(stage.label, stageLabelWidth)} `;
       let stageText =
-        this.theme.fg("dim", connector) +
-        this.theme.fg(color, badge);
+        this.theme.fg("dim", connector) + this.theme.fg(color, badge);
       if (index === this.selected) {
         stageText =
           this.theme.fg("dim", connector) +
@@ -222,7 +246,10 @@ class EvidenceRailPrototype {
       const childConnector = last ? "     " : " │   ";
       row(
         this.theme.fg("dim", childConnector + "└─ ") +
-          this.theme.fg(index === this.selected ? "accent" : "muted", stage.summary),
+          this.theme.fg(
+            index === this.selected ? "accent" : "muted",
+            stage.summary,
+          ),
         rightRows[rightIndex++] ?? "",
       );
     });
@@ -248,26 +275,49 @@ class EvidenceRailPrototype {
 
   private detailRows(stage: Stage): string[] {
     const th = this.theme;
-    const color = stage.state === "done" ? "success" : stage.state === "active" ? "warning" : stage.state === "failed" ? "error" : "muted";
+    const color =
+      stage.state === "done"
+        ? "success"
+        : stage.state === "active"
+          ? "warning"
+          : stage.state === "failed"
+            ? "error"
+            : "muted";
 
     if (stage.kind) {
       const rows = [
-        th.bg("customMessageBg", th.fg("customMessageLabel", th.bold(" Registry entry "))),
+        th.bg(
+          "customMessageBg",
+          th.fg("customMessageLabel", th.bold(" Registry entry ")),
+        ),
         th.fg("muted", " kind        ") + th.fg("syntaxNumber", stage.kind),
         th.fg("muted", " state       ") + th.fg(color, th.bold(stage.state)),
-        th.fg("muted", " observed    ") + th.fg("text", stage.observedAt ?? "unknown"),
+        th.fg("muted", " observed    ") +
+          th.fg("text", stage.observedAt ?? "unknown"),
         th.fg("muted", " summary     ") + th.fg("text", stage.summary),
       ];
       if (!this.expanded) return rows;
-      if (stage.detail) rows.push(th.fg("muted", " detail      ") + th.fg("text", stage.detail));
+      if (stage.detail)
+        rows.push(
+          th.fg("muted", " detail      ") + th.fg("text", stage.detail),
+        );
       if (stage.command) {
         rows.push(th.fg("muted", " reproduce"));
         rows.push(th.fg("mdLink", ` ${stage.command}`));
       }
       if (stage.exitStatus !== undefined) {
-        rows.push(th.fg("muted", " exit        ") + th.fg(stage.exitStatus === 0 ? "success" : "error", String(stage.exitStatus)));
+        rows.push(
+          th.fg("muted", " exit        ") +
+            th.fg(
+              stage.exitStatus === 0 ? "success" : "error",
+              String(stage.exitStatus),
+            ),
+        );
       }
-      rows.push(th.fg("muted", " authority   ") + th.fg("mdLink", "Registry observation"));
+      rows.push(
+        th.fg("muted", " authority   ") +
+          th.fg("mdLink", "Registry observation"),
+      );
       return rows;
     }
 
@@ -289,14 +339,19 @@ function restoredRunId(ctx: ExtensionContext): string | undefined {
       entry.message.role !== "toolResult" ||
       entry.message.toolName !== "vault_hunter_run" ||
       entry.message.isError === true
-    ) continue;
-    const runId = (entry.message.details as { runId?: unknown } | undefined)?.runId;
+    )
+      continue;
+    const runId = (entry.message.details as { runId?: unknown } | undefined)
+      ?.runId;
     if (typeof runId === "string" && runId) return runId;
   }
   return undefined;
 }
 
-function registry(input: Record<string, unknown>, signal?: AbortSignal): Promise<any> {
+function registry(
+  input: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<any> {
   return new Promise((resolve, reject) => {
     const child = spawn("vault-hunter-registry", [], {
       stdio: ["pipe", "pipe", "pipe"],
@@ -304,12 +359,23 @@ function registry(input: Record<string, unknown>, signal?: AbortSignal): Promise
     });
     let stdout = "";
     let stderr = "";
-    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
-    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+    child.stdout.setEncoding("utf8").on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => {
+      stderr += chunk;
+    });
     child.on("error", reject);
     child.on("close", (code) => {
-      if (code !== 0) return reject(new Error(stderr.trim() || `vault-hunter-registry exited ${code}`));
-      try { resolve(JSON.parse(stdout)); } catch (error) { reject(error); }
+      if (code !== 0)
+        return reject(
+          new Error(stderr.trim() || `vault-hunter-registry exited ${code}`),
+        );
+      try {
+        resolve(JSON.parse(stdout));
+      } catch (error) {
+        reject(error);
+      }
     });
     child.stdin.end(JSON.stringify(input));
   });
@@ -319,13 +385,36 @@ function sessionIdentity(ctx: ExtensionContext) {
   const sessionFile = ctx.sessionManager.getSessionFile();
   return sessionFile
     ? { source: "herdr:pi", kind: "path", value: sessionFile }
-    : { source: "pi", kind: "session-id", value: ctx.sessionManager.getSessionId() };
+    : {
+        source: "pi",
+        kind: "session-id",
+        value: ctx.sessionManager.getSessionId(),
+      };
 }
 
 function stageState(value: unknown): Stage["state"] {
-  if (["red", "failed", "rejected", "interrupted", "error"].includes(String(value))) return "failed";
-  if (["active", "running", "invoked", "in-progress"].includes(String(value))) return "active";
-  if (["green", "passed", "accepted", "completed", "finished", "observed", "succeeded", "recorded", "supports"].includes(String(value))) return "done";
+  if (
+    ["red", "failed", "rejected", "interrupted", "error"].includes(
+      String(value),
+    )
+  )
+    return "failed";
+  if (["active", "running", "invoked", "in-progress"].includes(String(value)))
+    return "active";
+  if (
+    [
+      "green",
+      "passed",
+      "accepted",
+      "completed",
+      "finished",
+      "observed",
+      "succeeded",
+      "recorded",
+      "supports",
+    ].includes(String(value))
+  )
+    return "done";
   return "pending";
 }
 
@@ -348,7 +437,9 @@ function usageSummary(detail: unknown): string | undefined {
       Number.isFinite(requests) ? `${requests} requests` : undefined,
       Number.isFinite(tokens) ? formatTokens(tokens) : undefined,
       Number.isFinite(cost) ? `$${cost.toFixed(2)}` : undefined,
-    ].filter(Boolean).join(" · ");
+    ]
+      .filter(Boolean)
+      .join(" · ");
   } catch {
     return undefined;
   }
@@ -377,8 +468,12 @@ function telemetrySummary(payload: any): string | undefined {
     tokens !== undefined ? formatTokens(tokens) : undefined,
     Number.isFinite(turns) ? `${turns} turns` : undefined,
     Number.isFinite(tools) ? `${tools} tools` : undefined,
-    typeof amount === "string" && typeof currency === "string" ? `${amount} ${currency}` : undefined,
-  ].filter(Boolean).join(" · ");
+    typeof amount === "string" && typeof currency === "string"
+      ? `${amount} ${currency}`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join(" · ");
   return summary || undefined;
 }
 
@@ -388,7 +483,10 @@ function projectStages(record: any): Stage[] {
     const session = participant?.agent_session;
     const herdr = participant?.herdr;
     stages.push({
-      label: participant?.role === "driver" ? "Driver" : String(participant?.role ?? "Participant"),
+      label:
+        participant?.role === "driver"
+          ? "Driver"
+          : String(participant?.role ?? "Participant"),
       state: "active",
       summary: String(participant?.participant_id ?? "registered participant"),
       observedAt: participant?.observed_at,
@@ -396,30 +494,46 @@ function projectStages(record: any): Stage[] {
       detail: [
         session ? `${session.source}/${session.kind}` : undefined,
         herdr?.pane_id ? `pane ${herdr.pane_id}` : undefined,
-      ].filter(Boolean).join(" · "),
+      ]
+        .filter(Boolean)
+        .join(" · "),
     });
   }
   for (const event of record?.lifecycle ?? []) {
     const usage = usageSummary(event?.detail);
     stages.push({
-      label: event?.kind === "run" ? "Run" : event?.kind === "parent/usage" ? "Parent usage" : String(event?.kind ?? "Lifecycle"),
+      label:
+        event?.kind === "run"
+          ? "Run"
+          : event?.kind === "parent/usage"
+            ? "Parent usage"
+            : String(event?.kind ?? "Lifecycle"),
       state: stageState(event?.state),
       summary: usage ?? String(event?.detail || event?.state || "recorded"),
       observedAt: event?.observed_at,
       kind: String(event?.kind ?? "lifecycle"),
-      detail: usage ? `boundary telemetry · ${event?.state ?? "observed"}` : String(event?.detail ?? ""),
+      detail: usage
+        ? `boundary telemetry · ${event?.state ?? "observed"}`
+        : String(event?.detail ?? ""),
     });
   }
   for (const evidence of record?.evidence ?? []) {
     stages.push({
       label: String(evidence?.verifier_id ?? "Evidence"),
       state: stageState(evidence?.state),
-      summary: String(evidence?.detail || evidence?.state || "recorded evidence"),
+      summary: String(
+        evidence?.detail || evidence?.state || "recorded evidence",
+      ),
       observedAt: evidence?.observed_at,
       kind: "evidence",
-      detail: evidence?.artifact_sha256 ? `artifact ${String(evidence.artifact_sha256).slice(0, 12)}…` : "",
-      command: typeof evidence?.command === "string" ? evidence.command : undefined,
-      exitStatus: Number.isInteger(evidence?.exit_status) ? evidence.exit_status : undefined,
+      detail: evidence?.artifact_sha256
+        ? `artifact ${String(evidence.artifact_sha256).slice(0, 12)}…`
+        : "",
+      command:
+        typeof evidence?.command === "string" ? evidence.command : undefined,
+      exitStatus: Number.isInteger(evidence?.exit_status)
+        ? evidence.exit_status
+        : undefined,
     });
   }
   for (const observation of record?.observations ?? []) {
@@ -427,29 +541,50 @@ function projectStages(record: any): Stage[] {
     stages.push({
       label: String(observation?.title || observation?.kind || "Observation"),
       state: stageState(observation?.state),
-      summary: telemetry ?? String(observation?.summary || observation?.state || "recorded observation"),
+      summary:
+        telemetry ??
+        String(
+          observation?.summary || observation?.state || "recorded observation",
+        ),
       observedAt: observation?.observed_at,
       kind: String(observation?.kind ?? "observation"),
       detail: telemetry
-        ? [observation?.summary, observation?.payload?.runtime_telemetry?.boundary].filter(Boolean).join(" · ")
-        : typeof observation?.detail === "string" ? observation.detail : "",
+        ? [
+            observation?.summary,
+            observation?.payload?.runtime_telemetry?.boundary,
+          ]
+            .filter(Boolean)
+            .join(" · ")
+        : typeof observation?.detail === "string"
+          ? observation.detail
+          : "",
     });
   }
-  stages.sort((left, right) => String(left.observedAt ?? "").localeCompare(String(right.observedAt ?? "")));
-  return stages.length ? stages : [{
-    label: "Run",
-    state: "active",
-    summary: "Registry record loaded",
-    observedAt: record?.updated_at,
-    kind: "run",
-  }];
+  stages.sort((left, right) =>
+    String(left.observedAt ?? "").localeCompare(String(right.observedAt ?? "")),
+  );
+  return stages.length
+    ? stages
+    : [
+        {
+          label: "Run",
+          state: "active",
+          summary: "Registry record loaded",
+          observedAt: record?.updated_at,
+          kind: "run",
+        },
+      ];
 }
 
 function projectSnapshot(record: any): RunSnapshot {
   const runId = record?.run_id;
   const revision = record?.revision;
   const title = record?.task?.title ?? record?.work_reference?.title;
-  if (typeof runId !== "string" || !Number.isSafeInteger(revision) || typeof title !== "string") {
+  if (
+    typeof runId !== "string" ||
+    !Number.isSafeInteger(revision) ||
+    typeof title !== "string"
+  ) {
     throw new Error("Registry returned an incomplete Run.");
   }
   return {
@@ -479,11 +614,13 @@ export default function atlasEvidenceRailPrototype(pi: ExtensionAPI) {
     ctx.ui.setWidget(
       WIDGET_ID,
       (_tui, theme) => ({
-        render: (width: number) => [truncateToWidth(
-          `${theme.fg("accent", theme.bold("Vault Hunter"))}${theme.fg("dim", " · ")}${theme.fg("text", snapshot!.title)}${theme.fg("dim", ` · r${snapshot!.revision} · ${snapshot!.stage}`)}`,
-          width,
-          "…",
-        )],
+        render: (width: number) => [
+          truncateToWidth(
+            `${theme.fg("accent", theme.bold("Vault Hunter"))}${theme.fg("dim", " · ")}${theme.fg("text", snapshot!.title)}${theme.fg("dim", ` · r${snapshot!.revision} · ${snapshot!.stage}`)}`,
+            width,
+            "…",
+          ),
+        ],
         invalidate() {},
       }),
       { placement: "belowEditor" },
@@ -494,38 +631,64 @@ export default function atlasEvidenceRailPrototype(pi: ExtensionAPI) {
     );
   };
 
-  const refresh = async (ctx: ExtensionContext, expectedGeneration = generation) => {
-    if (polling || !candidateRunId || ctx.mode !== "tui" || expectedGeneration !== generation) return;
+  const refresh = async (
+    ctx: ExtensionContext,
+    expectedGeneration = generation,
+  ) => {
+    if (
+      polling ||
+      !candidateRunId ||
+      ctx.mode !== "tui" ||
+      expectedGeneration !== generation
+    )
+      return;
     const refreshController = new AbortController();
     controller = refreshController;
     polling = true;
     let changed = false;
     try {
-      const runs = await registry({
-        action: "list",
-        root: REGISTRY_ROOT,
-        filter: {
-          participant_id: `pi-${ctx.sessionManager.getSessionId()}`,
-          agent_session: sessionIdentity(ctx),
+      const runs = await registry(
+        {
+          action: "list",
+          root: REGISTRY_ROOT,
+          filter: {
+            participant_id: `pi-${ctx.sessionManager.getSessionId()}`,
+            agent_session: sessionIdentity(ctx),
+          },
         },
-      }, refreshController.signal);
-      if (refreshController.signal.aborted || expectedGeneration !== generation) return;
-      if (!Array.isArray(runs) || runs.length !== 1 || runs[0]?.run_id !== candidateRunId) {
+        refreshController.signal,
+      );
+      if (refreshController.signal.aborted || expectedGeneration !== generation)
+        return;
+      if (
+        !Array.isArray(runs) ||
+        runs.length !== 1 ||
+        runs[0]?.run_id !== candidateRunId
+      ) {
         if (snapshot) {
           snapshot = undefined;
           changed = true;
         }
         return;
       }
-      if (snapshot?.runId === candidateRunId && snapshot.revision === runs[0]?.revision) return;
-      const record = await registry({
-        action: "get",
-        root: REGISTRY_ROOT,
-        run_id: candidateRunId,
-      }, refreshController.signal);
-      if (refreshController.signal.aborted || expectedGeneration !== generation) return;
+      if (
+        snapshot?.runId === candidateRunId &&
+        snapshot.revision === runs[0]?.revision
+      )
+        return;
+      const record = await registry(
+        {
+          action: "get",
+          root: REGISTRY_ROOT,
+          run_id: candidateRunId,
+        },
+        refreshController.signal,
+      );
+      if (refreshController.signal.aborted || expectedGeneration !== generation)
+        return;
       const next = projectSnapshot(record);
-      if (next.runId !== candidateRunId) throw new Error("Registry returned a different Run.");
+      if (next.runId !== candidateRunId)
+        throw new Error("Registry returned a different Run.");
       snapshot = next;
       changed = true;
     } catch {
@@ -533,7 +696,12 @@ export default function atlasEvidenceRailPrototype(pi: ExtensionAPI) {
     } finally {
       if (controller === refreshController) controller = undefined;
       polling = false;
-      if (!refreshController.signal.aborted && expectedGeneration === generation && changed) display(ctx);
+      if (
+        !refreshController.signal.aborted &&
+        expectedGeneration === generation &&
+        changed
+      )
+        display(ctx);
     }
   };
 
@@ -547,7 +715,12 @@ export default function atlasEvidenceRailPrototype(pi: ExtensionAPI) {
   });
 
   pi.on("tool_result", async (event, ctx) => {
-    if (event.toolName !== "vault_hunter_run" || event.isError || ctx.mode !== "tui") return;
+    if (
+      event.toolName !== "vault_hunter_run" ||
+      event.isError ||
+      ctx.mode !== "tui"
+    )
+      return;
     const runId = (event.details as { runId?: unknown } | undefined)?.runId;
     if (typeof runId !== "string" || !runId) return;
     if (candidateRunId !== runId) {
@@ -575,12 +748,21 @@ export default function atlasEvidenceRailPrototype(pi: ExtensionAPI) {
     description: "Open the disposable Atlas evidence-forward rail",
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
       if (ctx.mode !== "tui") {
-        ctx.ui.notify("The Atlas rail prototype requires interactive TUI mode.", "warning");
+        ctx.ui.notify(
+          "The Atlas rail prototype requires interactive TUI mode.",
+          "warning",
+        );
         return;
       }
 
-      await ctx.ui.custom<void>((tui, theme, _keybindings, done) =>
-        new EvidenceRailPrototype(theme, () => tui.requestRender(), done, () => snapshot),
+      await ctx.ui.custom<void>(
+        (tui, theme, _keybindings, done) =>
+          new EvidenceRailPrototype(
+            theme,
+            () => tui.requestRender(),
+            done,
+            () => snapshot,
+          ),
       );
     },
   });

--- a/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
+++ b/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
@@ -1,6 +1,10 @@
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type {
   ExtensionAPI,
   ExtensionCommandContext,
+  ExtensionContext,
   Theme,
 } from "@earendil-works/pi-coding-agent";
 import {
@@ -12,24 +16,37 @@ import {
 
 type Stage = {
   label: string;
-  state: "done" | "active" | "pending";
+  state: "done" | "active" | "pending" | "failed";
   summary: string;
+  observedAt?: string;
+  kind?: string;
+  detail?: string;
+  command?: string;
+  exitStatus?: number;
 };
 
-const STAGES: Stage[] = [
-  { label: "Admission", state: "done", summary: "Registry fixture loaded" },
+type RunSnapshot = {
+  runId: string;
+  revision: number;
+  title: string;
+  stage: string;
+  updatedAt: string;
+  stages: Stage[];
+};
+
+const WIDGET_ID = "atlas-evidence-rail-prototype";
+const POLL_MS = 1000;
+const VIRTUAL_STEP_LIMIT = 8;
+const REGISTRY_ROOT =
+  process.env.VAULT_HUNTER_STATE_DIR ??
+  join(process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state"), "vault-hunter");
+
+const EMPTY_STAGES: Stage[] = [
   {
-    label: "Checkpoint one",
-    state: "done",
-    summary: "Human approval recorded",
+    label: "No registered Run",
+    state: "pending",
+    summary: "Launch Vault Hunter from this Pi session",
   },
-  {
-    label: "T02.V01",
-    state: "active",
-    summary: "Snapshot verification running",
-  },
-  { label: "Review", state: "pending", summary: "Awaiting verification" },
-  { label: "Delivery", state: "pending", summary: "Not started" },
 ];
 
 function pad(text: string, width: number): string {
@@ -38,16 +55,40 @@ function pad(text: string, width: number): string {
 }
 
 class EvidenceRailPrototype {
-  private selected = 2;
+  private selected = VIRTUAL_STEP_LIMIT - 1;
   private expanded = true;
+  private showAllSteps = false;
 
   constructor(
     private readonly theme: Theme,
     private readonly requestRender: () => void,
     private readonly done: () => void,
+    private readonly currentRun: () => RunSnapshot | undefined,
   ) {}
 
+  private allStages(): Stage[] {
+    return this.currentRun()?.stages.length
+      ? this.currentRun()!.stages
+      : EMPTY_STAGES;
+  }
+
+  private stages(): Stage[] {
+    const stages = this.allStages();
+    return this.showAllSteps ? stages : stages.slice(-VIRTUAL_STEP_LIMIT);
+  }
+
   handleInput(data: string): void {
+    const stages = this.stages();
+    if (matchesKey(data, Key.ctrl("v"))) {
+      const selectedStage = stages[this.selected];
+      this.showAllSteps = !this.showAllSteps;
+      const nextStages = this.stages();
+      const nextSelected = selectedStage ? nextStages.indexOf(selectedStage) : -1;
+      this.selected = nextSelected >= 0 ? nextSelected : Math.max(0, nextStages.length - 1);
+      this.requestRender();
+      return;
+    }
+
     if (
       matchesKey(data, "q") ||
       matchesKey(data, Key.escape) ||
@@ -59,7 +100,7 @@ class EvidenceRailPrototype {
 
     if (
       (matchesKey(data, "j") || matchesKey(data, Key.down)) &&
-      this.selected < STAGES.length - 1
+      this.selected < stages.length - 1
     ) {
       this.selected += 1;
       this.requestRender();
@@ -94,7 +135,11 @@ class EvidenceRailPrototype {
     const frameWidth = Math.min(width, 115);
     const leftWidth = Math.max(30, Math.floor((frameWidth - 3) * 0.39));
     const rightWidth = frameWidth - leftWidth - 3;
-    const selected = STAGES[this.selected]!;
+    const allStages = this.allStages();
+    const stages = this.stages();
+    const hiddenSteps = allStages.length - stages.length;
+    if (this.selected >= stages.length) this.selected = stages.length - 1;
+    const selected = stages[this.selected]!;
     const lines: string[] = [];
 
     const row = (left = "", right = "") => {
@@ -111,11 +156,15 @@ class EvidenceRailPrototype {
         "─".repeat(leftWidth) + "─┼─" + "─".repeat(rightWidth),
       );
 
+    const snapshot = this.currentRun();
     const title =
       this.theme.fg("accent", this.theme.bold("VAULT HUNTER")) +
       "  " +
-      this.theme.fg("text", this.theme.bold("T02.V01")) +
-      this.theme.fg("muted", " · atlas-rich-run");
+      this.theme.fg("text", this.theme.bold(snapshot?.title ?? "No registered Run")) +
+      this.theme.fg(
+        "muted",
+        ` · ${snapshot ? `${snapshot.runId} · r${snapshot.revision}` : "Registry unavailable"}`,
+      );
     const activeBadge = this.theme.bg(
       "toolSuccessBg",
       this.theme.fg("success", this.theme.bold(" ACTIVE ")),
@@ -124,10 +173,18 @@ class EvidenceRailPrototype {
 
     row(
       this.theme.fg("warning", this.theme.bold("Run timeline")),
-      this.theme.fg("warning", this.theme.bold(`Selected · ${selected.label}`)),
+      this.theme.fg(
+        "warning",
+        this.theme.bold(`Selected · ${selected.label}`),
+      ),
     );
     row(
-      this.theme.fg("muted", "2 complete · 1 active · 2 pending"),
+      this.theme.fg(
+        "muted",
+        snapshot
+          ? `${allStages.length} Registry entries · showing ${stages.length} · revision ${snapshot.revision}`
+          : "Registry session not bound",
+      ),
       this.theme.fg("muted", selected.summary),
     );
     lines.push(rule());
@@ -136,17 +193,17 @@ class EvidenceRailPrototype {
     let rightIndex = 0;
 
     row(this.theme.fg("dim", " │"), rightRows[rightIndex++] ?? "");
-    STAGES.forEach((stage, index) => {
-      const last = index === STAGES.length - 1;
+    if (hiddenSteps > 0) {
+      row(
+        this.theme.fg("dim", ` ├─ …  ${hiddenSteps} earlier ${hiddenSteps === 1 ? "step" : "steps"} · expand with <c-v>`),
+        "",
+      );
+    }
+    stages.forEach((stage, index) => {
+      const last = index === stages.length - 1;
       const connector = last ? " └─ " : " ├─ ";
-      const glyph =
-        stage.state === "done" ? "✓" : stage.state === "active" ? "◉" : "○";
-      const color =
-        stage.state === "done"
-          ? "success"
-          : stage.state === "active"
-            ? "warning"
-            : "muted";
+      const glyph = stage.state === "done" ? "✓" : stage.state === "active" ? "◉" : stage.state === "failed" ? "!" : "○";
+      const color = stage.state === "done" ? "success" : stage.state === "active" ? "warning" : stage.state === "failed" ? "error" : "muted";
       let stageText =
         this.theme.fg("dim", connector) +
         this.theme.fg(color, ` ${glyph} ${stage.label} `);
@@ -163,10 +220,7 @@ class EvidenceRailPrototype {
       const childConnector = last ? "     " : " │   ";
       row(
         this.theme.fg("dim", childConnector + "└─ ") +
-          this.theme.fg(
-            index === this.selected ? "accent" : "muted",
-            stage.summary,
-          ),
+          this.theme.fg(index === this.selected ? "accent" : "muted", stage.summary),
         rightRows[rightIndex++] ?? "",
       );
     });
@@ -177,10 +231,13 @@ class EvidenceRailPrototype {
 
     lines.push(rule());
     row(
-      this.theme.fg("dim", "j/k select · Enter expand · q quit"),
       this.theme.fg(
         "dim",
-        `recorded snapshot · ${frameWidth}×${lines.length + 2}`,
+        `j/k select · Enter detail · Ctrl+V ${this.showAllSteps ? "last 8" : "all"} · q quit`,
+      ),
+      this.theme.fg(
+        "dim",
+        `${snapshot ? `Registry ${snapshot.updatedAt || "snapshot"}` : "Registry unavailable"} · ${frameWidth}×${lines.length + 2}`,
       ),
     );
 
@@ -189,82 +246,302 @@ class EvidenceRailPrototype {
 
   private detailRows(stage: Stage): string[] {
     const th = this.theme;
-    const rows = [
-      th.fg("muted", "12:01  ") +
-        th.fg("syntaxNumber", " ○ ") +
-        "verifier queued ",
-      th.fg("muted", "12:05  ") +
-        th.bg("selectedBg", th.fg("warning", th.bold(" ◉ verifier active "))),
-      th.fg("accent", "       Rendering deterministic snapshots"),
-      th.fg("muted", "12:05  ") +
-        th.bg(
-          "toolErrorBg",
-          th.fg("error", th.bold(" ! baseline evidence · failed · exit 1 ")),
-        ),
-      th.fg("error", "       Expected baseline-red result"),
-    ];
+    const color = stage.state === "done" ? "success" : stage.state === "active" ? "warning" : stage.state === "failed" ? "error" : "muted";
 
-    if (!this.expanded) return rows;
-
-    if (stage.label !== "T02.V01") {
-      return [
-        th.fg("muted", "Recorded stage"),
-        th.bg(
-          "customMessageBg",
-          th.fg("customMessageLabel", ` ${stage.label} `),
-        ),
-        th.fg("muted", " state       ") +
-          th.fg(
-            stage.state === "done"
-              ? "success"
-              : stage.state === "active"
-                ? "warning"
-                : "muted",
-            stage.state,
-          ),
+    if (stage.kind) {
+      const rows = [
+        th.bg("customMessageBg", th.fg("customMessageLabel", th.bold(" Registry entry "))),
+        th.fg("muted", " kind        ") + th.fg("syntaxNumber", stage.kind),
+        th.fg("muted", " state       ") + th.fg(color, th.bold(stage.state)),
+        th.fg("muted", " observed    ") + th.fg("text", stage.observedAt ?? "unknown"),
         th.fg("muted", " summary     ") + th.fg("text", stage.summary),
       ];
+      if (!this.expanded) return rows;
+      if (stage.detail) rows.push(th.fg("muted", " detail      ") + th.fg("text", stage.detail));
+      if (stage.command) {
+        rows.push(th.fg("muted", " reproduce"));
+        rows.push(th.fg("mdLink", ` ${stage.command}`));
+      }
+      if (stage.exitStatus !== undefined) {
+        rows.push(th.fg("muted", " exit        ") + th.fg(stage.exitStatus === 0 ? "success" : "error", String(stage.exitStatus)));
+      }
+      rows.push(th.fg("muted", " authority   ") + th.fg("mdLink", "Registry observation"));
+      return rows;
     }
 
     return [
-      ...rows,
-      th.bg(
-        "customMessageBg",
-        th.fg("customMessageLabel", th.bold(" Result capsule ")),
-      ),
-      th.fg("muted", " outcome     ") + th.fg("error", th.bold("failed")),
-      th.fg("muted", " phase       ") + th.fg("syntaxNumber", "baseline"),
-      th.fg("muted", " reproduce"),
-      th.fg("mdLink", " scripts/verify-vault-hunter-atlas T02.V01"),
-      th.fg("muted", " artifact    ") + th.fg("syntaxNumber", "aaaaaaaaaaaa…"),
-      th.bg(
-        "customMessageBg",
-        th.fg("customMessageLabel", th.bold(" Ownership ")),
-      ),
-      th.fg("muted", " driver      ") + "implementer",
-      th.fg("muted", " review      ") + "reviewer",
-      th.fg("muted", " authority   ") + th.fg("mdLink", "observation only"),
+      th.fg("muted", "Registry session"),
+      th.bg("customMessageBg", th.fg("customMessageLabel", ` ${stage.label} `)),
+      th.fg("muted", " state       ") + th.fg(color, stage.state),
+      th.fg("muted", " summary     ") + th.fg("text", stage.summary),
     ];
   }
 
   invalidate(): void {}
 }
 
+function restoredRunId(ctx: ExtensionContext): string | undefined {
+  for (const entry of [...ctx.sessionManager.getBranch()].reverse()) {
+    if (
+      entry.type !== "message" ||
+      entry.message.role !== "toolResult" ||
+      entry.message.toolName !== "vault_hunter_run" ||
+      entry.message.isError === true
+    ) continue;
+    const runId = (entry.message.details as { runId?: unknown } | undefined)?.runId;
+    if (typeof runId === "string" && runId) return runId;
+  }
+  return undefined;
+}
+
+function registry(input: Record<string, unknown>, signal?: AbortSignal): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("vault-hunter-registry", [], {
+      stdio: ["pipe", "pipe", "pipe"],
+      signal,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) return reject(new Error(stderr.trim() || `vault-hunter-registry exited ${code}`));
+      try { resolve(JSON.parse(stdout)); } catch (error) { reject(error); }
+    });
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+function sessionIdentity(ctx: ExtensionContext) {
+  const sessionFile = ctx.sessionManager.getSessionFile();
+  return sessionFile
+    ? { source: "herdr:pi", kind: "path", value: sessionFile }
+    : { source: "pi", kind: "session-id", value: ctx.sessionManager.getSessionId() };
+}
+
+function stageState(value: unknown): Stage["state"] {
+  if (["failed", "rejected", "interrupted", "error"].includes(String(value))) return "failed";
+  if (["active", "running", "invoked", "in-progress"].includes(String(value))) return "active";
+  if (["passed", "accepted", "completed", "finished", "observed"].includes(String(value))) return "done";
+  return "pending";
+}
+
+function usageSummary(detail: unknown): string | undefined {
+  if (typeof detail !== "string") return undefined;
+  try {
+    const decoded = JSON.parse(detail);
+    if (decoded?.schema !== "vault-hunter-parent-usage/v1") return undefined;
+    const usage = decoded.usage ?? {};
+    const tokens = Number(usage.total_tokens);
+    const requests = Number(usage.requests);
+    const cost = Number(usage.cost);
+    return [
+      Number.isFinite(requests) ? `${requests} requests` : undefined,
+      Number.isFinite(tokens) ? `${(tokens / 1_000_000).toFixed(1)}m tokens` : undefined,
+      Number.isFinite(cost) ? `$${cost.toFixed(2)}` : undefined,
+    ].filter(Boolean).join(" · ");
+  } catch {
+    return undefined;
+  }
+}
+
+function projectStages(record: any): Stage[] {
+  const stages: Stage[] = [];
+  for (const participant of record?.participants ?? []) {
+    const session = participant?.agent_session;
+    const herdr = participant?.herdr;
+    stages.push({
+      label: participant?.role === "driver" ? "Driver" : String(participant?.role ?? "Participant"),
+      state: "active",
+      summary: String(participant?.participant_id ?? "registered participant"),
+      observedAt: participant?.observed_at,
+      kind: "participant",
+      detail: [
+        session ? `${session.source}/${session.kind}` : undefined,
+        herdr?.pane_id ? `pane ${herdr.pane_id}` : undefined,
+      ].filter(Boolean).join(" · "),
+    });
+  }
+  for (const event of record?.lifecycle ?? []) {
+    const usage = usageSummary(event?.detail);
+    stages.push({
+      label: event?.kind === "run" ? "Run" : event?.kind === "parent/usage" ? "Parent usage" : String(event?.kind ?? "Lifecycle"),
+      state: stageState(event?.state),
+      summary: usage ?? String(event?.detail || event?.state || "recorded"),
+      observedAt: event?.observed_at,
+      kind: String(event?.kind ?? "lifecycle"),
+      detail: usage ? `boundary telemetry · ${event?.state ?? "observed"}` : String(event?.detail ?? ""),
+    });
+  }
+  for (const evidence of record?.evidence ?? []) {
+    stages.push({
+      label: String(evidence?.verifier_id ?? "Evidence"),
+      state: stageState(evidence?.state),
+      summary: String(evidence?.detail || evidence?.state || "recorded evidence"),
+      observedAt: evidence?.observed_at,
+      kind: "evidence",
+      detail: evidence?.artifact_sha256 ? `artifact ${String(evidence.artifact_sha256).slice(0, 12)}…` : "",
+      command: typeof evidence?.command === "string" ? evidence.command : undefined,
+      exitStatus: Number.isInteger(evidence?.exit_status) ? evidence.exit_status : undefined,
+    });
+  }
+  for (const observation of record?.observations ?? []) {
+    stages.push({
+      label: String(observation?.title || observation?.kind || "Observation"),
+      state: stageState(observation?.state),
+      summary: String(observation?.summary || observation?.state || "recorded observation"),
+      observedAt: observation?.observed_at,
+      kind: String(observation?.kind ?? "observation"),
+      detail: typeof observation?.detail === "string" ? observation.detail : "",
+    });
+  }
+  stages.sort((left, right) => String(left.observedAt ?? "").localeCompare(String(right.observedAt ?? "")));
+  return stages.length ? stages : [{
+    label: "Run",
+    state: "active",
+    summary: "Registry record loaded",
+    observedAt: record?.updated_at,
+    kind: "run",
+  }];
+}
+
+function projectSnapshot(record: any): RunSnapshot {
+  const runId = record?.run_id;
+  const revision = record?.revision;
+  const title = record?.task?.title ?? record?.work_reference?.title;
+  if (typeof runId !== "string" || !Number.isSafeInteger(revision) || typeof title !== "string") {
+    throw new Error("Registry returned an incomplete Run.");
+  }
+  return {
+    runId,
+    revision,
+    title,
+    stage: typeof record?.stage === "string" ? record.stage : "active",
+    updatedAt: typeof record?.updated_at === "string" ? record.updated_at : "",
+    stages: projectStages(record),
+  };
+}
+
 export default function atlasEvidenceRailPrototype(pi: ExtensionAPI) {
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let controller: AbortController | undefined;
+  let polling = false;
+  let generation = 0;
+  let candidateRunId: string | undefined;
+  let snapshot: RunSnapshot | undefined;
+
+  const display = (ctx: ExtensionContext) => {
+    if (ctx.mode !== "tui" || !snapshot) {
+      ctx.ui.setWidget(WIDGET_ID, undefined);
+      ctx.ui.setStatus(WIDGET_ID, undefined);
+      return;
+    }
+    ctx.ui.setWidget(
+      WIDGET_ID,
+      (_tui, theme) => ({
+        render: (width: number) => [truncateToWidth(
+          `${theme.fg("accent", theme.bold("Vault Hunter"))}${theme.fg("dim", " · ")}${theme.fg("text", snapshot!.title)}${theme.fg("dim", ` · r${snapshot!.revision} · ${snapshot!.stage}`)}`,
+          width,
+          "…",
+        )],
+        invalidate() {},
+      }),
+      { placement: "belowEditor" },
+    );
+    ctx.ui.setStatus(
+      WIDGET_ID,
+      `${ctx.ui.theme.fg("success", "●")}${ctx.ui.theme.fg("dim", ` VH r${snapshot.revision}`)}`,
+    );
+  };
+
+  const refresh = async (ctx: ExtensionContext, expectedGeneration = generation) => {
+    if (polling || !candidateRunId || ctx.mode !== "tui" || expectedGeneration !== generation) return;
+    const refreshController = new AbortController();
+    controller = refreshController;
+    polling = true;
+    let changed = false;
+    try {
+      const runs = await registry({
+        action: "list",
+        root: REGISTRY_ROOT,
+        filter: {
+          participant_id: `pi-${ctx.sessionManager.getSessionId()}`,
+          agent_session: sessionIdentity(ctx),
+        },
+      }, refreshController.signal);
+      if (refreshController.signal.aborted || expectedGeneration !== generation) return;
+      if (!Array.isArray(runs) || runs.length !== 1 || runs[0]?.run_id !== candidateRunId) {
+        if (snapshot) {
+          snapshot = undefined;
+          changed = true;
+        }
+        return;
+      }
+      if (snapshot?.runId === candidateRunId && snapshot.revision === runs[0]?.revision) return;
+      const record = await registry({
+        action: "get",
+        root: REGISTRY_ROOT,
+        run_id: candidateRunId,
+      }, refreshController.signal);
+      if (refreshController.signal.aborted || expectedGeneration !== generation) return;
+      const next = projectSnapshot(record);
+      if (next.runId !== candidateRunId) throw new Error("Registry returned a different Run.");
+      snapshot = next;
+      changed = true;
+    } catch {
+      // Preserve the last valid frame across transient read failures.
+    } finally {
+      if (controller === refreshController) controller = undefined;
+      polling = false;
+      if (!refreshController.signal.aborted && expectedGeneration === generation && changed) display(ctx);
+    }
+  };
+
+  pi.on("session_start", (_event, ctx) => {
+    if (ctx.mode !== "tui") return;
+    candidateRunId = restoredRunId(ctx);
+    const sessionGeneration = ++generation;
+    void refresh(ctx, sessionGeneration);
+    timer = setInterval(() => void refresh(ctx, sessionGeneration), POLL_MS);
+    timer.unref?.();
+  });
+
+  pi.on("tool_result", async (event, ctx) => {
+    if (event.toolName !== "vault_hunter_run" || event.isError || ctx.mode !== "tui") return;
+    const runId = (event.details as { runId?: unknown } | undefined)?.runId;
+    if (typeof runId !== "string" || !runId) return;
+    if (candidateRunId !== runId) {
+      candidateRunId = runId;
+      snapshot = undefined;
+      display(ctx);
+    }
+    await refresh(ctx);
+  });
+
+  pi.on("session_shutdown", (_event, ctx) => {
+    generation++;
+    controller?.abort();
+    controller = undefined;
+    polling = false;
+    if (timer) clearInterval(timer);
+    timer = undefined;
+    candidateRunId = undefined;
+    snapshot = undefined;
+    ctx.ui.setWidget(WIDGET_ID, undefined);
+    ctx.ui.setStatus(WIDGET_ID, undefined);
+  });
+
   pi.registerCommand("atlas-rail-prototype", {
     description: "Open the disposable Atlas evidence-forward rail",
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
       if (ctx.mode !== "tui") {
-        ctx.ui.notify(
-          "The Atlas rail prototype requires interactive TUI mode.",
-          "warning",
-        );
+        ctx.ui.notify("The Atlas rail prototype requires interactive TUI mode.", "warning");
         return;
       }
 
-      await ctx.ui.custom<void>(
-        (tui, theme, _keybindings, done) =>
-          new EvidenceRailPrototype(theme, () => tui.requestRender(), done),
+      await ctx.ui.custom<void>((tui, theme, _keybindings, done) =>
+        new EvidenceRailPrototype(theme, () => tui.requestRender(), done, () => snapshot),
       );
     },
   });

--- a/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
+++ b/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
@@ -325,7 +325,7 @@ function sessionIdentity(ctx: ExtensionContext) {
 function stageState(value: unknown): Stage["state"] {
   if (["red", "failed", "rejected", "interrupted", "error"].includes(String(value))) return "failed";
   if (["active", "running", "invoked", "in-progress"].includes(String(value))) return "active";
-  if (["green", "passed", "accepted", "completed", "finished", "observed"].includes(String(value))) return "done";
+  if (["green", "passed", "accepted", "completed", "finished", "observed", "succeeded", "recorded", "supports"].includes(String(value))) return "done";
   return "pending";
 }
 

--- a/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
+++ b/pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts
@@ -199,20 +199,22 @@ class EvidenceRailPrototype {
         "",
       );
     }
+    const stageLabelWidth = Math.max(...stages.map((stage) => visibleWidth(stage.label)));
     stages.forEach((stage, index) => {
       const last = index === stages.length - 1;
       const connector = last ? " └─ " : " ├─ ";
       const glyph = stage.state === "done" ? "✓" : stage.state === "active" ? "◉" : stage.state === "failed" ? "!" : "○";
       const color = stage.state === "done" ? "success" : stage.state === "active" ? "warning" : stage.state === "failed" ? "error" : "muted";
+      const badge = ` ${glyph} ${pad(stage.label, stageLabelWidth)} `;
       let stageText =
         this.theme.fg("dim", connector) +
-        this.theme.fg(color, ` ${glyph} ${stage.label} `);
+        this.theme.fg(color, badge);
       if (index === this.selected) {
         stageText =
           this.theme.fg("dim", connector) +
           this.theme.bg(
             "selectedBg",
-            this.theme.fg(color, this.theme.bold(` ${glyph} ${stage.label} `)),
+            this.theme.fg(color, this.theme.bold(badge)),
           );
       }
       row(stageText, rightRows[rightIndex++] ?? "");
@@ -321,10 +323,16 @@ function sessionIdentity(ctx: ExtensionContext) {
 }
 
 function stageState(value: unknown): Stage["state"] {
-  if (["failed", "rejected", "interrupted", "error"].includes(String(value))) return "failed";
+  if (["red", "failed", "rejected", "interrupted", "error"].includes(String(value))) return "failed";
   if (["active", "running", "invoked", "in-progress"].includes(String(value))) return "active";
-  if (["passed", "accepted", "completed", "finished", "observed"].includes(String(value))) return "done";
+  if (["green", "passed", "accepted", "completed", "finished", "observed"].includes(String(value))) return "done";
   return "pending";
+}
+
+function formatTokens(tokens: number): string {
+  return tokens >= 1_000_000
+    ? `${(tokens / 1_000_000).toFixed(1)}m tokens`
+    : `${tokens.toLocaleString("en-US")} tokens`;
 }
 
 function usageSummary(detail: unknown): string | undefined {
@@ -338,12 +346,40 @@ function usageSummary(detail: unknown): string | undefined {
     const cost = Number(usage.cost);
     return [
       Number.isFinite(requests) ? `${requests} requests` : undefined,
-      Number.isFinite(tokens) ? `${(tokens / 1_000_000).toFixed(1)}m tokens` : undefined,
+      Number.isFinite(tokens) ? formatTokens(tokens) : undefined,
       Number.isFinite(cost) ? `$${cost.toFixed(2)}` : undefined,
     ].filter(Boolean).join(" · ");
   } catch {
     return undefined;
   }
+}
+
+function telemetrySummary(payload: any): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const usage = payload.usage;
+  const providerTotal = Number(usage?.provider_reported_total);
+  const inputTokens = Number(usage?.input_tokens);
+  const outputTokens = Number(usage?.output_tokens);
+  const derivedTotal =
+    Number.isFinite(inputTokens) && Number.isFinite(outputTokens)
+      ? inputTokens + outputTokens
+      : undefined;
+  const tokens = Number.isFinite(providerTotal) ? providerTotal : derivedTotal;
+  const requests = Number(usage?.requests);
+  const turns = Number(usage?.turns);
+  const tools = Number(usage?.tool_count);
+  const amount = payload.cost?.amount;
+  const currency = payload.cost?.currency;
+  const model = typeof payload.model === "string" ? payload.model : undefined;
+  const summary = [
+    model,
+    Number.isFinite(requests) ? `${requests} requests` : undefined,
+    tokens !== undefined ? formatTokens(tokens) : undefined,
+    Number.isFinite(turns) ? `${turns} turns` : undefined,
+    Number.isFinite(tools) ? `${tools} tools` : undefined,
+    typeof amount === "string" && typeof currency === "string" ? `${amount} ${currency}` : undefined,
+  ].filter(Boolean).join(" · ");
+  return summary || undefined;
 }
 
 function projectStages(record: any): Stage[] {
@@ -387,13 +423,16 @@ function projectStages(record: any): Stage[] {
     });
   }
   for (const observation of record?.observations ?? []) {
+    const telemetry = telemetrySummary(observation?.payload?.runtime_telemetry);
     stages.push({
       label: String(observation?.title || observation?.kind || "Observation"),
       state: stageState(observation?.state),
-      summary: String(observation?.summary || observation?.state || "recorded observation"),
+      summary: telemetry ?? String(observation?.summary || observation?.state || "recorded observation"),
       observedAt: observation?.observed_at,
       kind: String(observation?.kind ?? "observation"),
-      detail: typeof observation?.detail === "string" ? observation.detail : "",
+      detail: telemetry
+        ? [observation?.summary, observation?.payload?.runtime_telemetry?.boundary].filter(Boolean).join(" · ")
+        : typeof observation?.detail === "string" ? observation.detail : "",
     });
   }
   stages.sort((left, right) => String(left.observedAt ?? "").localeCompare(String(right.observedAt ?? "")));


### PR DESCRIPTION
## Intent

Ship the user-accepted disposable Pi Atlas evidence-rail prototype. It must bind primarily from a successful parent vault_hunter_run result, validate exactly one active Run using the parent participant ID and exact agent-session triple, read the real Run through the installed read-only Registry binary, and render real participants, lifecycle, evidence, usage, and v2 observations without writing state. It must poll safely, refresh only when the Run revision changes, preserve the viewport on unchanged polls, clean up on shutdown, reserve equal stage-label padding, show only the latest eight steps by default with a connected ellipsis, and toggle all versus eight locally with Ctrl+V without registering or changing Ctrl+S, Ctrl+O, or global clipboard behavior. Keep this explicitly disposable and compatible with the existing /atlas-rail-prototype interaction until T18 supplies the production Atlas envelope.

## What Changed
- Add a disposable Atlas evidence rail that binds to the current Vault Hunter Run and renders Registry participants, lifecycle events, evidence, usage, and v2 observations.
- Poll for revision changes while preserving the current view, limiting the default timeline to eight steps, and supporting local Ctrl+V expansion.
- Document the `/atlas-rail-prototype` command, navigation controls, and read-only Registry behavior.

## Risk Assessment

🚨 High: The live Registry rendering path exposes unsanitized persisted text directly to the interactive terminal and should not merge until that injection path is closed.

## Testing

Built and syntax-checked the extension, then rendered a representative real-Run snapshot end to end; successful v2 observations appeared completed, the compact rail showed the latest eight connected steps, and Ctrl+V revealed all steps. Reviewer-visible ANSI render artifacts were captured.

- Evidence: Compact latest-eight Atlas rail ANSI render (local file: <code>/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/no-mistakes-evidence/01KYMS4PYBPHWGEPHR1X87DTRD/rail-compact.ansi</code>)
- Evidence: Expanded all-steps Atlas rail ANSI render (local file: <code>/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/no-mistakes-evidence/01KYMS4PYBPHWGEPHR1X87DTRD/rail-expanded.ansi</code>)
<details>
<summary>Evidence: End-user render verification transcript</summary>

```text
Rendered real participant, lifecycle, evidence, and v2 observations; compact/all toggle verified.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (3m57s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts:323` - The required real evidence rendering is incorrect for Registry evidence states: canonical `green` and `red` values are not recognized, so both render as pending instead of done/failed. Map those states at this shared projection boundary.
- 🚨 `pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts:389` - The intent requires rendering real usage and v2 observations, but v2 `runtime_telemetry` usage lives under `observation.payload.runtime_telemetry`; this projection ignores the payload and reads nonexistent `observation.detail`, so v2 usage values are absent.
- 🚨 `pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts:207` - The intent requires equal stage-label padding, but each label badge is emitted at its natural width (`glyph + label`) without reserving the maximum label width, leaving unequal stage-label spans.
- ⚠️ `README.md:139` - The documentation still calls the command a fixture and omits its live Run binding and Ctrl+V all/eight toggle, making the documented interaction inconsistent with the shipped prototype.

🔧 Fix: Fix Atlas evidence and telemetry rendering
1 error still open:
- 🚨 `pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts:451` - Registry-controlled titles, labels, summaries, details, and commands are rendered without removing terminal control characters. A valid record can contain ESC/BEL/newlines (the repository&#39;s observer fixture includes these), allowing terminal manipulation or broken rail layout. Sanitize all Registry strings at the shared projection boundary before rendering.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts:325` - Canonical v2 observation states such as `succeeded`, `recorded`, and `supports` are not mapped to done, so successful real v2 observations render as pending instead of completed.
- `printf '{"type":"get_commands"}' | pi --offline --no-extensions --no-skills --no-themes --no-context-files --no-session --mode rpc -e ./pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts`
- <code>Compared `stageState` mappings with canonical `ObservationState` values in `internal/vaultregistry/model_v2.go`</code>
- <code>Read a real active Run using `vault-hunter-registry` to confirm the installed read-only Registry command contract and real participant/lifecycle/evidence shape</code>

🔧 Fix: Map successful v2 observations to done
✅ Re-checked - no issues remain.
- <code>`bun build pi/.pi/agent/extensions/atlas-evidence-rail-prototype.ts --target=node --external=&#39;@earendil-works/*&#39;` followed by `node --check`</code>
- `Focused render harness exercising participant, lifecycle, evidence, usage-capable projection, successful v2 observation states, latest-eight rendering, connected ellipsis, and local Ctrl+V expansion`
- `Verified rendered compact and expanded ANSI surfaces were generated and non-empty`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
