### PR TITLE
fix(atlas): skip unrenderable runs in interactive browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ atlas run retire <id> --expected-revision 7
 atlas capabilities --output json
 ```
 
+The interactive browser skips active Runs whose Project, Feature, or Task preview cannot be rendered and emits one
+startup warning with the Run ID and work-reference path. Machine-readable Run listings remain unchanged.
+
 The checked-in Pi config intentionally excludes `auth.json`, sessions, caches, and runtime state. MCP credentials should be provided out of band.
 
 Install/update Pi packages from the checked-in manifest:

--- a/cmd/atlas/browser.go
+++ b/cmd/atlas/browser.go
@@ -211,7 +211,7 @@ func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Read
 	for _, run := range runs {
 		runsByID[run.RunID] = run
 	}
-	summaries, err := atlaspkg.BuildActiveRunSummaries(vaultRoot, stateRoot)
+	summaries, err := atlaspkg.BuildRunSummaries(vaultRoot, stateRoot, runs)
 	if err != nil {
 		return nil, err
 	}
@@ -221,11 +221,7 @@ func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Read
 		if runID == "" {
 			continue
 		}
-		run, ok := runsByID[runID]
-		if !ok {
-			fmt.Fprintf(warnings, "atlas: warning: skipping unrenderable run %s: missing from active reader snapshot\n", runID)
-			continue
-		}
+		run := runsByID[runID]
 		projectID, projectName := mapPair(item, "project")
 		featureID, featureName := mapPair(item, "feature")
 		taskID, taskName := mapPair(item, "task")

--- a/cmd/atlas/browser.go
+++ b/cmd/atlas/browser.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -201,7 +202,7 @@ func (m browserModel) rightPane(width, rows int) []string {
 	return lines
 }
 
-func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Reader) ([]browserEntry, error) {
+func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Reader, warnings io.Writer) ([]browserEntry, error) {
 	runs, err := reader.List()
 	if err != nil {
 		return nil, err
@@ -222,22 +223,26 @@ func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Read
 		}
 		run, ok := runsByID[runID]
 		if !ok {
-			return nil, fmt.Errorf("atlas: run %s is missing from the active reader snapshot", runID)
+			fmt.Fprintf(warnings, "atlas: warning: skipping unrenderable run %s: missing from active reader snapshot\n", runID)
+			continue
 		}
 		projectID, projectName := mapPair(item, "project")
 		featureID, featureName := mapPair(item, "feature")
 		taskID, taskName := mapPair(item, "task")
 		projectPreview, err := previewEnvelope(vaultRoot, stateRoot, "projects", atlaspkg.MachineSelector{ID: projectID})
 		if err != nil {
-			return nil, err
+			warnUnrenderableRun(warnings, run, err)
+			continue
 		}
 		featurePreview, err := previewEnvelope(vaultRoot, stateRoot, "features", atlaspkg.MachineSelector{ID: featureID})
 		if err != nil {
-			return nil, err
+			warnUnrenderableRun(warnings, run, err)
+			continue
 		}
 		taskPreview, err := previewEnvelope(vaultRoot, stateRoot, "tasks", atlaspkg.MachineSelector{ID: taskID})
 		if err != nil {
-			return nil, err
+			warnUnrenderableRun(warnings, run, err)
+			continue
 		}
 		entries = append(entries, browserEntry{
 			runID:          runID,
@@ -253,6 +258,14 @@ func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Read
 		})
 	}
 	return entries, nil
+}
+
+func warnUnrenderableRun(w io.Writer, run vaultregistry.Run, err error) {
+	path := run.Task.Path
+	if run.WorkReference != nil {
+		path = run.WorkReference.Path
+	}
+	fmt.Fprintf(w, "atlas: warning: skipping unrenderable run %s (%s): %v\n", run.RunID, path, err)
 }
 
 func previewEnvelope(vaultRoot, stateRoot, resource string, selector atlaspkg.MachineSelector) (string, error) {

--- a/cmd/atlas/browser_test.go
+++ b/cmd/atlas/browser_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -157,12 +158,50 @@ func TestT18V03BrowserCompletenessIgnoresMachineByteCap(t *testing.T) {
 	if !listEnvelope.Meta["truncated"].(bool) || listEnvelope.Meta["count"].(int) != 6 || len(listData) >= 6 {
 		t.Fatalf("bounded run list = %#v", listEnvelope)
 	}
-	entries, err := buildBrowserEntries(vaultRoot, stateRoot, reader)
+	entries, err := buildBrowserEntries(vaultRoot, stateRoot, reader, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(entries) != 6 || entries[0].runID != "run-01" || entries[len(entries)-1].runID != "run-06" {
 		t.Fatalf("browser entries = %#v", entries)
+	}
+}
+
+func TestBrowserSkipsUnrenderableRunsWithWarning(t *testing.T) {
+	vaultRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	const taskPath = "1_projects/pi-agent/themes/pi-customization/features/vault-hunter-atlas/tasks/18-build-atlas.md"
+	const featurePath = "1_projects/pi-agent/themes/pi-customization/features/vault-hunter-atlas/feature.md"
+	writeBrowserFile(t, vaultRoot, "1_projects/pi-agent/README.md", "---\nworking_directory: /worktrees/dotfiles\nrepository: git@example.test/dotfiles\n---\n# pi-agent\n")
+	writeBrowserFile(t, vaultRoot, "1_projects/pi-agent/themes/pi-customization/theme.md", "---\n---\n# pi-customization\n")
+	writeBrowserFile(t, vaultRoot, featurePath, "---\n---\n# vault-hunter-atlas\n")
+	writeBrowserFile(t, vaultRoot, taskPath, "---\nstatus: in-progress\n---\n# T18: Build Atlas\n")
+	producer, err := vaultregistry.OpenProducer(stateRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := producer.CreateRun(browserRunRequest("renderable", "renderable", taskPath, featurePath)); err != nil {
+		t.Fatal(err)
+	}
+	unsupported := browserRunRequest("feature-run", "feature-run", featurePath, featurePath)
+	if _, err := producer.CreateRun(unsupported); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := vaultregistry.OpenReader(stateRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var warnings bytes.Buffer
+	entries, err := buildBrowserEntries(vaultRoot, stateRoot, reader, &warnings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].runID != "renderable" {
+		t.Fatalf("entries = %#v", entries)
+	}
+	warning := warnings.String()
+	if !strings.Contains(warning, "skipping unrenderable run feature-run") || !strings.Contains(warning, featurePath) {
+		t.Fatalf("warning = %q", warning)
 	}
 }
 

--- a/cmd/atlas/main.go
+++ b/cmd/atlas/main.go
@@ -724,11 +724,11 @@ func runBrowser(stdout io.Writer, reader *vaultregistry.Reader) error {
 	if err != nil {
 		return err
 	}
-	reload := func() ([]browserEntry, error) { return buildBrowserEntries(vaultRoot, stateRoot, reader) }
-	entries, err := reload()
+	entries, err := buildBrowserEntries(vaultRoot, stateRoot, reader, os.Stderr)
 	if err != nil {
 		return err
 	}
+	reload := func() ([]browserEntry, error) { return buildBrowserEntries(vaultRoot, stateRoot, reader, io.Discard) }
 	model := newBrowserModel(entries).withReload(reload).withColor(interactiveColorEnabled())
 	_, err = tea.NewProgram(model, tea.WithAltScreen()).Run()
 	return err

--- a/internal/atlas/api.go
+++ b/internal/atlas/api.go
@@ -243,11 +243,23 @@ func BuildActiveRunSummaries(vaultRoot, stateRoot string) ([]map[string]any, err
 	if err != nil {
 		return nil, err
 	}
-	data := make([]map[string]any, 0, len(loaded.activeRuns))
-	for _, run := range loaded.activeRuns {
-		data = append(data, loaded.runSummaryObject(run))
+	return buildRunSummaries(loaded, loaded.activeRuns), nil
+}
+
+func BuildRunSummaries(vaultRoot, stateRoot string, runs []vaultregistry.Run) ([]map[string]any, error) {
+	loaded, err := loadStore(vaultRoot, stateRoot)
+	if err != nil {
+		return nil, err
 	}
-	return data, nil
+	return buildRunSummaries(loaded, runs), nil
+}
+
+func buildRunSummaries(loaded *store, runs []vaultregistry.Run) []map[string]any {
+	data := make([]map[string]any, 0, len(runs))
+	for _, run := range runs {
+		data = append(data, loaded.runSummaryObject(renderRunProjection(run)))
+	}
+	return data
 }
 
 func BuildEvidenceEnvelope(vaultRoot, stateRoot string, selector MachineSelector) (Envelope, error) {


### PR DESCRIPTION
## Intent

Update the Atlas interactive browser so bare 'atlas observe' remains usable when an active Run cannot be hydrated into Project, Feature, and Task previews. Skip only unrenderable Runs, log one concise startup warning containing the Run ID and work-reference path, preserve machine-readable Run listings, avoid repeated refresh warnings, and add regression coverage. The user explicitly asked to merge the validated fix to main and push it.

## What Changed
- Skip active Runs whose Project, Feature, or Task previews cannot be rendered while keeping other Runs available in the interactive browser.
- Emit one startup warning with the Run ID and work-reference path, suppressing repeated refresh warnings while preserving machine-readable listings.
- Use a consistent Run snapshot for browser hydration and add regression coverage and documentation for the behavior.

## Risk Assessment

✅ Low: The change uses one Run snapshot for browser hydration, skips only preview failures with a single startup warning per affected Run, suppresses refresh warnings, and leaves machine-readable listings unchanged.

## Testing

Focused Atlas tests demonstrated that unrenderable active Runs are skipped with a startup warning containing the Run ID and work-reference path, renderable Runs remain browsable, and machine-readable get/watch listings remain valid; refresh warning suppression is covered by the reload path using a discarded warning writer. All checks passed and the worktree remained clean. No visual artifact was captured because the changed surface is an alternate-screen terminal TUI and the focused harness validates its startup data path rather than rendering an interactive terminal session.

<details>
<summary>Evidence: Targeted browser behavior test transcript</summary>

```text
=== RUN   TestT18V03BrowserCompletenessIgnoresMachineByteCap
--- PASS: TestT18V03BrowserCompletenessIgnoresMachineByteCap (0.48s)
=== RUN   TestBrowserSkipsUnrenderableRunsWithWarning
--- PASS: TestBrowserSkipsUnrenderableRunsWithWarning (0.17s)
PASS
ok  	github.com/aviral/dotfiles/cmd/atlas	0.835s
```
</details>
<details>
<summary>Evidence: Machine-readable listing regression transcript</summary>

```text
=== RUN   TestT18V03WatchEmitsCompleteEnvelopes
--- PASS: TestT18V03WatchEmitsCompleteEnvelopes (0.02s)
=== RUN   TestObserveAndGetRunsUseAtlasNameSelectors
--- PASS: TestObserveAndGetRunsUseAtlasNameSelectors (0.07s)
PASS
ok  	github.com/aviral/dotfiles/cmd/atlas	0.300s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `cmd/atlas/browser.go:226` - Intent requires each startup warning to contain the Run ID and work-reference path, but the newly handled reader/summary snapshot race emits only `skipping unrenderable run %s: missing from active reader snapshot`. A Run created between `reader.List()` and `BuildActiveRunSummaries()` reaches this branch without its path. Build entries from one consistent Run snapshot, or carry the work-reference path in the summary before warning.

🔧 Fix: Use consistent run snapshot for browser hydration
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./cmd/atlas -run 'TestBrowserSkipsUnrenderableRunsWithWarning|TestT18V03BrowserCompletenessIgnoresMachineByteCap' -count=1 -v`
- `go test ./internal/atlas -run 'RunSummar|ActiveRun|Run.*Envelope|Machine' -count=1 -v`
- `go test ./cmd/atlas -run 'TestBrowserSkipsUnrenderableRunsWithWarning|TestT18V03BrowserCompletenessIgnoresMachineByteCap|TestT18V01MachineCommands' -count=1 -v`
- `go test ./cmd/atlas -run 'TestObserveAndGetRunsUseAtlasNameSelectors|TestT18V03WatchEmitsCompleteEnvelopes' -count=1 -v`
- <code>`git status --short` confirmed testing left the worktree unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
