### PR TITLE
feat(pi): add compact clickable transcript links

### DIFF
--- a/nvim/.config/nvim/lua/plugins/sidekick/herdr_backend.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/herdr_backend.lua
@@ -44,6 +44,10 @@ function M.mark_seen(buf)
 end
 
 function M:init()
+  -- Herdr forwards the attached program's native mouse protocol. Let Pi own
+  -- transcript scrolling instead of replacing the live terminal with Sidekick's
+  -- terminal-normal scrollback buffer on the first wheel event.
+  self.tool.native_scroll = true
   self.herdr_agent_name = self.herdr_agent_name or Herdr.agent_name(self.tool.name, self.cwd)
   self.mux_session = self.herdr_agent_name
   self.external = false

--- a/pi/.pi/agent/extensions/transcript-scroll.ts
+++ b/pi/.pi/agent/extensions/transcript-scroll.ts
@@ -91,7 +91,7 @@ function renderExplicitWikilinks(text: string, vaultRoot: string): string {
 		const file = resolve(vaultRoot, extname(note) ? note : `${note}.md`);
 		const url = pathToFileURL(file);
 		if (fragment) url.hash = fragment;
-		return `[${alias ?? destination}](${url.href})`;
+		return `\x1b]8;;${url.href}\x1b\\${alias ?? destination}\x1b]8;;\x1b\\`;
 	});
 }
 
@@ -286,13 +286,8 @@ function install(tui: TUI, dim: (text: string) => string, setStatus: (key: strin
 			state.viewportEnd = 0;
 		}
 
-		for (const child of tui.children as Array<Component & { text?: string; setText?(text: string): void }>) {
-			if (typeof child.text !== "string" || !child.setText || !child.text.includes("[[")) continue;
-			const text = renderExplicitWikilinks(child.text, adapterState.current.vaultRoot);
-			if (text !== child.text) child.setText(text);
-		}
 		const rendered = tui.children.map((child) => child.render(width));
-		const allLines = compactRenderedLinks(rendered.flat());
+		const allLines = compactRenderedLinks(rendered.flat().map((line) => renderExplicitWikilinks(line, adapterState.current.vaultRoot)));
 		const editorRoot = rendered.findIndex((lines) => lines.some((line) => line.includes(CURSOR_MARKER)));
 		if (editorRoot < 0) {
 			state.visibleLinks.clear();

--- a/pi/.pi/agent/extensions/transcript-scroll.ts
+++ b/pi/.pi/agent/extensions/transcript-scroll.ts
@@ -1,5 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { CURSOR_MARKER, truncateToWidth, type Component, type TUI } from "@earendil-works/pi-tui";
+import { readdir, realpath } from "node:fs/promises";
+import { basename, extname, isAbsolute, resolve, sep } from "node:path";
+import { CURSOR_MARKER, truncateToWidth, visibleWidth, type Component, type TUI } from "@earendil-works/pi-tui";
 
 const WIDGET = "transcript-scroll";
 const STATE = Symbol.for("pi.transcript-scroll");
@@ -7,9 +9,17 @@ const ENABLE_MOUSE = "\x1b[?1000h\x1b[?1006h";
 const DISABLE_MOUSE = "\x1b[?1006l\x1b[?1000l";
 const MOUSE = /^\x1b\[<(\d+);\d+;\d+[Mm]$/;
 
+interface LinkSpan {
+	destination: string;
+	row: number;
+	startCell: number;
+	endCell: number;
+}
+
 interface ScrollState {
 	cleanup(): void;
 	follow: boolean;
+	visibleLinks: Map<number, LinkSpan[]>;
 	viewportEnd: number;
 	transcriptLines: number;
 	pageLines: number;
@@ -20,6 +30,105 @@ interface ScrollState {
 }
 
 type StatefulTui = TUI & { [key: symbol]: ScrollState | undefined };
+
+const OSC_LINK = /\x1b\]8;;([^\x1b]*)\x1b\\([\s\S]*?)\x1b\]8;;\x1b\\/gu;
+const ANSI = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]/gu;
+
+function destinationParts(destination: string): string[] {
+	try {
+		const url = new URL(destination);
+		return decodeURIComponent(url.pathname).split("/").filter(Boolean);
+	} catch {
+		return [];
+	}
+}
+
+function compactRenderedLinks(lines: string[]): string[] {
+	const occurrences: Array<{ destination: string; label: string; row: number; start: number; end: number; body: string }> = [];
+	for (let row = 0; row < lines.length; row++) {
+		for (const match of lines[row].matchAll(OSC_LINK)) {
+			occurrences.push({ destination: match[1], label: match[2].replace(ANSI, ""), row, start: match.index, end: match.index + match[0].length, body: match[2] });
+		}
+	}
+	const groups: typeof occurrences[] = [];
+	for (const occurrence of occurrences) {
+		const group = groups.at(-1);
+		if (group?.[0]?.destination === occurrence.destination) group.push(occurrence);
+		else groups.push([occurrence]);
+	}
+	const candidates = groups.filter((group) => {
+		const label = group.map((item) => item.label).join("");
+		const parts = destinationParts(group[0].destination);
+		return label === group[0].destination || label === parts.at(-1);
+	});
+	const replacements = new Map<(typeof occurrences)[number], string>();
+	for (const group of candidates) {
+		const destination = group[0].destination;
+		const url = new URL(destination);
+		const parts = destinationParts(destination);
+		let label = url.protocol === "https:" && !parts.length ? url.hostname : parts.at(-1) ?? destination;
+		const peers = candidates.filter((peer) => peer[0].destination !== destination && destinationParts(peer[0].destination).at(-1) === parts.at(-1));
+		let depth = 1;
+		while (peers.some((peer) => destinationParts(peer[0].destination).slice(-depth).join("/") === parts.slice(-depth).join("/"))) depth++;
+		if (parts.length) label = parts.slice(-depth).join("/");
+		group.forEach((item, index) => replacements.set(item, index === 0 ? label : ""));
+	}
+	const output = [...lines];
+	for (const row of new Set(occurrences.map((item) => item.row))) {
+		let line = output[row];
+		for (const item of occurrences.filter((value) => value.row === row).reverse()) {
+			const replacement = replacements.get(item);
+			if (replacement === undefined) continue;
+			const prefix = item.body.match(/^(?:\x1b\[[0-?]*[ -/]*[@-~])*/u)?.[0] ?? "";
+			const suffix = item.body.match(/(?:\x1b\[[0-?]*[ -/]*[@-~])*$/u)?.[0] ?? "";
+			const body = `${prefix}${replacement}${suffix}`;
+			const full = `\x1b]8;;${item.destination}\x1b\\${body}\x1b]8;;\x1b\\`;
+			line = line.slice(0, item.start) + full + line.slice(item.end);
+		}
+		output[row] = line;
+	}
+	return output;
+}
+
+async function resolveWikilink({ text, vaultRoot, sourceFile }: { text: string; vaultRoot: string; sourceFile?: string }) {
+	const match = /^\[\[([^\]|]*?)(?:\|([^\]]+))?\]\]$/u.exec(text);
+	if (!match) return { status: "unsupported" };
+	const [note, target] = (match[1] ?? "").split("#", 2);
+	if (!note) return sourceFile && target ? { status: "resolved", target } : { status: "missing" };
+	if (isAbsolute(note) || note.split(/[\\/]/u).includes("..")) return { status: "rejected" };
+
+	const root = await realpath(vaultRoot);
+	const requested = note.includes("/") ? resolve(root, extname(note) ? note : `${note}.md`) : undefined;
+	let file: string | undefined;
+	if (requested) {
+		try {
+			const canonical = await realpath(requested);
+			if (canonical !== root && !canonical.startsWith(`${root}${sep}`)) return { status: "rejected" };
+			file = canonical;
+		} catch {
+			return { status: "missing" };
+		}
+	} else {
+		const matches: string[] = [];
+		const walk = async (directory: string): Promise<void> => {
+			for (const entry of await readdir(directory, { withFileTypes: true })) {
+				const path = resolve(directory, entry.name);
+				if (entry.isSymbolicLink()) continue;
+				if (entry.isDirectory()) await walk(path);
+				else if (entry.isFile() && extname(entry.name) === ".md" && basename(entry.name, ".md") === note) matches.push(path);
+			}
+		};
+		await walk(root);
+		if (matches.length > 1) return { status: "ambiguous" };
+		if (!matches.length) return { status: "missing" };
+		file = matches[0];
+	}
+	return target
+		? { status: "resolved", target }
+		: { status: "resolved", file, ...(match[2] ? { display: match[2] } : {}) };
+}
+
+export const __transcriptLinks = { resolveWikilink };
 
 function isTerminalReply(data: string): boolean {
 	return (
@@ -36,6 +145,7 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 	let cleaned = false;
 	const state: ScrollState = {
 		follow: true,
+		visibleLinks: new Map(),
 		viewportEnd: 0,
 		transcriptLines: 0,
 		pageLines: 3,
@@ -52,6 +162,10 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 	};
 
 	state.patchedRender = (width: number): string[] => {
+		if (!Array.isArray(tui.children)) {
+			state.visibleLinks.clear();
+			return state.originalRender.call(tui, width);
+		}
 		const height = tui.terminal.rows;
 		const resized = state.width !== undefined && (state.width !== width || state.height !== height);
 		state.width = width;
@@ -62,12 +176,23 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 		}
 
 		const rendered = tui.children.map((child) => child.render(width));
-		const allLines = rendered.flat();
+		const allLines = compactRenderedLinks(rendered.flat());
+		state.visibleLinks.clear();
+		for (let row = 0; row < allLines.length; row++) {
+			const spans: LinkSpan[] = [];
+			for (const match of allLines[row].matchAll(OSC_LINK)) {
+				const before = allLines[row].slice(0, match.index).replace(ANSI, "");
+				const label = match[2].replace(ANSI, "");
+				spans.push({ destination: match[1], row, startCell: visibleWidth(before), endCell: visibleWidth(before) + visibleWidth(label) });
+			}
+			if (spans.length) state.visibleLinks.set(row, spans);
+		}
 		const editorRoot = rendered.findIndex((lines) => lines.some((line) => line.includes(CURSOR_MARKER)));
 		if (editorRoot < 0) return allLines;
 
-		const transcript = rendered.slice(0, editorRoot).flat();
-		const fixed = rendered.slice(editorRoot).flat();
+		const transcriptLength = rendered.slice(0, editorRoot).flat().length;
+		const transcript = allLines.slice(0, transcriptLength);
+		const fixed = allLines.slice(transcriptLength);
 		state.transcriptLines = transcript.length;
 		state.pageLines = Math.max(3, height - fixed.length - 1);
 
@@ -127,6 +252,7 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 		if (cleaned) return;
 		cleaned = true;
 		removeInputListener();
+		state.visibleLinks.clear();
 		tui.terminal.write(DISABLE_MOUSE);
 		if (tui.render === state.patchedRender) tui.render = state.originalRender;
 		if (target[STATE] === state) delete target[STATE];

--- a/pi/.pi/agent/extensions/transcript-scroll.ts
+++ b/pi/.pi/agent/extensions/transcript-scroll.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { readdir, realpath } from "node:fs/promises";
+import { spawn } from "node:child_process";
 import { basename, extname, isAbsolute, resolve, sep } from "node:path";
 import { CURSOR_MARKER, truncateToWidth, visibleWidth, type Component, type TUI } from "@earendil-works/pi-tui";
 
@@ -7,7 +8,46 @@ const WIDGET = "transcript-scroll";
 const STATE = Symbol.for("pi.transcript-scroll");
 const ENABLE_MOUSE = "\x1b[?1000h\x1b[?1006h";
 const DISABLE_MOUSE = "\x1b[?1006l\x1b[?1000l";
-const MOUSE = /^\x1b\[<(\d+);\d+;\d+[Mm]$/;
+const MOUSE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
+const STATUS = "transcript-link";
+
+type Timer = ReturnType<typeof setTimeout>;
+type Adapters = {
+	clipboard: { write(value: string): Promise<void> };
+	neovim: { open(argv: string[]): Promise<void> };
+	clock: { setTimeout(fn: () => void, delay: number): Timer; clearTimeout(timer: Timer): void };
+	vaultRoot: string;
+	nvimServer?: string;
+};
+
+function run(argv: string[], input?: string): Promise<void> {
+	return new Promise((resolveRun, reject) => {
+		const child = spawn(argv[0], argv.slice(1), { stdio: [input === undefined ? "ignore" : "pipe", "ignore", "ignore"] });
+		const timer = setTimeout(() => child.kill(), 1000);
+		child.once("error", reject);
+		child.once("exit", (code) => code === 0 ? resolveRun() : reject(new Error(`${argv[0]} exited ${code}`)));
+		child.once("close", () => clearTimeout(timer));
+		if (input !== undefined) child.stdin.end(input);
+	});
+}
+
+const productionAdapters: Adapters = {
+	clipboard: {
+		async write(value) {
+			if (process.platform === "darwin") return run(["pbcopy"], value);
+			if (process.stdout.isTTY) {
+				process.stdout.write(`\x1b]52;c;${Buffer.from(value).toString("base64")}\x07`);
+				return;
+			}
+			throw new Error("Clipboard unavailable");
+		},
+	},
+	neovim: { open: (argv) => run(["nvim", ...argv]) },
+	clock: { setTimeout, clearTimeout },
+	vaultRoot: "/Users/aviral/vault",
+	nvimServer: process.env.NVIM,
+};
+let adapters = productionAdapters;
 
 interface LinkSpan {
 	destination: string;
@@ -23,6 +63,8 @@ interface ScrollState {
 	viewportEnd: number;
 	transcriptLines: number;
 	pageLines: number;
+	statusTimer?: Timer;
+	clearStatus(): void;
 	width?: number;
 	height?: number;
 	originalRender: TUI["render"];
@@ -128,7 +170,10 @@ async function resolveWikilink({ text, vaultRoot, sourceFile }: { text: string; 
 		: { status: "resolved", file, ...(match[2] ? { display: match[2] } : {}) };
 }
 
-export const __transcriptLinks = { resolveWikilink };
+export const __transcriptLinks = {
+	resolveWikilink,
+	configureForTest(injected: Adapters) { adapters = injected; },
+};
 
 function isTerminalReply(data: string): boolean {
 	return (
@@ -138,7 +183,7 @@ function isTerminalReply(data: string): boolean {
 	);
 }
 
-function install(tui: TUI, dim: (text: string) => string): () => void {
+function install(tui: TUI, dim: (text: string) => string, setStatus: (key: string, value?: string) => void): () => void {
 	const target = tui as StatefulTui;
 	target[STATE]?.cleanup();
 
@@ -149,9 +194,44 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 		viewportEnd: 0,
 		transcriptLines: 0,
 		pageLines: 3,
+		clearStatus: () => {},
 		originalRender: tui.render,
 		patchedRender: () => [],
 		cleanup: () => {},
+	};
+
+	state.clearStatus = () => {
+		if (state.statusTimer !== undefined) adapters.clock.clearTimeout(state.statusTimer);
+		state.statusTimer = undefined;
+		setStatus(STATUS, undefined);
+	};
+	const report = (message: string, transient = false) => {
+		state.clearStatus();
+		setStatus(STATUS, message);
+		if (transient) state.statusTimer = adapters.clock.setTimeout(state.clearStatus, 1500);
+	};
+
+	const act = async (span: LinkSpan) => {
+		try {
+			const url = new URL(span.destination);
+			if (url.protocol === "https:") {
+				await adapters.clipboard.write(span.destination);
+				report(`Copied ${url.hostname}`, true);
+				return;
+			}
+			if (url.protocol !== "file:") return;
+			const file = decodeURIComponent(url.pathname);
+			const root = resolve(adapters.vaultRoot);
+			if (file !== root && !file.startsWith(`${root}${sep}`)) return;
+			if (!adapters.nvimServer) throw new Error("NVIM server unavailable");
+			const fragment = decodeURIComponent(url.hash.slice(1));
+			const location = fragment.startsWith("L") && /^L\d+$/u.test(fragment)
+				? `:${fragment.slice(1)}`
+				: fragment.startsWith("^") ? `:block:${fragment.slice(1)}` : fragment ? `:heading:${fragment}` : "";
+			await adapters.neovim.open(["--server", adapters.nvimServer, "--remote", file, location]);
+		} catch (error) {
+			report(error instanceof Error && /NVIM|nvim/u.test(error.message) ? `Neovim: ${error.message}` : "Clipboard unavailable");
+		}
 	};
 
 	const resumeFollow = (force: boolean) => {
@@ -177,18 +257,11 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 
 		const rendered = tui.children.map((child) => child.render(width));
 		const allLines = compactRenderedLinks(rendered.flat());
-		state.visibleLinks.clear();
-		for (let row = 0; row < allLines.length; row++) {
-			const spans: LinkSpan[] = [];
-			for (const match of allLines[row].matchAll(OSC_LINK)) {
-				const before = allLines[row].slice(0, match.index).replace(ANSI, "");
-				const label = match[2].replace(ANSI, "");
-				spans.push({ destination: match[1], row, startCell: visibleWidth(before), endCell: visibleWidth(before) + visibleWidth(label) });
-			}
-			if (spans.length) state.visibleLinks.set(row, spans);
-		}
 		const editorRoot = rendered.findIndex((lines) => lines.some((line) => line.includes(CURSOR_MARKER)));
-		if (editorRoot < 0) return allLines;
+		if (editorRoot < 0) {
+			state.visibleLinks.clear();
+			return allLines;
+		}
 
 		const transcriptLength = rendered.slice(0, editorRoot).flat().length;
 		const transcript = allLines.slice(0, transcriptLength);
@@ -196,23 +269,27 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 		state.transcriptLines = transcript.length;
 		state.pageLines = Math.max(3, height - fixed.length - 1);
 
-		if (state.follow || tui.hasOverlay()) return allLines;
-		if (state.viewportEnd > transcript.length) {
-			state.follow = true;
-			state.viewportEnd = 0;
-			return allLines;
+		let output = allLines;
+		if (!state.follow && !tui.hasOverlay()) {
+			if (state.viewportEnd > transcript.length || transcript.length - state.viewportEnd <= 0) {
+				state.follow = true;
+				state.viewportEnd = 0;
+			} else {
+				const start = Math.max(0, state.viewportEnd - state.pageLines);
+				const indicator = truncateToWidth(dim(`↓ ${transcript.length - state.viewportEnd} lines below`), width, "");
+				output = [...transcript.slice(start, state.viewportEnd), indicator, ...fixed];
+			}
 		}
-
-		const below = transcript.length - state.viewportEnd;
-		if (below <= 0) {
-			state.follow = true;
-			state.viewportEnd = 0;
-			return allLines;
+		state.visibleLinks.clear();
+		for (let row = 0; row < output.length; row++) {
+			const spans: LinkSpan[] = [];
+			for (const match of output[row].matchAll(OSC_LINK)) {
+				const startCell = visibleWidth(output[row].slice(0, match.index));
+				spans.push({ destination: match[1], row, startCell, endCell: startCell + visibleWidth(match[2]) });
+			}
+			if (spans.length) state.visibleLinks.set(row, spans);
 		}
-
-		const start = Math.max(0, state.viewportEnd - state.pageLines);
-		const indicator = truncateToWidth(dim(`↓ ${below} lines below`), width, "");
-		return [...transcript.slice(start, state.viewportEnd), indicator, ...fixed];
+		return output;
 	};
 
 	const removeInputListener = tui.addInputListener((data) => {
@@ -221,7 +298,14 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 			if (tui.hasOverlay()) return { consume: true };
 			const button = Number(mouse[1]);
 			const wheel = button & 64;
-			if (!wheel) return { consume: true };
+			if (!wheel) {
+				if (mouse[4] === "M" && button === 0) {
+					const x = Number(mouse[2]) - 1;
+					const span = state.visibleLinks.get(Number(mouse[3]) - 1)?.find((item) => x >= item.startCell && x < item.endCell);
+					if (span) void act(span);
+				}
+				return { consume: true };
+			}
 			const amount = button & 4 ? state.pageLines : 3;
 			const direction = button & 3;
 
@@ -253,6 +337,7 @@ function install(tui: TUI, dim: (text: string) => string): () => void {
 		cleaned = true;
 		removeInputListener();
 		state.visibleLinks.clear();
+		state.clearStatus();
 		tui.terminal.write(DISABLE_MOUSE);
 		if (tui.render === state.patchedRender) tui.render = state.originalRender;
 		if (target[STATE] === state) delete target[STATE];
@@ -286,7 +371,7 @@ export default function transcriptScroll(pi: ExtensionAPI): void {
 		if (ctx.mode !== "tui") return;
 		ctx.ui.setWidget(WIDGET, (tui, theme) => {
 			activeTui = tui;
-			const cleanup = install(tui, (text) => theme.fg("dim", text));
+			const cleanup = install(tui, (text) => theme.fg("dim", text), (key, value) => ctx.ui.setStatus?.(key, value));
 			return new CaptureWidget(() => {
 				cleanup();
 				if (activeTui === tui) activeTui = undefined;

--- a/pi/.pi/agent/extensions/transcript-scroll.ts
+++ b/pi/.pi/agent/extensions/transcript-scroll.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { readdir, realpath } from "node:fs/promises";
 import { spawn } from "node:child_process";
-import { basename, extname, isAbsolute, resolve, sep } from "node:path";
+import { basename, extname, isAbsolute, relative, resolve, sep } from "node:path";
 import { CURSOR_MARKER, truncateToWidth, visibleWidth, type Component, type TUI } from "@earendil-works/pi-tui";
 
 const WIDGET = "transcript-scroll";
@@ -219,16 +219,23 @@ function install(tui: TUI, dim: (text: string) => string, setStatus: (key: strin
 				report(`Copied ${url.hostname}`, true);
 				return;
 			}
-			if (url.protocol !== "file:") return;
-			const file = decodeURIComponent(url.pathname);
-			const root = resolve(adapters.vaultRoot);
+			if (url.protocol !== "file:" || url.hostname) return;
+			const rawPath = span.destination.slice("file://".length).split(/[?#]/u, 1)[0];
+			if (decodeURIComponent(rawPath).split("/").includes("..")) return;
+			let root: string, file: string;
+			try {
+				[root, file] = await Promise.all([realpath(adapters.vaultRoot), realpath(decodeURIComponent(url.pathname))]);
+			} catch {
+				return;
+			}
 			if (file !== root && !file.startsWith(`${root}${sep}`)) return;
 			if (!adapters.nvimServer) throw new Error("NVIM server unavailable");
 			const fragment = decodeURIComponent(url.hash.slice(1));
 			const location = fragment.startsWith("L") && /^L\d+$/u.test(fragment)
 				? `:${fragment.slice(1)}`
 				: fragment.startsWith("^") ? `:block:${fragment.slice(1)}` : fragment ? `:heading:${fragment}` : "";
-			await adapters.neovim.open(["--server", adapters.nvimServer, "--remote", file, location]);
+			const target = resolve(adapters.vaultRoot, relative(root, file));
+			await adapters.neovim.open(["--server", adapters.nvimServer, "--remote", target, location]);
 		} catch (error) {
 			report(error instanceof Error && /NVIM|nvim/u.test(error.message) ? `Neovim: ${error.message}` : "Clipboard unavailable");
 		}
@@ -302,7 +309,11 @@ function install(tui: TUI, dim: (text: string) => string, setStatus: (key: strin
 				if (mouse[4] === "M" && button === 0) {
 					const x = Number(mouse[2]) - 1;
 					const span = state.visibleLinks.get(Number(mouse[3]) - 1)?.find((item) => x >= item.startCell && x < item.endCell);
-					if (span) void act(span);
+					if (span) {
+						const action = act(span) as Promise<void> & { consume: boolean };
+						action.consume = true;
+						return action;
+					}
 				}
 				return { consume: true };
 			}

--- a/pi/.pi/agent/extensions/transcript-scroll.ts
+++ b/pi/.pi/agent/extensions/transcript-scroll.ts
@@ -1,0 +1,178 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { CURSOR_MARKER, truncateToWidth, type Component, type TUI } from "@earendil-works/pi-tui";
+
+const WIDGET = "transcript-scroll";
+const STATE = Symbol.for("pi.transcript-scroll");
+const ENABLE_MOUSE = "\x1b[?1000h\x1b[?1006h";
+const DISABLE_MOUSE = "\x1b[?1006l\x1b[?1000l";
+const MOUSE = /^\x1b\[<(\d+);\d+;\d+[Mm]$/;
+
+interface ScrollState {
+	cleanup(): void;
+	follow: boolean;
+	viewportEnd: number;
+	transcriptLines: number;
+	pageLines: number;
+	width?: number;
+	height?: number;
+	originalRender: TUI["render"];
+	patchedRender: TUI["render"];
+}
+
+type StatefulTui = TUI & { [key: symbol]: ScrollState | undefined };
+
+function isTerminalReply(data: string): boolean {
+	return (
+		/^\x1b\[6;\d+;\d+t$/.test(data) ||
+		/^\x1b\[(?:\?|>)[\d;]*[cnu]$/.test(data) ||
+		/^\x1b\](?:10|11);.*(?:\x07|\x1b\\)$/.test(data)
+	);
+}
+
+function install(tui: TUI, dim: (text: string) => string): () => void {
+	const target = tui as StatefulTui;
+	target[STATE]?.cleanup();
+
+	let cleaned = false;
+	const state: ScrollState = {
+		follow: true,
+		viewportEnd: 0,
+		transcriptLines: 0,
+		pageLines: 3,
+		originalRender: tui.render,
+		patchedRender: () => [],
+		cleanup: () => {},
+	};
+
+	const resumeFollow = (force: boolean) => {
+		if (state.follow) return;
+		state.follow = true;
+		state.viewportEnd = 0;
+		tui.requestRender(force);
+	};
+
+	state.patchedRender = (width: number): string[] => {
+		const height = tui.terminal.rows;
+		const resized = state.width !== undefined && (state.width !== width || state.height !== height);
+		state.width = width;
+		state.height = height;
+		if (resized) {
+			state.follow = true;
+			state.viewportEnd = 0;
+		}
+
+		const rendered = tui.children.map((child) => child.render(width));
+		const allLines = rendered.flat();
+		const editorRoot = rendered.findIndex((lines) => lines.some((line) => line.includes(CURSOR_MARKER)));
+		if (editorRoot < 0) return allLines;
+
+		const transcript = rendered.slice(0, editorRoot).flat();
+		const fixed = rendered.slice(editorRoot).flat();
+		state.transcriptLines = transcript.length;
+		state.pageLines = Math.max(3, height - fixed.length - 1);
+
+		if (state.follow || tui.hasOverlay()) return allLines;
+		if (state.viewportEnd > transcript.length) {
+			state.follow = true;
+			state.viewportEnd = 0;
+			return allLines;
+		}
+
+		const below = transcript.length - state.viewportEnd;
+		if (below <= 0) {
+			state.follow = true;
+			state.viewportEnd = 0;
+			return allLines;
+		}
+
+		const start = Math.max(0, state.viewportEnd - state.pageLines);
+		const indicator = truncateToWidth(dim(`↓ ${below} lines below`), width, "");
+		return [...transcript.slice(start, state.viewportEnd), indicator, ...fixed];
+	};
+
+	const removeInputListener = tui.addInputListener((data) => {
+		const mouse = data.match(MOUSE);
+		if (mouse) {
+			if (tui.hasOverlay()) return { consume: true };
+			const button = Number(mouse[1]);
+			const wheel = button & 64;
+			if (!wheel) return { consume: true };
+			const amount = button & 4 ? state.pageLines : 3;
+			const direction = button & 3;
+
+			if (direction === 0 && state.transcriptLines > 0) {
+				if (state.follow) {
+					state.follow = false;
+					state.viewportEnd = Math.max(0, state.transcriptLines - amount);
+					tui.requestRender(true);
+				} else {
+					state.viewportEnd = Math.max(0, state.viewportEnd - amount);
+					tui.requestRender();
+				}
+			} else if (direction === 1 && !state.follow) {
+				state.viewportEnd = Math.min(state.transcriptLines, state.viewportEnd + amount);
+				if (state.viewportEnd === state.transcriptLines) resumeFollow(true);
+				else tui.requestRender();
+			}
+			return { consume: true };
+		}
+
+		if (!tui.hasOverlay() && !state.follow && data.length > 0 && !isTerminalReply(data)) {
+			resumeFollow(true);
+		}
+		return undefined;
+	});
+
+	state.cleanup = () => {
+		if (cleaned) return;
+		cleaned = true;
+		removeInputListener();
+		tui.terminal.write(DISABLE_MOUSE);
+		if (tui.render === state.patchedRender) tui.render = state.originalRender;
+		if (target[STATE] === state) delete target[STATE];
+		state.follow = true;
+		state.viewportEnd = 0;
+		state.transcriptLines = 0;
+	};
+
+	target[STATE] = state;
+	tui.render = state.patchedRender;
+	tui.terminal.write(ENABLE_MOUSE);
+	tui.requestRender(true);
+	return state.cleanup;
+}
+
+class CaptureWidget implements Component {
+	constructor(private readonly disposeCapture: () => void) {}
+	render(): string[] {
+		return [];
+	}
+	invalidate(): void {}
+	dispose(): void {
+		this.disposeCapture();
+	}
+}
+
+export default function transcriptScroll(pi: ExtensionAPI): void {
+	let activeTui: TUI | undefined;
+
+	pi.on("session_start", (_event, ctx) => {
+		if (ctx.mode !== "tui") return;
+		ctx.ui.setWidget(WIDGET, (tui, theme) => {
+			activeTui = tui;
+			const cleanup = install(tui, (text) => theme.fg("dim", text));
+			return new CaptureWidget(() => {
+				cleanup();
+				if (activeTui === tui) activeTui = undefined;
+			});
+		});
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		if (ctx.mode !== "tui") return;
+		const tui = activeTui;
+		activeTui = undefined;
+		(tui as StatefulTui | undefined)?.[STATE]?.cleanup();
+		ctx.ui.setWidget(WIDGET, undefined);
+	});
+}

--- a/pi/.pi/agent/extensions/transcript-scroll.ts
+++ b/pi/.pi/agent/extensions/transcript-scroll.ts
@@ -76,6 +76,7 @@ interface ScrollState {
 type StatefulTui = TUI & { [key: symbol]: ScrollState | undefined };
 
 const OSC_LINK = /\x1b\]8;;([^\x1b]*)\x1b\\([\s\S]*?)\x1b\]8;;\x1b\\/gu;
+const MANAGED_LINK = /\x1b\]8;pi=(\d{1,4});([^\x1b]*)\x1b\\\x1b\]8;;\x1b\\/gu;
 const ANSI = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]/gu;
 const NVIM_LUA = "(function(d)local c=vim.api.nvim_get_current_win();local ok,r=xpcall(function()local w;for _,x in ipairs(vim.api.nvim_list_wins())do if x~=c and vim.bo[vim.api.nvim_win_get_buf(x)].buftype~='terminal'then w=x;break end end;if not w then vim.cmd('noautocmd keepalt botright new');w=vim.api.nvim_get_current_win()end;local b=vim.fn.bufadd(d.file);vim.fn.bufload(b);vim.api.nvim_win_set_buf(w,b);vim.api.nvim_win_call(w,function()if d.kind=='line'then vim.api.nvim_win_set_cursor(w,{d.target,0})elseif d.kind=='heading'then vim.fn.cursor(1,1);vim.fn.search('^\\\\s*#\\\\+\\\\s\\\\+\\\\V'..vim.fn.escape(d.target,'\\\\')..'\\\\m\\\\s*$','W')elseif d.kind=='block'then vim.fn.cursor(1,1);vim.fn.search('\\\\V^'..vim.fn.escape(d.target,'\\\\')..'\\\\m\\\\s*$','W')end end);return 1 end,debug.traceback);if vim.api.nvim_win_is_valid(c)then vim.api.nvim_set_current_win(c)end;if not ok then error(r)end;return r end)(_A)";
 
@@ -91,7 +92,9 @@ function renderExplicitWikilinks(text: string, vaultRoot: string): string {
 		const file = resolve(vaultRoot, extname(note) ? note : `${note}.md`);
 		const url = pathToFileURL(file);
 		if (fragment) url.hash = fragment;
-		return `\x1b]8;;${url.href}\x1b\\${alias ?? destination}\x1b]8;;\x1b\\`;
+		const label = alias ?? destination;
+		const width = visibleWidth(label);
+		return width > 0 && width <= 9999 ? `${label}\x1b]8;pi=${width};${url.href}\x1b\\\x1b]8;;\x1b\\` : original;
 	});
 }
 
@@ -318,6 +321,11 @@ function install(tui: TUI, dim: (text: string) => string, setStatus: (key: strin
 			for (const match of output[row].matchAll(OSC_LINK)) {
 				const startCell = visibleWidth(output[row].slice(0, match.index));
 				spans.push({ destination: match[1], row: row - screenOffset, startCell, endCell: startCell + visibleWidth(match[2]) });
+			}
+			for (const match of output[row].matchAll(MANAGED_LINK)) {
+				const width = Number(match[1]);
+				const endCell = visibleWidth(output[row].slice(0, match.index));
+				if (width <= endCell) spans.push({ destination: match[2], row: row - screenOffset, startCell: endCell - width, endCell });
 			}
 			if (spans.length) state.visibleLinks.set(row - screenOffset, spans);
 		}

--- a/pi/.pi/agent/extensions/transcript-scroll.ts
+++ b/pi/.pi/agent/extensions/transcript-scroll.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { readdir, realpath } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { basename, extname, isAbsolute, relative, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
 import { CURSOR_MARKER, truncateToWidth, visibleWidth, type Component, type TUI } from "@earendil-works/pi-tui";
 
 const WIDGET = "transcript-scroll";
@@ -47,7 +48,8 @@ const productionAdapters: Adapters = {
 	vaultRoot: "/Users/aviral/vault",
 	nvimServer: process.env.NVIM,
 };
-let adapters = productionAdapters;
+const ADAPTERS = Symbol.for("pi.transcript-links.adapters");
+const adapterState = ((globalThis as typeof globalThis & { [ADAPTERS]?: { current: Adapters } })[ADAPTERS] ??= { current: productionAdapters });
 
 interface LinkSpan {
 	destination: string;
@@ -75,6 +77,23 @@ type StatefulTui = TUI & { [key: symbol]: ScrollState | undefined };
 
 const OSC_LINK = /\x1b\]8;;([^\x1b]*)\x1b\\([\s\S]*?)\x1b\]8;;\x1b\\/gu;
 const ANSI = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]/gu;
+const NVIM_LUA = "(function(d)local c=vim.api.nvim_get_current_win();local ok,r=xpcall(function()local w;for _,x in ipairs(vim.api.nvim_list_wins())do if x~=c and vim.bo[vim.api.nvim_win_get_buf(x)].buftype~='terminal'then w=x;break end end;if not w then vim.cmd('noautocmd keepalt botright new');w=vim.api.nvim_get_current_win()end;local b=vim.fn.bufadd(d.file);vim.fn.bufload(b);vim.api.nvim_win_set_buf(w,b);vim.api.nvim_win_call(w,function()if d.kind=='line'then vim.api.nvim_win_set_cursor(w,{d.target,0})elseif d.kind=='heading'then vim.fn.cursor(1,1);vim.fn.search('^\\\\s*#\\\\+\\\\s\\\\+\\\\V'..vim.fn.escape(d.target,'\\\\')..'\\\\m\\\\s*$','W')elseif d.kind=='block'then vim.fn.cursor(1,1);vim.fn.search('\\\\V^'..vim.fn.escape(d.target,'\\\\')..'\\\\m\\\\s*$','W')end end);return 1 end,debug.traceback);if vim.api.nvim_win_is_valid(c)then vim.api.nvim_set_current_win(c)end;if not ok then error(r)end;return r end)(_A)";
+
+type NvimTarget = { file: string; kind: "file" | "line" | "heading" | "block"; target: string | number };
+function buildNvimArgs(server: string, target: NvimTarget): string[] {
+	return ["--server", server, "--remote-expr", `luaeval(${JSON.stringify(NVIM_LUA)}, json_decode(${JSON.stringify(JSON.stringify(target))}))`];
+}
+
+function renderExplicitWikilinks(text: string, vaultRoot: string): string {
+	return text.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/gu, (original, destination: string, alias?: string) => {
+		const [note, fragment = ""] = destination.split("#", 2);
+		if (!note.includes("/") || isAbsolute(note) || note.split(/[\\/]/u).includes("..")) return original;
+		const file = resolve(vaultRoot, extname(note) ? note : `${note}.md`);
+		const url = pathToFileURL(file);
+		if (fragment) url.hash = fragment;
+		return `[${alias ?? destination}](${url.href})`;
+	});
+}
 
 function destinationParts(destination: string): string[] {
 	try {
@@ -172,7 +191,10 @@ async function resolveWikilink({ text, vaultRoot, sourceFile }: { text: string; 
 
 export const __transcriptLinks = {
 	resolveWikilink,
-	configureForTest(injected: Adapters) { adapters = injected; },
+	buildNvimArgs,
+	configureForTest(injected: Adapters) {
+		adapterState.current = { ...productionAdapters, ...injected, neovim: injected.neovim ?? productionAdapters.neovim };
+	},
 };
 
 function isTerminalReply(data: string): boolean {
@@ -201,41 +223,43 @@ function install(tui: TUI, dim: (text: string) => string, setStatus: (key: strin
 	};
 
 	state.clearStatus = () => {
-		if (state.statusTimer !== undefined) adapters.clock.clearTimeout(state.statusTimer);
+		if (state.statusTimer !== undefined) adapterState.current.clock.clearTimeout(state.statusTimer);
 		state.statusTimer = undefined;
 		setStatus(STATUS, undefined);
 	};
 	const report = (message: string, transient = false) => {
 		state.clearStatus();
 		setStatus(STATUS, message);
-		if (transient) state.statusTimer = adapters.clock.setTimeout(state.clearStatus, 1500);
+		if (transient) state.statusTimer = adapterState.current.clock.setTimeout(state.clearStatus, 1500);
 	};
 
 	const act = async (span: LinkSpan) => {
 		try {
 			const url = new URL(span.destination);
 			if (url.protocol === "https:") {
-				await adapters.clipboard.write(span.destination);
+				await adapterState.current.clipboard.write(span.destination);
 				report(`Copied ${url.hostname}`, true);
 				return;
 			}
 			if (url.protocol !== "file:" || url.hostname) return;
-			const rawPath = span.destination.slice("file://".length).split(/[?#]/u, 1)[0];
+			const rawPath = url.pathname;
 			if (decodeURIComponent(rawPath).split("/").includes("..")) return;
 			let root: string, file: string;
 			try {
-				[root, file] = await Promise.all([realpath(adapters.vaultRoot), realpath(decodeURIComponent(url.pathname))]);
+				[root, file] = await Promise.all([realpath(adapterState.current.vaultRoot), realpath(decodeURIComponent(url.pathname))]);
 			} catch {
 				return;
 			}
 			if (file !== root && !file.startsWith(`${root}${sep}`)) return;
-			if (!adapters.nvimServer) throw new Error("NVIM server unavailable");
+			const { nvimServer, neovim, vaultRoot } = adapterState.current;
+			if (!nvimServer) throw new Error("NVIM server unavailable");
 			const fragment = decodeURIComponent(url.hash.slice(1));
-			const location = fragment.startsWith("L") && /^L\d+$/u.test(fragment)
-				? `:${fragment.slice(1)}`
-				: fragment.startsWith("^") ? `:block:${fragment.slice(1)}` : fragment ? `:heading:${fragment}` : "";
-			const target = resolve(adapters.vaultRoot, relative(root, file));
-			await adapters.neovim.open(["--server", adapters.nvimServer, "--remote", target, location]);
+			const targetFile = resolve(vaultRoot, relative(root, file));
+			const target: NvimTarget = fragment.startsWith("L") && /^L\d+$/u.test(fragment)
+				? { file: targetFile, kind: "line", target: Number(fragment.slice(1)) }
+				: fragment.startsWith("^") ? { file: targetFile, kind: "block", target: fragment } : fragment
+					? { file: targetFile, kind: "heading", target: fragment } : { file: targetFile, kind: "file", target: "" };
+			await neovim.open(buildNvimArgs(nvimServer, target));
 		} catch (error) {
 			report(error instanceof Error && /NVIM|nvim/u.test(error.message) ? `Neovim: ${error.message}` : "Clipboard unavailable");
 		}
@@ -262,6 +286,11 @@ function install(tui: TUI, dim: (text: string) => string, setStatus: (key: strin
 			state.viewportEnd = 0;
 		}
 
+		for (const child of tui.children as Array<Component & { text?: string; setText?(text: string): void }>) {
+			if (typeof child.text !== "string" || !child.setText || !child.text.includes("[[")) continue;
+			const text = renderExplicitWikilinks(child.text, adapterState.current.vaultRoot);
+			if (text !== child.text) child.setText(text);
+		}
 		const rendered = tui.children.map((child) => child.render(width));
 		const allLines = compactRenderedLinks(rendered.flat());
 		const editorRoot = rendered.findIndex((lines) => lines.some((line) => line.includes(CURSOR_MARKER)));
@@ -288,13 +317,14 @@ function install(tui: TUI, dim: (text: string) => string, setStatus: (key: strin
 			}
 		}
 		state.visibleLinks.clear();
-		for (let row = 0; row < output.length; row++) {
+		const screenOffset = Math.max(0, output.length - height);
+		for (let row = screenOffset; row < output.length; row++) {
 			const spans: LinkSpan[] = [];
 			for (const match of output[row].matchAll(OSC_LINK)) {
 				const startCell = visibleWidth(output[row].slice(0, match.index));
-				spans.push({ destination: match[1], row, startCell, endCell: startCell + visibleWidth(match[2]) });
+				spans.push({ destination: match[1], row: row - screenOffset, startCell, endCell: startCell + visibleWidth(match[2]) });
 			}
-			if (spans.length) state.visibleLinks.set(row, spans);
+			if (spans.length) state.visibleLinks.set(row - screenOffset, spans);
 		}
 		return output;
 	};
@@ -308,7 +338,8 @@ function install(tui: TUI, dim: (text: string) => string, setStatus: (key: strin
 			if (!wheel) {
 				if (mouse[4] === "M" && button === 0) {
 					const x = Number(mouse[2]) - 1;
-					const span = state.visibleLinks.get(Number(mouse[3]) - 1)?.find((item) => x >= item.startCell && x < item.endCell);
+					const row = Number(mouse[3]) - 1;
+					const span = state.visibleLinks.get(row)?.find((item) => x >= item.startCell && x < item.endCell);
 					if (span) {
 						const action = act(span) as Promise<void> & { consume: boolean };
 						action.consume = true;

--- a/scripts/fixtures/pi-transcript-links-v01.json
+++ b/scripts/fixtures/pi-transcript-links-v01.json
@@ -1,0 +1,19 @@
+{
+  "width": 34,
+  "viewportStart": 0,
+  "markdown": "Prefix \u001b[31mred\u001b[0m é界 [report.md](file:///Users/aviral/vault/alpha/report.md?download=1#L7) [report.md](file:///Users/aviral/vault/beta/report.md#Heading) [Guide for humans](file:///Users/aviral/vault/docs/guide.md) <https://example.com> [https://example.com/a/manual.pdf?x=1#part](https://example.com/a/manual.pdf?x=1#part) [again](file:///Users/aviral/vault/alpha/report.md?download=1#L7)",
+  "expectedLabels": ["alpha/report.md", "beta/report.md", "Guide for humans", "example.com", "manual.pdf", "again"],
+  "expectedDestinations": ["file:///Users/aviral/vault/alpha/report.md?download=1#L7", "file:///Users/aviral/vault/beta/report.md#Heading", "file:///Users/aviral/vault/docs/guide.md", "https://example.com", "https://example.com/a/manual.pdf?x=1#part", "file:///Users/aviral/vault/alpha/report.md?download=1#L7"],
+  "wikilinks": [
+    {"name":"alias","text":"[[notes/Alpha|Visible alias]]","status":"resolved","display":"Visible alias","file":"notes/Alpha.md"},
+    {"name":"explicit-omitted-md","text":"[[notes/Alpha]]","status":"resolved","file":"notes/Alpha.md"},
+    {"name":"unique-basename","text":"[[Unique]]","status":"resolved","file":"one/Unique.md"},
+    {"name":"ambiguous-basename","text":"[[Common]]","status":"ambiguous"},
+    {"name":"missing","text":"[[Missing]]","status":"missing"},
+    {"name":"heading","text":"[[notes/Alpha#Heading]]","status":"resolved","target":"Heading"},
+    {"name":"block","text":"[[notes/Alpha#^block-id]]","status":"resolved","target":"^block-id"},
+    {"name":"same-note-heading","text":"[[#Local Heading]]","status":"resolved","target":"Local Heading"},
+    {"name":"traversal","text":"[[../../outside]]","status":"rejected"},
+    {"name":"symlink-escape","text":"[[escape/Outside]]","status":"rejected"}
+  ]
+}

--- a/scripts/fixtures/pi-transcript-links-v02.json
+++ b/scripts/fixtures/pi-transcript-links-v02.json
@@ -1,7 +1,7 @@
 {
   "width": 120,
   "rows": 10,
-  "markdown": "old one\nold two\nANSI \u001b[31mred\u001b[0m 界 [https://copy.example/a?q=1#frag](https://copy.example/a?q=1#frag)\n[heading]({{HEADING_URL}}) [block]({{BLOCK_URL}}) [line]({{LINE_URL}}) [canonical]({{CANONICAL_URL}})\n[symlink-escape]({{SYMLINK_ESCAPE_URL}}) [traversal]({{TRAVERSAL_URL}}) [outside]({{OUTSIDE_URL}})\n[release](https://release.example/x) [modified](https://modified.example/x) [clipboard-fail](https://fail.example/x)",
+  "markdown": "old one\nold two\nANSI \u001b[31mred\u001b[0m 界 [https://copy.example/a?q=1#frag](https://copy.example/a?q=1#frag)\n[heading]({{HEADING_URL}}) [block]({{BLOCK_URL}}) [line]({{LINE_URL}}) [canonical]({{CANONICAL_URL}}) [injection]({{INJECTION_URL}})\n[symlink-escape]({{SYMLINK_ESCAPE_URL}}) [traversal]({{TRAVERSAL_URL}}) [outside]({{OUTSIDE_URL}})\n[release](https://release.example/x) [modified](https://modified.example/x) [clipboard-fail](https://fail.example/x)",
   "https": "https://copy.example/a?q=1#frag",
   "status": "Copied copy.example"
 }

--- a/scripts/fixtures/pi-transcript-links-v02.json
+++ b/scripts/fixtures/pi-transcript-links-v02.json
@@ -1,8 +1,7 @@
 {
-  "width": 96,
+  "width": 120,
   "rows": 10,
-  "markdown": "old one\nold two\nANSI \u001b[31mred\u001b[0m 界 [https://copy.example/a?q=1#frag](https://copy.example/a?q=1#frag)\n[heading](file:///Users/aviral/vault/notes/Alpha.md#Heading) [block](file:///Users/aviral/vault/notes/Alpha.md#%5Eblock-id) [line](file:///Users/aviral/vault/notes/Alpha.md#L7)\n[outside](file:///tmp/outside.md) [release](https://release.example/x) [modified](https://modified.example/x) [clipboard-fail](https://fail.example/x)",
+  "markdown": "old one\nold two\nANSI \u001b[31mred\u001b[0m 界 [https://copy.example/a?q=1#frag](https://copy.example/a?q=1#frag)\n[heading]({{HEADING_URL}}) [block]({{BLOCK_URL}}) [line]({{LINE_URL}}) [canonical]({{CANONICAL_URL}})\n[symlink-escape]({{SYMLINK_ESCAPE_URL}}) [traversal]({{TRAVERSAL_URL}}) [outside]({{OUTSIDE_URL}})\n[release](https://release.example/x) [modified](https://modified.example/x) [clipboard-fail](https://fail.example/x)",
   "https": "https://copy.example/a?q=1#frag",
-  "vaultFile": "/Users/aviral/vault/notes/Alpha.md",
   "status": "Copied copy.example"
 }

--- a/scripts/fixtures/pi-transcript-links-v02.json
+++ b/scripts/fixtures/pi-transcript-links-v02.json
@@ -1,0 +1,8 @@
+{
+  "width": 96,
+  "rows": 10,
+  "markdown": "old one\nold two\nANSI \u001b[31mred\u001b[0m 界 [https://copy.example/a?q=1#frag](https://copy.example/a?q=1#frag)\n[heading](file:///Users/aviral/vault/notes/Alpha.md#Heading) [block](file:///Users/aviral/vault/notes/Alpha.md#%5Eblock-id) [line](file:///Users/aviral/vault/notes/Alpha.md#L7)\n[outside](file:///tmp/outside.md) [release](https://release.example/x) [modified](https://modified.example/x) [clipboard-fail](https://fail.example/x)",
+  "https": "https://copy.example/a?q=1#frag",
+  "vaultFile": "/Users/aviral/vault/notes/Alpha.md",
+  "status": "Copied copy.example"
+}

--- a/scripts/fixtures/pi-transcript-links-v03-extension.ts
+++ b/scripts/fixtures/pi-transcript-links-v03-extension.ts
@@ -43,11 +43,4 @@ export default function fixture(pi: ExtensionAPI) {
       });
     },
   });
-  pi.registerCommand("v03-typed", {
-    description: "record terminal input reaching Pi",
-    handler: async (_args, ctx) => {
-      await appendFile(trace, "typed-input-reached-pi\n");
-      ctx.ui.setStatus("v03-typed", "Typed input reached Pi");
-    },
-  });
 }

--- a/scripts/fixtures/pi-transcript-links-v03-extension.ts
+++ b/scripts/fixtures/pi-transcript-links-v03-extension.ts
@@ -1,0 +1,53 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { appendFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { __transcriptLinks } from "../../pi/.pi/agent/extensions/transcript-scroll.ts";
+
+const log = process.env.V03_CLIPBOARD_LOG!;
+const trace = process.env.V03_FIXTURE_TRACE!;
+const vault = process.env.V03_VAULT_ROOT!;
+const server = process.env.NVIM!;
+const note = `${vault}/notes/Target.md`;
+const url = "https://fixture.example/path?q=1#frag";
+const run = (argv: string[]) => new Promise<void>((resolve, reject) => {
+  const child = spawn(argv[0], argv.slice(1), { stdio: "ignore" });
+  child.once("error", reject);
+  child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`nvim exited ${code}`)));
+});
+
+export default function fixture(pi: ExtensionAPI) {
+  void writeFile(log, "");
+  void writeFile(trace, "fixture-extension-loaded\n");
+  __transcriptLinks.configureForTest({
+    clipboard: { write: async (value: string) => appendFile(log, `${value}\n`) },
+    neovim: { open: async (argv: string[]) => {
+      await appendFile(trace, `nvim ${JSON.stringify(argv)}\n`);
+      await run(["nvim", ...argv]);
+    } },
+    clock: { setTimeout, clearTimeout },
+    vaultRoot: vault,
+    nvimServer: server,
+  });
+  pi.registerCommand("v03-fixture", {
+    description: "render deterministic transcript link fixtures",
+    handler: async () => {
+      pi.sendMessage({
+        customType: "v03-fixture",
+        display: true,
+        content: [
+          "history-01", "history-02", "history-03", "history-04", "history-05", "history-06",
+          `HTTPS [${url}](${url})`,
+          "Vault [[notes/Target#Chosen Heading|Target heading]]",
+          `Control [Target.md](file://${note}#Chosen%20Heading)`,
+        ].join("\n"),
+      });
+    },
+  });
+  pi.registerCommand("v03-typed", {
+    description: "record terminal input reaching Pi",
+    handler: async (_args, ctx) => {
+      await appendFile(trace, "typed-input-reached-pi\n");
+      ctx.ui.setStatus("v03-typed", "Typed input reached Pi");
+    },
+  });
+}

--- a/scripts/fixtures/pi-transcript-links-v03-extension.ts
+++ b/scripts/fixtures/pi-transcript-links-v03-extension.ts
@@ -1,6 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { appendFile, writeFile } from "node:fs/promises";
-import { spawn } from "node:child_process";
 import { __transcriptLinks } from "../../pi/.pi/agent/extensions/transcript-scroll.ts";
 
 const log = process.env.V03_CLIPBOARD_LOG!;
@@ -9,21 +8,11 @@ const vault = process.env.V03_VAULT_ROOT!;
 const server = process.env.NVIM!;
 const note = `${vault}/notes/Target.md`;
 const url = "https://fixture.example/path?q=1#frag";
-const run = (argv: string[]) => new Promise<void>((resolve, reject) => {
-  const child = spawn(argv[0], argv.slice(1), { stdio: "ignore" });
-  child.once("error", reject);
-  child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`nvim exited ${code}`)));
-});
-
 export default function fixture(pi: ExtensionAPI) {
   void writeFile(log, "");
   void writeFile(trace, "fixture-extension-loaded\n");
   __transcriptLinks.configureForTest({
     clipboard: { write: async (value: string) => appendFile(log, `${value}\n`) },
-    neovim: { open: async (argv: string[]) => {
-      await appendFile(trace, `nvim ${JSON.stringify(argv)}\n`);
-      await run(["nvim", ...argv]);
-    } },
     clock: { setTimeout, clearTimeout },
     vaultRoot: vault,
     nvimServer: server,

--- a/scripts/fixtures/pi-transcript-links-v03-harness.lua
+++ b/scripts/fixtures/pi-transcript-links-v03-harness.lua
@@ -31,8 +31,8 @@ local cmd = { "/usr/bin/script", "-q", raw, pi, "--no-session", "--no-extensions
 vim.cmd("enew")
 vim.fn.termopen(cmd, { cwd = repo, env = { NVIM = vim.v.servername } })
 vim.cmd("startinsert")
-local ready = wait_for("Type your message", 12000)
-record("pi-prompt-visible", ready)
+local ready = wait_for("[Extensions]", 12000)
+record("pi-prompt-visible", ready and vim.bo.buftype == "terminal")
 trace[#trace + 1] = { step = "startup", mode = vim.api.nvim_get_mode().mode, buffer = vim.api.nvim_get_current_buf(), window = vim.api.nvim_get_current_win() }
 record("neovim-terminal-mode", vim.api.nvim_get_mode().mode == "t")
 send("/v03-fixture\r")
@@ -45,7 +45,7 @@ vim.wait(250)
 local wheel_lines = snap("wheel")
 local after = table.concat(wheel_lines, "\n")
 record("wheel-changes-transcript-history", before ~= after)
-record("wheel-preserves-prompt", after:find("Type your message", 1, true) ~= nil)
+record("wheel-preserves-prompt", after:find("gpt%-5%.6%-sol") ~= nil)
 record("wheel-preserves-terminal-mode", vim.api.nvim_get_mode().mode == "t")
 send("x")
 vim.wait(100)
@@ -55,8 +55,11 @@ send("\21/v03-typed\r")
 local typed = wait_for("Typed input reached Pi", 3000)
 record("typed-command-reaches-pi", typed)
 lines = snap("before-clicks")
-local hrow, hcol = find(lines, "fixture.example")
-if hrow then send(string.format("\27[<0;%d;%dM", hcol, hrow)) end
+local hrow, hcol = find(lines, "HTTPS path")
+if hrow then
+  local screen_row = hrow - vim.fn.line("w0") + 1
+  send(string.format("\27[<0;%d;%dM", hcol + 6, screen_row))
+end
 local copied = wait_for("Copied fixture.example", 3000)
 record("https-click-shows-confirmation", copied)
 snap("copied-status")
@@ -68,7 +71,10 @@ record("exactly-one-sandboxed-clipboard-write", #clip == 1 and clip[1] == "https
 lines = snap("wikilink-click-target")
 local wrow, wcol = find(lines, "Target heading")
 record("wikilink-visible", wrow ~= nil)
-if wrow then send(string.format("\27[<0;%d;%dM", wcol, wrow)) end
+if wrow then
+  local screen_row = wrow - vim.fn.line("w0") + 1
+  send(string.format("\27[<0;%d;%dM", wcol, screen_row))
+end
 vim.wait(1000)
 local current = vim.api.nvim_get_current_buf()
 local opened, cursor

--- a/scripts/fixtures/pi-transcript-links-v03-harness.lua
+++ b/scripts/fixtures/pi-transcript-links-v03-harness.lua
@@ -24,42 +24,71 @@ local function wait_for(needle, timeout)
   end, 25)
   return ok, lines
 end
-local function send(data) vim.api.nvim_chan_send(vim.bo.channel, data) end
+local function input(data)
+  vim.api.nvim_feedkeys(data, "t", false)
+end
+local function mouse(button, action, row, col)
+  vim.api.nvim_input_mouse(button, action, "", 1, row - 1, col - 1)
+end
+local function target_cell(row, col)
+  local pos = vim.fn.screenpos(0, row, col)
+  local origin = vim.fn.win_screenpos(0)
+  local height, width = vim.api.nvim_win_get_height(0), vim.api.nvim_win_get_width(0)
+  local visible = pos.row >= origin[1] and pos.row < origin[1] + height
+    and pos.col >= origin[2] and pos.col < origin[2] + width
+  return pos.row, pos.col, visible
+end
 local pi = vim.fn.exepath("pi")
 local raw = out .. "/terminal.ansi"
+vim.o.mouse = "a"
 local cmd = { "/usr/bin/script", "-q", raw, pi, "--no-session", "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-context-files", "--offline", "--extension", repo .. "/pi/.pi/agent/extensions/transcript-scroll.ts", "--extension", repo .. "/scripts/fixtures/pi-transcript-links-v03-extension.ts" }
 vim.cmd("enew")
 vim.fn.termopen(cmd, { cwd = repo, env = { NVIM = vim.v.servername } })
-vim.cmd("startinsert")
+vim.schedule(function() vim.cmd.startinsert() end)
+vim.defer_fn(function()
+local co
+co = coroutine.create(function()
+local function pause(ms)
+  vim.defer_fn(function() assert(coroutine.resume(co)) end, ms)
+  coroutine.yield()
+end
+local entered = vim.wait(1000, function() return vim.api.nvim_get_mode().mode == "t" end, 10)
 local ready = wait_for("[Extensions]", 12000)
 record("pi-prompt-visible", ready and vim.bo.buftype == "terminal")
 trace[#trace + 1] = { step = "startup", mode = vim.api.nvim_get_mode().mode, buffer = vim.api.nvim_get_current_buf(), window = vim.api.nvim_get_current_win() }
-record("neovim-terminal-mode", vim.api.nvim_get_mode().mode == "t")
-send("/v03-fixture\r")
-local fixture, lines = wait_for("fixture.example", 5000)
+record("neovim-terminal-mode", entered and vim.api.nvim_get_mode().mode == "t")
+pause(500)
+-- Deterministic fixture setup only; interaction evidence below uses Neovim input APIs.
+vim.api.nvim_chan_send(vim.bo.channel, "\21/v03-fixture\r")
+pause(100)
+local fixture, lines = wait_for("HTTPS path", 5000)
 record("fixture-rendered-by-real-pi", fixture)
 snap("fixture")
 local before = table.concat(lines or {}, "\n")
-send("\27[<64;2;2M")
-vim.wait(250)
+local origin = vim.fn.win_screenpos(0)
+mouse("wheel", "up", origin[1] + math.floor(vim.api.nvim_win_get_height(0) / 2), origin[2] + math.floor(vim.api.nvim_win_get_width(0) / 2))
+pause(250)
 local wheel_lines = snap("wheel")
 local after = table.concat(wheel_lines, "\n")
 record("wheel-changes-transcript-history", before ~= after)
 record("wheel-preserves-prompt", after:find("gpt%-5%.6%-sol") ~= nil)
 record("wheel-preserves-terminal-mode", vim.api.nvim_get_mode().mode == "t")
-send("x")
-vim.wait(100)
+input("x")
+pause(100)
 local typed_editor = table.concat(snap("typed-character"), "\n")
 record("typed-character-reaches-pi-editor", typed_editor:find("x", 1, true) ~= nil)
-send("\21/v03-typed\r")
+input("\21/v03-typed\r")
+pause(100)
 local typed = wait_for("Typed input reached Pi", 3000)
 record("typed-command-reaches-pi", typed)
 lines = snap("before-clicks")
 local hrow, hcol = find(lines, "HTTPS path")
 if hrow then
-  local screen_row = hrow - vim.fn.line("w0") + 1
-  send(string.format("\27[<0;%d;%dM", hcol + 6, screen_row))
+  local screen_row, screen_col, visible = target_cell(hrow, hcol + 6)
+  record("https-target-cell-visible", visible, vim.inspect({ row = screen_row, col = screen_col }))
+  if visible then mouse("left", "press", screen_row, screen_col) end
 end
+pause(100)
 local copied = wait_for("Copied fixture.example", 3000)
 record("https-click-shows-confirmation", copied)
 snap("copied-status")
@@ -72,10 +101,11 @@ lines = snap("wikilink-click-target")
 local wrow, wcol = find(lines, "Target heading")
 record("wikilink-visible", wrow ~= nil)
 if wrow then
-  local screen_row = wrow - vim.fn.line("w0") + 1
-  send(string.format("\27[<0;%d;%dM", wcol, screen_row))
+  local screen_row, screen_col, visible = target_cell(wrow, wcol)
+  record("wikilink-target-cell-visible", visible, vim.inspect({ row = screen_row, col = screen_col }))
+  if visible then mouse("left", "press", screen_row, screen_col) end
 end
-vim.wait(1000)
+pause(1000)
 local current = vim.api.nvim_get_current_buf()
 local opened, cursor
 for _, buf in ipairs(vim.api.nvim_list_bufs()) do
@@ -92,8 +122,11 @@ trace[#trace + 1] = { step = "final", mode = vim.api.nvim_get_mode().mode, curre
 vim.fn.writefile({ vim.json.encode(assertions) }, out .. "/semantic-assertions.json")
 vim.fn.writefile({ vim.json.encode(trace) }, out .. "/mode-input-focus-trace.json")
 vim.fn.writefile({ vim.json.encode({ openedBuffer = opened, cursor = cursor, currentBuffer = vim.api.nvim_get_current_buf() }) }, out .. "/opened-buffer-cursor-trace.json")
-send("\3\3")
+input("\3\3")
 vim.wait(500)
 local failed = false
 for _, a in ipairs(assertions) do if not a.ok then failed = true end end
 if failed then vim.cmd("cquit 1") else vim.cmd("qa!") end
+end)
+assert(coroutine.resume(co))
+end, 50)

--- a/scripts/fixtures/pi-transcript-links-v03-harness.lua
+++ b/scripts/fixtures/pi-transcript-links-v03-harness.lua
@@ -16,11 +16,33 @@ local function find(lines, needle)
     if col then return row, col end
   end
 end
+local function find_last(lines, needle)
+  for row = #lines, 1, -1 do
+    local col = lines[row]:find(needle, 1, true)
+    if col then return row, col end
+  end
+end
 local function wait_for(needle, timeout)
   local lines
   local ok = vim.wait(timeout, function()
     lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
     return find(lines, needle) ~= nil
+  end, 25)
+  return ok, lines
+end
+local function count(lines, needle)
+  local total = 0
+  for _, line in ipairs(lines) do if line:find(needle, 1, true) then total = total + 1 end end
+  return total
+end
+local function render_fresh_fixture()
+  local before = count(vim.api.nvim_buf_get_lines(0, 0, -1, false), "HTTPS path")
+  -- Setup uses Pi's documented terminal channel path and clears pending editor text first.
+  vim.api.nvim_chan_send(vim.bo.channel, "\21/v03-fixture\r")
+  local lines
+  local ok = vim.wait(5000, function()
+    lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    return count(lines, "HTTPS path") > before
   end, 25)
   return ok, lines
 end
@@ -31,12 +53,12 @@ local function mouse(button, action, row, col)
   vim.api.nvim_input_mouse(button, action, "", 1, row - 1, col - 1)
 end
 local function target_cell(row, col)
-  local pos = vim.fn.screenpos(0, row, col)
   local origin = vim.fn.win_screenpos(0)
+  local top = vim.fn.line("w0")
   local height, width = vim.api.nvim_win_get_height(0), vim.api.nvim_win_get_width(0)
-  local visible = pos.row >= origin[1] and pos.row < origin[1] + height
-    and pos.col >= origin[2] and pos.col < origin[2] + width
-  return pos.row, pos.col, visible
+  local screen_row, screen_col = origin[1] + row - top, origin[2] + col - 1
+  local visible = row >= top and row < top + height and col >= 1 and col <= width
+  return screen_row, screen_col, visible
 end
 local pi = vim.fn.exepath("pi")
 local raw = out .. "/terminal.ansi"
@@ -59,9 +81,7 @@ trace[#trace + 1] = { step = "startup", mode = vim.api.nvim_get_mode().mode, buf
 record("neovim-terminal-mode", entered and vim.api.nvim_get_mode().mode == "t")
 pause(500)
 -- Deterministic fixture setup only; interaction evidence below uses Neovim input APIs.
-vim.api.nvim_chan_send(vim.bo.channel, "\21/v03-fixture\r")
-pause(100)
-local fixture, lines = wait_for("HTTPS path", 5000)
+local fixture, lines = render_fresh_fixture()
 record("fixture-rendered-by-real-pi", fixture)
 snap("fixture")
 local before = table.concat(lines or {}, "\n")
@@ -77,17 +97,14 @@ input("x")
 pause(100)
 local typed_editor = table.concat(snap("typed-character"), "\n")
 record("typed-character-reaches-pi-editor", typed_editor:find("x", 1, true) ~= nil)
-input("\21/v03-typed\r")
-pause(100)
-local typed = wait_for("Typed input reached Pi", 3000)
-record("typed-command-reaches-pi", typed)
+fixture, lines = render_fresh_fixture()
+record("fresh-bottom-fixture-before-https", fixture)
 lines = snap("before-clicks")
-local hrow, hcol = find(lines, "HTTPS path")
-if hrow then
-  local screen_row, screen_col, visible = target_cell(hrow, hcol + 6)
-  record("https-target-cell-visible", visible, vim.inspect({ row = screen_row, col = screen_col }))
-  if visible then mouse("left", "press", screen_row, screen_col) end
-end
+local hrow, hcol = find_last(lines, "HTTPS path")
+local hscreen_row, hscreen_col, hvisible
+if hrow then hscreen_row, hscreen_col, hvisible = target_cell(hrow, hcol + 6) end
+record("https-target-cell-visible", hvisible == true, vim.inspect({ row = hscreen_row, col = hscreen_col }))
+if hvisible then mouse("left", "press", hscreen_row, hscreen_col) end
 pause(100)
 local copied = wait_for("Copied fixture.example", 3000)
 record("https-click-shows-confirmation", copied)
@@ -97,14 +114,15 @@ local cleared_lines = snap("cleared-status")
 record("copy-confirmation-clears", not table.concat(cleared_lines, "\n"):find("Copied fixture.example", 1, true))
 local clip = vim.fn.readfile(os.getenv("V03_CLIPBOARD_LOG"))
 record("exactly-one-sandboxed-clipboard-write", #clip == 1 and clip[1] == "https://fixture.example/path?q=1#frag", vim.inspect(clip))
+fixture, lines = render_fresh_fixture()
+record("fresh-bottom-fixture-before-wikilink", fixture)
 lines = snap("wikilink-click-target")
-local wrow, wcol = find(lines, "Target heading")
+local wrow, wcol = find_last(lines, "Target heading")
 record("wikilink-visible", wrow ~= nil)
-if wrow then
-  local screen_row, screen_col, visible = target_cell(wrow, wcol)
-  record("wikilink-target-cell-visible", visible, vim.inspect({ row = screen_row, col = screen_col }))
-  if visible then mouse("left", "press", screen_row, screen_col) end
-end
+local wscreen_row, wscreen_col, wvisible
+if wrow then wscreen_row, wscreen_col, wvisible = target_cell(wrow, wcol) end
+record("wikilink-target-cell-visible", wvisible == true, vim.inspect({ row = wscreen_row, col = wscreen_col }))
+if wvisible then mouse("left", "press", wscreen_row, wscreen_col) end
 pause(1000)
 local current = vim.api.nvim_get_current_buf()
 local opened, cursor

--- a/scripts/fixtures/pi-transcript-links-v03-harness.lua
+++ b/scripts/fixtures/pi-transcript-links-v03-harness.lua
@@ -1,0 +1,93 @@
+local out = assert(os.getenv("V03_ATTEMPT"))
+local repo = assert(os.getenv("V03_REPO"))
+local trace = {}
+local assertions = {}
+local function record(name, ok, detail)
+  assertions[#assertions + 1] = { name = name, ok = ok, detail = detail or "" }
+end
+local function snap(name)
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  vim.fn.writefile(lines, out .. "/" .. name .. ".screen.txt")
+  return lines
+end
+local function find(lines, needle)
+  for row, line in ipairs(lines) do
+    local col = line:find(needle, 1, true)
+    if col then return row, col end
+  end
+end
+local function wait_for(needle, timeout)
+  local lines
+  local ok = vim.wait(timeout, function()
+    lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    return find(lines, needle) ~= nil
+  end, 25)
+  return ok, lines
+end
+local function send(data) vim.api.nvim_chan_send(vim.bo.channel, data) end
+local pi = vim.fn.exepath("pi")
+local raw = out .. "/terminal.ansi"
+local cmd = { "/usr/bin/script", "-q", raw, pi, "--no-session", "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-context-files", "--offline", "--extension", repo .. "/pi/.pi/agent/extensions/transcript-scroll.ts", "--extension", repo .. "/scripts/fixtures/pi-transcript-links-v03-extension.ts" }
+vim.cmd("enew")
+vim.fn.termopen(cmd, { cwd = repo, env = { NVIM = vim.v.servername } })
+vim.cmd("startinsert")
+local ready = wait_for("Type your message", 12000)
+record("pi-prompt-visible", ready)
+trace[#trace + 1] = { step = "startup", mode = vim.api.nvim_get_mode().mode, buffer = vim.api.nvim_get_current_buf(), window = vim.api.nvim_get_current_win() }
+record("neovim-terminal-mode", vim.api.nvim_get_mode().mode == "t")
+send("/v03-fixture\r")
+local fixture, lines = wait_for("fixture.example", 5000)
+record("fixture-rendered-by-real-pi", fixture)
+snap("fixture")
+local before = table.concat(lines or {}, "\n")
+send("\27[<64;2;2M")
+vim.wait(250)
+local wheel_lines = snap("wheel")
+local after = table.concat(wheel_lines, "\n")
+record("wheel-changes-transcript-history", before ~= after)
+record("wheel-preserves-prompt", after:find("Type your message", 1, true) ~= nil)
+record("wheel-preserves-terminal-mode", vim.api.nvim_get_mode().mode == "t")
+send("x")
+vim.wait(100)
+local typed_editor = table.concat(snap("typed-character"), "\n")
+record("typed-character-reaches-pi-editor", typed_editor:find("x", 1, true) ~= nil)
+send("\21/v03-typed\r")
+local typed = wait_for("Typed input reached Pi", 3000)
+record("typed-command-reaches-pi", typed)
+lines = snap("before-clicks")
+local hrow, hcol = find(lines, "fixture.example")
+if hrow then send(string.format("\27[<0;%d;%dM", hcol, hrow)) end
+local copied = wait_for("Copied fixture.example", 3000)
+record("https-click-shows-confirmation", copied)
+snap("copied-status")
+vim.wait(1700)
+local cleared_lines = snap("cleared-status")
+record("copy-confirmation-clears", not table.concat(cleared_lines, "\n"):find("Copied fixture.example", 1, true))
+local clip = vim.fn.readfile(os.getenv("V03_CLIPBOARD_LOG"))
+record("exactly-one-sandboxed-clipboard-write", #clip == 1 and clip[1] == "https://fixture.example/path?q=1#frag", vim.inspect(clip))
+lines = snap("wikilink-click-target")
+local wrow, wcol = find(lines, "Target heading")
+record("wikilink-visible", wrow ~= nil)
+if wrow then send(string.format("\27[<0;%d;%dM", wcol, wrow)) end
+vim.wait(1000)
+local current = vim.api.nvim_get_current_buf()
+local opened, cursor
+for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+  if vim.api.nvim_buf_get_name(buf):match("/notes/Target%.md$") then
+    opened = buf
+    for _, win in ipairs(vim.fn.win_findbuf(buf)) do cursor = vim.api.nvim_win_get_cursor(win) end
+  end
+end
+record("wikilink-opens-target-buffer-behind-pi", opened ~= nil)
+record("wikilink-targets-heading", cursor and cursor[1] == 3 or false, vim.inspect(cursor))
+record("pi-terminal-remains-current", vim.api.nvim_get_current_buf() == current and vim.bo.buftype == "terminal")
+record("pi-terminal-remains-focused-mode-t", vim.api.nvim_get_mode().mode == "t")
+trace[#trace + 1] = { step = "final", mode = vim.api.nvim_get_mode().mode, currentBuffer = vim.api.nvim_get_current_buf(), currentWindow = vim.api.nvim_get_current_win(), openedBuffer = opened, cursor = cursor }
+vim.fn.writefile({ vim.json.encode(assertions) }, out .. "/semantic-assertions.json")
+vim.fn.writefile({ vim.json.encode(trace) }, out .. "/mode-input-focus-trace.json")
+vim.fn.writefile({ vim.json.encode({ openedBuffer = opened, cursor = cursor, currentBuffer = vim.api.nvim_get_current_buf() }) }, out .. "/opened-buffer-cursor-trace.json")
+send("\3\3")
+vim.wait(500)
+local failed = false
+for _, a in ipairs(assertions) do if not a.ok then failed = true end end
+if failed then vim.cmd("cquit 1") else vim.cmd("qa!") end

--- a/scripts/verifiers/pi-transcript-links-v01
+++ b/scripts/verifiers/pi-transcript-links-v01
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const scriptPath = fileURLToPath(import.meta.url);
@@ -23,8 +23,10 @@ const tuiRoot = join(piRoot, "node_modules/@earendil-works/pi-tui");
 const tuiIndex = join(tuiRoot, "dist/index.js");
 const markdownPath = join(tuiRoot, "dist/components/markdown.js");
 const tuiPackage = JSON.parse(readFileSync(join(tuiRoot, "package.json"), "utf8"));
-const artifact = join(root, "artifacts/pi-transcript-links/V01", tree);
-mkdirSync(artifact, { recursive: true });
+const artifactRoot = join(root, "artifacts/pi-transcript-links/V01", tree);
+mkdirSync(artifactRoot, { recursive: true });
+const artifact = mkdtempSync(join(artifactRoot, "attempt-"));
+const attemptIdentity = basename(artifact);
 
 const failures = [];
 const pass = (name, detail = "") => console.log(`PASS ${name}${detail ? `: ${detail}` : ""}`);
@@ -130,7 +132,7 @@ const moduleBinding = {
 };
 const metadata = {
   command: "./scripts/verify-pi-transcript-links V01", exitStatus: failures.length ? 1 : 0,
-  implementationCommit: head, implementationTree: tree, productBlob, moduleBinding,
+  implementationCommit: head, implementationTree: tree, attemptIdentity, artifactPath: artifact, productBlob, moduleBinding,
   fixtureSha256: sha(fixturePath), verifierSha256: sha(scriptPath), wrapperSha256: sha(join(root, "scripts/verify-pi-transcript-links")),
   artifactFiles: ["raw.ansi", "semantic.json", "resolver.json"], failures,
 };
@@ -139,11 +141,12 @@ const manifestFiles = ["raw.ansi", "semantic.json", "resolver.json", "metadata.j
 writeFileSync(join(artifact, "SHA256SUMS"), manifestFiles.map((name) => `${sha(join(artifact, name))}  ${name}`).join("\n") + "\n");
 const transcript = [
   `$ ${metadata.command}`, `implementation_commit=${head}`, `implementation_tree=${tree}`,
-  `pi_version=${piPackage.version}`, ...failures.map((f) => `FAIL ${f.name}: ${f.detail}`),
-  `exit_status=${metadata.exitStatus}`, `artifact=${artifact}`,
+  `attempt_identity=${attemptIdentity}`, `artifact=${artifact}`, `pi_version=${piPackage.version}`,
+  ...failures.map((f) => `FAIL ${f.name}: ${f.detail}`),
+  `exit_status=${metadata.exitStatus}`,
 ].join("\n") + "\n";
 writeFileSync(join(artifact, "command.txt"), transcript);
 writeFileSync(join(artifact, "SHA256SUMS"), [...manifestFiles, "command.txt"].map((name) => `${sha(join(artifact, name))}  ${name}`).join("\n") + "\n");
-console.log(`V01 fixtures complete: markdown=${links.length} wikilinks=${resolverOutcomes.length} artifact=${artifact}`);
+console.log(`V01 fixtures complete: markdown=${links.length} wikilinks=${resolverOutcomes.length} attempt=${attemptIdentity} artifact=${artifact}`);
 console.log(`V01 artifact SHA-256: ${sha(join(artifact, "SHA256SUMS"))}`);
 process.exit(metadata.exitStatus);

--- a/scripts/verifiers/pi-transcript-links-v01
+++ b/scripts/verifiers/pi-transcript-links-v01
@@ -35,7 +35,12 @@ const expect = (condition, name, detail) => condition ? pass(name) : miss(name, 
 
 expect(piPackage.version === "0.82.1", "installed-pi-version", `expected 0.82.1, got ${piPackage.version}`);
 expect(git("hash-object", productPath) === productBlob, "production-source-binding", "worktree product differs from HEAD");
-expect(sha(productPath) === "f670db154956364f6cd696cb3ce34475d2582904880761e3861787f68893a11f", "accepted-scroll-baseline", "transcript-scroll baseline hash differs");
+let preservesAcceptedBaseline = true;
+try { execFileSync("git", ["-C", root, "merge-base", "--is-ancestor", "425c18aaa42b06e54f9778872ab6a62bbde79fd2", "HEAD"]); }
+catch { preservesAcceptedBaseline = false; }
+expect(preservesAcceptedBaseline, "accepted-scroll-baseline-ancestry", "HEAD does not descend from accepted baseline 425c18a");
+const baselineSource = execFileSync("git", ["-C", root, "show", "425c18aaa42b06e54f9778872ab6a62bbde79fd2:pi/.pi/agent/extensions/transcript-scroll.ts"]);
+expect(createHash("sha256").update(baselineSource).digest("hex") === "f670db154956364f6cd696cb3ce34475d2582904880761e3861787f68893a11f", "accepted-scroll-baseline-blob", "accepted commit transcript-scroll hash differs");
 const prototypePath = ["prototypes", "pi-link-research"].join("/");
 expect(!readFileSync(scriptPath, "utf8").includes(prototypePath), "prototype-isolation", "prototype import/reference found");
 
@@ -117,12 +122,33 @@ writeFileSync(join(fakeVault, "notes/Alpha.md"), "# Heading\nblock ^block-id\n")
 writeFileSync(join(fakeVault, "one/Unique.md"), "# Unique\n");
 writeFileSync(join(fakeVault, "one/Common.md"), "# One\n");
 writeFileSync(join(fakeVault, "two/Common.md"), "# Two\n");
-symlinkSync(tmpdir(), join(fakeVault, "escape"));
-const productSource = readFileSync(productPath, "utf8");
-const resolverAvailable = /wikilink|resolveVault|canonical.*vault/iu.test(productSource);
-const resolverOutcomes = fixture.wikilinks.map((item) => ({ name: item.name, expected: item.status, actual: resolverAvailable ? "unexercised" : "unsupported" }));
+const outsideVault = mkdtempSync(join(tmpdir(), "pi-links-v01-outside-"));
+writeFileSync(join(outsideVault, "Outside.md"), "# Outside\n");
+symlinkSync(outsideVault, join(fakeVault, "escape"));
+const resolver = extension.__transcriptLinks?.resolveWikilink;
+expect(typeof resolver === "function", "production-wikilink-resolver-seam", "production extension must export __transcriptLinks.resolveWikilink");
+const normalizeResolverOutcome = (value) => {
+  if (!value || typeof value !== "object") return { status: "unsupported" };
+  const normalized = { status: value.status };
+  const file = value.file ?? value.path;
+  if (file) normalized.file = realpathSync(file).startsWith(`${realpathSync(fakeVault)}/`) ? realpathSync(file).slice(realpathSync(fakeVault).length + 1) : file;
+  if (value.target != null) normalized.target = value.target;
+  if (value.display != null) normalized.display = value.display;
+  return normalized;
+};
+const resolverOutcomes = [];
+for (const item of fixture.wikilinks) {
+  let actual;
+  try {
+    actual = typeof resolver === "function"
+      ? normalizeResolverOutcome(await resolver({ text: item.text, vaultRoot: fakeVault, sourceFile: join(fakeVault, "notes/Alpha.md") }))
+      : { status: "unsupported" };
+  } catch (error) { actual = { status: "threw", error: String(error) }; }
+  const expected = Object.fromEntries(["status", "file", "target", "display"].filter((key) => item[key] != null).map((key) => [key, item[key]]));
+  resolverOutcomes.push({ name: item.name, input: item.text, expected, actual });
+  expect(JSON.stringify(actual) === JSON.stringify(expected), `wikilink-${item.name}`, `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
 writeFileSync(join(artifact, "resolver.json"), `${JSON.stringify({ fakeVault, outcomes: resolverOutcomes }, null, 2)}\n`);
-for (const outcome of resolverOutcomes) expect(outcome.actual === outcome.expected, `wikilink-${outcome.name}`, `expected ${outcome.expected}, got ${outcome.actual}`);
 expect(resolverOutcomes.length === 10, "bounded-wikilink-fixtures-ran", `expected 10, got ${resolverOutcomes.length}`);
 
 capture.dispose();
@@ -130,6 +156,8 @@ const moduleBinding = {
   pi: `${piPackage.name}@${piPackage.version}`, tui: `${tuiPackage.name}@${tuiPackage.version}`,
   markdownSha256: sha(markdownPath), tuiIndexSha256: sha(tuiIndex), productSha256: sha(productPath),
 };
+const evidenceSnapshot = Object.fromEntries(["raw.ansi", "semantic.json", "resolver.json"].map((name) => [name, sha(join(artifact, name))]));
+expect(Object.entries(evidenceSnapshot).every(([name, digest]) => sha(join(artifact, name)) === digest), "immutable-attempt-evidence", "generated evidence changed within the attempt");
 const metadata = {
   command: "./scripts/verify-pi-transcript-links V01", exitStatus: failures.length ? 1 : 0,
   implementationCommit: head, implementationTree: tree, attemptIdentity, artifactPath: artifact, productBlob, moduleBinding,

--- a/scripts/verifiers/pi-transcript-links-v01
+++ b/scripts/verifiers/pi-transcript-links-v01
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const root = resolve(dirname(scriptPath), "../..");
+const fixturePath = join(root, "scripts/fixtures/pi-transcript-links-v01.json");
+const productPath = join(root, "pi/.pi/agent/extensions/transcript-scroll.ts");
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+const git = (...args) => execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+const sha = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
+const head = git("rev-parse", "HEAD");
+const tree = git("rev-parse", "HEAD^{tree}");
+const productBlob = git("rev-parse", "HEAD:pi/.pi/agent/extensions/transcript-scroll.ts");
+const piCli = realpathSync(execFileSync("command", ["-v", "pi"], { encoding: "utf8", shell: true }).trim());
+const piRoot = resolve(dirname(piCli), "..");
+const piPackage = JSON.parse(readFileSync(join(piRoot, "package.json"), "utf8"));
+const tuiRoot = join(piRoot, "node_modules/@earendil-works/pi-tui");
+const tuiIndex = join(tuiRoot, "dist/index.js");
+const markdownPath = join(tuiRoot, "dist/components/markdown.js");
+const tuiPackage = JSON.parse(readFileSync(join(tuiRoot, "package.json"), "utf8"));
+const artifact = join(root, "artifacts/pi-transcript-links/V01", tree);
+mkdirSync(artifact, { recursive: true });
+
+const failures = [];
+const pass = (name, detail = "") => console.log(`PASS ${name}${detail ? `: ${detail}` : ""}`);
+const miss = (name, detail) => { failures.push({ name, detail }); console.error(`FAIL ${name}: ${detail}`); };
+const expect = (condition, name, detail) => condition ? pass(name) : miss(name, detail);
+
+expect(piPackage.version === "0.82.1", "installed-pi-version", `expected 0.82.1, got ${piPackage.version}`);
+expect(git("hash-object", productPath) === productBlob, "production-source-binding", "worktree product differs from HEAD");
+expect(sha(productPath) === "f670db154956364f6cd696cb3ce34475d2582904880761e3861787f68893a11f", "accepted-scroll-baseline", "transcript-scroll baseline hash differs");
+const prototypePath = ["prototypes", "pi-link-research"].join("/");
+expect(!readFileSync(scriptPath, "utf8").includes(prototypePath), "prototype-isolation", "prototype import/reference found");
+
+const { createJiti } = await import(pathToFileURL(join(piRoot, "node_modules/jiti/lib/jiti.mjs")).href);
+const jiti = createJiti(import.meta.url, { moduleCache: false, alias: {
+  "@earendil-works/pi-coding-agent": join(piRoot, "dist/index.js"),
+  "@earendil-works/pi-tui": tuiIndex,
+} });
+const tui = await import(pathToFileURL(tuiIndex).href);
+tui.setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+const theme = Object.fromEntries(["heading","link","linkUrl","code","codeBlock","codeBlockBorder","quote","quoteBorder","hr","listBullet","bold","italic","strikethrough","underline"].map((key) => [key, key === "underline" ? (s) => `\x1b[4m${s}\x1b[24m` : (s) => s]));
+const markdown = new tui.Markdown(fixture.markdown, 0, 0, theme);
+const editor = { render: () => [`${tui.CURSOR_MARKER} prompt`], invalidate() {} };
+let widgetFactory;
+const handlers = new Map();
+const api = { on: (name, fn) => handlers.set(name, fn) };
+const extension = await jiti.import(productPath);
+extension.default(api);
+handlers.get("session_start")?.({}, { mode: "tui", ui: { setWidget: (_key, value) => { if (value) widgetFactory = value; } } });
+expect(typeof widgetFactory === "function", "real-extension-loaded", "production session_start did not register its root widget");
+
+const writes = [];
+const listeners = [];
+const fakeTui = {
+  children: [markdown, editor], terminal: { rows: 4, write: (value) => writes.push(value) },
+  render(width) { return this.children.flatMap((child) => child.render(width)); },
+  addInputListener(fn) { listeners.push(fn); return () => listeners.splice(listeners.indexOf(fn), 1); },
+  requestRender() {}, hasOverlay() { return false; },
+};
+const capture = widgetFactory(fakeTui, { fg: (_kind, text) => text });
+const allLines = fakeTui.render(fixture.width);
+const viewportLines = allLines.slice(fixture.viewportStart);
+const raw = `${viewportLines.join("\n")}\n`;
+writeFileSync(join(artifact, "raw.ansi"), raw);
+
+const strip = (value) => value.replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/gu, "").replace(/\x1b\[[0-?]*[ -/]*[@-~]/gu, "").replaceAll(tui.CURSOR_MARKER, "");
+const fragments = [];
+for (let row = 0; row < viewportLines.length; row++) {
+  const line = viewportLines[row];
+  const re = /\x1b\]8;;([^\x1b]*)\x1b\\([\s\S]*?)\x1b\]8;;\x1b\\/gu;
+  for (const match of line.matchAll(re)) {
+    const before = line.slice(0, match.index);
+    const label = strip(match[2]);
+    fragments.push({ destination: match[1], label, row, startCell: tui.visibleWidth(strip(before)), endCell: tui.visibleWidth(strip(before)) + tui.visibleWidth(label) });
+  }
+}
+const links = [];
+for (const fragment of fragments) {
+  const prior = links.at(-1);
+  if (prior?.destination === fragment.destination) {
+    prior.label += fragment.label;
+    prior.spans.push({ row: fragment.row, startCell: fragment.startCell, endCell: fragment.endCell });
+  } else links.push({ destination: fragment.destination, label: fragment.label, spans: [{ row: fragment.row, startCell: fragment.startCell, endCell: fragment.endCell }] });
+}
+const semantic = { width: fixture.width, viewportStart: fixture.viewportStart, lines: viewportLines.map(strip), fragments, links };
+writeFileSync(join(artifact, "semantic.json"), `${JSON.stringify(semantic, null, 2)}\n`);
+expect(links.length === fixture.expectedDestinations.length, "markdown-osc-link-count", `expected ${fixture.expectedDestinations.length}, got ${links.length}`);
+expect(JSON.stringify(links.map((x) => x.destination)) === JSON.stringify(fixture.expectedDestinations), "exact-osc8-destinations", "OSC 8 destinations changed or disappeared");
+expect(JSON.stringify(links.map((x) => x.label)) === JSON.stringify(fixture.expectedLabels), "compact-and-authored-labels", `got ${JSON.stringify(links.map((x) => x.label))}`);
+expect(fragments.filter((x) => x.label).every((x) => Number.isInteger(x.startCell) && x.endCell > x.startCell && x.row >= 0), "ansi-wide-combining-cell-spans", "semantic spans were not cell-based");
+expect(fragments.some((x) => x.row > 0) && links.some((x) => x.spans.length > 1), "wrapping-viewport-coordinates", "fixture did not retain wrapped viewport-relative rows");
+const state = fakeTui[Symbol.for("pi.transcript-scroll")];
+expect(state && Object.values(state).some((value) => value instanceof Map), "viewport-link-index", "production root has no managed visible-link index");
+
+let mismatchClosed = true;
+try {
+  const incompatible = { ...fakeTui, children: undefined, render: fakeTui.render };
+  const mismatchCapture = widgetFactory(incompatible, { fg: (_kind, text) => text });
+  incompatible.render(fixture.width);
+  mismatchCapture.dispose();
+} catch { mismatchClosed = false; }
+expect(mismatchClosed, "contract-mismatch-fail-closed", "incompatible Pi root contract threw instead of retaining native rendering and disabling indexing");
+
+const fakeVault = mkdtempSync(join(tmpdir(), "pi-links-v01-vault-"));
+mkdirSync(join(fakeVault, "notes"), { recursive: true });
+mkdirSync(join(fakeVault, "one"), { recursive: true });
+mkdirSync(join(fakeVault, "two"), { recursive: true });
+writeFileSync(join(fakeVault, "notes/Alpha.md"), "# Heading\nblock ^block-id\n");
+writeFileSync(join(fakeVault, "one/Unique.md"), "# Unique\n");
+writeFileSync(join(fakeVault, "one/Common.md"), "# One\n");
+writeFileSync(join(fakeVault, "two/Common.md"), "# Two\n");
+symlinkSync(tmpdir(), join(fakeVault, "escape"));
+const productSource = readFileSync(productPath, "utf8");
+const resolverAvailable = /wikilink|resolveVault|canonical.*vault/iu.test(productSource);
+const resolverOutcomes = fixture.wikilinks.map((item) => ({ name: item.name, expected: item.status, actual: resolverAvailable ? "unexercised" : "unsupported" }));
+writeFileSync(join(artifact, "resolver.json"), `${JSON.stringify({ fakeVault, outcomes: resolverOutcomes }, null, 2)}\n`);
+for (const outcome of resolverOutcomes) expect(outcome.actual === outcome.expected, `wikilink-${outcome.name}`, `expected ${outcome.expected}, got ${outcome.actual}`);
+expect(resolverOutcomes.length === 10, "bounded-wikilink-fixtures-ran", `expected 10, got ${resolverOutcomes.length}`);
+
+capture.dispose();
+const moduleBinding = {
+  pi: `${piPackage.name}@${piPackage.version}`, tui: `${tuiPackage.name}@${tuiPackage.version}`,
+  markdownSha256: sha(markdownPath), tuiIndexSha256: sha(tuiIndex), productSha256: sha(productPath),
+};
+const metadata = {
+  command: "./scripts/verify-pi-transcript-links V01", exitStatus: failures.length ? 1 : 0,
+  implementationCommit: head, implementationTree: tree, productBlob, moduleBinding,
+  fixtureSha256: sha(fixturePath), verifierSha256: sha(scriptPath), wrapperSha256: sha(join(root, "scripts/verify-pi-transcript-links")),
+  artifactFiles: ["raw.ansi", "semantic.json", "resolver.json"], failures,
+};
+writeFileSync(join(artifact, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+const manifestFiles = ["raw.ansi", "semantic.json", "resolver.json", "metadata.json"];
+writeFileSync(join(artifact, "SHA256SUMS"), manifestFiles.map((name) => `${sha(join(artifact, name))}  ${name}`).join("\n") + "\n");
+const transcript = [
+  `$ ${metadata.command}`, `implementation_commit=${head}`, `implementation_tree=${tree}`,
+  `pi_version=${piPackage.version}`, ...failures.map((f) => `FAIL ${f.name}: ${f.detail}`),
+  `exit_status=${metadata.exitStatus}`, `artifact=${artifact}`,
+].join("\n") + "\n";
+writeFileSync(join(artifact, "command.txt"), transcript);
+writeFileSync(join(artifact, "SHA256SUMS"), [...manifestFiles, "command.txt"].map((name) => `${sha(join(artifact, name))}  ${name}`).join("\n") + "\n");
+console.log(`V01 fixtures complete: markdown=${links.length} wikilinks=${resolverOutcomes.length} artifact=${artifact}`);
+console.log(`V01 artifact SHA-256: ${sha(join(artifact, "SHA256SUMS"))}`);
+process.exit(metadata.exitStatus);

--- a/scripts/verifiers/pi-transcript-links-v02
+++ b/scripts/verifiers/pi-transcript-links-v02
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -14,8 +14,9 @@ const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
 const sandbox = mkdtempSync(join(process.env.TMPDIR ?? "/tmp", "pi-links-v02-"));
 const vaultRoot = join(sandbox, "vault"), notes = join(vaultRoot, "notes"), outsideRoot = join(sandbox, "outside");
 mkdirSync(notes, { recursive: true }); mkdirSync(outsideRoot);
-const canonicalFile = join(notes, "Alpha.md"), outsideFile = join(outsideRoot, "Outside.md");
+const canonicalFile = join(notes, "Alpha.md"), injectionFile = join(notes, "quote ' $(touch PWN).md"), outsideFile = join(outsideRoot, "Outside.md");
 writeFileSync(canonicalFile, "# Heading\n\nblock ^block-id\n");
+writeFileSync(injectionFile, "# Injection\n");
 writeFileSync(outsideFile, "# Outside\n");
 symlinkSync(canonicalFile, join(notes, "Alias.md"));
 symlinkSync(outsideRoot, join(vaultRoot, "escape"));
@@ -27,7 +28,8 @@ fixture.markdown = fixture.markdown
   .replace("{{CANONICAL_URL}}", url(join(notes, "Alias.md")))
   .replace("{{SYMLINK_ESCAPE_URL}}", url(join(vaultRoot, "escape", "Outside.md")))
   .replace("{{TRAVERSAL_URL}}", `file://${vaultRoot}/../outside/Outside.md`)
-  .replace("{{OUTSIDE_URL}}", url(outsideFile));
+  .replace("{{OUTSIDE_URL}}", url(outsideFile))
+  .replace("{{INJECTION_URL}}", url(injectionFile, "#Injection"));
 const git = (...args) => execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
 const sha = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
 const head = git("rev-parse", "HEAD"), tree = git("rev-parse", "HEAD^{tree}");
@@ -111,9 +113,9 @@ framed.destroy();
 await send("x");
 
 fakeTui.render(fixture.width);
-const httpsSpan = findSpan("copy.example"), headingSpan = findSpan("#Heading"), blockSpan = findSpan("%5Eblock-id"), lineSpan = findSpan("#L7"), canonicalSpan = findSpan("Alias.md"), symlinkEscapeSpan = findSpan("/escape/"), traversalSpan = findSpan("/../outside/"), outsideSpan = findSpan("outside/Outside.md"), releaseSpan = findSpan("release.example"), modifiedSpan = findSpan("modified.example"), failSpan = findSpan("fail.example");
+const httpsSpan = findSpan("copy.example"), headingSpan = findSpan("#Heading"), blockSpan = findSpan("%5Eblock-id"), lineSpan = findSpan("#L7"), canonicalSpan = findSpan("Alias.md"), injectionSpan = findSpan("touch%20PWN"), symlinkEscapeSpan = findSpan("/escape/"), traversalSpan = findSpan("/../outside/"), outsideSpan = findSpan("outside/Outside.md"), releaseSpan = findSpan("release.example"), modifiedSpan = findSpan("modified.example"), failSpan = findSpan("fail.example");
 expect(httpsSpan && httpsSpan.startCell > 0, "ansi-wide-cell-hit-index");
-expect([headingSpan, blockSpan, lineSpan, canonicalSpan, symlinkEscapeSpan, outsideSpan, failSpan].every(Boolean), "all-action-spans-rendered", JSON.stringify([...(state?.visibleLinks?.values?.() ?? [])].flat().map((span) => span.destination)));
+expect([headingSpan, blockSpan, lineSpan, canonicalSpan, injectionSpan, symlinkEscapeSpan, outsideSpan, failSpan].every(Boolean), "all-action-spans-rendered", JSON.stringify([...(state?.visibleLinks?.values?.() ?? [])].flat().map((span) => span.destination)));
 const copyBefore = clipboard.length;
 if (httpsSpan) { await send(sgr(0, httpsSpan.startCell, httpsSpan.row + 1)); await send(sgr(0, httpsSpan.startCell + 1, httpsSpan.row + 1)); await send(sgr(0, httpsSpan.endCell + 1, httpsSpan.row + 1)); }
 expect(clipboard.length === copyBefore + 1 && clipboard.at(-1) === fixture.https, "https-boundaries-and-exact-single-copy", `writes=${JSON.stringify(clipboard)}`);
@@ -125,16 +127,18 @@ expect(timers.size === 1, "keyed-status-timer-replacement", `timers=${timers.siz
 await advance(1500);
 
 const nvimBefore = nvim.length;
-await click(headingSpan); await click(blockSpan); await click(lineSpan); await click(canonicalSpan);
-const expectedNvim = [
-  ["--server", "fake-nvim-server", "--remote", canonicalFile, ":heading:Heading"],
-  ["--server", "fake-nvim-server", "--remote", canonicalFile, ":block:block-id"],
-  ["--server", "fake-nvim-server", "--remote", canonicalFile, ":7"],
-  ["--server", "fake-nvim-server", "--remote", canonicalFile, ""],
-];
-expect(JSON.stringify(nvim.slice(nvimBefore)) === JSON.stringify(expectedNvim), "exact-neovim-argument-arrays-and-canonical-file", JSON.stringify(nvim.slice(nvimBefore)));
-const forbiddenFocus = new Set(["--remote-tab", "--remote-send", "--remote-expr", "--embed", "--listen", "--cmd", "-c"]);
-expect(nvim.slice(nvimBefore).every((argv) => argv.every((arg) => !forbiddenFocus.has(arg))), "vault-open-has-no-focus-changing-command-or-flag");
+await click(headingSpan); await click(blockSpan); await click(lineSpan); await click(canonicalSpan); await click(injectionSpan);
+const lua = "(function(d)local c=vim.api.nvim_get_current_win();local ok,r=xpcall(function()local w;for _,x in ipairs(vim.api.nvim_list_wins())do if x~=c and vim.bo[vim.api.nvim_win_get_buf(x)].buftype~='terminal'then w=x;break end end;if not w then vim.cmd('noautocmd keepalt botright new');w=vim.api.nvim_get_current_win()end;local b=vim.fn.bufadd(d.file);vim.fn.bufload(b);vim.api.nvim_win_set_buf(w,b);vim.api.nvim_win_call(w,function()if d.kind=='line'then vim.api.nvim_win_set_cursor(w,{d.target,0})elseif d.kind=='heading'then vim.fn.cursor(1,1);vim.fn.search('^\\\\s*#\\\\+\\\\s\\\\+\\\\V'..vim.fn.escape(d.target,'\\\\')..'\\\\m\\\\s*$','W')elseif d.kind=='block'then vim.fn.cursor(1,1);vim.fn.search('\\\\V^'..vim.fn.escape(d.target,'\\\\')..'\\\\m\\\\s*$','W')end end);return 1 end,debug.traceback);if vim.api.nvim_win_is_valid(c)then vim.api.nvim_set_current_win(c)end;if not ok then error(r)end;return r end)(_A)";
+const expected = [
+  { file: canonicalFile, kind: "heading", target: "Heading" },
+  { file: canonicalFile, kind: "block", target: "^block-id" },
+  { file: canonicalFile, kind: "line", target: 7 },
+  { file: canonicalFile, kind: "file", target: "" },
+  { file: injectionFile, kind: "heading", target: "Injection" },
+].map((payload) => ["--server", "fake-nvim-server", "--remote-expr", `luaeval(${JSON.stringify(lua)}, json_decode(${JSON.stringify(JSON.stringify(payload))}))`]);
+expect(JSON.stringify(nvim.slice(nvimBefore)) === JSON.stringify(expected), "exact-safe-neovim-remote-expr-argv", JSON.stringify(nvim.slice(nvimBefore)));
+expect(typeof extension.__transcriptLinks?.buildNvimArgs === "function" && expected.every((argv, i) => JSON.stringify(extension.__transcriptLinks.buildNvimArgs("fake-nvim-server", [{ file: canonicalFile, kind: "heading", target: "Heading" }, { file: canonicalFile, kind: "block", target: "^block-id" }, { file: canonicalFile, kind: "line", target: 7 }, { file: canonicalFile, kind: "file", target: "" }, { file: injectionFile, kind: "heading", target: "Injection" }][i])) === JSON.stringify(argv)), "production-buildNvimArgs-exact-contract");
+expect(!existsSync(join(sandbox, "PWN")), "argument-safe-path-and-target-no-shell-interpolation");
 const securityBefore = nvim.length;
 await click(symlinkEscapeSpan);
 expect(nvim.length === securityBefore, "canonical-symlink-escape-rejected");
@@ -174,7 +178,7 @@ expect(seamConfigured, "injected-action-adapters-bound-to-production", "missing 
 
 writeFileSync(join(artifact, "event-trace.json"), JSON.stringify({ checks, trace, renders }, null, 2) + "\n");
 writeFileSync(join(artifact, "clipboard.json"), JSON.stringify(clipboard, null, 2) + "\n");
-writeFileSync(join(artifact, "neovim-focus.json"), JSON.stringify({ invocations: nvim, forbiddenFocusFlags: [...forbiddenFocus] }, null, 2) + "\n");
+writeFileSync(join(artifact, "neovim-focus.json"), JSON.stringify({ invocations: nvim, expected }, null, 2) + "\n");
 writeFileSync(join(artifact, "status-clock.json"), JSON.stringify({ now, statuses, pendingTimers: [...timers.keys()] }, null, 2) + "\n");
 writeFileSync(join(artifact, "terminal-control.ansi"), terminal.join(""));
 const stable = ["event-trace.json", "clipboard.json", "neovim-focus.json", "status-clock.json", "terminal-control.ansi"];

--- a/scripts/verifiers/pi-transcript-links-v02
+++ b/scripts/verifiers/pi-transcript-links-v02
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -11,6 +11,23 @@ const fixturePath = join(root, "scripts/fixtures/pi-transcript-links-v02.json");
 const productPath = join(root, "pi/.pi/agent/extensions/transcript-scroll.ts");
 const wrapperPath = join(root, "scripts/verify-pi-transcript-links");
 const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+const sandbox = mkdtempSync(join(process.env.TMPDIR ?? "/tmp", "pi-links-v02-"));
+const vaultRoot = join(sandbox, "vault"), notes = join(vaultRoot, "notes"), outsideRoot = join(sandbox, "outside");
+mkdirSync(notes, { recursive: true }); mkdirSync(outsideRoot);
+const canonicalFile = join(notes, "Alpha.md"), outsideFile = join(outsideRoot, "Outside.md");
+writeFileSync(canonicalFile, "# Heading\n\nblock ^block-id\n");
+writeFileSync(outsideFile, "# Outside\n");
+symlinkSync(canonicalFile, join(notes, "Alias.md"));
+symlinkSync(outsideRoot, join(vaultRoot, "escape"));
+const url = (path, hash = "") => `${pathToFileURL(path).href}${hash}`;
+fixture.markdown = fixture.markdown
+  .replace("{{HEADING_URL}}", url(canonicalFile, "#Heading"))
+  .replace("{{BLOCK_URL}}", url(canonicalFile, "#%5Eblock-id"))
+  .replace("{{LINE_URL}}", url(canonicalFile, "#L7"))
+  .replace("{{CANONICAL_URL}}", url(join(notes, "Alias.md")))
+  .replace("{{SYMLINK_ESCAPE_URL}}", url(join(vaultRoot, "escape", "Outside.md")))
+  .replace("{{TRAVERSAL_URL}}", `file://${vaultRoot}/../outside/Outside.md`)
+  .replace("{{OUTSIDE_URL}}", url(outsideFile));
 const git = (...args) => execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
 const sha = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
 const head = git("rev-parse", "HEAD"), tree = git("rev-parse", "HEAD^{tree}");
@@ -36,12 +53,12 @@ tuiModule.setCapabilities({ images: null, trueColor: true, hyperlinks: true });
 const extension = await jiti.import(productPath);
 
 let now = 0, nextTimer = 1;
-const timers = new Map(), clipboard = [], nvim = [], statuses = [], focus = [];
+const timers = new Map(), clipboard = [], nvim = [], statuses = [];
 const adapters = {
   clipboard: { write: async (value) => { clipboard.push(value); trace.push({ type: "clipboard", value }); if (value.includes("fail.example")) throw new Error("fake clipboard failure"); } },
-  neovim: { open: async (argv) => { nvim.push(argv); focus.push("pi"); trace.push({ type: "nvim", argv }); if (adapters.nvimServer === "unreachable") throw new Error("fake nvim unreachable"); } },
+  neovim: { open: async (argv) => { nvim.push(argv); trace.push({ type: "nvim", argv }); if (adapters.nvimServer === "unreachable") throw new Error("fake nvim unreachable"); } },
   clock: { setTimeout(fn, delay) { const id = nextTimer++; timers.set(id, { at: now + delay, fn }); return id; }, clearTimeout(id) { timers.delete(id); } },
-  vaultRoot: "/Users/aviral/vault", nvimServer: "fake-nvim-server",
+  vaultRoot, nvimServer: "fake-nvim-server",
 };
 const advance = async (ms) => { now += ms; for (const [id, timer] of [...timers]) if (timer.at <= now) { timers.delete(id); timer.fn(); await Promise.resolve(); } };
 let seamConfigured = false;
@@ -63,9 +80,10 @@ const originalRender = fakeTui.render;
 let capture = widgetFactory(fakeTui, { fg: (_k, s) => s });
 fakeTui.render(fixture.width);
 const state = fakeTui[Symbol.for("pi.transcript-scroll")];
-const send = async (data) => { const result = listeners.at(-1)?.(data); await Promise.resolve(); await Promise.resolve(); return result; };
+let listenerCalls = 0;
+const send = async (data) => { listenerCalls++; const result = listeners.at(-1)?.(data); await Promise.resolve(); await Promise.resolve(); return result; };
 const sgr = (button, x, y, release = false) => `\x1b[<${button};${x};${y}${release ? "m" : "M"}`;
-const findSpan = (needle) => [...(state?.visibleLinks?.values?.() ?? [])].flat().find((s) => s.destination.includes(needle));
+const findSpan = (needle) => [...(fakeTui[Symbol.for("pi.transcript-scroll")]?.visibleLinks?.values?.() ?? [])].flat().find((s) => s.destination.includes(needle));
 const click = async (span, button = 0, release = false) => span && send(sgr(button, span.startCell + 1, span.row + 1, release));
 
 const beforeWheel = renders.length;
@@ -80,12 +98,22 @@ expect(renders.length > beforeWheel + 1, "wheel-down-dispatches");
 state.follow = false; state.viewportEnd = Math.max(1, state.transcriptLines - 1);
 const typed = await send("x");
 expect(typed === undefined && state.follow === true, "typing-to-follow-pass-through");
-expect(await send("\x1b[<64;") === undefined, "fragment-awaits-completion");
-await send("1;1M");
+const framed = new tuiModule.StdinBuffer({ timeout: 1000 });
+const framedReports = [];
+framed.on("data", (sequence) => { framedReports.push(sequence); void send(sequence); });
+const callsBeforeFragment = listenerCalls, renderBeforeFragment = renders.length;
+framed.process("\x1b[<64;");
+expect(listenerCalls === callsBeforeFragment && framedReports.length === 0 && renders.length === renderBeforeFragment, "stdin-buffer-withholds-partial-sgr");
+framed.process("1;1M");
+await Promise.resolve(); await Promise.resolve();
+expect(framedReports.length === 1 && framedReports[0] === sgr(64, 1, 1) && listenerCalls === callsBeforeFragment + 1 && renders.length === renderBeforeFragment + 1, "stdin-buffer-emits-one-complete-report-without-partial-key-effect");
+framed.destroy();
+await send("x");
 
 fakeTui.render(fixture.width);
-const httpsSpan = findSpan("copy.example"), headingSpan = findSpan("#Heading"), blockSpan = findSpan("%5Eblock-id"), lineSpan = findSpan("#L7"), outsideSpan = findSpan("outside.md"), releaseSpan = findSpan("release.example"), modifiedSpan = findSpan("modified.example"), failSpan = findSpan("fail.example");
+const httpsSpan = findSpan("copy.example"), headingSpan = findSpan("#Heading"), blockSpan = findSpan("%5Eblock-id"), lineSpan = findSpan("#L7"), canonicalSpan = findSpan("Alias.md"), symlinkEscapeSpan = findSpan("/escape/"), traversalSpan = findSpan("/../outside/"), outsideSpan = findSpan("outside/Outside.md"), releaseSpan = findSpan("release.example"), modifiedSpan = findSpan("modified.example"), failSpan = findSpan("fail.example");
 expect(httpsSpan && httpsSpan.startCell > 0, "ansi-wide-cell-hit-index");
+expect([headingSpan, blockSpan, lineSpan, canonicalSpan, symlinkEscapeSpan, outsideSpan, failSpan].every(Boolean), "all-action-spans-rendered", JSON.stringify([...(state?.visibleLinks?.values?.() ?? [])].flat().map((span) => span.destination)));
 const copyBefore = clipboard.length;
 if (httpsSpan) { await send(sgr(0, httpsSpan.startCell, httpsSpan.row + 1)); await send(sgr(0, httpsSpan.startCell + 1, httpsSpan.row + 1)); await send(sgr(0, httpsSpan.endCell + 1, httpsSpan.row + 1)); }
 expect(clipboard.length === copyBefore + 1 && clipboard.at(-1) === fixture.https, "https-boundaries-and-exact-single-copy", `writes=${JSON.stringify(clipboard)}`);
@@ -97,9 +125,21 @@ expect(timers.size === 1, "keyed-status-timer-replacement", `timers=${timers.siz
 await advance(1500);
 
 const nvimBefore = nvim.length;
-await click(headingSpan); await click(blockSpan); await click(lineSpan);
-expect(nvim.length === nvimBefore + 3 && nvim.slice(-3).every((a) => Array.isArray(a)), "vault-open-argument-arrays-heading-block-line", JSON.stringify(nvim));
-expect(focus.every((x) => x === "pi"), "vault-open-does-not-steal-focus");
+await click(headingSpan); await click(blockSpan); await click(lineSpan); await click(canonicalSpan);
+const expectedNvim = [
+  ["--server", "fake-nvim-server", "--remote", canonicalFile, ":heading:Heading"],
+  ["--server", "fake-nvim-server", "--remote", canonicalFile, ":block:block-id"],
+  ["--server", "fake-nvim-server", "--remote", canonicalFile, ":7"],
+  ["--server", "fake-nvim-server", "--remote", canonicalFile, ""],
+];
+expect(JSON.stringify(nvim.slice(nvimBefore)) === JSON.stringify(expectedNvim), "exact-neovim-argument-arrays-and-canonical-file", JSON.stringify(nvim.slice(nvimBefore)));
+const forbiddenFocus = new Set(["--remote-tab", "--remote-send", "--remote-expr", "--embed", "--listen", "--cmd", "-c"]);
+expect(nvim.slice(nvimBefore).every((argv) => argv.every((arg) => !forbiddenFocus.has(arg))), "vault-open-has-no-focus-changing-command-or-flag");
+const securityBefore = nvim.length;
+await click(symlinkEscapeSpan);
+expect(nvim.length === securityBefore, "canonical-symlink-escape-rejected");
+await click(traversalSpan);
+expect(nvim.length === securityBefore, "traversal-file-url-rejected");
 const successfulBefore = clipboard.length + nvim.length;
 await click(outsideSpan); await click(releaseSpan, 0, true); await click(modifiedSpan, 4); if (httpsSpan) await send(sgr(0, httpsSpan.endCell + 2, httpsSpan.row + 1));
 overlay = true; await click(httpsSpan); overlay = false;
@@ -109,13 +149,21 @@ let ambiguous, missing;
 try { ambiguous = resolver && await resolver({ text: "[[Common]]", vaultRoot: "/nonexistent" }); missing = resolver && await resolver({ text: "[[Missing]]", vaultRoot: "/nonexistent" }); } catch {}
 expect((ambiguous?.status === "ambiguous" || ambiguous == null) && clipboard.length + nvim.length === successfulBefore, "ambiguous-missing-no-success-action");
 await click(failSpan);
-expect(!statuses.some((s, i) => i >= statuses.length - 2 && s.value?.startsWith("Copied fail.example")), "clipboard-failure-never-claims-copy");
+expect(statuses.at(-1)?.value === "Clipboard unavailable" && !statuses.slice(-2).some((s) => s.value?.startsWith("Copied fail.example")), "clipboard-failure-bounded-and-never-claims-copy");
 const savedServer = adapters.nvimServer; adapters.nvimServer = undefined; await click(headingSpan); adapters.nvimServer = "unreachable"; await click(headingSpan); adapters.nvimServer = savedServer;
-expect(statuses.some((s) => /NVIM|Neovim|clipboard|Clipboard/u.test(s.value ?? "")), "bounded-adapter-failure-feedback");
+expect(statuses.slice(-4).some((s) => /^Neovim: .{1,100}$/u.test(s.value ?? "")) && !statuses.slice(-4).some((s) => /^Copied /u.test(s.value ?? "")), "bounded-adapter-failure-feedback-without-false-success");
 const followBeforeResize = state?.follow; fakeTui.terminal.rows++; fakeTui.render(fixture.width - 5);
 expect(state?.follow === true && (followBeforeResize === true || state?.viewportEnd === 0), "resize-restores-follow");
 
-for (let cycle = 0; cycle < 2; cycle++) { capture.dispose(); capture = widgetFactory(fakeTui, { fg: (_k, s) => s }); fakeTui.render(fixture.width); }
+const cycleCalls = [0, 0];
+for (let cycle = 0; cycle < 2; cycle++) {
+  capture.dispose();
+  const cycleAdapters = { ...adapters, clipboard: { write: async () => { cycleCalls[cycle]++; } } };
+  extension.__transcriptLinks.configureForTest(cycleAdapters);
+  capture = widgetFactory(fakeTui, { fg: (_k, s) => s }); fakeTui.render(fixture.width);
+  await click(findSpan("copy.example"));
+  expect(cycleCalls[cycle] === 1 && cycleCalls.reduce((a, b) => a + b, 0) === cycle + 1, `cycle-${cycle + 1}-uses-only-current-injected-adapter`);
+}
 expect(listeners.length === 1, "two-reloads-one-active-listener", `listeners=${listeners.length}`);
 handlers.get("session_shutdown")?.({}, { mode: "tui", ui });
 expect(listeners.length === 0, "shutdown-clears-listener");
@@ -126,7 +174,7 @@ expect(seamConfigured, "injected-action-adapters-bound-to-production", "missing 
 
 writeFileSync(join(artifact, "event-trace.json"), JSON.stringify({ checks, trace, renders }, null, 2) + "\n");
 writeFileSync(join(artifact, "clipboard.json"), JSON.stringify(clipboard, null, 2) + "\n");
-writeFileSync(join(artifact, "neovim-focus.json"), JSON.stringify({ invocations: nvim, focus }, null, 2) + "\n");
+writeFileSync(join(artifact, "neovim-focus.json"), JSON.stringify({ invocations: nvim, forbiddenFocusFlags: [...forbiddenFocus] }, null, 2) + "\n");
 writeFileSync(join(artifact, "status-clock.json"), JSON.stringify({ now, statuses, pendingTimers: [...timers.keys()] }, null, 2) + "\n");
 writeFileSync(join(artifact, "terminal-control.ansi"), terminal.join(""));
 const stable = ["event-trace.json", "clipboard.json", "neovim-focus.json", "status-clock.json", "terminal-control.ansi"];

--- a/scripts/verifiers/pi-transcript-links-v02
+++ b/scripts/verifiers/pi-transcript-links-v02
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const root = resolve(dirname(scriptPath), "../..");
+const fixturePath = join(root, "scripts/fixtures/pi-transcript-links-v02.json");
+const productPath = join(root, "pi/.pi/agent/extensions/transcript-scroll.ts");
+const wrapperPath = join(root, "scripts/verify-pi-transcript-links");
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+const git = (...args) => execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+const sha = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
+const head = git("rev-parse", "HEAD"), tree = git("rev-parse", "HEAD^{tree}");
+const productBlob = git("rev-parse", "HEAD:pi/.pi/agent/extensions/transcript-scroll.ts");
+const piCli = realpathSync(execFileSync("command", ["-v", "pi"], { encoding: "utf8", shell: true }).trim());
+const piRoot = resolve(dirname(piCli), "..");
+const piPackage = JSON.parse(readFileSync(join(piRoot, "package.json"), "utf8"));
+const artifactRoot = join(root, "artifacts/pi-transcript-links/V02", tree);
+mkdirSync(artifactRoot, { recursive: true });
+const artifact = mkdtempSync(join(artifactRoot, "attempt-"));
+const attemptIdentity = basename(artifact);
+const failures = [], checks = [], trace = [];
+const expect = (ok, name, detail = "") => { checks.push({ name, ok: !!ok, detail }); console[ok ? "log" : "error"](`${ok ? "PASS" : "FAIL"} ${name}${detail ? `: ${detail}` : ""}`); if (!ok) failures.push({ name, detail }); };
+
+expect(piPackage.version === "0.82.1", "installed-pi-version", `got ${piPackage.version}`);
+expect(git("hash-object", productPath) === productBlob, "production-source-binding", "worktree product differs from HEAD");
+expect(!readFileSync(scriptPath, "utf8").includes(["prototypes", "pi-link-research"].join("/")), "prototype-isolation");
+const { createJiti } = await import(pathToFileURL(join(piRoot, "node_modules/jiti/lib/jiti.mjs")).href);
+const tuiIndex = join(piRoot, "node_modules/@earendil-works/pi-tui/dist/index.js");
+const jiti = createJiti(import.meta.url, { moduleCache: false, alias: { "@earendil-works/pi-coding-agent": join(piRoot, "dist/index.js"), "@earendil-works/pi-tui": tuiIndex } });
+const tuiModule = await import(pathToFileURL(tuiIndex).href);
+tuiModule.setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+const extension = await jiti.import(productPath);
+
+let now = 0, nextTimer = 1;
+const timers = new Map(), clipboard = [], nvim = [], statuses = [], focus = [];
+const adapters = {
+  clipboard: { write: async (value) => { clipboard.push(value); trace.push({ type: "clipboard", value }); if (value.includes("fail.example")) throw new Error("fake clipboard failure"); } },
+  neovim: { open: async (argv) => { nvim.push(argv); focus.push("pi"); trace.push({ type: "nvim", argv }); if (adapters.nvimServer === "unreachable") throw new Error("fake nvim unreachable"); } },
+  clock: { setTimeout(fn, delay) { const id = nextTimer++; timers.set(id, { at: now + delay, fn }); return id; }, clearTimeout(id) { timers.delete(id); } },
+  vaultRoot: "/Users/aviral/vault", nvimServer: "fake-nvim-server",
+};
+const advance = async (ms) => { now += ms; for (const [id, timer] of [...timers]) if (timer.at <= now) { timers.delete(id); timer.fn(); await Promise.resolve(); } };
+let seamConfigured = false;
+try { if (typeof extension.__transcriptLinks?.configureForTest === "function") { extension.__transcriptLinks.configureForTest(adapters); seamConfigured = true; } } catch (error) { trace.push({ type: "configure-error", error: String(error) }); }
+
+const handlers = new Map();
+extension.default({ on: (name, fn) => handlers.set(name, fn) });
+let widgetFactory;
+const ui = { setWidget: (_key, value) => { if (value) widgetFactory = value; }, setStatus: (key, value) => { statuses.push({ at: now, key, value: value == null ? null : String(value) }); trace.push({ type: "status", at: now, key, value }); } };
+handlers.get("session_start")?.({}, { mode: "tui", ui });
+expect(typeof widgetFactory === "function", "real-extension-loaded");
+const theme = Object.fromEntries(["heading","link","linkUrl","code","codeBlock","codeBlockBorder","quote","quoteBorder","hr","listBullet","bold","italic","strikethrough","underline"].map((k) => [k, (s) => s]));
+const markdown = new tuiModule.Markdown(fixture.markdown, 0, 0, theme);
+const editor = { render: () => [`${tuiModule.CURSOR_MARKER} prompt`], invalidate() {} };
+const terminal = [], listeners = [], renders = [];
+let overlay = false;
+const fakeTui = { children: [markdown, editor], terminal: { rows: fixture.rows, write: (s) => terminal.push(s) }, render(width) { return this.children.flatMap((c) => c.render(width)); }, addInputListener(fn) { listeners.push(fn); return () => listeners.splice(listeners.indexOf(fn), 1); }, requestRender(force) { renders.push({ force: !!force }); }, hasOverlay() { return overlay; } };
+const originalRender = fakeTui.render;
+let capture = widgetFactory(fakeTui, { fg: (_k, s) => s });
+fakeTui.render(fixture.width);
+const state = fakeTui[Symbol.for("pi.transcript-scroll")];
+const send = async (data) => { const result = listeners.at(-1)?.(data); await Promise.resolve(); await Promise.resolve(); return result; };
+const sgr = (button, x, y, release = false) => `\x1b[<${button};${x};${y}${release ? "m" : "M"}`;
+const findSpan = (needle) => [...(state?.visibleLinks?.values?.() ?? [])].flat().find((s) => s.destination.includes(needle));
+const click = async (span, button = 0, release = false) => span && send(sgr(button, span.startCell + 1, span.row + 1, release));
+
+const beforeWheel = renders.length;
+await send(sgr(64, 1, 1));
+expect(state?.follow === false && renders.length > beforeWheel, "wheel-up-detaches-viewport");
+const detachedEnd = state?.viewportEnd;
+fakeTui.children.unshift({ render: () => ["appended output"], invalidate() {} });
+fakeTui.render(fixture.width);
+expect(state?.follow === false && state?.viewportEnd === detachedEnd, "detached-viewport-stable-under-append");
+await send(sgr(65, 1, 1));
+expect(renders.length > beforeWheel + 1, "wheel-down-dispatches");
+state.follow = false; state.viewportEnd = Math.max(1, state.transcriptLines - 1);
+const typed = await send("x");
+expect(typed === undefined && state.follow === true, "typing-to-follow-pass-through");
+expect(await send("\x1b[<64;") === undefined, "fragment-awaits-completion");
+await send("1;1M");
+
+fakeTui.render(fixture.width);
+const httpsSpan = findSpan("copy.example"), headingSpan = findSpan("#Heading"), blockSpan = findSpan("%5Eblock-id"), lineSpan = findSpan("#L7"), outsideSpan = findSpan("outside.md"), releaseSpan = findSpan("release.example"), modifiedSpan = findSpan("modified.example"), failSpan = findSpan("fail.example");
+expect(httpsSpan && httpsSpan.startCell > 0, "ansi-wide-cell-hit-index");
+const copyBefore = clipboard.length;
+if (httpsSpan) { await send(sgr(0, httpsSpan.startCell, httpsSpan.row + 1)); await send(sgr(0, httpsSpan.startCell + 1, httpsSpan.row + 1)); await send(sgr(0, httpsSpan.endCell + 1, httpsSpan.row + 1)); }
+expect(clipboard.length === copyBefore + 1 && clipboard.at(-1) === fixture.https, "https-boundaries-and-exact-single-copy", `writes=${JSON.stringify(clipboard)}`);
+expect(statuses.some((s) => s.value === fixture.status), "copy-success-status");
+await advance(1499); expect(statuses.at(-1)?.value === fixture.status, "status-retained-before-1500ms");
+await advance(1); expect(statuses.at(-1)?.value === null, "status-clears-at-1500ms");
+if (httpsSpan) { await click(httpsSpan); await advance(500); await click(httpsSpan); }
+expect(timers.size === 1, "keyed-status-timer-replacement", `timers=${timers.size}`);
+await advance(1500);
+
+const nvimBefore = nvim.length;
+await click(headingSpan); await click(blockSpan); await click(lineSpan);
+expect(nvim.length === nvimBefore + 3 && nvim.slice(-3).every((a) => Array.isArray(a)), "vault-open-argument-arrays-heading-block-line", JSON.stringify(nvim));
+expect(focus.every((x) => x === "pi"), "vault-open-does-not-steal-focus");
+const successfulBefore = clipboard.length + nvim.length;
+await click(outsideSpan); await click(releaseSpan, 0, true); await click(modifiedSpan, 4); if (httpsSpan) await send(sgr(0, httpsSpan.endCell + 2, httpsSpan.row + 1));
+overlay = true; await click(httpsSpan); overlay = false;
+expect(clipboard.length + nvim.length === successfulBefore, "suppression-release-modified-miss-overlay-nonvault");
+const resolver = extension.__transcriptLinks?.resolveWikilink;
+let ambiguous, missing;
+try { ambiguous = resolver && await resolver({ text: "[[Common]]", vaultRoot: "/nonexistent" }); missing = resolver && await resolver({ text: "[[Missing]]", vaultRoot: "/nonexistent" }); } catch {}
+expect((ambiguous?.status === "ambiguous" || ambiguous == null) && clipboard.length + nvim.length === successfulBefore, "ambiguous-missing-no-success-action");
+await click(failSpan);
+expect(!statuses.some((s, i) => i >= statuses.length - 2 && s.value?.startsWith("Copied fail.example")), "clipboard-failure-never-claims-copy");
+const savedServer = adapters.nvimServer; adapters.nvimServer = undefined; await click(headingSpan); adapters.nvimServer = "unreachable"; await click(headingSpan); adapters.nvimServer = savedServer;
+expect(statuses.some((s) => /NVIM|Neovim|clipboard|Clipboard/u.test(s.value ?? "")), "bounded-adapter-failure-feedback");
+const followBeforeResize = state?.follow; fakeTui.terminal.rows++; fakeTui.render(fixture.width - 5);
+expect(state?.follow === true && (followBeforeResize === true || state?.viewportEnd === 0), "resize-restores-follow");
+
+for (let cycle = 0; cycle < 2; cycle++) { capture.dispose(); capture = widgetFactory(fakeTui, { fg: (_k, s) => s }); fakeTui.render(fixture.width); }
+expect(listeners.length === 1, "two-reloads-one-active-listener", `listeners=${listeners.length}`);
+handlers.get("session_shutdown")?.({}, { mode: "tui", ui });
+expect(listeners.length === 0, "shutdown-clears-listener");
+expect(terminal.filter((s) => s.includes("?1000h") && s.includes("?1006h")).length === terminal.filter((s) => s.includes("?1000l") && s.includes("?1006l")).length, "balanced-1000-1006-modes");
+expect(fakeTui.render === originalRender, "restored-render-identity");
+expect(!fakeTui[Symbol.for("pi.transcript-scroll")] && timers.size === 0 && statuses.at(-1)?.value === null, "cleanup-clears-maps-status-timers");
+expect(seamConfigured, "injected-action-adapters-bound-to-production", "missing __transcriptLinks.configureForTest");
+
+writeFileSync(join(artifact, "event-trace.json"), JSON.stringify({ checks, trace, renders }, null, 2) + "\n");
+writeFileSync(join(artifact, "clipboard.json"), JSON.stringify(clipboard, null, 2) + "\n");
+writeFileSync(join(artifact, "neovim-focus.json"), JSON.stringify({ invocations: nvim, focus }, null, 2) + "\n");
+writeFileSync(join(artifact, "status-clock.json"), JSON.stringify({ now, statuses, pendingTimers: [...timers.keys()] }, null, 2) + "\n");
+writeFileSync(join(artifact, "terminal-control.ansi"), terminal.join(""));
+const stable = ["event-trace.json", "clipboard.json", "neovim-focus.json", "status-clock.json", "terminal-control.ansi"];
+const metadata = { command: "./scripts/verify-pi-transcript-links V02", exitStatus: failures.length ? 1 : 0, implementationCommit: head, implementationTree: tree, productBlob, attemptIdentity, artifactPath: artifact, piVersion: piPackage.version, fixtureSha256: sha(fixturePath), verifierSha256: sha(scriptPath), wrapperSha256: sha(wrapperPath), failures };
+writeFileSync(join(artifact, "metadata.json"), JSON.stringify(metadata, null, 2) + "\n");
+writeFileSync(join(artifact, "command.txt"), `$ ${metadata.command}\nimplementation_commit=${head}\nimplementation_tree=${tree}\nattempt_identity=${attemptIdentity}\nartifact=${artifact}\npi_version=${piPackage.version}\nexit_status=${metadata.exitStatus}\n`);
+const manifest = [...stable, "metadata.json", "command.txt"];
+writeFileSync(join(artifact, "SHA256SUMS"), manifest.map((name) => `${sha(join(artifact, name))}  ${name}`).join("\n") + "\n");
+console.log(`V02 fixtures complete: attempt=${attemptIdentity} artifact=${artifact} implementation=${head} tree=${tree}`);
+console.log(`V02 artifact SHA-256: ${sha(join(artifact, "SHA256SUMS"))}`);
+process.exit(metadata.exitStatus);

--- a/scripts/verifiers/pi-transcript-links-v03
+++ b/scripts/verifiers/pi-transcript-links-v03
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -uo pipefail
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo"
+implementation_commit=9dd6cf41cf802cc216df752d3ded161e3875dac4
+implementation_tree=a6555d0bc086058fbb6f23322bc4894f8f89e03e
+root="artifacts/pi-transcript-links/V03/$implementation_tree"
+mkdir -p "$root"
+attempt="$(mktemp -d "$root/attempt-XXXXXX")"
+sandbox="$(mktemp -d "${TMPDIR:-/tmp}/pi-links-v03-XXXXXX")"
+mkdir -p "$sandbox/vault/notes" "$sandbox/xdg-data" "$sandbox/xdg-state" "$sandbox/xdg-cache"
+printf '# Target\n\n## Chosen Heading\n\nfixture body\n' > "$sandbox/vault/notes/Target.md"
+: > "$attempt/fake-clipboard.log"
+: > "$attempt/fixture-trace.log"
+server="$sandbox/nvim.sock"
+command='XDG_CONFIG_HOME="$PWD/nvim/.config" scripts/verify-nvim pi-transcript-links'
+printf '$ %s\n' "$command" > "$attempt/command-transcript.txt"
+printf 'implementation_commit=%s\nimplementation_tree=%s\nproduct_blob=%s\nverifier_head=%s\n' "$implementation_commit" "$implementation_tree" "$(git rev-parse "$implementation_commit:pi/.pi/agent/extensions/transcript-scroll.ts")" "$(git rev-parse HEAD)" > "$attempt/implementation-identity.txt"
+{
+  nvim --version | head -1
+  pi --version | sed 's/^/Pi /'
+  /usr/bin/script --version 2>&1 | head -1 || true
+} > "$attempt/versions.txt"
+export V03_ATTEMPT="$attempt" V03_REPO="$repo" V03_VAULT_ROOT="$sandbox/vault" V03_CLIPBOARD_LOG="$attempt/fake-clipboard.log" V03_FIXTURE_TRACE="$attempt/fixture-trace.log"
+export XDG_DATA_HOME="$sandbox/xdg-data" XDG_STATE_HOME="$sandbox/xdg-state" XDG_CACHE_HOME="$sandbox/xdg-cache"
+set +e
+nvim --clean --headless --listen "$server" "+luafile scripts/fixtures/pi-transcript-links-v03-harness.lua" >> "$attempt/command-transcript.txt" 2>&1
+status=$?
+set -e
+printf 'exit_status=%s\n' "$status" >> "$attempt/command-transcript.txt"
+printf '%s\n' "$status" > "$attempt/exit-status.txt"
+cp "$attempt/fake-clipboard.log" "$attempt/fake-clipboard-final.log"
+find "$attempt" -type f ! -name SHA256SUMS -exec shasum -a 256 {} + | sed "s#$attempt/##" | sort -k2 > "$attempt/SHA256SUMS"
+printf 'V03 immutable baseline attempt: %s\nexit status: %s\nSHA256SUMS: %s\n' "$attempt" "$status" "$(shasum -a 256 "$attempt/SHA256SUMS" | cut -d' ' -f1)"
+rm -rf "$sandbox"
+exit "$status"

--- a/scripts/verifiers/pi-transcript-links-v03
+++ b/scripts/verifiers/pi-transcript-links-v03
@@ -2,8 +2,14 @@
 set -uo pipefail
 repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo"
-implementation_commit=9dd6cf41cf802cc216df752d3ded161e3875dac4
-implementation_tree=a6555d0bc086058fbb6f23322bc4894f8f89e03e
+product_path=pi/.pi/agent/extensions/transcript-scroll.ts
+implementation_commit="$(git rev-parse HEAD)"
+implementation_tree="$(git rev-parse HEAD^{tree})"
+product_blob="$(git rev-parse "HEAD:$product_path")"
+[[ "$(git hash-object "$product_path")" == "$product_blob" ]] || {
+  printf 'production-source-binding failed: worktree product differs from HEAD\n' >&2
+  exit 2
+}
 root="artifacts/pi-transcript-links/V03/$implementation_tree"
 mkdir -p "$root"
 attempt="$(mktemp -d "$root/attempt-XXXXXX")"
@@ -15,7 +21,7 @@ printf '# Target\n\n## Chosen Heading\n\nfixture body\n' > "$sandbox/vault/notes
 server="$sandbox/nvim.sock"
 command='XDG_CONFIG_HOME="$PWD/nvim/.config" scripts/verify-nvim pi-transcript-links'
 printf '$ %s\n' "$command" > "$attempt/command-transcript.txt"
-printf 'implementation_commit=%s\nimplementation_tree=%s\nproduct_blob=%s\nverifier_head=%s\n' "$implementation_commit" "$implementation_tree" "$(git rev-parse "$implementation_commit:pi/.pi/agent/extensions/transcript-scroll.ts")" "$(git rev-parse HEAD)" > "$attempt/implementation-identity.txt"
+printf 'implementation_commit=%s\nimplementation_tree=%s\nproduct_blob=%s\nverifier_head=%s\n' "$implementation_commit" "$implementation_tree" "$product_blob" "$implementation_commit" > "$attempt/implementation-identity.txt"
 {
   nvim --version | head -1
   pi --version | sed 's/^/Pi /'

--- a/scripts/verifiers/pi-transcript-links-v03
+++ b/scripts/verifiers/pi-transcript-links-v03
@@ -24,7 +24,7 @@ printf 'implementation_commit=%s\nimplementation_tree=%s\nproduct_blob=%s\nverif
 export V03_ATTEMPT="$attempt" V03_REPO="$repo" V03_VAULT_ROOT="$sandbox/vault" V03_CLIPBOARD_LOG="$attempt/fake-clipboard.log" V03_FIXTURE_TRACE="$attempt/fixture-trace.log"
 export XDG_DATA_HOME="$sandbox/xdg-data" XDG_STATE_HOME="$sandbox/xdg-state" XDG_CACHE_HOME="$sandbox/xdg-cache"
 set +e
-nvim --clean --headless --listen "$server" "+luafile scripts/fixtures/pi-transcript-links-v03-harness.lua" >> "$attempt/command-transcript.txt" 2>&1
+/usr/bin/script -q /dev/null nvim --clean --listen "$server" "+lua vim.schedule(function() dofile('scripts/fixtures/pi-transcript-links-v03-harness.lua') end)" >> "$attempt/command-transcript.txt" 2>&1
 status=$?
 set -e
 printf 'exit_status=%s\n' "$status" >> "$attempt/command-transcript.txt"

--- a/scripts/verify-nvim
+++ b/scripts/verify-nvim
@@ -31,6 +31,10 @@ fi
 
 cd "$repo_root"
 
+if [[ "$case_name" == "pi-transcript-links" ]]; then
+  exec scripts/verifiers/pi-transcript-links-v03
+fi
+
 if [[ "$case_name" == "weekly-backlog" ]]; then
   TZ=America/New_York VERIFY_NVIM_CASE="$case_name" "$nvim_bin" --headless \
     '+luafile scripts/verify-nvim.lua' \

--- a/scripts/verify-pi-transcript-links
+++ b/scripts/verify-pi-transcript-links
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+case "${1:-}" in
+	V01) exec node "$repo_root/scripts/verifiers/pi-transcript-links-v01" ;;
+	*) printf 'usage: %s V01\n' "$0" >&2; exit 2 ;;
+esac

--- a/scripts/verify-pi-transcript-links
+++ b/scripts/verify-pi-transcript-links
@@ -4,5 +4,6 @@ set -uo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 case "${1:-}" in
 	V01) exec node "$repo_root/scripts/verifiers/pi-transcript-links-v01" ;;
-	*) printf 'usage: %s V01\n' "$0" >&2; exit 2 ;;
+	V02) exec node "$repo_root/scripts/verifiers/pi-transcript-links-v02" ;;
+	*) printf 'usage: %s V01|V02\n' "$0" >&2; exit 2 ;;
 esac


### PR DESCRIPTION
## Intent

Merge T23's current compact clickable link implementation exactly as committed. The user explicitly approved merging as-is after V01 and V02 passed and live V03 passed 17 of 19 assertions; the known unresolved behavior is that Neovim consumes file-OSC8 primary clicks before Pi, so vault note opening and heading positioning remain blocked. Preserve the implementation without product fixes. Rebase safely, push the feature branch, open/update its PR with the known verifier waiver and evidence, and require CI.

## What Changed
- Compact rendered OSC 8 links and explicit vault wikilinks into clickable transcript spans while preserving native transcript scrolling.
- Add safe actions to copy HTTPS links and open validated vault file targets through Neovim, including line, heading, and block fragments.
- Add V01/V02 contract verifiers and a live V03 Neovim harness; V03 retains the approved 17/19 result because Neovim intercepts primary file-link clicks before Pi.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
