### PR TITLE
feat(vault-hunter): add Herdr crew custody pipeline

### DIFF
--- a/.agents/skills/vault-hunter/SKILL.md
+++ b/.agents/skills/vault-hunter/SKILL.md
@@ -1,126 +1,164 @@
 ---
 name: vault-hunter
-description: Execute one autonomous-ready vault Task from any conversation or agent runtime, using bounded workers, recorded verifier evidence, independent review, and parent-owned canonical decisions. Use when invoked as $vault-hunter with a Task or other work reference; route ambiguous or under-specified work to $vault-scout before implementation.
+description: Execute one autonomous-ready vault Task with a registered three-persona Herdr crew, No Mistakes review and verifier certification, and parent-owned canonical vault decisions. Use when invoked as $vault-hunter with a Task or other work reference; route ambiguous work to $vault-scout.
 ---
 
 # Vault Hunter
 
-Execute one ready Task. Treat Pi, Codex, Herdr, and other agent systems as interchangeable hosts for the same workflow.
-The driving parent owns the Run, routing, evidence acceptance, and canonical vault writes.
+Execute one ready Task. The driving parent owns sequencing, the Run, and every canonical vault mutation. The Crew owns
+only exact child process custody and safe process observations. No Mistakes owns independent review and final verifier
+certification.
 
-## Domain
+## Domain and authority
 
 - A **Project** contains Themes; a **Theme** contains Features; a **Feature** contains Tasks.
-- An **Issue** captures work that is not ready for autonomous execution.
-- A **Task** contains one or more Goals, stable Verifiers, and required Evidence.
-- A **Goal** states an outcome. A **Verifier** decides whether it holds. **Evidence** is the reproducible, immutable
-  output of running that verifier against a named implementation.
-- A **Run** records one attempt to execute a Task.
-
-The vault is canonical for hierarchy and status. The Run Registry records attempts, participants, evidence metadata,
-parent decisions, and cost. Atlas reads that state and records explicit parent attempt decisions and exact-revision Run
-retirement; it does not accept verifier evidence or change canonical vault status. Herdr owns visible process, workspace,
-and worktree custody. No Mistakes-style delivery supplies independent diff review, targeted tests, and landing confidence;
-it does not replace Hunter authority.
+- An **Issue** is unresolved work. A ready **Task** has Goals, stable Verifiers, and required Evidence.
+- A **Run** records one execution attempt. The vault remains canonical for hierarchy and status.
+- `vault-hunter-run.ts` is the Registry/Atlas adapter. `vault-hunter-crew.ts` owns Herdr child processes. Do not combine
+  those responsibilities or treat process completion as acceptance.
+- The parent alone writes Task, Feature, backlog, and checkpoint state. Children never edit the vault.
+- No Mistakes, not the parent, independently reviews the candidate and records accepted final verifier attempts and
+  certification in the Run Registry.
 
 ## Admission gate
 
-Accept a Task from any conversation, vault link, path, checkbox, or issue reference. Continue only when it has:
+Continue only when the supplied Task has:
 
-- explicit Goals and boundaries;
+- explicit Goals, boundaries, and resolved decisions;
 - stable Verifier IDs with exact commands or manual observations;
 - expected evidence and reproduction metadata;
-- resolved decisions and an implementation repository or bounded non-repository target; and
-- a linked prototype or an explicit explanation of why existing behavior is concrete enough.
+- an implementation repository or bounded non-repository target; and
+- a linked prototype, or an explicit reason existing behavior is concrete enough.
 
-If any item is missing, invoke `$vault-scout` on the source Issue or supplied text and stop before implementation.
+If any item is missing, invoke `$vault-scout` and stop before implementation.
 
 ## Start the Run
 
-1. Resolve the canonical Task and owning Feature. Preserve unrelated state.
-2. Open or resume one Registry Run through the host's available adapter. In Pi, use `agent_run_preflight`,
-   `atlas_create`, and the exact Atlas machine tools; do not revive the legacy `vault_hunter_*` compatibility tools.
-3. Bind the exact driver, repository, branch, worktree, and Herdr identity when present. A non-Pi or headless Run uses
-   the same domain contract without inventing Herdr identity.
-4. The parent creates or reuses the Task-owned implementation worktree and a Herdr workspace for implementation,
-   review, verification, and delivery workers; `$vault-hunter-worker` receives those exact resources and never
-   provisions a route itself. Visible children keep one dedicated tab each, and the parent records their exact
-   workspace, tab, pane, terminal, and agent-session binding before relying on output. Use a headless route only when
-   the user explicitly requests it or Herdr cannot represent the work, and record that exception before launch.
-5. Mark only this Task and Feature checklist item in progress, add one weekly backlog timeline, and use
-   `$vault-hunter-checkpoint` for serialized vault commits.
+1. Resolve the exact Task and Feature and preserve unrelated state.
+2. In Pi, run `agent_run_preflight`, then create or reopen the Run through `atlas_create` and the typed Atlas reads.
+   Bind the exact driver session, repository, branch, worktree, and complete Herdr tuple.
+3. Create or reuse one Task-owned implementation worktree and one Task-specific Herdr workspace. Every crew child gets
+   a dedicated one-pane tab in that same workspace.
+4. Write the invocation and checkpoint through `$vault-hunter-checkpoint`. Never let a child write canonical vault
+   state.
+5. Before any launch or after parent reload/resume/crash, inspect the automatically reconnected crew. Resolve any
+   ownership mismatch or active foreign writer before advancing.
 
-Never let a child write the vault. Only the parent accepts or rejects evidence and changes canonical state.
+## Crew tools and custody
 
-## Execute
+Use only these typed process tools for formal crew personas:
 
-Work one Goal and one verifier gate at a time:
+- `vault_hunter_crew_launch`: reserve a tab, start Pi without the Task, register exact ownership, then release the
+  bounded prompt.
+- `vault_hunter_crew_send`: send one exact follow-up to an existing child.
+- `vault_hunter_crew_release`: retain a verifier-builder during grace, close after a validated handoff, or abort incomplete exact Run-owned custody.
+- `vault_hunter_crew_inspect`: read bounded safe telemetry; it never certifies work.
 
-1. Capture a small accepted context capsule: Task contract, instructions, base, branch, head/tree, and relevant paths.
-2. Run the verifier on the original baseline and record the attempt, including command, exit, tree, artifact reference,
-   and SHA-256. Do not require a persistent verifier steward.
-3. Launch one bounded implementation worker for the smallest slice that can satisfy the active verifier.
-4. Run targeted checks, then the active complete verifier set, against an immutable head/tree.
-5. If a worker must be replaced because a verifier context changes, safe bounds are reached, or `/handoff` is required,
-   capture one bounded handoff with the exact Goal, base, head/tree, changed paths, verifier matrix, validations,
-   risks, and stop reason, then continue in a fresh `/new` session that consumes only that handoff.
-6. Require every verifier execution—pass, fail, interruption, or retry—to write an immutable Registry attempt.
-7. Read the compact Registry result capsule, not raw verifier output. Accept, reject, or supersede the exact attempt.
-   If the capsule is insufficient, launch a cheap read-only certification auditor; record its own traced Run and verdict
-   before the parent decides.
-8. Update Task evidence only after acceptance, then activate the next gate.
+A launch is fail-closed and two-phase:
 
-An audit-ready signal means sufficient evidence exists to inspect. An auditor verdict is advisory. Only the parent may
-certify a verifier or update canonical Goal, Task, or Feature state.
+1. reserve one dedicated tab in the parent's exact Herdr workspace;
+2. start Pi with no Task prompt, only the child companion extension, no discovered extension commands/skills/templates, and no active model tools; pass Run, Goal, role, journal, participant, and release-token identity by environment;
+3. resolve the child Pi session plus workspace, tab, pane, and terminal, and durably register the exact participant and
+   worker lifecycle in the Run;
+4. release the Task prompt only after registration succeeds; and
+5. on any failure, close the exact reserved tab, verify cleanup, and do not allow Task work to begin.
 
-## Agent routing
+Reject a launch unless recovery completed, the current parent exactly owns the Run/workspace/cwd, and no prior crew persona retains active or unreconciled custody. The three personas run sequentially, so only one crew write lease can exist. Never move, rename, close, or infer ownership of foreign resources.
 
-- Default every delegated worker to the Pi coding agent (`pi`). Do not substitute Codex, Claude, or another runtime
-  unless the user explicitly requests it or the task requires a capability Pi cannot provide, such as Codex computer
-  use; record the reason before launch.
-- Launch implementation, review, verification, and delivery workers as visible, Herdr-tracked `$vault-hunter-worker`
-  sessions by default. Headless subagents are the exception for tiny read-only work where visibility adds no value, or
-  when the user explicitly requests them; never use a headless writer by default.
-- Give every child one Goal, exact inputs, an allowlist, validations, output shape, and stop conditions.
-- Use a fresh read-only Pi agent for independent diff review. Pin base, head, tree, and Task contract; require findings
-  with severity and path/line, or an explicit clean verdict.
-- Name visible sessions `pi-<feature-slug>-<run-key>-<role>`.
-- Consume each accepted child handoff as bounded context, not as a prompt to reopen settled design or rediscover the
-  repository.
-- After a child finishes, the parent inspects the handoff, records attempts, makes the parent decision, and advances
-  autonomously without asking the user to resume while safe progress remains.
-- Never run parallel writers in one worktree. Children may produce repository changes and evidence, but not vault
-  status, acceptance, or completion decisions.
+The parent automatically reconnects live children by exact Run and agent-session identity. A persistent Run-wide crew
+widget shows live role, lifecycle, tab, retention, verifier-builder grace, and the latest safe steering summary/hash. Retention restores from durable parent tool history. Prompt Activities remain immutable and
+may show only the prompt-local Crew snapshot returned by that tool call.
 
-Registry hooks may observe child lifecycle automatically. Correlate each child with the stable Task Goal and stage;
-runtime completion alone is not acceptance.
+### Steering and telemetry
 
-## Review, evidence, and landing
+The parent is the primary steerer, but direct child-tab steering is allowed. The child companion projects every direct
+prompt as only a control-character-free first line (160 characters maximum) plus SHA-256 of the full prompt. Never
+mirror the full prompt, raw output, secrets, or reasoning.
 
-After all verifiers first pass:
+Per-child JSONL journals live under `${XDG_STATE_HOME:-~/.local/state}/vault-hunter/crew/<run>/<participant>.jsonl`.
+They are mode `0600` in `0700` directories, rotate at 1 MiB, and retain only the current file plus `.1` and `.2`.
+Allowed records are identity-safe lifecycle, tool/command summary and argument hash, bounded character-count progress,
+numeric usage, steering summary/hash, and final handoff summary/hash plus validated-label presence. Event identity and sequence are fixed to the child, and journal symlinks/non-regular files are rejected. Journal events are process facts, not Registry
+truth or evidence acceptance.
 
-1. Run one independent diff review and fix accepted blocker or major findings.
-2. Rerun affected verifiers and the complete declared set.
-3. Use `$vault-hunter-check` for exact frozen checks when applicable.
-4. For user-visible behavior, capture reviewable screenshots or video. For ANSI-capable CLIs, capture an ANSI-preserving
-   terminal screenshot in addition to semantic assertions and transcripts.
-5. Open or update the implementation PR with `## Verifiers` and `## Evidence`, mapping every artifact to a stable
-   verifier and reviewed commit/tree. Do not bypass required human merge approval.
-6. After merge, record the merged PR and commit identity, clean only Run-owned resources, and use
-   `$vault-hunter-checkpoint` to complete the Task and backlog on vault `main`. Verify the merged ref only when the Task
-   explicitly declares a post-merge verifier or the user requests it.
+Closing a child must close its exact tab, remove all three possible journal files, verify their absence, and record that
+cleanup proof. A missing or corrupt journal degrades inspection to exact Registry/Herdr lifecycle only. It never implies
+handoff, verifier success, certification, or Task success.
 
-Use `atlas` for Run status, machine reads, explicit parent attempt decisions, and exact-revision Run retirement. The
-standalone compatibility status surface is removed. Atlas does not accept verifier evidence or change canonical vault
-status.
+## Three-persona timeline
+
+### 1. Verifier builder
+
+Launch `verifier-builder` first when verifier construction or sharpening is needed. Give it the Task contract, stable
+Verifier IDs, baseline, exact paths, output manifest shape, and stop conditions. It may build the declared verifier
+boundary and capture baseline-red observations, but it cannot accept evidence or alter canonical state.
+
+After its structured handoff is durable, the widget shows a 30-second grace period. The parent or user may retain it
+with `vault_hunter_crew_release { disposition: "retain" }`; otherwise it closes automatically when idle. A retained
+verifier-builder requires an explicit close. Do not start convergence until verifier-builder custody has closed.
+
+### 2. Convergence engineer
+
+Launch exactly one `convergence-engineer` with the frozen verifier manifest, baseline facts, allowed implementation
+paths, and required checks. It owns the only active implementation write lease. Iterate with
+`vault_hunter_crew_send` while its bounded context remains valid.
+
+Require a handoff containing base/head/tree, changed paths, ordered verifier results, artifacts/hashes, risks, and
+blockers. Normal close is refused until every required handoff label is durable; use `disposition: "abort"` to close incomplete custody without implying success. Then explicitly close it. **Convergence must hand off and close before delivery starts**; do not suspend its
+write tools or leave it open beside delivery.
+
+### 3. Delivery steward
+
+Launch `delivery-steward` only after convergence is closed. It drives the existing No Mistakes gate with the full user
+intent and frozen candidate, including review, tests, docs, lint, certification, push, PR, and CI. It does not perform
+an extra Hunter-owned review and does not ask the parent to accept verifier attempts individually.
+
+The steward requires a validated labeled handoff and explicit release. Abort, rather than normally close, incomplete delivery custody. Preserve it at an unresolved No Mistakes gate or human
+approval boundary; close it only when no follow-up continuity is needed.
+
+## No Mistakes certification boundary
+
+No Mistakes must implement a dedicated `certify` phase with this contract:
+
+1. Run after review findings, fixes, tests, documentation, and lint have settled, and before push, PR, or CI.
+2. Freeze and report one candidate commit and tree. Any subsequent fix invalidates certification and returns through
+   the existing fix/re-review loop before certifying a new tree.
+3. Execute the Task's complete ordered verifier manifest, not only affected checks. Every attempt records verifier ID,
+   specification and environment hashes, invocation, command/cwd, candidate commit/tree, timestamps, exit status,
+   authenticated result-manifest path/hash, and diagnostics or interruption.
+4. Directly append the final `verifier_attempt` observations and `verifier_decision: accepted` observations to the exact
+   Run Registry revision. Certification succeeds only when every declared verifier has a passed final attempt on the
+   same frozen tree and an accepted decision. Record retry relations and failed/interrupted attempts rather than
+   overwriting them.
+5. Emit one bounded certification result mapping every Verifier ID to its accepted attempt, manifest hash, candidate
+   tree, and Registry revision. The parent consumes that result for canonical evidence/checkpoint writes; it does not
+   call `atlas_accept_verifier_attempt` itself.
+6. Keep certification failures inside No Mistakes's normal gate/fix/re-review loop. Findings that would change user
+   intent cross the existing `ask-user` boundary unless the user supplied standing `--yes` consent.
+
+Do not emulate this phase outside No Mistakes, skip it, or interpret ordinary test success as certification. Until the
+external No Mistakes binary implements this contract, delivery is blocked at certification; document the limitation
+rather than claiming a certified Run.
+
+## Evidence, landing, and canonical updates
+
+- Use `$vault-hunter-check` for exact frozen checks only when the Task or No Mistakes manifest delegates them.
+- Capture user-visible artifacts required by the Task, including ANSI-preserving terminal evidence where applicable.
+- After No Mistakes certification, the parent verifies the returned Run/tree mapping and writes Task evidence through
+  `$vault-hunter-checkpoint`. The parent does not make per-verifier accept/reject decisions.
+- No Mistakes owns push, PR, and CI. Do not bypass required human merge approval.
+- After merge, record PR and commit identity, close only exact Run-owned resources, and complete Task/Feature/backlog
+  state through checkpoint two. Run post-merge verification only when declared by the Task or requested by the user.
 
 ## Stop conditions
 
-Stop on unresolved specification ambiguity, overlapping Task ownership, unrecorded verifier output, changed evidence
-identity, an active foreign writer, unsafe Git state, failed canonical checkpoint, or missing required human approval.
-Record the exact frontier without interpreting missing telemetry as success.
+Stop on specification ambiguity, overlapping Task ownership, an active foreign or second convergence writer, changed
+candidate identity, missing verifier attempts, failed certification, corrupt ownership identity, unsafe Git state,
+failed canonical checkpoint, or missing human approval. Preserve live children needed for follow-up and report the exact
+frontier. Missing telemetry is never success.
 
 ## Handoff
 
-Report the Task and Feature links, Run ID, accepted Goals and verifier evidence, implementation and merge state,
-Registry decisions, vault checkpoint commits, cleanup, remaining blockers, and preserved unrelated state.
+Report Task and Feature links, Run ID, crew participants and closure state, candidate commit/tree, No Mistakes review and
+certification result, verifier evidence mapping, PR/merge state, checkpoint commits, journal/resource cleanup proof,
+remaining blockers, and preserved unrelated state.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,8 +27,8 @@ _Avoid_: workspace
 ## Vault Work
 
 **Vault Hunter**:
-The skill that routes a Vault Feature, Vault Task, or Wayfinder effort into its appropriate planning or execution flow.
-_Avoid_: vault skill
+The skill that routes ambiguous work to Vault Scout and executes an autonomous-ready Vault Task with a registered, sequential Herdr crew. The driving parent owns Run sequencing and canonical vault mutations; No Mistakes owns independent review and final verifier certification.
+_Avoid_: vault skill, parent-owned review or verifier certification
 
 **Run Registry**:
 A versioned durable store of immutable Run observations emitted by the active Vault Hunter driver. Schema version 1 retains participant, lifecycle, and evidence histories; schema version 2 adds typed verifier attempts and parent decisions, participants and workers, runtime telemetry, and auditor verdicts. Reader APIs remain forward-readable while producer APIs strictly validate known contracts, and the Registry never becomes the authority for vault lifecycle, goal advancement, acceptance, or completion.
@@ -41,6 +41,10 @@ _Avoid_: run controller, registry writer
 **Registered Participant**:
 A Task Run participant whose exact Herdr and agent-session identities are recorded in the Run Registry and can therefore be correlated with Atlas.
 _Avoid_: any Sidekick row, inferred participant
+
+**Vault Hunter Crew**:
+The sequential `verifier-builder`, `convergence-engineer`, and `delivery-steward` processes whose exact Run, Pi session, and Herdr custody is owned by the production crew extension. The Run Registry adapter remains separate, and process completion or telemetry never implies evidence acceptance.
+_Avoid_: generic inline subagents, Registry adapter, acceptance authority
 
 **Atlas Companion**:
 The read-only Atlas process attached exactly once to an eligible Task Run. T16 owns starting and stopping it; Atlas T03 owns its command and attachment semantics.
@@ -59,12 +63,12 @@ The To Spec structure stored in the canonical Vault Task note before execution. 
 _Avoid_: GitHub execution issue, duplicate spec
 
 **Task Goal Timeline**:
-The continuous Task Run timeline whose restartable Codex goals cover vault checkpoint one; each Verifier Entry; Refactor Gate; Review Convergence; opening the implementation pull request while capturing final evidence; CI, repairs, merge, and merged-main checks; then workspace and vault cleanup. Final evidence is part of the pull-request goal, not a separate goal. Goal boundaries do not need ordinal labels.
-_Avoid_: one monolithic task goal, final-evidence-only goal
+The continuous Task Run timeline covers checkpoint one; verifier construction; single-writer implementation convergence; No Mistakes review, documentation, lint, tests, and final verifier certification; push, pull request, CI, and merge; then exact resource cleanup and checkpoint two. Crew personas hand off and close sequentially.
+_Avoid_: parallel crew writers, parent-owned delivery review, uncertified landing
 
 **Verifier Cycle**:
-One independent Codex goal in a Task Goal Timeline: prove one planned verifier red against the baseline, then update the current verifier and implementation until the complete active verifier set is green. A verifier that already passes on the current implementation remains valid when its baseline-red evidence is preserved.
-_Avoid_: artificial failure
+The convergence engineer works against a frozen ordered verifier manifest and returns results for a named candidate. No Mistakes later executes the complete manifest against one frozen commit and tree in its dedicated certification phase; any fix invalidates that certification candidate.
+_Avoid_: affected-check-only certification, ordinary test success as certification
 
 **Verifier Entry**:
 A stable `V01`, `V02`, … item in a Vault Task note recording one externally observable behavior, its exact check, baseline-red proof, and latest result.
@@ -75,12 +79,12 @@ The point after every Verifier Entry has reached green once. Refactoring may imp
 _Avoid_: feature expansion
 
 **Review Refactor**:
-The post-review pass that fixes every bug found by local code review before the complete verifier set runs again.
-_Avoid_: review-only report
+The No Mistakes fix pass that addresses accepted independent-review findings before the candidate returns through review and final verifier certification.
+_Avoid_: Hunter parent review, review-only report
 
-**Review Convergence Loop**:
-The dedicated Task Goal that repeats local review, Review Refactor, and the complete active-verifier run until no bugs or major spec or architecture violations remain. It may use separate coding and reviewing subagents, and review may add a stable Verifier Entry for newly uncovered behavior; the implementation pull request opens only after convergence.
-_Avoid_: one-shot review, opening a pull request with relevant findings
+**Review and Certification Loop**:
+The No Mistakes-owned loop that settles review findings and fixes, then certifies the complete declared verifier manifest on one frozen candidate tree before push, pull request, or CI. The external No Mistakes binary does not yet implement the required `certify` phase, so Vault Hunter delivery remains blocked at that boundary rather than emulating certification.
+_Avoid_: generic reviewer substitution, parent acceptance of verifier attempts, claiming current certification support
 
 **Pull Request Evidence**:
 The links to every implementation pull request created during a Task Run, preserved in the canonical Vault Task note with final merge evidence. Vault updates are committed and pushed directly without a vault pull request.
@@ -91,8 +95,8 @@ One of two pushed Task Run states: the in-progress Task Spec and verifier plan b
 _Avoid_: per-cycle vault commit
 
 **Landing Gate**:
-The always-present post-PR Task Goal that owns required CI, repairs, auto-merge, and merged-main checks, or mergeable status plus the complete local verifier set when no CI exists. Vault Hunter never bypasses repository protections.
-_Avoid_: manual protection bypass
+The No Mistakes-owned delivery boundary after successful final verifier certification, covering push, pull request, required CI, repairs, merge, and declared merged-main checks. Vault Hunter never bypasses repository protections, and certification must precede push, pull request, or CI.
+_Avoid_: manual protection bypass, landing without certification
 
 **Workspace Cleanup Gate**:
 The final Task Goal where Vault Hunter closes every Herdr tab in the task's Herdr Workspace and every Neovim Workspace Tab bound to it, verifies they are gone, records final task evidence, and pushes the completed vault checkpoint. Other Herdr Workspaces and Unbound Tabs remain untouched.

--- a/cmd/vault-hunter-registry/main.go
+++ b/cmd/vault-hunter-registry/main.go
@@ -46,6 +46,15 @@ type appendRequest struct {
 	Evidence    *vaultregistry.Evidence    `json:"evidence,omitempty"`
 }
 
+type appendObservationRequest struct {
+	Action           string                     `json:"action"`
+	Root             string                     `json:"root,omitempty"`
+	RunID            *string                    `json:"run_id"`
+	ExpectedRevision *uint64                    `json:"expected_revision"`
+	UpdatedAt        *string                    `json:"updated_at"`
+	Observation      *vaultregistry.Observation `json:"observation"`
+}
+
 type listAgentSessionFilter struct {
 	Source string `json:"source"`
 	Kind   string `json:"kind"`
@@ -122,6 +131,14 @@ func serve(input io.Reader, output io.Writer) error {
 			RunID: *req.RunID, UpdatedAt: *req.UpdatedAt,
 			Participant: req.Participant, Lifecycle: req.Lifecycle, Evidence: req.Evidence,
 		})
+	case appendObservationRequest:
+		producer, openErr := vaultregistry.OpenExistingProducer(req.Root)
+		if openErr != nil {
+			return openErr
+		}
+		response, err = producer.AppendObservation(
+			*req.RunID, *req.ExpectedRevision, *req.UpdatedAt, *req.Observation,
+		)
 	case listRequest:
 		reader, openErr := vaultregistry.OpenReader(req.Root)
 		if openErr != nil {
@@ -198,6 +215,8 @@ func decodeRequest(input io.Reader) (any, error) {
 		command = &getRequest{}
 	case "append":
 		command = &appendRequest{}
+	case "append_observation":
+		command = &appendObservationRequest{}
 	case "list":
 		command = &listRequest{}
 	case "retire":
@@ -226,6 +245,12 @@ func decodeRequest(input io.Reader) (any, error) {
 	case *appendRequest:
 		if req.Action != "append" || req.RunID == nil || req.UpdatedAt == nil {
 			return nil, malformedRequest(errors.New("append requires run_id and updated_at"))
+		}
+		return *req, nil
+	case *appendObservationRequest:
+		if req.Action != "append_observation" || req.RunID == nil || req.ExpectedRevision == nil ||
+			req.UpdatedAt == nil || req.Observation == nil {
+			return nil, malformedRequest(errors.New("append_observation requires run_id, expected_revision, updated_at, and observation"))
 		}
 		return *req, nil
 	case *listRequest:

--- a/cmd/vault-hunter-registry/main_test.go
+++ b/cmd/vault-hunter-registry/main_test.go
@@ -50,6 +50,75 @@ func TestCreateAndIdempotentAppend(t *testing.T) {
 	}
 }
 
+func TestAppendObservationCommandWritesStrictV2AndReplaysIdempotently(t *testing.T) {
+	root := t.TempDir()
+	producer, err := vaultregistry.OpenProducer(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := "2026-07-28T12:00:00Z"
+	session := vaultregistry.AgentSession{Source: "herdr:pi", Kind: "path", Value: "/tmp/driver.jsonl"}
+	driver := vaultregistry.Observation{
+		ObservationID: "driver-started", Kind: vaultregistry.KindRegisteredParticipant, State: vaultregistry.StateActive,
+		GoalID: "run", Title: "driver started", Summary: "driver started.", ObservedAt: started, CorrelationID: "crew-v2",
+		Actor:  vaultregistry.Identity{Kind: "participant", ID: "driver", AgentSession: &session},
+		Source: vaultregistry.Identity{Kind: "producer", ID: "test"}, RedactionClass: "internal", StartedAt: &started,
+		Payload: vaultregistry.ObservationPayload{RegisteredParticipant: &vaultregistry.RegisteredParticipantPayload{
+			ParticipantID: "driver", Role: "driver", AgentSession: session,
+		}},
+	}
+	run := vaultregistry.Run{
+		SchemaVersion: 2, RunID: "crew-v2", Name: "crew-v2", RunKind: vaultregistry.RunKindHunter,
+		WorkReference: &vaultregistry.WorkReference{ID: "T01", Title: "Crew", Path: "task.md", FeaturePath: "feature.md", Kind: "task"},
+		Revision:      0, State: vaultregistry.RunStateActive, Stage: "invoked", InvokedAt: started, UpdatedAt: started,
+	}
+	created, err := producer.CreateRun(vaultregistry.CreateRequest{Run: run, InitialDriver: driver})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observed := "2026-07-28T12:01:00Z"
+	childSession := vaultregistry.AgentSession{Source: "herdr:pi", Kind: "path", Value: "/tmp/child.jsonl"}
+	observation := vaultregistry.Observation{
+		ObservationID: "child-started", Kind: vaultregistry.KindRegisteredParticipant, State: vaultregistry.StateActive,
+		GoalID: "G01", Title: "child started", Summary: "child started.", ObservedAt: observed, CorrelationID: run.RunID,
+		Actor:  vaultregistry.Identity{Kind: "participant", ID: "child", AgentSession: &childSession},
+		Source: vaultregistry.Identity{Kind: "producer", ID: "vault-hunter-crew"}, RedactionClass: "internal", StartedAt: &observed,
+		Payload: vaultregistry.ObservationPayload{RegisteredParticipant: &vaultregistry.RegisteredParticipantPayload{
+			ParticipantID: "child", Role: "verifier-builder", AgentSession: childSession,
+		}},
+	}
+	request := map[string]any{
+		"action": "append_observation", "root": root, "run_id": run.RunID,
+		"expected_revision": created.Revision, "updated_at": observed, "observation": observation,
+	}
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var firstOutput bytes.Buffer
+	if err := serve(bytes.NewReader(encoded), &firstOutput); err != nil {
+		t.Fatal(err)
+	}
+	var first vaultregistry.Run
+	if err := json.Unmarshal(firstOutput.Bytes(), &first); err != nil {
+		t.Fatal(err)
+	}
+	if first.Revision != 2 || len(first.Observations) != 2 {
+		t.Fatalf("first append = revision %d observations %d", first.Revision, len(first.Observations))
+	}
+	var replayOutput bytes.Buffer
+	if err := serve(bytes.NewReader(encoded), &replayOutput); err != nil {
+		t.Fatal(err)
+	}
+	var replay vaultregistry.Run
+	if err := json.Unmarshal(replayOutput.Bytes(), &replay); err != nil {
+		t.Fatal(err)
+	}
+	if replay.Revision != first.Revision || len(replay.Observations) != len(first.Observations) {
+		t.Fatalf("replay changed Run: %#v", replay)
+	}
+}
+
 func TestAppendRejectsIdentityCollisionsAndKeepsNewestUpdateTime(t *testing.T) {
 	producer, err := vaultregistry.OpenProducer(t.TempDir())
 	if err != nil {
@@ -137,6 +206,8 @@ func TestAdministrationRequestsAreStrictBeforeOpeningStorage(t *testing.T) {
 		`{"action":"get_retired","root":"` + root + `","run_id":"run"}`,
 		`{"action":"retire","root":"` + root + `","run_id":"run","expected_revision":"1"}`,
 		`{"action":"retire","root":"` + root + `","run_id":"run","expected_revision":1,"extra":true}`,
+		`{"action":"append_observation","root":"` + root + `","run_id":"run","updated_at":"2026-07-28T00:00:00Z","observation":{}}`,
+		`{"action":"append_observation","root":"` + root + `","run_id":"run","expected_revision":1,"updated_at":"2026-07-28T00:00:00Z","observation":{},"extra":true}`,
 		`{"action":"list","root":"` + root + `"}{"action":"list","root":"` + root + `"}`,
 	} {
 		var output bytes.Buffer

--- a/pi/.pi/agent/extensions/vault-hunter-agents.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-agents.ts
@@ -21,20 +21,24 @@ const readOnlyTools = ["read", "bash", "grep", "find", "ls"];
 const agents: Agent[] = [
   {
     name: "delegate",
-    description: "Return exact mechanical observations without synthesis or edits.",
+    description:
+      "Return exact mechanical observations without synthesis or edits.",
     tools: readOnlyTools,
     model: "openai-codex/gpt-5.6-luna",
     thinking: "low",
-    systemPrompt: "Perform only the bounded mechanical task. Do not edit files. Report exact commands, paths, values, and exit statuses. Stop when the requested evidence is complete.",
+    systemPrompt:
+      "Perform only the bounded mechanical task. Do not edit files. Report exact commands, paths, values, and exit statuses. Stop when the requested evidence is complete.",
     filePath,
   },
   {
     name: "context-builder",
-    description: "Draft specifications and verifier contracts from accepted context.",
+    description:
+      "Draft specifications and verifier contracts from accepted context.",
     tools: readOnlyTools,
     model: "openai-codex/gpt-5.6-sol",
     thinking: "high",
-    systemPrompt: "Use the supplied context to resolve the requested specification or verifier-design question. Read only directly relevant files. Do not edit files. Report concrete contracts, ambiguities, and evidence.",
+    systemPrompt:
+      "Use the supplied context to resolve the requested specification or verifier-design question. Read only directly relevant files. Do not edit files. Report concrete contracts, ambiguities, and evidence.",
     filePath,
   },
   {
@@ -43,7 +47,8 @@ const agents: Agent[] = [
     tools: ["read", "write", "edit", "bash", "grep", "find", "ls"],
     model: "openai-codex/gpt-5.6-sol",
     thinking: "high",
-    systemPrompt: "Implement only the bounded task in the supplied worktree. Follow repository instructions, preserve unrelated state, run the requested checks, and report changed paths, commands, exit statuses, commit/tree, and remaining risks.",
+    systemPrompt:
+      "Implement only the bounded task in the supplied worktree. Follow repository instructions, preserve unrelated state, run the requested checks, and report changed paths, commands, exit statuses, commit/tree, and remaining risks.",
     filePath,
   },
   {
@@ -52,7 +57,8 @@ const agents: Agent[] = [
     tools: readOnlyTools,
     model: "openai-codex/gpt-5.6-sol",
     thinking: "high",
-    systemPrompt: "Independently review the supplied change. Do not edit files. Prioritize correctness and requirement gaps. Report findings by severity with exact evidence, then residual risks.",
+    systemPrompt:
+      "Independently review the supplied change. Do not edit files. Prioritize correctness and requirement gaps. Report findings by severity with exact evidence, then residual risks.",
     filePath,
   },
 ];
@@ -61,9 +67,21 @@ export default function (pi: ExtensionAPI) {
   let installed = false;
   pi.on("before_agent_start", async (event) => {
     if (!installed) {
-      const registry = (globalThis as { __pi_subagents?: Registry }).__pi_subagents;
-      if (!registry) throw new Error("The configured subagent extension did not expose its agent registry.");
-      for (const name of ["scout", "researcher", "worker", "delegate", "context-builder", "reviewer"]) registry.unregisterAgent(name);
+      const registry = (globalThis as { __pi_subagents?: Registry })
+        .__pi_subagents;
+      if (!registry)
+        throw new Error(
+          "The configured subagent extension did not expose its agent registry.",
+        );
+      for (const name of [
+        "scout",
+        "researcher",
+        "worker",
+        "delegate",
+        "context-builder",
+        "reviewer",
+      ])
+        registry.unregisterAgent(name);
       for (const agent of agents) registry.registerAgent(agent);
       installed = true;
     }

--- a/pi/.pi/agent/extensions/vault-hunter-agents.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-agents.ts
@@ -68,7 +68,7 @@ export default function (pi: ExtensionAPI) {
       installed = true;
     }
     return {
-      systemPrompt: `${event.systemPrompt}\n\nThe configured subagents are delegate, context-builder, worker, and reviewer. Each launch is a full session-backed Pi agent observed inline in this session. Vault Hunter still defaults implementation, verification, review, and delivery to visible Herdr Pi sessions unless the user explicitly requests inline subagents.`,
+      systemPrompt: `${event.systemPrompt}\n\nThe configured inline subagents are the generic delegate, context-builder, worker, and reviewer capabilities. They are distinct from Vault Hunter's visible Herdr verifier-builder, convergence-engineer, and delivery-steward crew. Vault Hunter must not use the generic reviewer as its independent-review stage because No Mistakes owns review and verifier certification.`,
     };
   });
 }

--- a/pi/.pi/agent/extensions/vault-hunter-crew-child.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-crew-child.ts
@@ -1,0 +1,320 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const MAX_JOURNAL_BYTES = 1 << 20;
+const ROLES = new Set([
+  "verifier-builder",
+  "convergence-engineer",
+  "delivery-steward",
+]);
+const SAFE_ID = /^[A-Za-z0-9_-]+$/;
+
+type Config = {
+  runId: string;
+  goalId: string;
+  participantId: string;
+  role: string;
+  journal: string;
+  releaseToken: string;
+};
+
+function stateRoot(): string {
+  return process.env.XDG_STATE_HOME
+    ? join(process.env.XDG_STATE_HOME, "vault-hunter", "crew")
+    : join(homedir(), ".local", "state", "vault-hunter", "crew");
+}
+
+function config(): Config | undefined {
+  const value = {
+    runId: process.env.VAULT_HUNTER_RUN_ID,
+    goalId: process.env.VAULT_HUNTER_GOAL_ID,
+    participantId: process.env.VAULT_HUNTER_CREW_PARTICIPANT_ID,
+    role: process.env.VAULT_HUNTER_CREW_ROLE,
+    journal: process.env.VAULT_HUNTER_CREW_JOURNAL,
+    releaseToken: process.env.VAULT_HUNTER_CREW_RELEASE_TOKEN,
+  };
+  if (Object.values(value).every((item) => item === undefined)) return undefined;
+  if (
+    !value.runId ||
+    !value.goalId ||
+    !value.participantId ||
+    !value.role ||
+    !value.journal ||
+    !value.releaseToken ||
+    !SAFE_ID.test(value.runId) ||
+    !/^[A-Za-z0-9._:-]{1,128}$/.test(value.goalId) ||
+    !SAFE_ID.test(value.participantId) ||
+    !ROLES.has(value.role) ||
+    !/^[a-f0-9]{64}$/.test(value.releaseToken)
+  ) return undefined;
+  const expected = join(stateRoot(), value.runId, `${value.participantId}.jsonl`);
+  if (resolve(value.journal) !== resolve(expected)) return undefined;
+  return value as Config;
+}
+
+function hash(value: unknown): string {
+  const input = typeof value === "string" ? value : JSON.stringify(value ?? null);
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function summary(value: string): string {
+  return (
+    value
+      .split(/\r?\n/, 1)[0]
+      ?.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 160) || "(empty)"
+  );
+}
+
+function assistantText(message: any): string {
+  if (message?.role !== "assistant" || !Array.isArray(message.content)) return "";
+  return message.content
+    .filter((item: any) => item?.type === "text" && typeof item.text === "string")
+    .map((item: any) => item.text)
+    .join("\n");
+}
+
+function toolSummary(name: string, args: unknown): string {
+  const input = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+  if (name === "bash") return "bash command";
+  return typeof input.path === "string"
+    ? `${summary(name)} ${summary(input.path).split("/").at(-1)}`
+    : summary(name);
+}
+
+function numericUsage(message: any): Record<string, number> | undefined {
+  const usage = message?.usage;
+  if (!usage || typeof usage !== "object") return undefined;
+  const output: Record<string, number> = {};
+  for (const key of ["input", "output", "cacheRead", "cacheWrite", "totalTokens"] as const) {
+    const value = usage[key];
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0)
+      output[key] = value;
+  }
+  const cost = usage.cost?.total;
+  if (typeof cost === "number" && Number.isFinite(cost) && cost >= 0)
+    output.cost = cost;
+  return Object.keys(output).length ? output : undefined;
+}
+
+function regularFileOrAbsent(path: string): number {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink())
+      throw new Error(`unsafe journal path: ${path}`);
+    return stat.size;
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return 0;
+    throw error;
+  }
+}
+
+function existingEvents(path: string): any[] {
+  const events: any[] = [];
+  for (const candidate of [`${path}.2`, `${path}.1`, path]) {
+    if (regularFileOrAbsent(candidate) === 0) continue;
+    for (const line of readFileSync(candidate, "utf8").split("\n"))
+      if (line) events.push(JSON.parse(line));
+  }
+  return events;
+}
+
+function handoffFields(role: string, text: string): { fields: string[]; valid: boolean } {
+  const required: Record<string, string[]> = {
+    "verifier-builder": ["outcome", "verifier manifest", "baseline", "evidence", "risks", "blockers"],
+    "convergence-engineer": ["outcome", "base", "head", "tree", "changed paths", "verifier results", "artifacts", "risks", "blockers"],
+    "delivery-steward": ["outcome", "candidate tree", "review", "certification", "pr/ci", "risks", "blockers"],
+  };
+  const fields = required[role] ?? [];
+  const present = fields.filter((field) => new RegExp(`^\\s*(?:[-*]\\s*)?${field.replace("/", "\\/")}\\s*:\\s*\\S.*$`, "im").test(text));
+  return { fields: present, valid: present.length === fields.length };
+}
+
+function createWriter(cfg: Config) {
+  let sequence = existingEvents(cfg.journal).reduce(
+    (maximum, event) => Number.isInteger(event?.seq) ? Math.max(maximum, event.seq) : maximum,
+    0,
+  );
+  const directory = dirname(cfg.journal);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const directoryStat = lstatSync(directory);
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink())
+    throw new Error(`unsafe journal directory: ${directory}`);
+  chmodSync(directory, 0o700);
+
+  return (type: string, data: Record<string, unknown> = {}) => {
+    const event = {
+      v: 1,
+      seq: ++sequence,
+      at: new Date().toISOString(),
+      runId: cfg.runId,
+      goalId: cfg.goalId,
+      participantId: cfg.participantId,
+      role: cfg.role,
+      type,
+      ...data,
+    };
+    const line = `${JSON.stringify(event)}\n`;
+    const lineBytes = Buffer.byteLength(line);
+    if (lineBytes > MAX_JOURNAL_BYTES) throw new Error("telemetry event exceeds journal bound");
+    const size = regularFileOrAbsent(cfg.journal);
+    regularFileOrAbsent(`${cfg.journal}.1`);
+    regularFileOrAbsent(`${cfg.journal}.2`);
+    if (size + lineBytes > MAX_JOURNAL_BYTES) {
+      rmSync(`${cfg.journal}.2`, { force: true });
+      if (regularFileOrAbsent(`${cfg.journal}.1`) > 0)
+        renameSync(`${cfg.journal}.1`, `${cfg.journal}.2`);
+      if (regularFileOrAbsent(cfg.journal) > 0)
+        renameSync(cfg.journal, `${cfg.journal}.1`);
+    }
+    const fd = openSync(
+      cfg.journal,
+      constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      writeSync(fd, line);
+      fsyncSync(fd);
+    } finally { closeSync(fd); }
+    chmodSync(cfg.journal, 0o600);
+  };
+}
+
+export default function (pi: ExtensionAPI) {
+  const cfg = config();
+  if (!cfg) return;
+  const priorEvents = existingEvents(cfg.journal);
+  const record = createWriter(cfg);
+  const marker = `[vault-hunter-release:${cfg.releaseToken}]`;
+  const releaseProof = hash(`released:${cfg.releaseToken}`);
+  let released = priorEvents.some((event) => event?.type === "released" && event?.proof === releaseProof);
+  const reservedTools = pi.getActiveTools();
+  if (!released) pi.setActiveTools([]);
+  let lastAssistant = "";
+  let lastProgressAt = 0;
+
+  pi.on("session_start", (_event, ctx) => {
+    const sessionFile = ctx.sessionManager.getSessionFile();
+    record("ready", {
+      session: {
+        source: sessionFile ? "herdr:pi" : "pi",
+        kind: sessionFile ? "path" : "session-id",
+        value: sessionFile ?? ctx.sessionManager.getSessionId(),
+      },
+      herdr: {
+        workspaceId: process.env.HERDR_WORKSPACE_ID,
+        tabId: process.env.HERDR_TAB_ID,
+        paneId: process.env.HERDR_PANE_ID,
+      },
+    });
+    record("lifecycle", { state: "idle" });
+  });
+
+  pi.on("session_before_switch", () => ({ cancel: true }));
+  pi.on("session_before_fork", () => ({ cancel: true }));
+
+  pi.on("input", (event, ctx) => {
+    if (!released) {
+      if (!event.text.startsWith(marker)) {
+        ctx.ui.notify("Vault Hunter child is reserved until Run registration completes.", "warning");
+        return { action: "handled" as const };
+      }
+      const prompt = event.text.slice(marker.length).replace(/^\s*\n?/, "");
+      released = true;
+      record("released", { summary: summary(prompt), sha256: hash(prompt), proof: releaseProof });
+      pi.setActiveTools(reservedTools);
+      return { action: "transform" as const, text: prompt };
+    }
+    if (event.source !== "extension")
+      record("steering", { summary: summary(event.text), sha256: hash(event.text) });
+    return { action: "continue" as const };
+  });
+
+  pi.on("user_bash", () => {
+    if (released) return;
+    return {
+      result: {
+        output: "Vault Hunter child is reserved until Run registration completes.",
+        exitCode: 1,
+        cancelled: false,
+        truncated: false,
+      },
+    };
+  });
+
+  pi.on("agent_start", () => {
+    lastAssistant = "";
+    record("lifecycle", { state: "working" });
+  });
+  pi.on("tool_execution_start", (event) =>
+    record("tool", {
+      phase: "start",
+      name: summary(event.toolName),
+      summary: toolSummary(event.toolName, event.args),
+      sha256: hash(event.args),
+    }),
+  );
+  pi.on("tool_execution_end", (event) =>
+    record("tool", {
+      phase: "end",
+      name: summary(event.toolName),
+      failed: event.isError === true,
+    }),
+  );
+  pi.on("message_update", (event) => {
+    const now = Date.now();
+    if (now - lastProgressAt < 2_000) return;
+    lastProgressAt = now;
+    const content = Array.isArray((event.message as any)?.content)
+      ? (event.message as any).content
+      : [];
+    record("progress", {
+      textChars: content
+        .filter((item: any) => item?.type === "text")
+        .reduce((total: number, item: any) => total + String(item.text ?? "").length, 0),
+      thinkingChars: content
+        .filter((item: any) => item?.type === "thinking")
+        .reduce((total: number, item: any) => total + String(item.thinking ?? "").length, 0),
+    });
+  });
+  pi.on("message_end", (event) => {
+    const text = assistantText(event.message);
+    if (text) lastAssistant = text;
+  });
+  pi.on("turn_end", (event) => {
+    const usage = numericUsage((event as any).message);
+    if (usage) record("usage", { usage });
+  });
+  pi.on("agent_settled", () => {
+    record("lifecycle", { state: "idle" });
+    if (/^\s*(?:#{1,6}\s*)?HANDOFF:/i.test(lastAssistant)) {
+      const structure = handoffFields(cfg.role, lastAssistant);
+      record("handoff", {
+        summary: summary(lastAssistant),
+        sha256: hash(lastAssistant),
+        fields: structure.fields,
+        valid: structure.valid,
+      });
+    }
+  });
+  pi.on("session_shutdown", (event) =>
+    record("lifecycle", { state: "shutdown", reason: summary(event.reason) }),
+  );
+}

--- a/pi/.pi/agent/extensions/vault-hunter-crew-child.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-crew-child.ts
@@ -48,7 +48,8 @@ function config(): Config | undefined {
     journal: process.env.VAULT_HUNTER_CREW_JOURNAL,
     releaseToken: process.env.VAULT_HUNTER_CREW_RELEASE_TOKEN,
   };
-  if (Object.values(value).every((item) => item === undefined)) return undefined;
+  if (Object.values(value).every((item) => item === undefined))
+    return undefined;
   if (
     !value.runId ||
     !value.goalId ||
@@ -61,14 +62,20 @@ function config(): Config | undefined {
     !SAFE_ID.test(value.participantId) ||
     !ROLES.has(value.role) ||
     !/^[a-f0-9]{64}$/.test(value.releaseToken)
-  ) return undefined;
-  const expected = join(stateRoot(), value.runId, `${value.participantId}.jsonl`);
+  )
+    return undefined;
+  const expected = join(
+    stateRoot(),
+    value.runId,
+    `${value.participantId}.jsonl`,
+  );
   if (resolve(value.journal) !== resolve(expected)) return undefined;
   return value as Config;
 }
 
 function hash(value: unknown): string {
-  const input = typeof value === "string" ? value : JSON.stringify(value ?? null);
+  const input =
+    typeof value === "string" ? value : JSON.stringify(value ?? null);
   return createHash("sha256").update(input).digest("hex");
 }
 
@@ -84,15 +91,19 @@ function summary(value: string): string {
 }
 
 function assistantText(message: any): string {
-  if (message?.role !== "assistant" || !Array.isArray(message.content)) return "";
+  if (message?.role !== "assistant" || !Array.isArray(message.content))
+    return "";
   return message.content
-    .filter((item: any) => item?.type === "text" && typeof item.text === "string")
+    .filter(
+      (item: any) => item?.type === "text" && typeof item.text === "string",
+    )
     .map((item: any) => item.text)
     .join("\n");
 }
 
 function toolSummary(name: string, args: unknown): string {
-  const input = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+  const input =
+    args && typeof args === "object" ? (args as Record<string, unknown>) : {};
   if (name === "bash") return "bash command";
   return typeof input.path === "string"
     ? `${summary(name)} ${summary(input.path).split("/").at(-1)}`
@@ -103,7 +114,13 @@ function numericUsage(message: any): Record<string, number> | undefined {
   const usage = message?.usage;
   if (!usage || typeof usage !== "object") return undefined;
   const output: Record<string, number> = {};
-  for (const key of ["input", "output", "cacheRead", "cacheWrite", "totalTokens"] as const) {
+  for (const key of [
+    "input",
+    "output",
+    "cacheRead",
+    "cacheWrite",
+    "totalTokens",
+  ] as const) {
     const value = usage[key];
     if (typeof value === "number" && Number.isFinite(value) && value >= 0)
       output[key] = value;
@@ -136,20 +153,54 @@ function existingEvents(path: string): any[] {
   return events;
 }
 
-function handoffFields(role: string, text: string): { fields: string[]; valid: boolean } {
+function handoffFields(
+  role: string,
+  text: string,
+): { fields: string[]; valid: boolean } {
   const required: Record<string, string[]> = {
-    "verifier-builder": ["outcome", "verifier manifest", "baseline", "evidence", "risks", "blockers"],
-    "convergence-engineer": ["outcome", "base", "head", "tree", "changed paths", "verifier results", "artifacts", "risks", "blockers"],
-    "delivery-steward": ["outcome", "candidate tree", "review", "certification", "pr/ci", "risks", "blockers"],
+    "verifier-builder": [
+      "outcome",
+      "verifier manifest",
+      "baseline",
+      "evidence",
+      "risks",
+      "blockers",
+    ],
+    "convergence-engineer": [
+      "outcome",
+      "base",
+      "head",
+      "tree",
+      "changed paths",
+      "verifier results",
+      "artifacts",
+      "risks",
+      "blockers",
+    ],
+    "delivery-steward": [
+      "outcome",
+      "candidate tree",
+      "review",
+      "certification",
+      "pr/ci",
+      "risks",
+      "blockers",
+    ],
   };
   const fields = required[role] ?? [];
-  const present = fields.filter((field) => new RegExp(`^\\s*(?:[-*]\\s*)?${field.replace("/", "\\/")}\\s*:\\s*\\S.*$`, "im").test(text));
+  const present = fields.filter((field) =>
+    new RegExp(
+      `^\\s*(?:[-*]\\s*)?${field.replace("/", "\\/")}\\s*:\\s*\\S.*$`,
+      "im",
+    ).test(text),
+  );
   return { fields: present, valid: present.length === fields.length };
 }
 
 function createWriter(cfg: Config) {
   let sequence = existingEvents(cfg.journal).reduce(
-    (maximum, event) => Number.isInteger(event?.seq) ? Math.max(maximum, event.seq) : maximum,
+    (maximum, event) =>
+      Number.isInteger(event?.seq) ? Math.max(maximum, event.seq) : maximum,
     0,
   );
   const directory = dirname(cfg.journal);
@@ -173,7 +224,8 @@ function createWriter(cfg: Config) {
     };
     const line = `${JSON.stringify(event)}\n`;
     const lineBytes = Buffer.byteLength(line);
-    if (lineBytes > MAX_JOURNAL_BYTES) throw new Error("telemetry event exceeds journal bound");
+    if (lineBytes > MAX_JOURNAL_BYTES)
+      throw new Error("telemetry event exceeds journal bound");
     const size = regularFileOrAbsent(cfg.journal);
     regularFileOrAbsent(`${cfg.journal}.1`);
     regularFileOrAbsent(`${cfg.journal}.2`);
@@ -186,13 +238,18 @@ function createWriter(cfg: Config) {
     }
     const fd = openSync(
       cfg.journal,
-      constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW,
+      constants.O_APPEND |
+        constants.O_CREAT |
+        constants.O_WRONLY |
+        constants.O_NOFOLLOW,
       0o600,
     );
     try {
       writeSync(fd, line);
       fsyncSync(fd);
-    } finally { closeSync(fd); }
+    } finally {
+      closeSync(fd);
+    }
     chmodSync(cfg.journal, 0o600);
   };
 }
@@ -204,7 +261,9 @@ export default function (pi: ExtensionAPI) {
   const record = createWriter(cfg);
   const marker = `[vault-hunter-release:${cfg.releaseToken}]`;
   const releaseProof = hash(`released:${cfg.releaseToken}`);
-  let released = priorEvents.some((event) => event?.type === "released" && event?.proof === releaseProof);
+  let released = priorEvents.some(
+    (event) => event?.type === "released" && event?.proof === releaseProof,
+  );
   const reservedTools = pi.getActiveTools();
   if (!released) pi.setActiveTools([]);
   let lastAssistant = "";
@@ -233,17 +292,27 @@ export default function (pi: ExtensionAPI) {
   pi.on("input", (event, ctx) => {
     if (!released) {
       if (!event.text.startsWith(marker)) {
-        ctx.ui.notify("Vault Hunter child is reserved until Run registration completes.", "warning");
+        ctx.ui.notify(
+          "Vault Hunter child is reserved until Run registration completes.",
+          "warning",
+        );
         return { action: "handled" as const };
       }
       const prompt = event.text.slice(marker.length).replace(/^\s*\n?/, "");
       released = true;
-      record("released", { summary: summary(prompt), sha256: hash(prompt), proof: releaseProof });
+      record("released", {
+        summary: summary(prompt),
+        sha256: hash(prompt),
+        proof: releaseProof,
+      });
       pi.setActiveTools(reservedTools);
       return { action: "transform" as const, text: prompt };
     }
     if (event.source !== "extension")
-      record("steering", { summary: summary(event.text), sha256: hash(event.text) });
+      record("steering", {
+        summary: summary(event.text),
+        sha256: hash(event.text),
+      });
     return { action: "continue" as const };
   });
 
@@ -251,7 +320,8 @@ export default function (pi: ExtensionAPI) {
     if (released) return;
     return {
       result: {
-        output: "Vault Hunter child is reserved until Run registration completes.",
+        output:
+          "Vault Hunter child is reserved until Run registration completes.",
         exitCode: 1,
         cancelled: false,
         truncated: false,
@@ -288,10 +358,17 @@ export default function (pi: ExtensionAPI) {
     record("progress", {
       textChars: content
         .filter((item: any) => item?.type === "text")
-        .reduce((total: number, item: any) => total + String(item.text ?? "").length, 0),
+        .reduce(
+          (total: number, item: any) => total + String(item.text ?? "").length,
+          0,
+        ),
       thinkingChars: content
         .filter((item: any) => item?.type === "thinking")
-        .reduce((total: number, item: any) => total + String(item.thinking ?? "").length, 0),
+        .reduce(
+          (total: number, item: any) =>
+            total + String(item.thinking ?? "").length,
+          0,
+        ),
     });
   });
   pi.on("message_end", (event) => {

--- a/pi/.pi/agent/extensions/vault-hunter-crew.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-crew.ts
@@ -32,8 +32,12 @@ const SAFE_ID = /^[A-Za-z0-9_-]+$/;
 const MAX_TOOL_OUTPUT = 40_000;
 const MAX_REGISTRY_OUTPUT = 1 << 20;
 const EXTENSION_DIR = dirname(fileURLToPath(import.meta.url));
-const CHILD_EXTENSION = realpathSync(join(EXTENSION_DIR, "vault-hunter-crew-child.ts"));
-const HERDR_STATE_EXTENSION = realpathSync(join(EXTENSION_DIR, "herdr-agent-state.ts"));
+const CHILD_EXTENSION = realpathSync(
+  join(EXTENSION_DIR, "vault-hunter-crew-child.ts"),
+);
+const HERDR_STATE_EXTENSION = realpathSync(
+  join(EXTENSION_DIR, "herdr-agent-state.ts"),
+);
 
 type Role = (typeof ROLES)[number];
 type TerminalState = "succeeded" | "failed" | "interrupted";
@@ -92,10 +96,22 @@ type RegistryRun = {
 const LaunchSchema = Type.Object(
   {
     runId: Type.String({ description: "Exact active Vault Hunter Run ID." }),
-    goalId: Type.String({ pattern: "^[A-Za-z0-9._:-]{1,128}$", description: "Stable Goal or verifier ID for this child." }),
+    goalId: Type.String({
+      pattern: "^[A-Za-z0-9._:-]{1,128}$",
+      description: "Stable Goal or verifier ID for this child.",
+    }),
     role: StringEnum(ROLES, { description: "Vault Hunter crew persona." }),
-    prompt: Type.String({ minLength: 1, maxLength: 200_000, description: "Complete bounded assignment released only after registration." }),
-    cwd: Type.Optional(Type.String({ description: "Run-owned working directory; defaults to the parent cwd." })),
+    prompt: Type.String({
+      minLength: 1,
+      maxLength: 200_000,
+      description:
+        "Complete bounded assignment released only after registration.",
+    }),
+    cwd: Type.Optional(
+      Type.String({
+        description: "Run-owned working directory; defaults to the parent cwd.",
+      }),
+    ),
   },
   { additionalProperties: false },
 );
@@ -112,7 +128,13 @@ const ReleaseSchema = Type.Object(
     runId: Type.String(),
     participantId: Type.String(),
     disposition: StringEnum(["close", "retain", "abort"] as const),
-    result: Type.Optional(Type.String({ maxLength: 160, description: "Safe process-result summary; never a Task acceptance decision." })),
+    result: Type.Optional(
+      Type.String({
+        maxLength: 160,
+        description:
+          "Safe process-result summary; never a Task acceptance decision.",
+      }),
+    ),
   },
   { additionalProperties: false },
 );
@@ -156,11 +178,13 @@ function safeLine(value: string): string {
 }
 
 function slug(value: string, length = 40): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, length) || "crew";
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, length) || "crew"
+  );
 }
 
 function result(content: string, details: unknown) {
@@ -179,7 +203,10 @@ async function herdr(
 ): Promise<any> {
   const response = await pi.exec("herdr", args, { signal, timeout: 15_000 });
   if (response.code !== 0)
-    throw new Error(response.stderr.trim() || `herdr ${args.slice(0, 2).join(" ")} exited ${response.code}`);
+    throw new Error(
+      response.stderr.trim() ||
+        `herdr ${args.slice(0, 2).join(" ")} exited ${response.code}`,
+    );
   if (Buffer.byteLength(response.stdout) > MAX_TOOL_OUTPUT)
     throw new Error("Herdr output exceeded the Vault Hunter Crew bound.");
   return unwrap(response.stdout);
@@ -206,16 +233,30 @@ async function registry(
       if (bytes > MAX_REGISTRY_OUTPUT) child.kill();
       else stdout += chunk;
     });
-    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
     child.on("error", reject);
     child.on("close", (code) => {
       if (bytes > MAX_REGISTRY_OUTPUT)
-        return reject(new Error("Registry output exceeded the 1 MiB Vault Hunter Crew bound."));
+        return reject(
+          new Error(
+            "Registry output exceeded the 1 MiB Vault Hunter Crew bound.",
+          ),
+        );
       if (code !== 0)
-        return reject(new Error(stderr.trim() || `vault-hunter-registry exited ${code}`));
-      try { resolveRequest(JSON.parse(stdout)); } catch (error) { reject(error); }
+        return reject(
+          new Error(stderr.trim() || `vault-hunter-registry exited ${code}`),
+        );
+      try {
+        resolveRequest(JSON.parse(stdout));
+      } catch (error) {
+        reject(error);
+      }
     });
-    child.stdin.end(`${JSON.stringify({ ...request, ...(registryRoot() ? { root: registryRoot() } : {}) })}\n`);
+    child.stdin.end(
+      `${JSON.stringify({ ...request, ...(registryRoot() ? { root: registryRoot() } : {}) })}\n`,
+    );
   });
 }
 
@@ -225,7 +266,11 @@ async function getRun(
   signal?: AbortSignal,
 ): Promise<RegistryRun> {
   if (!SAFE_ID.test(runId)) throw new Error(`Invalid Run ID ${runId}.`);
-  return await registry(pi, { action: "get", run_id: runId }, signal) as RegistryRun;
+  return (await registry(
+    pi,
+    { action: "get", run_id: runId },
+    signal,
+  )) as RegistryRun;
 }
 
 function wireHerdr(value: HerdrIdentity) {
@@ -246,37 +291,62 @@ function sameSession(a: any, b: SessionIdentity): boolean {
 }
 
 function sameHerdr(a: any, b: HerdrIdentity): boolean {
-  return a?.workspace_id === b.workspaceId &&
+  return (
+    a?.workspace_id === b.workspaceId &&
     a?.tab_id === b.tabId &&
     a?.pane_id === b.paneId &&
-    a?.terminal_id === b.terminalId;
+    a?.terminal_id === b.terminalId
+  );
 }
 
-function participantObservation(run: RegistryRun, member: Member): any | undefined {
+function participantObservation(
+  run: RegistryRun,
+  member: Member,
+): any | undefined {
   if (run.schema_version === 1)
     return run.participants?.find(
-      (item) => item.participant_id === member.participantId &&
-        sameSession(item.agent_session, member.session) && sameHerdr(item.herdr, member.herdr),
+      (item) =>
+        item.participant_id === member.participantId &&
+        sameSession(item.agent_session, member.session) &&
+        sameHerdr(item.herdr, member.herdr),
     );
   return run.observations?.find((item) => {
     const payload = item.payload?.registered_participant;
-    return payload?.participant_id === member.participantId &&
-      sameSession(payload.agent_session, member.session) && sameHerdr(payload.herdr, member.herdr);
+    return (
+      payload?.participant_id === member.participantId &&
+      sameSession(payload.agent_session, member.session) &&
+      sameHerdr(payload.herdr, member.herdr)
+    );
   });
 }
 
 function runHasActiveRole(run: RegistryRun, role: Role): boolean {
   if (run.schema_version === 1)
-    return Boolean(run.participants?.some((participant) =>
-      participant.role === role && !(run as any).lifecycle?.some((item: any) =>
-        item.observation_id === `${participant.participant_id}-terminal`)));
+    return Boolean(
+      run.participants?.some(
+        (participant) =>
+          participant.role === role &&
+          !(run as any).lifecycle?.some(
+            (item: any) =>
+              item.observation_id === `${participant.participant_id}-terminal`,
+          ),
+      ),
+    );
   const observations = run.observations ?? [];
   return observations.some((observation) => {
     const participant = observation.payload?.registered_participant;
-    return observation.kind === "registered_participant" && observation.state === "active" &&
-      participant?.role === role && !observations.some((item) =>
-        item.kind === "registered_participant" && item.state !== "active" &&
-        item.payload?.registered_participant?.participant_id === participant.participant_id);
+    return (
+      observation.kind === "registered_participant" &&
+      observation.state === "active" &&
+      participant?.role === role &&
+      !observations.some(
+        (item) =>
+          item.kind === "registered_participant" &&
+          item.state !== "active" &&
+          item.payload?.registered_participant?.participant_id ===
+            participant.participant_id,
+      )
+    );
   });
 }
 
@@ -286,16 +356,26 @@ function driverOwnsRun(
   workspaceId: string,
 ): boolean {
   if (run.schema_version === 1)
-    return Boolean(run.participants?.some(
-      (item) => item.role === "driver" && sameSession(item.agent_session, session) &&
-        item.herdr?.workspace_id === workspaceId,
-    ));
-  return Boolean(run.observations?.some((item) => {
-    const payload = item.payload?.registered_participant;
-    return item.kind === "registered_participant" && item.state === "active" &&
-      payload?.role === "driver" && sameSession(payload.agent_session, session) &&
-      payload.herdr?.workspace_id === workspaceId;
-  }));
+    return Boolean(
+      run.participants?.some(
+        (item) =>
+          item.role === "driver" &&
+          sameSession(item.agent_session, session) &&
+          item.herdr?.workspace_id === workspaceId,
+      ),
+    );
+  return Boolean(
+    run.observations?.some((item) => {
+      const payload = item.payload?.registered_participant;
+      return (
+        item.kind === "registered_participant" &&
+        item.state === "active" &&
+        payload?.role === "driver" &&
+        sameSession(payload.agent_session, session) &&
+        payload.herdr?.workspace_id === workspaceId
+      );
+    }),
+  );
 }
 
 function envelope(
@@ -316,13 +396,19 @@ function envelope(
     summary: `${member.role} process ${state}.`,
     observed_at: observedAt,
     correlation_id: member.runId,
-    actor: { kind: "participant", id: member.participantId, agent_session: wireSession(member.session) },
+    actor: {
+      kind: "participant",
+      id: member.participantId,
+      agent_session: wireSession(member.session),
+    },
     source: { kind: "producer", id: "vault-hunter-crew" },
     redaction_class: "internal",
-    ...(kind !== "runtime_telemetry" ? {
-      started_at: member.startedAt,
-      ...(terminal ? { finished_at: observedAt } : {}),
-    } : {}),
+    ...(kind !== "runtime_telemetry"
+      ? {
+          started_at: member.startedAt,
+          ...(terminal ? { finished_at: observedAt } : {}),
+        }
+      : {}),
     payload: { [kind]: payload },
   };
 }
@@ -336,13 +422,17 @@ async function appendV2(
   for (let attempt = 0; attempt < 8; attempt++) {
     const run = await getRun(pi, runId, signal);
     try {
-      return await registry(pi, {
-        action: "append_observation",
-        run_id: runId,
-        expected_revision: run.revision,
-        updated_at: observation.observed_at,
-        observation,
-      }, signal) as RegistryRun;
+      return (await registry(
+        pi,
+        {
+          action: "append_observation",
+          run_id: runId,
+          expected_revision: run.revision,
+          updated_at: observation.observed_at,
+          observation,
+        },
+        signal,
+      )) as RegistryRun;
     } catch (error) {
       if (!String(error).includes("revision conflict")) throw error;
     }
@@ -357,62 +447,76 @@ async function registerMember(
   signal?: AbortSignal,
 ): Promise<void> {
   if (run.schema_version === 1) {
-    await registry(pi, {
-      action: "append",
-      run_id: member.runId,
-      updated_at: member.startedAt,
-      participant: {
-        participant_id: member.participantId,
-        observed_at: member.startedAt,
-        role: member.role,
-        goal_id: member.goalId,
-        herdr: wireHerdr(member.herdr),
-        agent_session: wireSession(member.session),
+    await registry(
+      pi,
+      {
+        action: "append",
+        run_id: member.runId,
+        updated_at: member.startedAt,
+        participant: {
+          participant_id: member.participantId,
+          observed_at: member.startedAt,
+          role: member.role,
+          goal_id: member.goalId,
+          herdr: wireHerdr(member.herdr),
+          agent_session: wireSession(member.session),
+        },
+        lifecycle: {
+          observation_id: `${member.participantId}-started`,
+          observed_at: member.startedAt,
+          kind: "worker",
+          goal_id: member.goalId,
+          state: "active",
+          detail: `${member.role} registered in exact Run-owned Herdr tab.`,
+        },
       },
-      lifecycle: {
-        observation_id: `${member.participantId}-started`,
-        observed_at: member.startedAt,
-        kind: "worker",
-        goal_id: member.goalId,
-        state: "active",
-        detail: `${member.role} registered in exact Run-owned Herdr tab.`,
-      },
-    }, signal);
+      signal,
+    );
     member.registered = true;
     member.workerRegistered = true;
     return;
   }
   if (run.schema_version !== 2)
     throw new Error(`Unsupported Registry schema ${run.schema_version}.`);
-  await appendV2(pi, member.runId, envelope(
-    member,
-    `${member.participantId}-participant-started`,
-    "registered_participant",
-    "active",
-    member.startedAt,
-    {
-      participant_id: member.participantId,
-      role: member.role,
-      agent_session: wireSession(member.session),
-      herdr: wireHerdr(member.herdr),
-    },
-  ), signal);
+  await appendV2(
+    pi,
+    member.runId,
+    envelope(
+      member,
+      `${member.participantId}-participant-started`,
+      "registered_participant",
+      "active",
+      member.startedAt,
+      {
+        participant_id: member.participantId,
+        role: member.role,
+        agent_session: wireSession(member.session),
+        herdr: wireHerdr(member.herdr),
+      },
+    ),
+    signal,
+  );
   member.registered = true;
-  await appendV2(pi, member.runId, envelope(
-    member,
-    `${member.workerId}-started`,
-    "worker",
-    "active",
-    member.startedAt,
-    {
-      worker_id: member.workerId,
-      role: member.role,
-      stage: member.role,
-      owner_participant_id: member.participantId,
-      agent_session: wireSession(member.session),
-      herdr: wireHerdr(member.herdr),
-    },
-  ), signal);
+  await appendV2(
+    pi,
+    member.runId,
+    envelope(
+      member,
+      `${member.workerId}-started`,
+      "worker",
+      "active",
+      member.startedAt,
+      {
+        worker_id: member.workerId,
+        role: member.role,
+        stage: member.role,
+        owner_participant_id: member.participantId,
+        agent_session: wireSession(member.session),
+        herdr: wireHerdr(member.herdr),
+      },
+    ),
+    signal,
+  );
   member.workerRegistered = true;
 }
 
@@ -427,7 +531,9 @@ async function recordTerminal(
   member.terminalReason ??= safeLine(reason);
   member.terminalState ??= state;
   if (member.terminalState !== state)
-    throw new Error(`Terminal state for ${member.participantId} changed during retry.`);
+    throw new Error(
+      `Terminal state for ${member.participantId} changed during retry.`,
+    );
   const observedAt = member.terminalAt;
   const run = await getRun(pi, member.runId);
   if (run.schema_version === 1) {
@@ -448,44 +554,58 @@ async function recordTerminal(
   }
   const resultText = `${member.terminalReason}; journal cleanup verified`;
   if (member.workerRegistered)
-    await appendV2(pi, member.runId, envelope(
+    await appendV2(
+      pi,
+      member.runId,
+      envelope(
+        member,
+        `${member.workerId}-terminal`,
+        "worker",
+        member.terminalState,
+        observedAt,
+        {
+          worker_id: member.workerId,
+          role: member.role,
+          stage: member.role,
+          owner_participant_id: member.participantId,
+          agent_session: wireSession(member.session),
+          herdr: wireHerdr(member.herdr),
+          terminal_result: resultText,
+        },
+        true,
+      ),
+    );
+  await appendV2(
+    pi,
+    member.runId,
+    envelope(
       member,
-      `${member.workerId}-terminal`,
-      "worker",
+      `${member.participantId}-participant-terminal`,
+      "registered_participant",
       member.terminalState,
       observedAt,
       {
-        worker_id: member.workerId,
+        participant_id: member.participantId,
         role: member.role,
-        stage: member.role,
-        owner_participant_id: member.participantId,
         agent_session: wireSession(member.session),
         herdr: wireHerdr(member.herdr),
         terminal_result: resultText,
       },
       true,
-    ));
-  await appendV2(pi, member.runId, envelope(
-    member,
-    `${member.participantId}-participant-terminal`,
-    "registered_participant",
-    member.terminalState,
-    observedAt,
-    {
-      participant_id: member.participantId,
-      role: member.role,
-      agent_session: wireSession(member.session),
-      herdr: wireHerdr(member.herdr),
-      terminal_result: resultText,
-    },
-    true,
-  ));
+    ),
+  );
 }
 
-async function assertMemberOwnership(pi: ExtensionAPI, member: Member, signal?: AbortSignal): Promise<void> {
+async function assertMemberOwnership(
+  pi: ExtensionAPI,
+  member: Member,
+  signal?: AbortSignal,
+): Promise<void> {
   const run = await getRun(pi, member.runId, signal);
   if (!participantObservation(run, member))
-    throw new Error(`Registry ownership for ${member.participantId} no longer matches its exact Pi and Herdr identity.`);
+    throw new Error(
+      `Registry ownership for ${member.participantId} no longer matches its exact Pi and Herdr identity.`,
+    );
 }
 
 async function parentPlacement(
@@ -493,17 +613,44 @@ async function parentPlacement(
   ctx: ExtensionContext,
   signal?: AbortSignal,
 ): Promise<{ herdr: HerdrIdentity; session: SessionIdentity }> {
-  if (ctx.mode !== "tui" || process.env.HERDR_ENV !== "1" || !process.env.HERDR_PANE_ID)
-    throw new Error("Vault Hunter Crew requires an interactive Herdr-bound parent Pi session.");
-  const resolved = await herdr(pi, ["pane", "get", process.env.HERDR_PANE_ID], signal);
+  if (
+    ctx.mode !== "tui" ||
+    process.env.HERDR_ENV !== "1" ||
+    !process.env.HERDR_PANE_ID
+  )
+    throw new Error(
+      "Vault Hunter Crew requires an interactive Herdr-bound parent Pi session.",
+    );
+  const resolved = await herdr(
+    pi,
+    ["pane", "get", process.env.HERDR_PANE_ID],
+    signal,
+  );
   const pane = resolved.pane ?? resolved;
   const sessionFile = ctx.sessionManager.getSessionFile();
   const session = pane.agent_session;
-  if (!sessionFile || !sameSession(session, { source: "herdr:pi", kind: "path", value: sessionFile }))
+  if (
+    !sessionFile ||
+    !sameSession(session, {
+      source: "herdr:pi",
+      kind: "path",
+      value: sessionFile,
+    })
+  )
     throw new Error("The current Herdr pane is not bound to this Pi session.");
-  const fields = [pane.workspace_id, pane.tab_id, pane.pane_id, pane.terminal_id];
-  if (fields.some((value) => typeof value !== "string" || !value) || pane.pane_id !== process.env.HERDR_PANE_ID)
-    throw new Error("Herdr returned an incomplete or contradictory parent identity.");
+  const fields = [
+    pane.workspace_id,
+    pane.tab_id,
+    pane.pane_id,
+    pane.terminal_id,
+  ];
+  if (
+    fields.some((value) => typeof value !== "string" || !value) ||
+    pane.pane_id !== process.env.HERDR_PANE_ID
+  )
+    throw new Error(
+      "Herdr returned an incomplete or contradictory parent identity.",
+    );
   return {
     herdr: {
       workspaceId: pane.workspace_id,
@@ -511,12 +658,23 @@ async function parentPlacement(
       paneId: pane.pane_id,
       terminalId: pane.terminal_id,
     },
-    session: { source: session.source, kind: session.kind, value: session.value },
+    session: {
+      source: session.source,
+      kind: session.kind,
+      value: session.value,
+    },
   };
 }
 
 const BASE_FIELDS = new Set([
-  "v", "seq", "at", "runId", "goalId", "participantId", "role", "type",
+  "v",
+  "seq",
+  "at",
+  "runId",
+  "goalId",
+  "participantId",
+  "role",
+  "type",
 ]);
 const EVENT_FIELDS: Record<string, Set<string>> = {
   ready: new Set(["session", "herdr"]),
@@ -532,57 +690,135 @@ const EVENT_FIELDS: Record<string, Set<string>> = {
 function safeEvent(value: unknown): value is JournalEvent {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const event = value as any;
-  if (event.v !== 1 || !Number.isInteger(event.seq) || event.seq < 1 ||
-    typeof event.at !== "string" || !SAFE_ID.test(event.runId ?? "") ||
-    typeof event.goalId !== "string" || !/^[A-Za-z0-9._:-]{1,128}$/.test(event.goalId) || !SAFE_ID.test(event.participantId ?? "") ||
-    !ROLES.includes(event.role) || !EVENT_FIELDS[event.type]) return false;
+  if (
+    event.v !== 1 ||
+    !Number.isInteger(event.seq) ||
+    event.seq < 1 ||
+    typeof event.at !== "string" ||
+    !SAFE_ID.test(event.runId ?? "") ||
+    typeof event.goalId !== "string" ||
+    !/^[A-Za-z0-9._:-]{1,128}$/.test(event.goalId) ||
+    !SAFE_ID.test(event.participantId ?? "") ||
+    !ROLES.includes(event.role) ||
+    !EVENT_FIELDS[event.type]
+  )
+    return false;
   const allowed = EVENT_FIELDS[event.type]!;
-  if (Object.keys(event).some((key) => !BASE_FIELDS.has(key) && !allowed.has(key))) return false;
-  for (const key of ["summary", "sha256", "proof", "state", "reason", "phase", "name"])
-    if (event[key] !== undefined && typeof event[key] !== "string") return false;
-  if (event.sha256 !== undefined && !/^[a-f0-9]{64}$/.test(event.sha256)) return false;
-  if (event.proof !== undefined && !/^[a-f0-9]{64}$/.test(event.proof)) return false;
+  if (
+    Object.keys(event).some((key) => !BASE_FIELDS.has(key) && !allowed.has(key))
+  )
+    return false;
+  for (const key of [
+    "summary",
+    "sha256",
+    "proof",
+    "state",
+    "reason",
+    "phase",
+    "name",
+  ])
+    if (event[key] !== undefined && typeof event[key] !== "string")
+      return false;
+  if (event.sha256 !== undefined && !/^[a-f0-9]{64}$/.test(event.sha256))
+    return false;
+  if (event.proof !== undefined && !/^[a-f0-9]{64}$/.test(event.proof))
+    return false;
   if (event.summary !== undefined && event.summary.length > 160) return false;
-  if (event.failed !== undefined && typeof event.failed !== "boolean") return false;
-  if (event.valid !== undefined && typeof event.valid !== "boolean") return false;
-  if (event.fields !== undefined && (!Array.isArray(event.fields) ||
-    event.fields.some((item: unknown) => typeof item !== "string" || item.length > 40))) return false;
+  if (event.failed !== undefined && typeof event.failed !== "boolean")
+    return false;
+  if (event.valid !== undefined && typeof event.valid !== "boolean")
+    return false;
+  if (
+    event.fields !== undefined &&
+    (!Array.isArray(event.fields) ||
+      event.fields.some(
+        (item: unknown) => typeof item !== "string" || item.length > 40,
+      ))
+  )
+    return false;
   if (event.usage !== undefined) {
-    if (!event.usage || typeof event.usage !== "object" || Array.isArray(event.usage)) return false;
-    if (Object.entries(event.usage).some(([key, item]) =>
-      !["input", "output", "cacheRead", "cacheWrite", "totalTokens", "cost"].includes(key) ||
-      typeof item !== "number" || !Number.isFinite(item) || item < 0)) return false;
+    if (
+      !event.usage ||
+      typeof event.usage !== "object" ||
+      Array.isArray(event.usage)
+    )
+      return false;
+    if (
+      Object.entries(event.usage).some(
+        ([key, item]) =>
+          ![
+            "input",
+            "output",
+            "cacheRead",
+            "cacheWrite",
+            "totalTokens",
+            "cost",
+          ].includes(key) ||
+          typeof item !== "number" ||
+          !Number.isFinite(item) ||
+          item < 0,
+      )
+    )
+      return false;
   }
   if (event.type === "ready") {
-    if (!event.session || typeof event.session !== "object" || Array.isArray(event.session) ||
-      Object.keys(event.session).some((key) => !["source", "kind", "value"].includes(key)) ||
-      [event.session.source, event.session.kind, event.session.value].some((item) => typeof item !== "string" || !item)) return false;
-    if (!event.herdr || typeof event.herdr !== "object" || Array.isArray(event.herdr) ||
-      Object.keys(event.herdr).some((key) => !["workspaceId", "tabId", "paneId"].includes(key)) ||
-      [event.herdr.workspaceId, event.herdr.tabId, event.herdr.paneId].some((item) => typeof item !== "string" || !item)) return false;
+    if (
+      !event.session ||
+      typeof event.session !== "object" ||
+      Array.isArray(event.session) ||
+      Object.keys(event.session).some(
+        (key) => !["source", "kind", "value"].includes(key),
+      ) ||
+      [event.session.source, event.session.kind, event.session.value].some(
+        (item) => typeof item !== "string" || !item,
+      )
+    )
+      return false;
+    if (
+      !event.herdr ||
+      typeof event.herdr !== "object" ||
+      Array.isArray(event.herdr) ||
+      Object.keys(event.herdr).some(
+        (key) => !["workspaceId", "tabId", "paneId"].includes(key),
+      ) ||
+      [event.herdr.workspaceId, event.herdr.tabId, event.herdr.paneId].some(
+        (item) => typeof item !== "string" || !item,
+      )
+    )
+      return false;
   }
   for (const key of ["textChars", "thinkingChars"])
-    if (event[key] !== undefined && (!Number.isInteger(event[key]) || event[key] < 0)) return false;
+    if (
+      event[key] !== undefined &&
+      (!Number.isInteger(event[key]) || event[key] < 0)
+    )
+      return false;
   return true;
 }
 
 function readJournal(
   path: string,
-  expected?: Partial<Pick<Member, "runId" | "goalId" | "participantId" | "role">>,
+  expected?: Partial<
+    Pick<Member, "runId" | "goalId" | "participantId" | "role">
+  >,
 ): { events: JournalEvent[]; lifecycleOnly: boolean; problem?: string } {
-  if (!existsSync(path)) return { events: [], lifecycleOnly: true, problem: "journal missing" };
+  if (!existsSync(path))
+    return { events: [], lifecycleOnly: true, problem: "journal missing" };
   const events: JournalEvent[] = [];
   try {
     let priorSequence = 0;
     for (const candidate of [`${path}.2`, `${path}.1`, path]) {
       if (!existsSync(candidate)) continue;
       const stat = lstatSync(candidate);
-      if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`unsafe journal file ${basename(candidate)}`);
+      if (!stat.isFile() || stat.isSymbolicLink())
+        throw new Error(`unsafe journal file ${basename(candidate)}`);
       for (const line of readFileSync(candidate, "utf8").split("\n")) {
         if (!line) continue;
         const value = JSON.parse(line);
-        if (!safeEvent(value)) throw new Error(`unsafe event in ${basename(candidate)}`);
-        if (value.seq <= priorSequence) throw new Error(`non-monotonic sequence in ${basename(candidate)}`);
+        if (!safeEvent(value))
+          throw new Error(`unsafe event in ${basename(candidate)}`);
+        if (value.seq <= priorSequence)
+          throw new Error(`non-monotonic sequence in ${basename(candidate)}`);
         priorSequence = value.seq;
         for (const key of ["runId", "goalId", "participantId", "role"] as const)
           if (expected?.[key] !== undefined && value[key] !== expected[key])
@@ -591,20 +827,30 @@ function readJournal(
       }
     }
   } catch (error) {
-    return { events: [], lifecycleOnly: true, problem: `journal corrupt: ${safeLine(String(error))}` };
+    return {
+      events: [],
+      lifecycleOnly: true,
+      problem: `journal corrupt: ${safeLine(String(error))}`,
+    };
   }
   return { events, lifecycleOnly: false };
 }
 
 function currentHandoff(events: JournalEvent[]): any | undefined {
-  const handoffIndex = events.findLastIndex((event) => event.type === "handoff");
-  const steeringIndex = events.findLastIndex((event) => event.type === "steering");
+  const handoffIndex = events.findLastIndex(
+    (event) => event.type === "handoff",
+  );
+  const steeringIndex = events.findLastIndex(
+    (event) => event.type === "steering",
+  );
   return handoffIndex > steeringIndex ? events[handoffIndex] : undefined;
 }
 
 function pathExists(path: string): boolean {
-  try { lstatSync(path); return true; }
-  catch (error: any) {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error: any) {
     if (error?.code === "ENOENT") return false;
     throw error;
   }
@@ -615,26 +861,44 @@ function journalPath(runId: string, participantId: string): string {
 }
 
 function cleanupJournal(member: Member): void {
-  for (const path of [member.journal, `${member.journal}.1`, `${member.journal}.2`])
+  for (const path of [
+    member.journal,
+    `${member.journal}.1`,
+    `${member.journal}.2`,
+  ])
     rmSync(path, { force: true });
-  if ([member.journal, `${member.journal}.1`, `${member.journal}.2`].some(existsSync))
-    throw new Error(`Journal cleanup could not be verified for ${member.participantId}.`);
+  if (
+    [member.journal, `${member.journal}.1`, `${member.journal}.2`].some(
+      existsSync,
+    )
+  )
+    throw new Error(
+      `Journal cleanup could not be verified for ${member.participantId}.`,
+    );
   try {
     if (readdirSync(dirname(member.journal)).length === 0)
       rmSync(dirname(member.journal), { recursive: false });
-  } catch { /* another child still owns this Run directory */ }
+  } catch {
+    /* another child still owns this Run directory */
+  }
 }
 
 function personaPrompt(role: Role, prompt: string): string {
   const contract: Record<Role, string> = {
-    "verifier-builder": "Build or sharpen only the declared verifier boundary and return a structured handoff. Do not accept evidence or mutate canonical vault state.",
-    "convergence-engineer": "Own the single active implementation write lease. Converge the frozen verifier manifest, then return a structured handoff and wait for explicit release.",
-    "delivery-steward": "Drive the outer No Mistakes delivery boundary. Independent review and final verifier certification belong inside No Mistakes; never make canonical vault decisions.",
+    "verifier-builder":
+      "Build or sharpen only the declared verifier boundary and return a structured handoff. Do not accept evidence or mutate canonical vault state.",
+    "convergence-engineer":
+      "Own the single active implementation write lease. Converge the frozen verifier manifest, then return a structured handoff and wait for explicit release.",
+    "delivery-steward":
+      "Drive the outer No Mistakes delivery boundary. Independent review and final verifier certification belong inside No Mistakes; never make canonical vault decisions.",
   };
   const templates: Record<Role, string> = {
-    "verifier-builder": "HANDOFF:\nOutcome:\nVerifier manifest:\nBaseline:\nEvidence:\nRisks:\nBlockers:",
-    "convergence-engineer": "HANDOFF:\nOutcome:\nBase:\nHead:\nTree:\nChanged paths:\nVerifier results:\nArtifacts:\nRisks:\nBlockers:",
-    "delivery-steward": "HANDOFF:\nOutcome:\nCandidate tree:\nReview:\nCertification:\nPR/CI:\nRisks:\nBlockers:",
+    "verifier-builder":
+      "HANDOFF:\nOutcome:\nVerifier manifest:\nBaseline:\nEvidence:\nRisks:\nBlockers:",
+    "convergence-engineer":
+      "HANDOFF:\nOutcome:\nBase:\nHead:\nTree:\nChanged paths:\nVerifier results:\nArtifacts:\nRisks:\nBlockers:",
+    "delivery-steward":
+      "HANDOFF:\nOutcome:\nCandidate tree:\nReview:\nCertification:\nPR/CI:\nRisks:\nBlockers:",
   };
   return [
     `You are the Vault Hunter ${role}.`,
@@ -653,10 +917,18 @@ async function assertSoloTab(
   tabId: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  const listed = await herdr(pi, ["tab", "list", "--workspace", workspaceId], signal);
-  const tab = Array.isArray(listed.tabs) ? listed.tabs.find((item: any) => item.tab_id === tabId) : undefined;
+  const listed = await herdr(
+    pi,
+    ["tab", "list", "--workspace", workspaceId],
+    signal,
+  );
+  const tab = Array.isArray(listed.tabs)
+    ? listed.tabs.find((item: any) => item.tab_id === tabId)
+    : undefined;
   if (!tab || tab.workspace_id !== workspaceId || tab.pane_count !== 1)
-    throw new Error(`Refusing to close ${tabId}: it is absent, moved, or no longer a dedicated one-pane tab.`);
+    throw new Error(
+      `Refusing to close ${tabId}: it is absent, moved, or no longer a dedicated one-pane tab.`,
+    );
 }
 
 async function waitForExactTermination(
@@ -669,11 +941,20 @@ async function waitForExactTermination(
     signal?.throwIfAborted();
     const listed = await herdr(pi, ["agent", "list"], signal);
     if (!Array.isArray(listed.agents))
-      throw new Error("Herdr returned a malformed agent list while awaiting child termination.");
-    if (!listed.agents.some((agent: any) => sameSession(agent.agent_session, member.session))) return;
+      throw new Error(
+        "Herdr returned a malformed agent list while awaiting child termination.",
+      );
+    if (
+      !listed.agents.some((agent: any) =>
+        sameSession(agent.agent_session, member.session),
+      )
+    )
+      return;
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
   }
-  throw new Error(`Exact child ${member.participantId} remained live after tab closure.`);
+  throw new Error(
+    `Exact child ${member.participantId} remained live after tab closure.`,
+  );
 }
 
 async function waitForTabTermination(
@@ -686,11 +967,15 @@ async function waitForTabTermination(
     signal?.throwIfAborted();
     const listed = await herdr(pi, ["agent", "list"], signal);
     if (!Array.isArray(listed.agents))
-      throw new Error("Herdr returned a malformed agent list while awaiting tab termination.");
+      throw new Error(
+        "Herdr returned a malformed agent list while awaiting tab termination.",
+      );
     if (!listed.agents.some((agent: any) => agent.tab_id === tabId)) return;
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
   }
-  throw new Error(`Child in exact tab ${tabId} remained live after tab closure.`);
+  throw new Error(
+    `Child in exact tab ${tabId} remained live after tab closure.`,
+  );
 }
 
 async function sendPrompt(
@@ -702,22 +987,43 @@ async function sendPrompt(
 ): Promise<void> {
   const live = await herdr(pi, ["agent", "get", member.name], signal);
   const agent = live.agent ?? live;
-  if (!sameSession(agent.agent_session, member.session) ||
+  if (
+    !sameSession(agent.agent_session, member.session) ||
     agent.workspace_id !== member.herdr.workspaceId ||
-    agent.tab_id !== member.herdr.tabId || agent.pane_id !== member.herdr.paneId ||
-    agent.terminal_id !== member.herdr.terminalId)
-    throw new Error(`Live identity for ${member.participantId} no longer matches its exact Run ownership.`);
-  await herdr(pi, ["pane", "send-text", member.herdr.paneId, `${marker}${prompt}`], signal);
+    agent.tab_id !== member.herdr.tabId ||
+    agent.pane_id !== member.herdr.paneId ||
+    agent.terminal_id !== member.herdr.terminalId
+  )
+    throw new Error(
+      `Live identity for ${member.participantId} no longer matches its exact Run ownership.`,
+    );
+  await herdr(
+    pi,
+    ["pane", "send-text", member.herdr.paneId, `${marker}${prompt}`],
+    signal,
+  );
   await herdr(pi, ["pane", "send-keys", member.herdr.paneId, "return"], signal);
 }
 
 async function waitForReady(
   pi: ExtensionAPI,
-  member: Omit<Member, "session" | "herdr" | "registered" | "workerRegistered" | "status" | "retained"> & { tabId: string },
+  member: Omit<
+    Member,
+    | "session"
+    | "herdr"
+    | "registered"
+    | "workerRegistered"
+    | "status"
+    | "retained"
+  > & { tabId: string },
   expectedWorkspace: string,
   expectedPane: string | undefined,
   signal?: AbortSignal,
-): Promise<{ session: SessionIdentity; herdr: HerdrIdentity; startedAt: string }> {
+): Promise<{
+  session: SessionIdentity;
+  herdr: HerdrIdentity;
+  startedAt: string;
+}> {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     signal?.throwIfAborted();
@@ -732,18 +1038,27 @@ async function waitForReady(
         paneId: agent.pane_id,
         terminalId: agent.terminal_id,
       };
-      if (!sameSession(agent.agent_session, ready.session) ||
-        identity.workspaceId !== expectedWorkspace || identity.tabId !== member.tabId ||
-        !identity.paneId || !identity.terminalId ||
+      if (
+        !sameSession(agent.agent_session, ready.session) ||
+        identity.workspaceId !== expectedWorkspace ||
+        identity.tabId !== member.tabId ||
+        !identity.paneId ||
+        !identity.terminalId ||
         ready.herdr?.workspaceId !== identity.workspaceId ||
-        ready.herdr?.tabId !== identity.tabId || ready.herdr?.paneId !== identity.paneId ||
-        expectedPane && identity.paneId !== expectedPane)
-        throw new Error("Child companion and Herdr returned contradictory launch identities.");
+        ready.herdr?.tabId !== identity.tabId ||
+        ready.herdr?.paneId !== identity.paneId ||
+        (expectedPane && identity.paneId !== expectedPane)
+      )
+        throw new Error(
+          "Child companion and Herdr returned contradictory launch identities.",
+        );
       return { session: ready.session, herdr: identity, startedAt: ready.at };
     }
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
   }
-  throw new Error("Child companion did not durably report its Pi session within 30 seconds.");
+  throw new Error(
+    "Child companion did not durably report its Pi session within 30 seconds.",
+  );
 }
 
 export default function (pi: ExtensionAPI) {
@@ -757,37 +1072,56 @@ export default function (pi: ExtensionAPI) {
   async function serializeCustody<T>(work: () => Promise<T>): Promise<T> {
     const previous = custodyQueue;
     let release!: () => void;
-    custodyQueue = new Promise<void>((resolveQueue) => { release = resolveQueue; });
+    custodyQueue = new Promise<void>((resolveQueue) => {
+      release = resolveQueue;
+    });
     await previous;
-    try { return await work(); }
-    finally { release(); }
+    try {
+      return await work();
+    } finally {
+      release();
+    }
   }
 
   function retainedFromSession(ctx: ExtensionContext): Set<string> {
     const retained = new Set<string>();
     for (const entry of ctx.sessionManager.getBranch()) {
-      if (entry.type !== "message" || entry.message.role !== "toolResult" ||
-        entry.message.toolName !== "vault_hunter_crew_release" || entry.message.isError) continue;
+      if (
+        entry.type !== "message" ||
+        entry.message.role !== "toolResult" ||
+        entry.message.toolName !== "vault_hunter_crew_release" ||
+        entry.message.isError
+      )
+        continue;
       const details = entry.message.details as any;
       if (typeof details?.participantId !== "string") continue;
       if (details.retained === true) retained.add(details.participantId);
-      if (details.journalCleanupVerified === true) retained.delete(details.participantId);
+      if (details.journalCleanupVerified === true)
+        retained.delete(details.participantId);
     }
     return retained;
   }
 
   function active(runId: string, role?: Role): Member[] {
-    return [...members.values()].filter((member) =>
-      member.runId === runId && member.status !== "closed" && (!role || member.role === role));
+    return [...members.values()].filter(
+      (member) =>
+        member.runId === runId &&
+        member.status !== "closed" &&
+        (!role || member.role === role),
+    );
   }
 
   function renderWidget(ctx: ExtensionContext): void {
-    const live = [...members.values()].filter((member) => member.status !== "closed");
+    const live = [...members.values()].filter(
+      (member) => member.status !== "closed",
+    );
     if (!live.length) {
       ctx.ui.setWidget(WIDGET_ID, undefined);
       return;
     }
-    const lines = [ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Vault Hunter Crew"))];
+    const lines = [
+      ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Vault Hunter Crew")),
+    ];
     for (const member of live) {
       const grace = member.graceDeadline
         ? ` · closes in ${Math.max(0, Math.ceil((member.graceDeadline - Date.now()) / 1000))}s`
@@ -796,12 +1130,18 @@ export default function (pi: ExtensionAPI) {
       const steering = member.lastSteering
         ? ` · steer ${member.lastSteering.summary} #${member.lastSteering.sha256.slice(0, 8)}`
         : "";
-      lines.push(`${member.role} · ${member.status}${grace}${degraded}${steering} · ${member.herdr.tabId}`);
+      lines.push(
+        `${member.role} · ${member.status}${grace}${degraded}${steering} · ${member.herdr.tabId}`,
+      );
     }
     ctx.ui.setWidget(WIDGET_ID, lines);
   }
 
-  async function closeMember(member: Member, state: TerminalState, reason: string): Promise<void> {
+  async function closeMember(
+    member: Member,
+    state: TerminalState,
+    reason: string,
+  ): Promise<void> {
     if (member.status === "closed") return;
     await assertMemberOwnership(pi, member);
     if (member.status === "closed-unrecorded") {
@@ -812,17 +1152,27 @@ export default function (pi: ExtensionAPI) {
     }
     const live = await herdr(pi, ["agent", "get", member.name]);
     const agent = live.agent ?? live;
-    if (!sameSession(agent.agent_session, member.session) || !sameHerdr({
-      workspace_id: agent.workspace_id,
-      tab_id: agent.tab_id,
-      pane_id: agent.pane_id,
-      terminal_id: agent.terminal_id,
-    }, member.herdr))
-      throw new Error(`Refusing to close ${member.participantId}: live ownership changed.`);
+    if (
+      !sameSession(agent.agent_session, member.session) ||
+      !sameHerdr(
+        {
+          workspace_id: agent.workspace_id,
+          tab_id: agent.tab_id,
+          pane_id: agent.pane_id,
+          terminal_id: agent.terminal_id,
+        },
+        member.herdr,
+      )
+    )
+      throw new Error(
+        `Refusing to close ${member.participantId}: live ownership changed.`,
+      );
     await assertSoloTab(pi, member.herdr.workspaceId, member.herdr.tabId);
     const closed = await herdr(pi, ["tab", "close", member.herdr.tabId]);
     if (closed.type !== "tab_closed" || closed.tab_id !== member.herdr.tabId)
-      throw new Error(`Herdr did not confirm exact tab closure for ${member.participantId}.`);
+      throw new Error(
+        `Herdr did not confirm exact tab closure for ${member.participantId}.`,
+      );
     await waitForExactTermination(pi, member);
     cleanupJournal(member);
     member.status = "closed-unrecorded";
@@ -841,28 +1191,57 @@ export default function (pi: ExtensionAPI) {
         const journal = readJournal(member.journal, member);
         member.lifecycleOnly = journal.lifecycleOnly;
         if (!journal.lifecycleOnly) {
-          const lifecycle = [...journal.events].reverse().find((event) => event.type === "lifecycle") as any;
+          const lifecycle = [...journal.events]
+            .reverse()
+            .find((event) => event.type === "lifecycle") as any;
           if (lifecycle?.state) member.status = lifecycle.state;
-          const handoffIndex = journal.events.findLastIndex((event) => event.type === "handoff");
+          const handoffIndex = journal.events.findLastIndex(
+            (event) => event.type === "handoff",
+          );
           const handoff = currentHandoff(journal.events);
           const steeringAfterHandoff = handoffIndex >= 0 && !handoff;
           const key = handoff ? `${handoff.at}:${handoff.sha256}` : undefined;
           member.handoffValid = handoff?.valid === true;
-          const steering = [...journal.events].reverse().find((event) => event.type === "steering") as any;
+          const steering = [...journal.events]
+            .reverse()
+            .find((event) => event.type === "steering") as any;
           if (steering?.summary && steering?.sha256)
-            member.lastSteering = { summary: steering.summary, sha256: steering.sha256 };
-          if (member.status === "working" || steeringAfterHandoff) member.graceDeadline = undefined;
-          if (member.role === "verifier-builder" && member.handoffValid && key && key !== member.lastHandoffKey) {
+            member.lastSteering = {
+              summary: steering.summary,
+              sha256: steering.sha256,
+            };
+          if (member.status === "working" || steeringAfterHandoff)
+            member.graceDeadline = undefined;
+          if (
+            member.role === "verifier-builder" &&
+            member.handoffValid &&
+            key &&
+            key !== member.lastHandoffKey
+          ) {
             member.lastHandoffKey = key;
-            if (!member.retained && !steeringAfterHandoff) member.graceDeadline = Date.now() + GRACE_MS;
+            if (!member.retained && !steeringAfterHandoff)
+              member.graceDeadline = Date.now() + GRACE_MS;
           }
         }
-        if (member.role === "verifier-builder" && member.graceDeadline &&
-          Date.now() >= member.graceDeadline && member.status === "idle")
-          await serializeCustody(() => closeMember(member, "succeeded", "verifier-builder grace elapsed after validated durable handoff"));
+        if (
+          member.role === "verifier-builder" &&
+          member.graceDeadline &&
+          Date.now() >= member.graceDeadline &&
+          member.status === "idle"
+        )
+          await serializeCustody(() =>
+            closeMember(
+              member,
+              "succeeded",
+              "verifier-builder grace elapsed after validated durable handoff",
+            ),
+          );
       }
     } catch (error) {
-      currentCtx.ui.notify(`Vault Hunter Crew monitor: ${safeLine(String(error))}`, "warning");
+      currentCtx.ui.notify(
+        `Vault Hunter Crew monitor: ${safeLine(String(error))}`,
+        "warning",
+      );
     } finally {
       polling = false;
       if (currentCtx) renderWidget(currentCtx);
@@ -874,24 +1253,43 @@ export default function (pi: ExtensionAPI) {
     const retained = retainedFromSession(ctx);
     const placement = await parentPlacement(pi, ctx);
     const listed = await herdr(pi, ["agent", "list"]);
-    if (!Array.isArray(listed.agents)) throw new Error("Herdr returned a malformed agent list during Crew recovery.");
+    if (!Array.isArray(listed.agents))
+      throw new Error(
+        "Herdr returned a malformed agent list during Crew recovery.",
+      );
     const agents = listed.agents;
-    for (const runId of existsSync(stateRoot()) ? readdirSync(stateRoot()) : []) {
+    for (const runId of existsSync(stateRoot())
+      ? readdirSync(stateRoot())
+      : []) {
       const directory = join(stateRoot(), runId);
       let files: string[];
-      try { files = readdirSync(directory).filter((file) => file.endsWith(".jsonl")); }
-      catch { continue; }
+      try {
+        files = readdirSync(directory).filter((file) =>
+          file.endsWith(".jsonl"),
+        );
+      } catch {
+        continue;
+      }
       for (const file of files) {
         const journal = join(directory, file);
         const replay = readJournal(journal, {
           runId,
           participantId: file.slice(0, -".jsonl".length),
         });
-        const ready = replay.events.find((event) => event.type === "ready") as any;
+        const ready = replay.events.find(
+          (event) => event.type === "ready",
+        ) as any;
         if (!ready || ready.runId !== runId) continue;
-        const live = agents.find((agent: any) => sameSession(agent.agent_session, ready.session));
-        if (!live || live.workspace_id !== placement.herdr.workspaceId ||
-          live.tab_id !== ready.herdr?.tabId || live.pane_id !== ready.herdr?.paneId) continue;
+        const live = agents.find((agent: any) =>
+          sameSession(agent.agent_session, ready.session),
+        );
+        if (
+          !live ||
+          live.workspace_id !== placement.herdr.workspaceId ||
+          live.tab_id !== ready.herdr?.tabId ||
+          live.pane_id !== ready.herdr?.paneId
+        )
+          continue;
         const member: Member = {
           runId,
           goalId: ready.goalId,
@@ -918,8 +1316,16 @@ export default function (pi: ExtensionAPI) {
         const run = await getRun(pi, runId);
         if (!participantObservation(run, member)) continue;
         member.registered = true;
-        member.workerRegistered = run.schema_version === 1 || Boolean(run.observations?.some((item: any) =>
-          item.kind === "worker" && item.payload?.worker?.owner_participant_id === member.participantId));
+        member.workerRegistered =
+          run.schema_version === 1 ||
+          Boolean(
+            run.observations?.some(
+              (item: any) =>
+                item.kind === "worker" &&
+                item.payload?.worker?.owner_participant_id ===
+                  member.participantId,
+            ),
+          );
         members.set(member.participantId, member);
       }
     }
@@ -930,129 +1336,215 @@ export default function (pi: ExtensionAPI) {
       action: "list",
       filter: { agent_session: wireSession(placement.session) },
     });
-    if (!Array.isArray(summaries)) throw new Error("Registry returned a malformed Run list during Crew recovery.");
+    if (!Array.isArray(summaries))
+      throw new Error(
+        "Registry returned a malformed Run list during Crew recovery.",
+      );
     for (const summary of summaries) {
-        const run = await getRun(pi, summary.run_id);
-        if (!driverOwnsRun(run, placement.session, placement.herdr.workspaceId)) continue;
-        if (run.schema_version === 1) {
-          for (const participant of run.participants ?? []) {
-            if (!ROLES.includes(participant.role) || members.has(participant.participant_id)) continue;
-            if ((run as any).lifecycle?.some((item: any) => item.observation_id === `${participant.participant_id}-terminal`)) continue;
-            const live = agents.find((item: any) => sameSession(item.agent_session, participant.agent_session));
-            if (!live) {
-              if (participant.herdr?.workspace_id !== placement.herdr.workspaceId)
-                throw new Error(`Registry custody for ${participant.participant_id} is outside the driver workspace.`);
-              const stale: Member = {
-                runId: run.run_id, goalId: participant.goal_id,
-                participantId: participant.participant_id,
-                workerId: `${participant.participant_id}-worker`, role: participant.role,
-                name: participant.participant_id, cwd: ctx.cwd,
-                journal: journalPath(run.run_id, participant.participant_id),
-                session: participant.agent_session,
-                herdr: {
-                  workspaceId: participant.herdr.workspace_id, tabId: participant.herdr.tab_id,
-                  paneId: participant.herdr.pane_id, terminalId: participant.herdr.terminal_id,
-                },
-                startedAt: participant.observed_at, status: "closed-unrecorded", retained: false,
-                registered: true, workerRegistered: true, lifecycleOnly: true,
-              };
-              cleanupJournal(stale);
-              await recordTerminal(pi, stale, "interrupted", "exact-owned child was no longer live during recovery");
-              continue;
-            }
-            if (!sameHerdr(participant.herdr, {
-              workspaceId: live.workspace_id, tabId: live.tab_id,
-              paneId: live.pane_id, terminalId: live.terminal_id,
-            }) || live.workspace_id !== placement.herdr.workspaceId)
-              throw new Error(`Live identity for ${participant.participant_id} contradicts Registry custody.`);
-            members.set(participant.participant_id, {
+      const run = await getRun(pi, summary.run_id);
+      if (!driverOwnsRun(run, placement.session, placement.herdr.workspaceId))
+        continue;
+      if (run.schema_version === 1) {
+        for (const participant of run.participants ?? []) {
+          if (
+            !ROLES.includes(participant.role) ||
+            members.has(participant.participant_id)
+          )
+            continue;
+          if (
+            (run as any).lifecycle?.some(
+              (item: any) =>
+                item.observation_id ===
+                `${participant.participant_id}-terminal`,
+            )
+          )
+            continue;
+          const live = agents.find((item: any) =>
+            sameSession(item.agent_session, participant.agent_session),
+          );
+          if (!live) {
+            if (participant.herdr?.workspace_id !== placement.herdr.workspaceId)
+              throw new Error(
+                `Registry custody for ${participant.participant_id} is outside the driver workspace.`,
+              );
+            const stale: Member = {
               runId: run.run_id,
               goalId: participant.goal_id,
               participantId: participant.participant_id,
               workerId: `${participant.participant_id}-worker`,
               role: participant.role,
-              name: live.name,
-              cwd: live.cwd,
+              name: participant.participant_id,
+              cwd: ctx.cwd,
               journal: journalPath(run.run_id, participant.participant_id),
               session: participant.agent_session,
               herdr: {
-                workspaceId: live.workspace_id, tabId: live.tab_id,
-                paneId: live.pane_id, terminalId: live.terminal_id,
+                workspaceId: participant.herdr.workspace_id,
+                tabId: participant.herdr.tab_id,
+                paneId: participant.herdr.pane_id,
+                terminalId: participant.herdr.terminal_id,
               },
               startedAt: participant.observed_at,
-              status: live.agent_status ?? "unknown",
-              retained: retained.has(participant.participant_id),
+              status: "closed-unrecorded",
+              retained: false,
               registered: true,
               workerRegistered: true,
               lifecycleOnly: true,
-            });
-          }
-          continue;
-        }
-        for (const observation of run.observations ?? []) {
-          const participant = observation.payload?.registered_participant;
-          if (observation.kind !== "registered_participant" || observation.state !== "active" ||
-            !participant || !ROLES.includes(participant.role) || members.has(participant.participant_id)) continue;
-          const terminal = run.observations?.some((item: any) =>
-            item.kind === "registered_participant" && item.state !== "active" &&
-            item.payload?.registered_participant?.participant_id === participant.participant_id);
-          if (terminal) continue;
-          const live = agents.find((item: any) => sameSession(item.agent_session, participant.agent_session));
-          const worker = run.observations?.find((item: any) =>
-            item.kind === "worker" && item.state === "active" &&
-            item.payload?.worker?.owner_participant_id === participant.participant_id)?.payload?.worker;
-          if (!live) {
-            if (participant.herdr?.workspace_id !== placement.herdr.workspaceId)
-              throw new Error(`Registry custody for ${participant.participant_id} is outside the driver workspace.`);
-            const stale: Member = {
-              runId: run.run_id, goalId: observation.goal_id,
-              participantId: participant.participant_id,
-              workerId: worker?.worker_id ?? `${participant.participant_id}-worker`, role: participant.role,
-              name: participant.participant_id, cwd: ctx.cwd,
-              journal: journalPath(run.run_id, participant.participant_id),
-              session: participant.agent_session,
-              herdr: {
-                workspaceId: participant.herdr.workspace_id, tabId: participant.herdr.tab_id,
-                paneId: participant.herdr.pane_id, terminalId: participant.herdr.terminal_id,
-              },
-              startedAt: observation.started_at, status: "closed-unrecorded", retained: false,
-              registered: true, workerRegistered: Boolean(worker), lifecycleOnly: true,
             };
             cleanupJournal(stale);
-            await recordTerminal(pi, stale, "interrupted", "exact-owned child was no longer live during recovery");
+            await recordTerminal(
+              pi,
+              stale,
+              "interrupted",
+              "exact-owned child was no longer live during recovery",
+            );
             continue;
           }
-          if (!sameHerdr(participant.herdr, {
-            workspaceId: live.workspace_id, tabId: live.tab_id,
-            paneId: live.pane_id, terminalId: live.terminal_id,
-          }) || live.workspace_id !== placement.herdr.workspaceId)
-            throw new Error(`Live identity for ${participant.participant_id} contradicts Registry custody.`);
+          if (
+            !sameHerdr(participant.herdr, {
+              workspaceId: live.workspace_id,
+              tabId: live.tab_id,
+              paneId: live.pane_id,
+              terminalId: live.terminal_id,
+            }) ||
+            live.workspace_id !== placement.herdr.workspaceId
+          )
+            throw new Error(
+              `Live identity for ${participant.participant_id} contradicts Registry custody.`,
+            );
           members.set(participant.participant_id, {
             runId: run.run_id,
-            goalId: observation.goal_id,
+            goalId: participant.goal_id,
             participantId: participant.participant_id,
-            workerId: worker?.worker_id ?? `${participant.participant_id}-worker`,
+            workerId: `${participant.participant_id}-worker`,
             role: participant.role,
             name: live.name,
             cwd: live.cwd,
             journal: journalPath(run.run_id, participant.participant_id),
             session: participant.agent_session,
             herdr: {
-              workspaceId: live.workspace_id, tabId: live.tab_id,
-              paneId: live.pane_id, terminalId: live.terminal_id,
+              workspaceId: live.workspace_id,
+              tabId: live.tab_id,
+              paneId: live.pane_id,
+              terminalId: live.terminal_id,
             },
-            startedAt: observation.started_at,
+            startedAt: participant.observed_at,
             status: live.agent_status ?? "unknown",
             retained: retained.has(participant.participant_id),
             registered: true,
-            workerRegistered: Boolean(worker),
+            workerRegistered: true,
             lifecycleOnly: true,
           });
         }
+        continue;
       }
+      for (const observation of run.observations ?? []) {
+        const participant = observation.payload?.registered_participant;
+        if (
+          observation.kind !== "registered_participant" ||
+          observation.state !== "active" ||
+          !participant ||
+          !ROLES.includes(participant.role) ||
+          members.has(participant.participant_id)
+        )
+          continue;
+        const terminal = run.observations?.some(
+          (item: any) =>
+            item.kind === "registered_participant" &&
+            item.state !== "active" &&
+            item.payload?.registered_participant?.participant_id ===
+              participant.participant_id,
+        );
+        if (terminal) continue;
+        const live = agents.find((item: any) =>
+          sameSession(item.agent_session, participant.agent_session),
+        );
+        const worker = run.observations?.find(
+          (item: any) =>
+            item.kind === "worker" &&
+            item.state === "active" &&
+            item.payload?.worker?.owner_participant_id ===
+              participant.participant_id,
+        )?.payload?.worker;
+        if (!live) {
+          if (participant.herdr?.workspace_id !== placement.herdr.workspaceId)
+            throw new Error(
+              `Registry custody for ${participant.participant_id} is outside the driver workspace.`,
+            );
+          const stale: Member = {
+            runId: run.run_id,
+            goalId: observation.goal_id,
+            participantId: participant.participant_id,
+            workerId:
+              worker?.worker_id ?? `${participant.participant_id}-worker`,
+            role: participant.role,
+            name: participant.participant_id,
+            cwd: ctx.cwd,
+            journal: journalPath(run.run_id, participant.participant_id),
+            session: participant.agent_session,
+            herdr: {
+              workspaceId: participant.herdr.workspace_id,
+              tabId: participant.herdr.tab_id,
+              paneId: participant.herdr.pane_id,
+              terminalId: participant.herdr.terminal_id,
+            },
+            startedAt: observation.started_at,
+            status: "closed-unrecorded",
+            retained: false,
+            registered: true,
+            workerRegistered: Boolean(worker),
+            lifecycleOnly: true,
+          };
+          cleanupJournal(stale);
+          await recordTerminal(
+            pi,
+            stale,
+            "interrupted",
+            "exact-owned child was no longer live during recovery",
+          );
+          continue;
+        }
+        if (
+          !sameHerdr(participant.herdr, {
+            workspaceId: live.workspace_id,
+            tabId: live.tab_id,
+            paneId: live.pane_id,
+            terminalId: live.terminal_id,
+          }) ||
+          live.workspace_id !== placement.herdr.workspaceId
+        )
+          throw new Error(
+            `Live identity for ${participant.participant_id} contradicts Registry custody.`,
+          );
+        members.set(participant.participant_id, {
+          runId: run.run_id,
+          goalId: observation.goal_id,
+          participantId: participant.participant_id,
+          workerId: worker?.worker_id ?? `${participant.participant_id}-worker`,
+          role: participant.role,
+          name: live.name,
+          cwd: live.cwd,
+          journal: journalPath(run.run_id, participant.participant_id),
+          session: participant.agent_session,
+          herdr: {
+            workspaceId: live.workspace_id,
+            tabId: live.tab_id,
+            paneId: live.pane_id,
+            terminalId: live.terminal_id,
+          },
+          startedAt: observation.started_at,
+          status: live.agent_status ?? "unknown",
+          retained: retained.has(participant.participant_id),
+          registered: true,
+          workerRegistered: Boolean(worker),
+          lifecycleOnly: true,
+        });
+      }
+    }
     for (const member of members.values())
       if (realpathSync(member.cwd) !== realpathSync(ctx.cwd))
-        throw new Error(`Recovered Crew cwd for ${member.participantId} is outside the parent Run custody.`);
+        throw new Error(
+          `Recovered Crew cwd for ${member.participantId} is outside the parent Run custody.`,
+        );
     renderWidget(ctx);
   }
 
@@ -1063,7 +1555,10 @@ export default function (pi: ExtensionAPI) {
       await reconnect(ctx);
       recoveryHealthy = true;
     } catch (error) {
-      ctx.ui.notify(`Vault Hunter Crew recovery failed closed: ${safeLine(String(error))}`, "error");
+      ctx.ui.notify(
+        `Vault Hunter Crew recovery failed closed: ${safeLine(String(error))}`,
+        "error",
+      );
     }
     timer = setInterval(() => void poll(), POLL_MS);
     timer.unref?.();
@@ -1079,8 +1574,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "vault_hunter_crew_launch",
     label: "Launch Vault Hunter Crew Persona",
-    description: "Fail-closed two-phase launch of one registered Vault Hunter persona in a dedicated tab in the parent Herdr workspace. The Task prompt is withheld until exact Run, Pi session, and Herdr ownership are registered.",
-    promptSnippet: "Launch a registered Vault Hunter verifier-builder, convergence-engineer, or delivery-steward.",
+    description:
+      "Fail-closed two-phase launch of one registered Vault Hunter persona in a dedicated tab in the parent Herdr workspace. The Task prompt is withheld until exact Run, Pi session, and Herdr ownership are registered.",
+    promptSnippet:
+      "Launch a registered Vault Hunter verifier-builder, convergence-engineer, or delivery-steward.",
     promptGuidelines: [
       "Use vault_hunter_crew_launch for formal Vault Hunter persona work; never launch these writers through generic subagents.",
       "Close convergence-engineer through vault_hunter_crew_release before launching delivery-steward.",
@@ -1088,156 +1585,250 @@ export default function (pi: ExtensionAPI) {
     parameters: LaunchSchema,
     async execute(_id, params, signal, _update, ctx) {
       return await serializeCustody(async () => {
-      if (!recoveryHealthy)
-        throw new Error("Crew recovery is unhealthy; launch is disabled until exact Run/session custody reconnects.");
-      const placement = await parentPlacement(pi, ctx, signal);
-      const run = await getRun(pi, params.runId, signal);
-      if (!driverOwnsRun(run, placement.session, placement.herdr.workspaceId))
-        throw new Error(`The current parent does not exactly own Run ${params.runId} in this Herdr workspace.`);
-      const activeRoles = ROLES.filter((role) => runHasActiveRole(run, role));
-      if (active(params.runId).length || activeRoles.length)
-        throw new Error(`Run ${params.runId} already has active or unreconciled crew custody: ${activeRoles.join(", ") || "live child"}.`);
+        if (!recoveryHealthy)
+          throw new Error(
+            "Crew recovery is unhealthy; launch is disabled until exact Run/session custody reconnects.",
+          );
+        const placement = await parentPlacement(pi, ctx, signal);
+        const run = await getRun(pi, params.runId, signal);
+        if (!driverOwnsRun(run, placement.session, placement.herdr.workspaceId))
+          throw new Error(
+            `The current parent does not exactly own Run ${params.runId} in this Herdr workspace.`,
+          );
+        const activeRoles = ROLES.filter((role) => runHasActiveRole(run, role));
+        if (active(params.runId).length || activeRoles.length)
+          throw new Error(
+            `Run ${params.runId} already has active or unreconciled crew custody: ${activeRoles.join(", ") || "live child"}.`,
+          );
 
-      const participantId = `crew-${params.role}-${randomUUID()}`;
-      const workerId = `${participantId}-worker`;
-      const cwd = resolve(params.cwd ?? ctx.cwd);
-      if (realpathSync(cwd) !== realpathSync(ctx.cwd))
-        throw new Error("Crew cwd must be the parent driver's exact Run-owned working directory.");
-      for (const extensionPath of [CHILD_EXTENSION, HERDR_STATE_EXTENSION]) {
-        const extensionStat = lstatSync(extensionPath);
-        if (!extensionStat.isFile() || extensionStat.isSymbolicLink())
-          throw new Error(`Vault Hunter child extension is not a regular production file: ${extensionPath}`);
-      }
-      const journal = journalPath(params.runId, participantId);
-      if ([journal, `${journal}.1`, `${journal}.2`].some(pathExists))
-        throw new Error("Fresh Crew participant journal identity is already occupied.");
-      const journalDirectory = dirname(journal);
-      mkdirSync(journalDirectory, { recursive: true, mode: 0o700 });
-      const journalDirectoryStat = lstatSync(journalDirectory);
-      if (!journalDirectoryStat.isDirectory() || journalDirectoryStat.isSymbolicLink())
-        throw new Error("Crew journal directory is not a private regular directory.");
-      chmodSync(journalDirectory, 0o700);
-      const tabLabel = `Vault Hunter · ${params.role} · ${safeLine(params.goalId)}`;
-      let tabId: string | undefined;
-      let provisional: Member | undefined;
-      try {
-        const created = await herdr(pi, [
-          "tab", "create", "--workspace", placement.herdr.workspaceId,
-          "--cwd", cwd, "--label", tabLabel, "--no-focus",
-        ], signal);
-        const tab = created.tab;
-        const rootPane = created.root_pane;
-        tabId = tab?.tab_id;
-        if (created.type !== "tab_created" || !tabId || tab.workspace_id !== placement.herdr.workspaceId ||
-          tab.pane_count !== 1 || !rootPane?.pane_id || rootPane.tab_id !== tabId)
-          throw new Error("Herdr returned a malformed reserved tab.");
-
-        const releaseToken = randomBytes(32).toString("hex");
-        const name = `pi-vh-${slug(params.runId, 20)}-${slug(params.role, 24)}-${participantId.slice(-8)}`;
-        const launched = await herdr(pi, [
-          "agent", "start", name,
-          "--cwd", cwd,
-          "--workspace", placement.herdr.workspaceId,
-          "--tab", tabId,
-          "--no-focus",
-          "--env", `SIDEKICK_NAMED_SESSION=${name.slice(3)}`,
-          "--env", `VAULT_HUNTER_RUN_ID=${params.runId}`,
-          "--env", `VAULT_HUNTER_GOAL_ID=${params.goalId}`,
-          "--env", `VAULT_HUNTER_CREW_PARTICIPANT_ID=${participantId}`,
-          "--env", `VAULT_HUNTER_CREW_ROLE=${params.role}`,
-          "--env", `VAULT_HUNTER_CREW_JOURNAL=${journal}`,
-          "--env", `VAULT_HUNTER_CREW_RELEASE_TOKEN=${releaseToken}`,
-          "--", "pi", "--no-extensions", "--no-skills", "--no-prompt-templates",
-          "-e", HERDR_STATE_EXTENSION, "-e", CHILD_EXTENSION, "--name", name.slice(3),
-        ], signal);
-        const launchedAgent = launched.agent ?? {};
-        if (!launchedAgent.pane_id)
-          throw new Error("Herdr did not start the reserved Pi child.");
-        if (rootPane.pane_id !== launchedAgent.pane_id) {
-          const rootClosed = await herdr(pi, ["pane", "close", rootPane.pane_id], signal);
-          if (rootClosed.type !== "pane_closed" || rootClosed.pane_id !== rootPane.pane_id)
-            throw new Error(`Herdr did not confirm temporary root pane closure for ${rootPane.pane_id}.`);
+        const participantId = `crew-${params.role}-${randomUUID()}`;
+        const workerId = `${participantId}-worker`;
+        const cwd = resolve(params.cwd ?? ctx.cwd);
+        if (realpathSync(cwd) !== realpathSync(ctx.cwd))
+          throw new Error(
+            "Crew cwd must be the parent driver's exact Run-owned working directory.",
+          );
+        for (const extensionPath of [CHILD_EXTENSION, HERDR_STATE_EXTENSION]) {
+          const extensionStat = lstatSync(extensionPath);
+          if (!extensionStat.isFile() || extensionStat.isSymbolicLink())
+            throw new Error(
+              `Vault Hunter child extension is not a regular production file: ${extensionPath}`,
+            );
         }
+        const journal = journalPath(params.runId, participantId);
+        if ([journal, `${journal}.1`, `${journal}.2`].some(pathExists))
+          throw new Error(
+            "Fresh Crew participant journal identity is already occupied.",
+          );
+        const journalDirectory = dirname(journal);
+        mkdirSync(journalDirectory, { recursive: true, mode: 0o700 });
+        const journalDirectoryStat = lstatSync(journalDirectory);
+        if (
+          !journalDirectoryStat.isDirectory() ||
+          journalDirectoryStat.isSymbolicLink()
+        )
+          throw new Error(
+            "Crew journal directory is not a private regular directory.",
+          );
+        chmodSync(journalDirectory, 0o700);
+        const tabLabel = `Vault Hunter · ${params.role} · ${safeLine(params.goalId)}`;
+        let tabId: string | undefined;
+        let provisional: Member | undefined;
+        try {
+          const created = await herdr(
+            pi,
+            [
+              "tab",
+              "create",
+              "--workspace",
+              placement.herdr.workspaceId,
+              "--cwd",
+              cwd,
+              "--label",
+              tabLabel,
+              "--no-focus",
+            ],
+            signal,
+          );
+          const tab = created.tab;
+          const rootPane = created.root_pane;
+          tabId = tab?.tab_id;
+          if (
+            created.type !== "tab_created" ||
+            !tabId ||
+            tab.workspace_id !== placement.herdr.workspaceId ||
+            tab.pane_count !== 1 ||
+            !rootPane?.pane_id ||
+            rootPane.tab_id !== tabId
+          )
+            throw new Error("Herdr returned a malformed reserved tab.");
 
-        const base = {
-          runId: params.runId,
-          goalId: params.goalId,
-          participantId,
-          workerId,
-          role: params.role,
-          name: launchedAgent.name ?? name,
-          cwd,
-          journal,
-          startedAt: "",
-          tabId,
-        };
-        const ready = await waitForReady(pi, base, placement.herdr.workspaceId, launchedAgent.pane_id, signal);
-        provisional = {
-          ...base,
-          startedAt: ready.startedAt,
-          session: ready.session,
-          herdr: ready.herdr,
-          registered: false,
-          workerRegistered: false,
-          status: "reserved",
-          retained: false,
-        };
-        await registerMember(pi, run, provisional, signal);
-        members.set(participantId, provisional);
-        await sendPrompt(
-          pi,
-          provisional,
-          personaPrompt(params.role, params.prompt),
-          `[vault-hunter-release:${releaseToken}]`,
-          signal,
-        );
-        provisional.status = "working";
-        renderWidget(ctx);
-        return result(`Launched and registered ${params.role} ${participantId}.`, {
-          runId: params.runId,
-          goalId: params.goalId,
-          participantId,
-          role: params.role,
-          herdr: provisional.herdr,
-          agentSession: provisional.session,
-          journal: { mode: "0600", maxBytes: 1 << 20, files: 3 },
-        });
-      } catch (error) {
-        let cleanupError: unknown;
-        if (tabId) {
-          try {
-            await assertSoloTab(pi, placement.herdr.workspaceId, tabId);
-            const closed = await herdr(pi, ["tab", "close", tabId]);
-            if (closed.type !== "tab_closed" || closed.tab_id !== tabId)
-              throw new Error(`Herdr did not confirm exact reserved tab closure for ${tabId}.`);
-            if (provisional) await waitForExactTermination(pi, provisional, signal);
-            else await waitForTabTermination(pi, tabId, signal);
-          } catch (closeError) { cleanupError = closeError; }
-        }
-        if (provisional && !cleanupError) {
-          try {
-            cleanupJournal(provisional);
-            provisional.status = "closed-unrecorded";
-            await recordTerminal(pi, provisional, "failed", `launch failed: ${safeLine(String(error))}`);
-            provisional.status = "closed";
-          } catch (recordError) {
-            cleanupError = recordError;
-            if (provisional.registered) members.set(provisional.participantId, provisional);
+          const releaseToken = randomBytes(32).toString("hex");
+          const name = `pi-vh-${slug(params.runId, 20)}-${slug(params.role, 24)}-${participantId.slice(-8)}`;
+          const launched = await herdr(
+            pi,
+            [
+              "agent",
+              "start",
+              name,
+              "--cwd",
+              cwd,
+              "--workspace",
+              placement.herdr.workspaceId,
+              "--tab",
+              tabId,
+              "--no-focus",
+              "--env",
+              `SIDEKICK_NAMED_SESSION=${name.slice(3)}`,
+              "--env",
+              `VAULT_HUNTER_RUN_ID=${params.runId}`,
+              "--env",
+              `VAULT_HUNTER_GOAL_ID=${params.goalId}`,
+              "--env",
+              `VAULT_HUNTER_CREW_PARTICIPANT_ID=${participantId}`,
+              "--env",
+              `VAULT_HUNTER_CREW_ROLE=${params.role}`,
+              "--env",
+              `VAULT_HUNTER_CREW_JOURNAL=${journal}`,
+              "--env",
+              `VAULT_HUNTER_CREW_RELEASE_TOKEN=${releaseToken}`,
+              "--",
+              "pi",
+              "--no-extensions",
+              "--no-skills",
+              "--no-prompt-templates",
+              "-e",
+              HERDR_STATE_EXTENSION,
+              "-e",
+              CHILD_EXTENSION,
+              "--name",
+              name.slice(3),
+            ],
+            signal,
+          );
+          const launchedAgent = launched.agent ?? {};
+          if (!launchedAgent.pane_id)
+            throw new Error("Herdr did not start the reserved Pi child.");
+          if (rootPane.pane_id !== launchedAgent.pane_id) {
+            const rootClosed = await herdr(
+              pi,
+              ["pane", "close", rootPane.pane_id],
+              signal,
+            );
+            if (
+              rootClosed.type !== "pane_closed" ||
+              rootClosed.pane_id !== rootPane.pane_id
+            )
+              throw new Error(
+                `Herdr did not confirm temporary root pane closure for ${rootPane.pane_id}.`,
+              );
           }
-        } else if (!provisional && !cleanupError) {
-          for (const path of [journal, `${journal}.1`, `${journal}.2`]) rmSync(path, { force: true });
-          if ([journal, `${journal}.1`, `${journal}.2`].some(existsSync))
-            cleanupError = new Error(`Reserved journal cleanup could not be verified for ${participantId}.`);
-        }
-        if (cleanupError) {
-          if (provisional?.registered) {
-            if (provisional.status !== "closed-unrecorded") provisional.status = "cleanup-blocked";
-            members.set(provisional.participantId, provisional);
+
+          const base = {
+            runId: params.runId,
+            goalId: params.goalId,
+            participantId,
+            workerId,
+            role: params.role,
+            name: launchedAgent.name ?? name,
+            cwd,
+            journal,
+            startedAt: "",
+            tabId,
+          };
+          const ready = await waitForReady(
+            pi,
+            base,
+            placement.herdr.workspaceId,
+            launchedAgent.pane_id,
+            signal,
+          );
+          provisional = {
+            ...base,
+            startedAt: ready.startedAt,
+            session: ready.session,
+            herdr: ready.herdr,
+            registered: false,
+            workerRegistered: false,
+            status: "reserved",
+            retained: false,
+          };
+          await registerMember(pi, run, provisional, signal);
+          members.set(participantId, provisional);
+          await sendPrompt(
+            pi,
+            provisional,
+            personaPrompt(params.role, params.prompt),
+            `[vault-hunter-release:${releaseToken}]`,
+            signal,
+          );
+          provisional.status = "working";
+          renderWidget(ctx);
+          return result(
+            `Launched and registered ${params.role} ${participantId}.`,
+            {
+              runId: params.runId,
+              goalId: params.goalId,
+              participantId,
+              role: params.role,
+              herdr: provisional.herdr,
+              agentSession: provisional.session,
+              journal: { mode: "0600", maxBytes: 1 << 20, files: 3 },
+            },
+          );
+        } catch (error) {
+          let cleanupError: unknown;
+          if (tabId) {
+            try {
+              await assertSoloTab(pi, placement.herdr.workspaceId, tabId);
+              const closed = await herdr(pi, ["tab", "close", tabId]);
+              if (closed.type !== "tab_closed" || closed.tab_id !== tabId)
+                throw new Error(
+                  `Herdr did not confirm exact reserved tab closure for ${tabId}.`,
+                );
+              if (provisional)
+                await waitForExactTermination(pi, provisional, signal);
+              else await waitForTabTermination(pi, tabId, signal);
+            } catch (closeError) {
+              cleanupError = closeError;
+            }
           }
-          throw new Error(`${safeLine(String(error))} Cleanup failed closed: ${safeLine(String(cleanupError))}`);
+          if (provisional && !cleanupError) {
+            try {
+              cleanupJournal(provisional);
+              provisional.status = "closed-unrecorded";
+              await recordTerminal(
+                pi,
+                provisional,
+                "failed",
+                `launch failed: ${safeLine(String(error))}`,
+              );
+              provisional.status = "closed";
+            } catch (recordError) {
+              cleanupError = recordError;
+              if (provisional.registered)
+                members.set(provisional.participantId, provisional);
+            }
+          } else if (!provisional && !cleanupError) {
+            for (const path of [journal, `${journal}.1`, `${journal}.2`])
+              rmSync(path, { force: true });
+            if ([journal, `${journal}.1`, `${journal}.2`].some(existsSync))
+              cleanupError = new Error(
+                `Reserved journal cleanup could not be verified for ${participantId}.`,
+              );
+          }
+          if (cleanupError) {
+            if (provisional?.registered) {
+              if (provisional.status !== "closed-unrecorded")
+                provisional.status = "cleanup-blocked";
+              members.set(provisional.participantId, provisional);
+            }
+            throw new Error(
+              `${safeLine(String(error))} Cleanup failed closed: ${safeLine(String(cleanupError))}`,
+            );
+          }
+          throw error;
         }
-        throw error;
-      }
       });
     },
   });
@@ -1245,22 +1836,29 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "vault_hunter_crew_send",
     label: "Steer Vault Hunter Crew Persona",
-    description: "Send one bounded follow-up to an exact Run-owned crew persona. The companion records only a sanitized first line and SHA-256, never the raw prompt or reasoning.",
+    description:
+      "Send one bounded follow-up to an exact Run-owned crew persona. The companion records only a sanitized first line and SHA-256, never the raw prompt or reasoning.",
     parameters: SendSchema,
     async execute(_id, params, signal) {
       return await serializeCustody(async () => {
-      const member = members.get(params.participantId);
-      if (!member || member.runId !== params.runId || member.status.startsWith("closed"))
-        throw new Error("No active exact Run-owned crew participant matches this request.");
-      member.graceDeadline = undefined;
-      await assertMemberOwnership(pi, member, signal);
-      await sendPrompt(pi, member, params.prompt, "", signal);
-      return result(`Steered ${member.role} ${member.participantId}.`, {
-        runId: member.runId,
-        participantId: member.participantId,
-        summary: safeLine(params.prompt),
-        sha256: hash(params.prompt),
-      });
+        const member = members.get(params.participantId);
+        if (
+          !member ||
+          member.runId !== params.runId ||
+          member.status.startsWith("closed")
+        )
+          throw new Error(
+            "No active exact Run-owned crew participant matches this request.",
+          );
+        member.graceDeadline = undefined;
+        await assertMemberOwnership(pi, member, signal);
+        await sendPrompt(pi, member, params.prompt, "", signal);
+        return result(`Steered ${member.role} ${member.participantId}.`, {
+          runId: member.runId,
+          participantId: member.participantId,
+          summary: safeLine(params.prompt),
+          sha256: hash(params.prompt),
+        });
       });
     },
   });
@@ -1268,40 +1866,65 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "vault_hunter_crew_release",
     label: "Release Vault Hunter Crew Persona",
-    description: "Retain a verifier-builder during its 30-second grace, close a persona after a validated structured handoff, or abort exact Run-owned custody without implying success. Convergence and delivery never auto-close.",
+    description:
+      "Retain a verifier-builder during its 30-second grace, close a persona after a validated structured handoff, or abort exact Run-owned custody without implying success. Convergence and delivery never auto-close.",
     parameters: ReleaseSchema,
     async execute(_id, params) {
       return await serializeCustody(async () => {
-      const member = members.get(params.participantId);
-      if (!member || member.runId !== params.runId || member.status === "closed")
-        throw new Error("No active exact Run-owned crew participant matches this request.");
-      const journal = readJournal(member.journal, member);
-      if (!journal.lifecycleOnly) {
-        const handoff = currentHandoff(journal.events);
-        member.handoffValid = handoff?.valid === true;
-      }
-      if (params.disposition === "retain") {
-        if (member.role !== "verifier-builder" || !member.handoffValid)
-          throw new Error("Only a verifier-builder with a validated durable handoff can be retained during grace.");
-        member.retained = true;
-        member.graceDeadline = undefined;
-        if (currentCtx) renderWidget(currentCtx);
-        return result(`Retained ${member.participantId}; explicit close is now required.`, {
-          runId: member.runId,
-          participantId: member.participantId,
-          retained: true,
-        });
-      }
-      if (params.disposition === "close" && !member.handoffValid)
-        throw new Error("A validated structured handoff is required before normal persona closure; use abort for incomplete custody.");
-      const state: TerminalState = params.disposition === "abort" ? "interrupted" : "succeeded";
-      await closeMember(member, state, params.result ?? (state === "succeeded" ? "validated handoff released" : "explicit custody abort"));
-      return result(`Closed exact Run-owned crew participant ${member.participantId}.`, {
-        runId: member.runId,
-        participantId: member.participantId,
-        journalCleanupVerified: true,
-        terminalState: state,
-      });
+        const member = members.get(params.participantId);
+        if (
+          !member ||
+          member.runId !== params.runId ||
+          member.status === "closed"
+        )
+          throw new Error(
+            "No active exact Run-owned crew participant matches this request.",
+          );
+        const journal = readJournal(member.journal, member);
+        if (!journal.lifecycleOnly) {
+          const handoff = currentHandoff(journal.events);
+          member.handoffValid = handoff?.valid === true;
+        }
+        if (params.disposition === "retain") {
+          if (member.role !== "verifier-builder" || !member.handoffValid)
+            throw new Error(
+              "Only a verifier-builder with a validated durable handoff can be retained during grace.",
+            );
+          member.retained = true;
+          member.graceDeadline = undefined;
+          if (currentCtx) renderWidget(currentCtx);
+          return result(
+            `Retained ${member.participantId}; explicit close is now required.`,
+            {
+              runId: member.runId,
+              participantId: member.participantId,
+              retained: true,
+            },
+          );
+        }
+        if (params.disposition === "close" && !member.handoffValid)
+          throw new Error(
+            "A validated structured handoff is required before normal persona closure; use abort for incomplete custody.",
+          );
+        const state: TerminalState =
+          params.disposition === "abort" ? "interrupted" : "succeeded";
+        await closeMember(
+          member,
+          state,
+          params.result ??
+            (state === "succeeded"
+              ? "validated handoff released"
+              : "explicit custody abort"),
+        );
+        return result(
+          `Closed exact Run-owned crew participant ${member.participantId}.`,
+          {
+            runId: member.runId,
+            participantId: member.participantId,
+            journalCleanupVerified: true,
+            terminalState: state,
+          },
+        );
       });
     },
   });
@@ -1309,37 +1932,55 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "vault_hunter_crew_inspect",
     label: "Inspect Vault Hunter Crew",
-    description: "Inspect safe bounded crew telemetry for one Run. Missing or corrupt journals degrade to lifecycle-only facts and never imply Task or verifier success.",
+    description:
+      "Inspect safe bounded crew telemetry for one Run. Missing or corrupt journals degrade to lifecycle-only facts and never imply Task or verifier success.",
     parameters: InspectSchema,
     async execute(_id, params) {
-      const selected = active(params.runId).filter((member) =>
-        !params.participantId || member.participantId === params.participantId);
-      const inspections = await Promise.all(selected.map(async (member) => {
-        const journal = readJournal(member.journal, member);
-        let liveState = "unavailable";
-        try {
-          const live = await herdr(pi, ["agent", "get", member.name]);
-          const agent = live.agent ?? live;
-          liveState = sameSession(agent.agent_session, member.session) ? agent.agent_status ?? "unknown" : "ownership-mismatch";
-        } catch { /* lifecycle unavailable */ }
-        const safeEvents = journal.lifecycleOnly
-          ? []
-          : journal.events.slice(-200).map((event) => {
-              const { v, runId, goalId, participantId, role, proof, ...bounded } = event;
-              return bounded;
-            });
-        return {
-          participantId: member.participantId,
-          role: member.role,
-          liveState,
-          herdr: member.herdr,
-          agentSession: member.session,
-          lifecycleOnly: journal.lifecycleOnly,
-          problem: journal.problem,
-          events: safeEvents,
-          successInferred: false,
-        };
-      }));
+      const selected = active(params.runId).filter(
+        (member) =>
+          !params.participantId ||
+          member.participantId === params.participantId,
+      );
+      const inspections = await Promise.all(
+        selected.map(async (member) => {
+          const journal = readJournal(member.journal, member);
+          let liveState = "unavailable";
+          try {
+            const live = await herdr(pi, ["agent", "get", member.name]);
+            const agent = live.agent ?? live;
+            liveState = sameSession(agent.agent_session, member.session)
+              ? (agent.agent_status ?? "unknown")
+              : "ownership-mismatch";
+          } catch {
+            /* lifecycle unavailable */
+          }
+          const safeEvents = journal.lifecycleOnly
+            ? []
+            : journal.events.slice(-200).map((event) => {
+                const {
+                  v,
+                  runId,
+                  goalId,
+                  participantId,
+                  role,
+                  proof,
+                  ...bounded
+                } = event;
+                return bounded;
+              });
+          return {
+            participantId: member.participantId,
+            role: member.role,
+            liveState,
+            herdr: member.herdr,
+            agentSession: member.session,
+            lifecycleOnly: journal.lifecycleOnly,
+            problem: journal.problem,
+            events: safeEvents,
+            successInferred: false,
+          };
+        }),
+      );
       return result(
         inspections.length
           ? `Inspected ${inspections.length} Run-owned crew participant(s); no success was inferred.`

--- a/pi/.pi/agent/extensions/vault-hunter-crew.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-crew.ts
@@ -659,6 +659,40 @@ async function assertSoloTab(
     throw new Error(`Refusing to close ${tabId}: it is absent, moved, or no longer a dedicated one-pane tab.`);
 }
 
+async function waitForExactTermination(
+  pi: ExtensionAPI,
+  member: Pick<Member, "participantId" | "session">,
+  signal?: AbortSignal,
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    signal?.throwIfAborted();
+    const listed = await herdr(pi, ["agent", "list"], signal);
+    if (!Array.isArray(listed.agents))
+      throw new Error("Herdr returned a malformed agent list while awaiting child termination.");
+    if (!listed.agents.some((agent: any) => sameSession(agent.agent_session, member.session))) return;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+  throw new Error(`Exact child ${member.participantId} remained live after tab closure.`);
+}
+
+async function waitForTabTermination(
+  pi: ExtensionAPI,
+  tabId: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    signal?.throwIfAborted();
+    const listed = await herdr(pi, ["agent", "list"], signal);
+    if (!Array.isArray(listed.agents))
+      throw new Error("Herdr returned a malformed agent list while awaiting tab termination.");
+    if (!listed.agents.some((agent: any) => agent.tab_id === tabId)) return;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+  throw new Error(`Child in exact tab ${tabId} remained live after tab closure.`);
+}
+
 async function sendPrompt(
   pi: ExtensionAPI,
   member: Member,
@@ -789,6 +823,7 @@ export default function (pi: ExtensionAPI) {
     const closed = await herdr(pi, ["tab", "close", member.herdr.tabId]);
     if (closed.type !== "tab_closed" || closed.tab_id !== member.herdr.tabId)
       throw new Error(`Herdr did not confirm exact tab closure for ${member.participantId}.`);
+    await waitForExactTermination(pi, member);
     cleanupJournal(member);
     member.status = "closed-unrecorded";
     await recordTerminal(pi, member, state, reason);
@@ -904,10 +939,32 @@ export default function (pi: ExtensionAPI) {
             if (!ROLES.includes(participant.role) || members.has(participant.participant_id)) continue;
             if ((run as any).lifecycle?.some((item: any) => item.observation_id === `${participant.participant_id}-terminal`)) continue;
             const live = agents.find((item: any) => sameSession(item.agent_session, participant.agent_session));
-            if (!live || !sameHerdr(participant.herdr, {
+            if (!live) {
+              if (participant.herdr?.workspace_id !== placement.herdr.workspaceId)
+                throw new Error(`Registry custody for ${participant.participant_id} is outside the driver workspace.`);
+              const stale: Member = {
+                runId: run.run_id, goalId: participant.goal_id,
+                participantId: participant.participant_id,
+                workerId: `${participant.participant_id}-worker`, role: participant.role,
+                name: participant.participant_id, cwd: ctx.cwd,
+                journal: journalPath(run.run_id, participant.participant_id),
+                session: participant.agent_session,
+                herdr: {
+                  workspaceId: participant.herdr.workspace_id, tabId: participant.herdr.tab_id,
+                  paneId: participant.herdr.pane_id, terminalId: participant.herdr.terminal_id,
+                },
+                startedAt: participant.observed_at, status: "closed-unrecorded", retained: false,
+                registered: true, workerRegistered: true, lifecycleOnly: true,
+              };
+              cleanupJournal(stale);
+              await recordTerminal(pi, stale, "interrupted", "exact-owned child was no longer live during recovery");
+              continue;
+            }
+            if (!sameHerdr(participant.herdr, {
               workspaceId: live.workspace_id, tabId: live.tab_id,
               paneId: live.pane_id, terminalId: live.terminal_id,
-            }) || live.workspace_id !== placement.herdr.workspaceId) continue;
+            }) || live.workspace_id !== placement.herdr.workspaceId)
+              throw new Error(`Live identity for ${participant.participant_id} contradicts Registry custody.`);
             members.set(participant.participant_id, {
               runId: run.run_id,
               goalId: participant.goal_id,
@@ -941,13 +998,35 @@ export default function (pi: ExtensionAPI) {
             item.payload?.registered_participant?.participant_id === participant.participant_id);
           if (terminal) continue;
           const live = agents.find((item: any) => sameSession(item.agent_session, participant.agent_session));
-          if (!live || !sameHerdr(participant.herdr, {
-            workspaceId: live.workspace_id, tabId: live.tab_id,
-            paneId: live.pane_id, terminalId: live.terminal_id,
-          }) || live.workspace_id !== placement.herdr.workspaceId) continue;
           const worker = run.observations?.find((item: any) =>
             item.kind === "worker" && item.state === "active" &&
             item.payload?.worker?.owner_participant_id === participant.participant_id)?.payload?.worker;
+          if (!live) {
+            if (participant.herdr?.workspace_id !== placement.herdr.workspaceId)
+              throw new Error(`Registry custody for ${participant.participant_id} is outside the driver workspace.`);
+            const stale: Member = {
+              runId: run.run_id, goalId: observation.goal_id,
+              participantId: participant.participant_id,
+              workerId: worker?.worker_id ?? `${participant.participant_id}-worker`, role: participant.role,
+              name: participant.participant_id, cwd: ctx.cwd,
+              journal: journalPath(run.run_id, participant.participant_id),
+              session: participant.agent_session,
+              herdr: {
+                workspaceId: participant.herdr.workspace_id, tabId: participant.herdr.tab_id,
+                paneId: participant.herdr.pane_id, terminalId: participant.herdr.terminal_id,
+              },
+              startedAt: observation.started_at, status: "closed-unrecorded", retained: false,
+              registered: true, workerRegistered: Boolean(worker), lifecycleOnly: true,
+            };
+            cleanupJournal(stale);
+            await recordTerminal(pi, stale, "interrupted", "exact-owned child was no longer live during recovery");
+            continue;
+          }
+          if (!sameHerdr(participant.herdr, {
+            workspaceId: live.workspace_id, tabId: live.tab_id,
+            paneId: live.pane_id, terminalId: live.terminal_id,
+          }) || live.workspace_id !== placement.herdr.workspaceId)
+            throw new Error(`Live identity for ${participant.participant_id} contradicts Registry custody.`);
           members.set(participant.participant_id, {
             runId: run.run_id,
             goalId: observation.goal_id,
@@ -1131,6 +1210,8 @@ export default function (pi: ExtensionAPI) {
             const closed = await herdr(pi, ["tab", "close", tabId]);
             if (closed.type !== "tab_closed" || closed.tab_id !== tabId)
               throw new Error(`Herdr did not confirm exact reserved tab closure for ${tabId}.`);
+            if (provisional) await waitForExactTermination(pi, provisional, signal);
+            else await waitForTabTermination(pi, tabId, signal);
           } catch (closeError) { cleanupError = closeError; }
         }
         if (provisional && !cleanupError) {

--- a/pi/.pi/agent/extensions/vault-hunter-crew.ts
+++ b/pi/.pi/agent/extensions/vault-hunter-crew.ts
@@ -1,0 +1,1275 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type, type Static } from "typebox";
+import { spawn } from "node:child_process";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROLES = [
+  "verifier-builder",
+  "convergence-engineer",
+  "delivery-steward",
+] as const;
+const WIDGET_ID = "vault-hunter-crew";
+const GRACE_MS = 30_000;
+const POLL_MS = 1_000;
+const SAFE_ID = /^[A-Za-z0-9_-]+$/;
+const MAX_TOOL_OUTPUT = 40_000;
+const MAX_REGISTRY_OUTPUT = 1 << 20;
+const EXTENSION_DIR = dirname(fileURLToPath(import.meta.url));
+const CHILD_EXTENSION = realpathSync(join(EXTENSION_DIR, "vault-hunter-crew-child.ts"));
+const HERDR_STATE_EXTENSION = realpathSync(join(EXTENSION_DIR, "herdr-agent-state.ts"));
+
+type Role = (typeof ROLES)[number];
+type TerminalState = "succeeded" | "failed" | "interrupted";
+type SessionIdentity = { source: string; kind: string; value: string };
+type HerdrIdentity = {
+  workspaceId: string;
+  tabId: string;
+  paneId: string;
+  terminalId: string;
+};
+type JournalEvent = {
+  v: 1;
+  seq: number;
+  at: string;
+  runId: string;
+  goalId: string;
+  participantId: string;
+  role: Role;
+  type: string;
+  [key: string]: unknown;
+};
+type Member = {
+  runId: string;
+  goalId: string;
+  participantId: string;
+  workerId: string;
+  role: Role;
+  name: string;
+  cwd: string;
+  journal: string;
+  session: SessionIdentity;
+  herdr: HerdrIdentity;
+  startedAt: string;
+  status: string;
+  retained: boolean;
+  registered: boolean;
+  workerRegistered: boolean;
+  lifecycleOnly?: boolean;
+  graceDeadline?: number;
+  lastHandoffKey?: string;
+  handoffValid?: boolean;
+  lastSteering?: { summary: string; sha256: string };
+  terminalAt?: string;
+  terminalReason?: string;
+  terminalState?: TerminalState;
+};
+
+type RegistryRun = {
+  schema_version: number;
+  run_id: string;
+  revision: number;
+  participants?: any[];
+  observations?: any[];
+};
+
+const LaunchSchema = Type.Object(
+  {
+    runId: Type.String({ description: "Exact active Vault Hunter Run ID." }),
+    goalId: Type.String({ pattern: "^[A-Za-z0-9._:-]{1,128}$", description: "Stable Goal or verifier ID for this child." }),
+    role: StringEnum(ROLES, { description: "Vault Hunter crew persona." }),
+    prompt: Type.String({ minLength: 1, maxLength: 200_000, description: "Complete bounded assignment released only after registration." }),
+    cwd: Type.Optional(Type.String({ description: "Run-owned working directory; defaults to the parent cwd." })),
+  },
+  { additionalProperties: false },
+);
+const SendSchema = Type.Object(
+  {
+    runId: Type.String(),
+    participantId: Type.String(),
+    prompt: Type.String({ minLength: 1, maxLength: 200_000 }),
+  },
+  { additionalProperties: false },
+);
+const ReleaseSchema = Type.Object(
+  {
+    runId: Type.String(),
+    participantId: Type.String(),
+    disposition: StringEnum(["close", "retain", "abort"] as const),
+    result: Type.Optional(Type.String({ maxLength: 160, description: "Safe process-result summary; never a Task acceptance decision." })),
+  },
+  { additionalProperties: false },
+);
+const InspectSchema = Type.Object(
+  {
+    runId: Type.String(),
+    participantId: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+function stateRoot(): string {
+  return process.env.XDG_STATE_HOME
+    ? join(process.env.XDG_STATE_HOME, "vault-hunter", "crew")
+    : join(homedir(), ".local", "state", "vault-hunter", "crew");
+}
+
+function registryRoot(): string | undefined {
+  return process.env.VAULT_HUNTER_STATE_DIR;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function hash(value: unknown): string {
+  return createHash("sha256")
+    .update(typeof value === "string" ? value : JSON.stringify(value ?? null))
+    .digest("hex");
+}
+
+function safeLine(value: string): string {
+  return (
+    value
+      .split(/\r?\n/, 1)[0]
+      ?.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 160) || "(empty)"
+  );
+}
+
+function slug(value: string, length = 40): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, length) || "crew";
+}
+
+function result(content: string, details: unknown) {
+  return { content: [{ type: "text" as const, text: content }], details };
+}
+
+function unwrap(stdout: string): any {
+  const decoded = JSON.parse(stdout);
+  return decoded?.result ?? decoded;
+}
+
+async function herdr(
+  pi: ExtensionAPI,
+  args: string[],
+  signal?: AbortSignal,
+): Promise<any> {
+  const response = await pi.exec("herdr", args, { signal, timeout: 15_000 });
+  if (response.code !== 0)
+    throw new Error(response.stderr.trim() || `herdr ${args.slice(0, 2).join(" ")} exited ${response.code}`);
+  if (Buffer.byteLength(response.stdout) > MAX_TOOL_OUTPUT)
+    throw new Error("Herdr output exceeded the Vault Hunter Crew bound.");
+  return unwrap(response.stdout);
+}
+
+async function registry(
+  _pi: ExtensionAPI,
+  request: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<any> {
+  signal?.throwIfAborted();
+  return await new Promise((resolveRequest, reject) => {
+    const child = spawn("vault-hunter-registry", [], {
+      stdio: ["pipe", "pipe", "pipe"],
+      signal,
+    });
+    let stdout = "";
+    let stderr = "";
+    let bytes = 0;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      bytes += Buffer.byteLength(chunk);
+      if (bytes > MAX_REGISTRY_OUTPUT) child.kill();
+      else stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (bytes > MAX_REGISTRY_OUTPUT)
+        return reject(new Error("Registry output exceeded the 1 MiB Vault Hunter Crew bound."));
+      if (code !== 0)
+        return reject(new Error(stderr.trim() || `vault-hunter-registry exited ${code}`));
+      try { resolveRequest(JSON.parse(stdout)); } catch (error) { reject(error); }
+    });
+    child.stdin.end(`${JSON.stringify({ ...request, ...(registryRoot() ? { root: registryRoot() } : {}) })}\n`);
+  });
+}
+
+async function getRun(
+  pi: ExtensionAPI,
+  runId: string,
+  signal?: AbortSignal,
+): Promise<RegistryRun> {
+  if (!SAFE_ID.test(runId)) throw new Error(`Invalid Run ID ${runId}.`);
+  return await registry(pi, { action: "get", run_id: runId }, signal) as RegistryRun;
+}
+
+function wireHerdr(value: HerdrIdentity) {
+  return {
+    workspace_id: value.workspaceId,
+    tab_id: value.tabId,
+    pane_id: value.paneId,
+    terminal_id: value.terminalId,
+  };
+}
+
+function wireSession(value: SessionIdentity) {
+  return { source: value.source, kind: value.kind, value: value.value };
+}
+
+function sameSession(a: any, b: SessionIdentity): boolean {
+  return a?.source === b.source && a?.kind === b.kind && a?.value === b.value;
+}
+
+function sameHerdr(a: any, b: HerdrIdentity): boolean {
+  return a?.workspace_id === b.workspaceId &&
+    a?.tab_id === b.tabId &&
+    a?.pane_id === b.paneId &&
+    a?.terminal_id === b.terminalId;
+}
+
+function participantObservation(run: RegistryRun, member: Member): any | undefined {
+  if (run.schema_version === 1)
+    return run.participants?.find(
+      (item) => item.participant_id === member.participantId &&
+        sameSession(item.agent_session, member.session) && sameHerdr(item.herdr, member.herdr),
+    );
+  return run.observations?.find((item) => {
+    const payload = item.payload?.registered_participant;
+    return payload?.participant_id === member.participantId &&
+      sameSession(payload.agent_session, member.session) && sameHerdr(payload.herdr, member.herdr);
+  });
+}
+
+function runHasActiveRole(run: RegistryRun, role: Role): boolean {
+  if (run.schema_version === 1)
+    return Boolean(run.participants?.some((participant) =>
+      participant.role === role && !(run as any).lifecycle?.some((item: any) =>
+        item.observation_id === `${participant.participant_id}-terminal`)));
+  const observations = run.observations ?? [];
+  return observations.some((observation) => {
+    const participant = observation.payload?.registered_participant;
+    return observation.kind === "registered_participant" && observation.state === "active" &&
+      participant?.role === role && !observations.some((item) =>
+        item.kind === "registered_participant" && item.state !== "active" &&
+        item.payload?.registered_participant?.participant_id === participant.participant_id);
+  });
+}
+
+function driverOwnsRun(
+  run: RegistryRun,
+  session: SessionIdentity,
+  workspaceId: string,
+): boolean {
+  if (run.schema_version === 1)
+    return Boolean(run.participants?.some(
+      (item) => item.role === "driver" && sameSession(item.agent_session, session) &&
+        item.herdr?.workspace_id === workspaceId,
+    ));
+  return Boolean(run.observations?.some((item) => {
+    const payload = item.payload?.registered_participant;
+    return item.kind === "registered_participant" && item.state === "active" &&
+      payload?.role === "driver" && sameSession(payload.agent_session, session) &&
+      payload.herdr?.workspace_id === workspaceId;
+  }));
+}
+
+function envelope(
+  member: Member,
+  observationId: string,
+  kind: "registered_participant" | "worker" | "runtime_telemetry",
+  state: string,
+  observedAt: string,
+  payload: Record<string, unknown>,
+  terminal = false,
+) {
+  return {
+    observation_id: observationId,
+    kind,
+    state,
+    goal_id: member.goalId,
+    title: `${member.role} ${state}`,
+    summary: `${member.role} process ${state}.`,
+    observed_at: observedAt,
+    correlation_id: member.runId,
+    actor: { kind: "participant", id: member.participantId, agent_session: wireSession(member.session) },
+    source: { kind: "producer", id: "vault-hunter-crew" },
+    redaction_class: "internal",
+    ...(kind !== "runtime_telemetry" ? {
+      started_at: member.startedAt,
+      ...(terminal ? { finished_at: observedAt } : {}),
+    } : {}),
+    payload: { [kind]: payload },
+  };
+}
+
+async function appendV2(
+  pi: ExtensionAPI,
+  runId: string,
+  observation: any,
+  signal?: AbortSignal,
+): Promise<RegistryRun> {
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const run = await getRun(pi, runId, signal);
+    try {
+      return await registry(pi, {
+        action: "append_observation",
+        run_id: runId,
+        expected_revision: run.revision,
+        updated_at: observation.observed_at,
+        observation,
+      }, signal) as RegistryRun;
+    } catch (error) {
+      if (!String(error).includes("revision conflict")) throw error;
+    }
+  }
+  throw new Error(`Registry revision conflicts did not settle for ${runId}.`);
+}
+
+async function registerMember(
+  pi: ExtensionAPI,
+  run: RegistryRun,
+  member: Member,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (run.schema_version === 1) {
+    await registry(pi, {
+      action: "append",
+      run_id: member.runId,
+      updated_at: member.startedAt,
+      participant: {
+        participant_id: member.participantId,
+        observed_at: member.startedAt,
+        role: member.role,
+        goal_id: member.goalId,
+        herdr: wireHerdr(member.herdr),
+        agent_session: wireSession(member.session),
+      },
+      lifecycle: {
+        observation_id: `${member.participantId}-started`,
+        observed_at: member.startedAt,
+        kind: "worker",
+        goal_id: member.goalId,
+        state: "active",
+        detail: `${member.role} registered in exact Run-owned Herdr tab.`,
+      },
+    }, signal);
+    member.registered = true;
+    member.workerRegistered = true;
+    return;
+  }
+  if (run.schema_version !== 2)
+    throw new Error(`Unsupported Registry schema ${run.schema_version}.`);
+  await appendV2(pi, member.runId, envelope(
+    member,
+    `${member.participantId}-participant-started`,
+    "registered_participant",
+    "active",
+    member.startedAt,
+    {
+      participant_id: member.participantId,
+      role: member.role,
+      agent_session: wireSession(member.session),
+      herdr: wireHerdr(member.herdr),
+    },
+  ), signal);
+  member.registered = true;
+  await appendV2(pi, member.runId, envelope(
+    member,
+    `${member.workerId}-started`,
+    "worker",
+    "active",
+    member.startedAt,
+    {
+      worker_id: member.workerId,
+      role: member.role,
+      stage: member.role,
+      owner_participant_id: member.participantId,
+      agent_session: wireSession(member.session),
+      herdr: wireHerdr(member.herdr),
+    },
+  ), signal);
+  member.workerRegistered = true;
+}
+
+async function recordTerminal(
+  pi: ExtensionAPI,
+  member: Member,
+  state: TerminalState,
+  reason: string,
+): Promise<void> {
+  if (!member.registered) return;
+  member.terminalAt ??= now();
+  member.terminalReason ??= safeLine(reason);
+  member.terminalState ??= state;
+  if (member.terminalState !== state)
+    throw new Error(`Terminal state for ${member.participantId} changed during retry.`);
+  const observedAt = member.terminalAt;
+  const run = await getRun(pi, member.runId);
+  if (run.schema_version === 1) {
+    await registry(pi, {
+      action: "append",
+      run_id: member.runId,
+      updated_at: observedAt,
+      lifecycle: {
+        observation_id: `${member.participantId}-terminal`,
+        observed_at: observedAt,
+        kind: "worker",
+        goal_id: member.goalId,
+        state: member.terminalState,
+        detail: `${member.terminalReason}; journal cleanup verified.`,
+      },
+    });
+    return;
+  }
+  const resultText = `${member.terminalReason}; journal cleanup verified`;
+  if (member.workerRegistered)
+    await appendV2(pi, member.runId, envelope(
+      member,
+      `${member.workerId}-terminal`,
+      "worker",
+      member.terminalState,
+      observedAt,
+      {
+        worker_id: member.workerId,
+        role: member.role,
+        stage: member.role,
+        owner_participant_id: member.participantId,
+        agent_session: wireSession(member.session),
+        herdr: wireHerdr(member.herdr),
+        terminal_result: resultText,
+      },
+      true,
+    ));
+  await appendV2(pi, member.runId, envelope(
+    member,
+    `${member.participantId}-participant-terminal`,
+    "registered_participant",
+    member.terminalState,
+    observedAt,
+    {
+      participant_id: member.participantId,
+      role: member.role,
+      agent_session: wireSession(member.session),
+      herdr: wireHerdr(member.herdr),
+      terminal_result: resultText,
+    },
+    true,
+  ));
+}
+
+async function assertMemberOwnership(pi: ExtensionAPI, member: Member, signal?: AbortSignal): Promise<void> {
+  const run = await getRun(pi, member.runId, signal);
+  if (!participantObservation(run, member))
+    throw new Error(`Registry ownership for ${member.participantId} no longer matches its exact Pi and Herdr identity.`);
+}
+
+async function parentPlacement(
+  pi: ExtensionAPI,
+  ctx: ExtensionContext,
+  signal?: AbortSignal,
+): Promise<{ herdr: HerdrIdentity; session: SessionIdentity }> {
+  if (ctx.mode !== "tui" || process.env.HERDR_ENV !== "1" || !process.env.HERDR_PANE_ID)
+    throw new Error("Vault Hunter Crew requires an interactive Herdr-bound parent Pi session.");
+  const resolved = await herdr(pi, ["pane", "get", process.env.HERDR_PANE_ID], signal);
+  const pane = resolved.pane ?? resolved;
+  const sessionFile = ctx.sessionManager.getSessionFile();
+  const session = pane.agent_session;
+  if (!sessionFile || !sameSession(session, { source: "herdr:pi", kind: "path", value: sessionFile }))
+    throw new Error("The current Herdr pane is not bound to this Pi session.");
+  const fields = [pane.workspace_id, pane.tab_id, pane.pane_id, pane.terminal_id];
+  if (fields.some((value) => typeof value !== "string" || !value) || pane.pane_id !== process.env.HERDR_PANE_ID)
+    throw new Error("Herdr returned an incomplete or contradictory parent identity.");
+  return {
+    herdr: {
+      workspaceId: pane.workspace_id,
+      tabId: pane.tab_id,
+      paneId: pane.pane_id,
+      terminalId: pane.terminal_id,
+    },
+    session: { source: session.source, kind: session.kind, value: session.value },
+  };
+}
+
+const BASE_FIELDS = new Set([
+  "v", "seq", "at", "runId", "goalId", "participantId", "role", "type",
+]);
+const EVENT_FIELDS: Record<string, Set<string>> = {
+  ready: new Set(["session", "herdr"]),
+  released: new Set(["summary", "sha256", "proof"]),
+  steering: new Set(["summary", "sha256"]),
+  lifecycle: new Set(["state", "reason"]),
+  tool: new Set(["phase", "name", "summary", "sha256", "failed"]),
+  progress: new Set(["textChars", "thinkingChars"]),
+  usage: new Set(["usage"]),
+  handoff: new Set(["summary", "sha256", "fields", "valid"]),
+};
+
+function safeEvent(value: unknown): value is JournalEvent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const event = value as any;
+  if (event.v !== 1 || !Number.isInteger(event.seq) || event.seq < 1 ||
+    typeof event.at !== "string" || !SAFE_ID.test(event.runId ?? "") ||
+    typeof event.goalId !== "string" || !/^[A-Za-z0-9._:-]{1,128}$/.test(event.goalId) || !SAFE_ID.test(event.participantId ?? "") ||
+    !ROLES.includes(event.role) || !EVENT_FIELDS[event.type]) return false;
+  const allowed = EVENT_FIELDS[event.type]!;
+  if (Object.keys(event).some((key) => !BASE_FIELDS.has(key) && !allowed.has(key))) return false;
+  for (const key of ["summary", "sha256", "proof", "state", "reason", "phase", "name"])
+    if (event[key] !== undefined && typeof event[key] !== "string") return false;
+  if (event.sha256 !== undefined && !/^[a-f0-9]{64}$/.test(event.sha256)) return false;
+  if (event.proof !== undefined && !/^[a-f0-9]{64}$/.test(event.proof)) return false;
+  if (event.summary !== undefined && event.summary.length > 160) return false;
+  if (event.failed !== undefined && typeof event.failed !== "boolean") return false;
+  if (event.valid !== undefined && typeof event.valid !== "boolean") return false;
+  if (event.fields !== undefined && (!Array.isArray(event.fields) ||
+    event.fields.some((item: unknown) => typeof item !== "string" || item.length > 40))) return false;
+  if (event.usage !== undefined) {
+    if (!event.usage || typeof event.usage !== "object" || Array.isArray(event.usage)) return false;
+    if (Object.entries(event.usage).some(([key, item]) =>
+      !["input", "output", "cacheRead", "cacheWrite", "totalTokens", "cost"].includes(key) ||
+      typeof item !== "number" || !Number.isFinite(item) || item < 0)) return false;
+  }
+  if (event.type === "ready") {
+    if (!event.session || typeof event.session !== "object" || Array.isArray(event.session) ||
+      Object.keys(event.session).some((key) => !["source", "kind", "value"].includes(key)) ||
+      [event.session.source, event.session.kind, event.session.value].some((item) => typeof item !== "string" || !item)) return false;
+    if (!event.herdr || typeof event.herdr !== "object" || Array.isArray(event.herdr) ||
+      Object.keys(event.herdr).some((key) => !["workspaceId", "tabId", "paneId"].includes(key)) ||
+      [event.herdr.workspaceId, event.herdr.tabId, event.herdr.paneId].some((item) => typeof item !== "string" || !item)) return false;
+  }
+  for (const key of ["textChars", "thinkingChars"])
+    if (event[key] !== undefined && (!Number.isInteger(event[key]) || event[key] < 0)) return false;
+  return true;
+}
+
+function readJournal(
+  path: string,
+  expected?: Partial<Pick<Member, "runId" | "goalId" | "participantId" | "role">>,
+): { events: JournalEvent[]; lifecycleOnly: boolean; problem?: string } {
+  if (!existsSync(path)) return { events: [], lifecycleOnly: true, problem: "journal missing" };
+  const events: JournalEvent[] = [];
+  try {
+    let priorSequence = 0;
+    for (const candidate of [`${path}.2`, `${path}.1`, path]) {
+      if (!existsSync(candidate)) continue;
+      const stat = lstatSync(candidate);
+      if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`unsafe journal file ${basename(candidate)}`);
+      for (const line of readFileSync(candidate, "utf8").split("\n")) {
+        if (!line) continue;
+        const value = JSON.parse(line);
+        if (!safeEvent(value)) throw new Error(`unsafe event in ${basename(candidate)}`);
+        if (value.seq <= priorSequence) throw new Error(`non-monotonic sequence in ${basename(candidate)}`);
+        priorSequence = value.seq;
+        for (const key of ["runId", "goalId", "participantId", "role"] as const)
+          if (expected?.[key] !== undefined && value[key] !== expected[key])
+            throw new Error(`journal ${key} does not match custody`);
+        events.push(value);
+      }
+    }
+  } catch (error) {
+    return { events: [], lifecycleOnly: true, problem: `journal corrupt: ${safeLine(String(error))}` };
+  }
+  return { events, lifecycleOnly: false };
+}
+
+function currentHandoff(events: JournalEvent[]): any | undefined {
+  const handoffIndex = events.findLastIndex((event) => event.type === "handoff");
+  const steeringIndex = events.findLastIndex((event) => event.type === "steering");
+  return handoffIndex > steeringIndex ? events[handoffIndex] : undefined;
+}
+
+function pathExists(path: string): boolean {
+  try { lstatSync(path); return true; }
+  catch (error: any) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function journalPath(runId: string, participantId: string): string {
+  return join(stateRoot(), runId, `${participantId}.jsonl`);
+}
+
+function cleanupJournal(member: Member): void {
+  for (const path of [member.journal, `${member.journal}.1`, `${member.journal}.2`])
+    rmSync(path, { force: true });
+  if ([member.journal, `${member.journal}.1`, `${member.journal}.2`].some(existsSync))
+    throw new Error(`Journal cleanup could not be verified for ${member.participantId}.`);
+  try {
+    if (readdirSync(dirname(member.journal)).length === 0)
+      rmSync(dirname(member.journal), { recursive: false });
+  } catch { /* another child still owns this Run directory */ }
+}
+
+function personaPrompt(role: Role, prompt: string): string {
+  const contract: Record<Role, string> = {
+    "verifier-builder": "Build or sharpen only the declared verifier boundary and return a structured handoff. Do not accept evidence or mutate canonical vault state.",
+    "convergence-engineer": "Own the single active implementation write lease. Converge the frozen verifier manifest, then return a structured handoff and wait for explicit release.",
+    "delivery-steward": "Drive the outer No Mistakes delivery boundary. Independent review and final verifier certification belong inside No Mistakes; never make canonical vault decisions.",
+  };
+  const templates: Record<Role, string> = {
+    "verifier-builder": "HANDOFF:\nOutcome:\nVerifier manifest:\nBaseline:\nEvidence:\nRisks:\nBlockers:",
+    "convergence-engineer": "HANDOFF:\nOutcome:\nBase:\nHead:\nTree:\nChanged paths:\nVerifier results:\nArtifacts:\nRisks:\nBlockers:",
+    "delivery-steward": "HANDOFF:\nOutcome:\nCandidate tree:\nReview:\nCertification:\nPR/CI:\nRisks:\nBlockers:",
+  };
+  return [
+    `You are the Vault Hunter ${role}.`,
+    contract[role],
+    "Stay within the supplied paths and stop conditions. Never expose chain-of-thought or raw secrets in the handoff.",
+    "Finish with exactly this labeled handoff shape; every label is required even when its value is None:",
+    templates[role],
+    "",
+    prompt,
+  ].join("\n");
+}
+
+async function assertSoloTab(
+  pi: ExtensionAPI,
+  workspaceId: string,
+  tabId: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const listed = await herdr(pi, ["tab", "list", "--workspace", workspaceId], signal);
+  const tab = Array.isArray(listed.tabs) ? listed.tabs.find((item: any) => item.tab_id === tabId) : undefined;
+  if (!tab || tab.workspace_id !== workspaceId || tab.pane_count !== 1)
+    throw new Error(`Refusing to close ${tabId}: it is absent, moved, or no longer a dedicated one-pane tab.`);
+}
+
+async function sendPrompt(
+  pi: ExtensionAPI,
+  member: Member,
+  prompt: string,
+  marker = "",
+  signal?: AbortSignal,
+): Promise<void> {
+  const live = await herdr(pi, ["agent", "get", member.name], signal);
+  const agent = live.agent ?? live;
+  if (!sameSession(agent.agent_session, member.session) ||
+    agent.workspace_id !== member.herdr.workspaceId ||
+    agent.tab_id !== member.herdr.tabId || agent.pane_id !== member.herdr.paneId ||
+    agent.terminal_id !== member.herdr.terminalId)
+    throw new Error(`Live identity for ${member.participantId} no longer matches its exact Run ownership.`);
+  await herdr(pi, ["pane", "send-text", member.herdr.paneId, `${marker}${prompt}`], signal);
+  await herdr(pi, ["pane", "send-keys", member.herdr.paneId, "return"], signal);
+}
+
+async function waitForReady(
+  pi: ExtensionAPI,
+  member: Omit<Member, "session" | "herdr" | "registered" | "workerRegistered" | "status" | "retained"> & { tabId: string },
+  expectedWorkspace: string,
+  expectedPane: string | undefined,
+  signal?: AbortSignal,
+): Promise<{ session: SessionIdentity; herdr: HerdrIdentity; startedAt: string }> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    signal?.throwIfAborted();
+    const journal = readJournal(member.journal, member);
+    const ready = journal.events.find((event) => event.type === "ready") as any;
+    if (ready) {
+      const live = await herdr(pi, ["agent", "get", member.name], signal);
+      const agent = live.agent ?? live;
+      const identity = {
+        workspaceId: agent.workspace_id,
+        tabId: agent.tab_id,
+        paneId: agent.pane_id,
+        terminalId: agent.terminal_id,
+      };
+      if (!sameSession(agent.agent_session, ready.session) ||
+        identity.workspaceId !== expectedWorkspace || identity.tabId !== member.tabId ||
+        !identity.paneId || !identity.terminalId ||
+        ready.herdr?.workspaceId !== identity.workspaceId ||
+        ready.herdr?.tabId !== identity.tabId || ready.herdr?.paneId !== identity.paneId ||
+        expectedPane && identity.paneId !== expectedPane)
+        throw new Error("Child companion and Herdr returned contradictory launch identities.");
+      return { session: ready.session, herdr: identity, startedAt: ready.at };
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+  throw new Error("Child companion did not durably report its Pi session within 30 seconds.");
+}
+
+export default function (pi: ExtensionAPI) {
+  const members = new Map<string, Member>();
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let currentCtx: ExtensionContext | undefined;
+  let polling = false;
+  let recoveryHealthy = false;
+  let custodyQueue = Promise.resolve();
+
+  async function serializeCustody<T>(work: () => Promise<T>): Promise<T> {
+    const previous = custodyQueue;
+    let release!: () => void;
+    custodyQueue = new Promise<void>((resolveQueue) => { release = resolveQueue; });
+    await previous;
+    try { return await work(); }
+    finally { release(); }
+  }
+
+  function retainedFromSession(ctx: ExtensionContext): Set<string> {
+    const retained = new Set<string>();
+    for (const entry of ctx.sessionManager.getBranch()) {
+      if (entry.type !== "message" || entry.message.role !== "toolResult" ||
+        entry.message.toolName !== "vault_hunter_crew_release" || entry.message.isError) continue;
+      const details = entry.message.details as any;
+      if (typeof details?.participantId !== "string") continue;
+      if (details.retained === true) retained.add(details.participantId);
+      if (details.journalCleanupVerified === true) retained.delete(details.participantId);
+    }
+    return retained;
+  }
+
+  function active(runId: string, role?: Role): Member[] {
+    return [...members.values()].filter((member) =>
+      member.runId === runId && member.status !== "closed" && (!role || member.role === role));
+  }
+
+  function renderWidget(ctx: ExtensionContext): void {
+    const live = [...members.values()].filter((member) => member.status !== "closed");
+    if (!live.length) {
+      ctx.ui.setWidget(WIDGET_ID, undefined);
+      return;
+    }
+    const lines = [ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Vault Hunter Crew"))];
+    for (const member of live) {
+      const grace = member.graceDeadline
+        ? ` · closes in ${Math.max(0, Math.ceil((member.graceDeadline - Date.now()) / 1000))}s`
+        : "";
+      const degraded = member.lifecycleOnly ? " · lifecycle-only" : "";
+      const steering = member.lastSteering
+        ? ` · steer ${member.lastSteering.summary} #${member.lastSteering.sha256.slice(0, 8)}`
+        : "";
+      lines.push(`${member.role} · ${member.status}${grace}${degraded}${steering} · ${member.herdr.tabId}`);
+    }
+    ctx.ui.setWidget(WIDGET_ID, lines);
+  }
+
+  async function closeMember(member: Member, state: TerminalState, reason: string): Promise<void> {
+    if (member.status === "closed") return;
+    await assertMemberOwnership(pi, member);
+    if (member.status === "closed-unrecorded") {
+      await recordTerminal(pi, member, state, reason);
+      member.status = "closed";
+      if (currentCtx) renderWidget(currentCtx);
+      return;
+    }
+    const live = await herdr(pi, ["agent", "get", member.name]);
+    const agent = live.agent ?? live;
+    if (!sameSession(agent.agent_session, member.session) || !sameHerdr({
+      workspace_id: agent.workspace_id,
+      tab_id: agent.tab_id,
+      pane_id: agent.pane_id,
+      terminal_id: agent.terminal_id,
+    }, member.herdr))
+      throw new Error(`Refusing to close ${member.participantId}: live ownership changed.`);
+    await assertSoloTab(pi, member.herdr.workspaceId, member.herdr.tabId);
+    const closed = await herdr(pi, ["tab", "close", member.herdr.tabId]);
+    if (closed.type !== "tab_closed" || closed.tab_id !== member.herdr.tabId)
+      throw new Error(`Herdr did not confirm exact tab closure for ${member.participantId}.`);
+    cleanupJournal(member);
+    member.status = "closed-unrecorded";
+    await recordTerminal(pi, member, state, reason);
+    member.status = "closed";
+    member.graceDeadline = undefined;
+    renderWidget(currentCtx!);
+  }
+
+  async function poll(): Promise<void> {
+    if (polling || !currentCtx) return;
+    polling = true;
+    try {
+      for (const member of members.values()) {
+        if (member.status === "closed") continue;
+        const journal = readJournal(member.journal, member);
+        member.lifecycleOnly = journal.lifecycleOnly;
+        if (!journal.lifecycleOnly) {
+          const lifecycle = [...journal.events].reverse().find((event) => event.type === "lifecycle") as any;
+          if (lifecycle?.state) member.status = lifecycle.state;
+          const handoffIndex = journal.events.findLastIndex((event) => event.type === "handoff");
+          const handoff = currentHandoff(journal.events);
+          const steeringAfterHandoff = handoffIndex >= 0 && !handoff;
+          const key = handoff ? `${handoff.at}:${handoff.sha256}` : undefined;
+          member.handoffValid = handoff?.valid === true;
+          const steering = [...journal.events].reverse().find((event) => event.type === "steering") as any;
+          if (steering?.summary && steering?.sha256)
+            member.lastSteering = { summary: steering.summary, sha256: steering.sha256 };
+          if (member.status === "working" || steeringAfterHandoff) member.graceDeadline = undefined;
+          if (member.role === "verifier-builder" && member.handoffValid && key && key !== member.lastHandoffKey) {
+            member.lastHandoffKey = key;
+            if (!member.retained && !steeringAfterHandoff) member.graceDeadline = Date.now() + GRACE_MS;
+          }
+        }
+        if (member.role === "verifier-builder" && member.graceDeadline &&
+          Date.now() >= member.graceDeadline && member.status === "idle")
+          await serializeCustody(() => closeMember(member, "succeeded", "verifier-builder grace elapsed after validated durable handoff"));
+      }
+    } catch (error) {
+      currentCtx.ui.notify(`Vault Hunter Crew monitor: ${safeLine(String(error))}`, "warning");
+    } finally {
+      polling = false;
+      if (currentCtx) renderWidget(currentCtx);
+    }
+  }
+
+  async function reconnect(ctx: ExtensionContext): Promise<void> {
+    members.clear();
+    const retained = retainedFromSession(ctx);
+    const placement = await parentPlacement(pi, ctx);
+    const listed = await herdr(pi, ["agent", "list"]);
+    if (!Array.isArray(listed.agents)) throw new Error("Herdr returned a malformed agent list during Crew recovery.");
+    const agents = listed.agents;
+    for (const runId of existsSync(stateRoot()) ? readdirSync(stateRoot()) : []) {
+      const directory = join(stateRoot(), runId);
+      let files: string[];
+      try { files = readdirSync(directory).filter((file) => file.endsWith(".jsonl")); }
+      catch { continue; }
+      for (const file of files) {
+        const journal = join(directory, file);
+        const replay = readJournal(journal, {
+          runId,
+          participantId: file.slice(0, -".jsonl".length),
+        });
+        const ready = replay.events.find((event) => event.type === "ready") as any;
+        if (!ready || ready.runId !== runId) continue;
+        const live = agents.find((agent: any) => sameSession(agent.agent_session, ready.session));
+        if (!live || live.workspace_id !== placement.herdr.workspaceId ||
+          live.tab_id !== ready.herdr?.tabId || live.pane_id !== ready.herdr?.paneId) continue;
+        const member: Member = {
+          runId,
+          goalId: ready.goalId,
+          participantId: ready.participantId,
+          workerId: `${ready.participantId}-worker`,
+          role: ready.role,
+          name: live.name,
+          cwd: live.cwd,
+          journal,
+          session: ready.session,
+          herdr: {
+            workspaceId: live.workspace_id,
+            tabId: live.tab_id,
+            paneId: live.pane_id,
+            terminalId: live.terminal_id,
+          },
+          startedAt: ready.at,
+          status: live.agent_status ?? "unknown",
+          retained: retained.has(ready.participantId),
+          registered: false,
+          workerRegistered: false,
+          lifecycleOnly: replay.lifecycleOnly,
+        };
+        const run = await getRun(pi, runId);
+        if (!participantObservation(run, member)) continue;
+        member.registered = true;
+        member.workerRegistered = run.schema_version === 1 || Boolean(run.observations?.some((item: any) =>
+          item.kind === "worker" && item.payload?.worker?.owner_participant_id === member.participantId));
+        members.set(member.participantId, member);
+      }
+    }
+
+    // A missing or corrupt journal cannot prove absence. Rebuild lifecycle-only
+    // custody from the exact Registry participant/session and live Herdr tuple.
+    const summaries = await registry(pi, {
+      action: "list",
+      filter: { agent_session: wireSession(placement.session) },
+    });
+    if (!Array.isArray(summaries)) throw new Error("Registry returned a malformed Run list during Crew recovery.");
+    for (const summary of summaries) {
+        const run = await getRun(pi, summary.run_id);
+        if (!driverOwnsRun(run, placement.session, placement.herdr.workspaceId)) continue;
+        if (run.schema_version === 1) {
+          for (const participant of run.participants ?? []) {
+            if (!ROLES.includes(participant.role) || members.has(participant.participant_id)) continue;
+            if ((run as any).lifecycle?.some((item: any) => item.observation_id === `${participant.participant_id}-terminal`)) continue;
+            const live = agents.find((item: any) => sameSession(item.agent_session, participant.agent_session));
+            if (!live || !sameHerdr(participant.herdr, {
+              workspaceId: live.workspace_id, tabId: live.tab_id,
+              paneId: live.pane_id, terminalId: live.terminal_id,
+            }) || live.workspace_id !== placement.herdr.workspaceId) continue;
+            members.set(participant.participant_id, {
+              runId: run.run_id,
+              goalId: participant.goal_id,
+              participantId: participant.participant_id,
+              workerId: `${participant.participant_id}-worker`,
+              role: participant.role,
+              name: live.name,
+              cwd: live.cwd,
+              journal: journalPath(run.run_id, participant.participant_id),
+              session: participant.agent_session,
+              herdr: {
+                workspaceId: live.workspace_id, tabId: live.tab_id,
+                paneId: live.pane_id, terminalId: live.terminal_id,
+              },
+              startedAt: participant.observed_at,
+              status: live.agent_status ?? "unknown",
+              retained: retained.has(participant.participant_id),
+              registered: true,
+              workerRegistered: true,
+              lifecycleOnly: true,
+            });
+          }
+          continue;
+        }
+        for (const observation of run.observations ?? []) {
+          const participant = observation.payload?.registered_participant;
+          if (observation.kind !== "registered_participant" || observation.state !== "active" ||
+            !participant || !ROLES.includes(participant.role) || members.has(participant.participant_id)) continue;
+          const terminal = run.observations?.some((item: any) =>
+            item.kind === "registered_participant" && item.state !== "active" &&
+            item.payload?.registered_participant?.participant_id === participant.participant_id);
+          if (terminal) continue;
+          const live = agents.find((item: any) => sameSession(item.agent_session, participant.agent_session));
+          if (!live || !sameHerdr(participant.herdr, {
+            workspaceId: live.workspace_id, tabId: live.tab_id,
+            paneId: live.pane_id, terminalId: live.terminal_id,
+          }) || live.workspace_id !== placement.herdr.workspaceId) continue;
+          const worker = run.observations?.find((item: any) =>
+            item.kind === "worker" && item.state === "active" &&
+            item.payload?.worker?.owner_participant_id === participant.participant_id)?.payload?.worker;
+          members.set(participant.participant_id, {
+            runId: run.run_id,
+            goalId: observation.goal_id,
+            participantId: participant.participant_id,
+            workerId: worker?.worker_id ?? `${participant.participant_id}-worker`,
+            role: participant.role,
+            name: live.name,
+            cwd: live.cwd,
+            journal: journalPath(run.run_id, participant.participant_id),
+            session: participant.agent_session,
+            herdr: {
+              workspaceId: live.workspace_id, tabId: live.tab_id,
+              paneId: live.pane_id, terminalId: live.terminal_id,
+            },
+            startedAt: observation.started_at,
+            status: live.agent_status ?? "unknown",
+            retained: retained.has(participant.participant_id),
+            registered: true,
+            workerRegistered: Boolean(worker),
+            lifecycleOnly: true,
+          });
+        }
+      }
+    for (const member of members.values())
+      if (realpathSync(member.cwd) !== realpathSync(ctx.cwd))
+        throw new Error(`Recovered Crew cwd for ${member.participantId} is outside the parent Run custody.`);
+    renderWidget(ctx);
+  }
+
+  pi.on("session_start", async (_event, ctx) => {
+    currentCtx = ctx;
+    recoveryHealthy = false;
+    try {
+      await reconnect(ctx);
+      recoveryHealthy = true;
+    } catch (error) {
+      ctx.ui.notify(`Vault Hunter Crew recovery failed closed: ${safeLine(String(error))}`, "error");
+    }
+    timer = setInterval(() => void poll(), POLL_MS);
+    timer.unref?.();
+  });
+  pi.on("session_shutdown", (_event, ctx) => {
+    if (timer) clearInterval(timer);
+    timer = undefined;
+    recoveryHealthy = false;
+    ctx.ui.setWidget(WIDGET_ID, undefined);
+    currentCtx = undefined;
+  });
+
+  pi.registerTool({
+    name: "vault_hunter_crew_launch",
+    label: "Launch Vault Hunter Crew Persona",
+    description: "Fail-closed two-phase launch of one registered Vault Hunter persona in a dedicated tab in the parent Herdr workspace. The Task prompt is withheld until exact Run, Pi session, and Herdr ownership are registered.",
+    promptSnippet: "Launch a registered Vault Hunter verifier-builder, convergence-engineer, or delivery-steward.",
+    promptGuidelines: [
+      "Use vault_hunter_crew_launch for formal Vault Hunter persona work; never launch these writers through generic subagents.",
+      "Close convergence-engineer through vault_hunter_crew_release before launching delivery-steward.",
+    ],
+    parameters: LaunchSchema,
+    async execute(_id, params, signal, _update, ctx) {
+      return await serializeCustody(async () => {
+      if (!recoveryHealthy)
+        throw new Error("Crew recovery is unhealthy; launch is disabled until exact Run/session custody reconnects.");
+      const placement = await parentPlacement(pi, ctx, signal);
+      const run = await getRun(pi, params.runId, signal);
+      if (!driverOwnsRun(run, placement.session, placement.herdr.workspaceId))
+        throw new Error(`The current parent does not exactly own Run ${params.runId} in this Herdr workspace.`);
+      const activeRoles = ROLES.filter((role) => runHasActiveRole(run, role));
+      if (active(params.runId).length || activeRoles.length)
+        throw new Error(`Run ${params.runId} already has active or unreconciled crew custody: ${activeRoles.join(", ") || "live child"}.`);
+
+      const participantId = `crew-${params.role}-${randomUUID()}`;
+      const workerId = `${participantId}-worker`;
+      const cwd = resolve(params.cwd ?? ctx.cwd);
+      if (realpathSync(cwd) !== realpathSync(ctx.cwd))
+        throw new Error("Crew cwd must be the parent driver's exact Run-owned working directory.");
+      for (const extensionPath of [CHILD_EXTENSION, HERDR_STATE_EXTENSION]) {
+        const extensionStat = lstatSync(extensionPath);
+        if (!extensionStat.isFile() || extensionStat.isSymbolicLink())
+          throw new Error(`Vault Hunter child extension is not a regular production file: ${extensionPath}`);
+      }
+      const journal = journalPath(params.runId, participantId);
+      if ([journal, `${journal}.1`, `${journal}.2`].some(pathExists))
+        throw new Error("Fresh Crew participant journal identity is already occupied.");
+      const journalDirectory = dirname(journal);
+      mkdirSync(journalDirectory, { recursive: true, mode: 0o700 });
+      const journalDirectoryStat = lstatSync(journalDirectory);
+      if (!journalDirectoryStat.isDirectory() || journalDirectoryStat.isSymbolicLink())
+        throw new Error("Crew journal directory is not a private regular directory.");
+      chmodSync(journalDirectory, 0o700);
+      const tabLabel = `Vault Hunter · ${params.role} · ${safeLine(params.goalId)}`;
+      let tabId: string | undefined;
+      let provisional: Member | undefined;
+      try {
+        const created = await herdr(pi, [
+          "tab", "create", "--workspace", placement.herdr.workspaceId,
+          "--cwd", cwd, "--label", tabLabel, "--no-focus",
+        ], signal);
+        const tab = created.tab;
+        const rootPane = created.root_pane;
+        tabId = tab?.tab_id;
+        if (created.type !== "tab_created" || !tabId || tab.workspace_id !== placement.herdr.workspaceId ||
+          tab.pane_count !== 1 || !rootPane?.pane_id || rootPane.tab_id !== tabId)
+          throw new Error("Herdr returned a malformed reserved tab.");
+
+        const releaseToken = randomBytes(32).toString("hex");
+        const name = `pi-vh-${slug(params.runId, 20)}-${slug(params.role, 24)}-${participantId.slice(-8)}`;
+        const launched = await herdr(pi, [
+          "agent", "start", name,
+          "--cwd", cwd,
+          "--workspace", placement.herdr.workspaceId,
+          "--tab", tabId,
+          "--no-focus",
+          "--env", `SIDEKICK_NAMED_SESSION=${name.slice(3)}`,
+          "--env", `VAULT_HUNTER_RUN_ID=${params.runId}`,
+          "--env", `VAULT_HUNTER_GOAL_ID=${params.goalId}`,
+          "--env", `VAULT_HUNTER_CREW_PARTICIPANT_ID=${participantId}`,
+          "--env", `VAULT_HUNTER_CREW_ROLE=${params.role}`,
+          "--env", `VAULT_HUNTER_CREW_JOURNAL=${journal}`,
+          "--env", `VAULT_HUNTER_CREW_RELEASE_TOKEN=${releaseToken}`,
+          "--", "pi", "--no-extensions", "--no-skills", "--no-prompt-templates",
+          "-e", HERDR_STATE_EXTENSION, "-e", CHILD_EXTENSION, "--name", name.slice(3),
+        ], signal);
+        const launchedAgent = launched.agent ?? {};
+        if (!launchedAgent.pane_id)
+          throw new Error("Herdr did not start the reserved Pi child.");
+        if (rootPane.pane_id !== launchedAgent.pane_id) {
+          const rootClosed = await herdr(pi, ["pane", "close", rootPane.pane_id], signal);
+          if (rootClosed.type !== "pane_closed" || rootClosed.pane_id !== rootPane.pane_id)
+            throw new Error(`Herdr did not confirm temporary root pane closure for ${rootPane.pane_id}.`);
+        }
+
+        const base = {
+          runId: params.runId,
+          goalId: params.goalId,
+          participantId,
+          workerId,
+          role: params.role,
+          name: launchedAgent.name ?? name,
+          cwd,
+          journal,
+          startedAt: "",
+          tabId,
+        };
+        const ready = await waitForReady(pi, base, placement.herdr.workspaceId, launchedAgent.pane_id, signal);
+        provisional = {
+          ...base,
+          startedAt: ready.startedAt,
+          session: ready.session,
+          herdr: ready.herdr,
+          registered: false,
+          workerRegistered: false,
+          status: "reserved",
+          retained: false,
+        };
+        await registerMember(pi, run, provisional, signal);
+        members.set(participantId, provisional);
+        await sendPrompt(
+          pi,
+          provisional,
+          personaPrompt(params.role, params.prompt),
+          `[vault-hunter-release:${releaseToken}]`,
+          signal,
+        );
+        provisional.status = "working";
+        renderWidget(ctx);
+        return result(`Launched and registered ${params.role} ${participantId}.`, {
+          runId: params.runId,
+          goalId: params.goalId,
+          participantId,
+          role: params.role,
+          herdr: provisional.herdr,
+          agentSession: provisional.session,
+          journal: { mode: "0600", maxBytes: 1 << 20, files: 3 },
+        });
+      } catch (error) {
+        let cleanupError: unknown;
+        if (tabId) {
+          try {
+            await assertSoloTab(pi, placement.herdr.workspaceId, tabId);
+            const closed = await herdr(pi, ["tab", "close", tabId]);
+            if (closed.type !== "tab_closed" || closed.tab_id !== tabId)
+              throw new Error(`Herdr did not confirm exact reserved tab closure for ${tabId}.`);
+          } catch (closeError) { cleanupError = closeError; }
+        }
+        if (provisional && !cleanupError) {
+          try {
+            cleanupJournal(provisional);
+            provisional.status = "closed-unrecorded";
+            await recordTerminal(pi, provisional, "failed", `launch failed: ${safeLine(String(error))}`);
+            provisional.status = "closed";
+          } catch (recordError) {
+            cleanupError = recordError;
+            if (provisional.registered) members.set(provisional.participantId, provisional);
+          }
+        } else if (!provisional && !cleanupError) {
+          for (const path of [journal, `${journal}.1`, `${journal}.2`]) rmSync(path, { force: true });
+          if ([journal, `${journal}.1`, `${journal}.2`].some(existsSync))
+            cleanupError = new Error(`Reserved journal cleanup could not be verified for ${participantId}.`);
+        }
+        if (cleanupError) {
+          if (provisional?.registered) {
+            if (provisional.status !== "closed-unrecorded") provisional.status = "cleanup-blocked";
+            members.set(provisional.participantId, provisional);
+          }
+          throw new Error(`${safeLine(String(error))} Cleanup failed closed: ${safeLine(String(cleanupError))}`);
+        }
+        throw error;
+      }
+      });
+    },
+  });
+
+  pi.registerTool({
+    name: "vault_hunter_crew_send",
+    label: "Steer Vault Hunter Crew Persona",
+    description: "Send one bounded follow-up to an exact Run-owned crew persona. The companion records only a sanitized first line and SHA-256, never the raw prompt or reasoning.",
+    parameters: SendSchema,
+    async execute(_id, params, signal) {
+      return await serializeCustody(async () => {
+      const member = members.get(params.participantId);
+      if (!member || member.runId !== params.runId || member.status.startsWith("closed"))
+        throw new Error("No active exact Run-owned crew participant matches this request.");
+      member.graceDeadline = undefined;
+      await assertMemberOwnership(pi, member, signal);
+      await sendPrompt(pi, member, params.prompt, "", signal);
+      return result(`Steered ${member.role} ${member.participantId}.`, {
+        runId: member.runId,
+        participantId: member.participantId,
+        summary: safeLine(params.prompt),
+        sha256: hash(params.prompt),
+      });
+      });
+    },
+  });
+
+  pi.registerTool({
+    name: "vault_hunter_crew_release",
+    label: "Release Vault Hunter Crew Persona",
+    description: "Retain a verifier-builder during its 30-second grace, close a persona after a validated structured handoff, or abort exact Run-owned custody without implying success. Convergence and delivery never auto-close.",
+    parameters: ReleaseSchema,
+    async execute(_id, params) {
+      return await serializeCustody(async () => {
+      const member = members.get(params.participantId);
+      if (!member || member.runId !== params.runId || member.status === "closed")
+        throw new Error("No active exact Run-owned crew participant matches this request.");
+      const journal = readJournal(member.journal, member);
+      if (!journal.lifecycleOnly) {
+        const handoff = currentHandoff(journal.events);
+        member.handoffValid = handoff?.valid === true;
+      }
+      if (params.disposition === "retain") {
+        if (member.role !== "verifier-builder" || !member.handoffValid)
+          throw new Error("Only a verifier-builder with a validated durable handoff can be retained during grace.");
+        member.retained = true;
+        member.graceDeadline = undefined;
+        if (currentCtx) renderWidget(currentCtx);
+        return result(`Retained ${member.participantId}; explicit close is now required.`, {
+          runId: member.runId,
+          participantId: member.participantId,
+          retained: true,
+        });
+      }
+      if (params.disposition === "close" && !member.handoffValid)
+        throw new Error("A validated structured handoff is required before normal persona closure; use abort for incomplete custody.");
+      const state: TerminalState = params.disposition === "abort" ? "interrupted" : "succeeded";
+      await closeMember(member, state, params.result ?? (state === "succeeded" ? "validated handoff released" : "explicit custody abort"));
+      return result(`Closed exact Run-owned crew participant ${member.participantId}.`, {
+        runId: member.runId,
+        participantId: member.participantId,
+        journalCleanupVerified: true,
+        terminalState: state,
+      });
+      });
+    },
+  });
+
+  pi.registerTool({
+    name: "vault_hunter_crew_inspect",
+    label: "Inspect Vault Hunter Crew",
+    description: "Inspect safe bounded crew telemetry for one Run. Missing or corrupt journals degrade to lifecycle-only facts and never imply Task or verifier success.",
+    parameters: InspectSchema,
+    async execute(_id, params) {
+      const selected = active(params.runId).filter((member) =>
+        !params.participantId || member.participantId === params.participantId);
+      const inspections = await Promise.all(selected.map(async (member) => {
+        const journal = readJournal(member.journal, member);
+        let liveState = "unavailable";
+        try {
+          const live = await herdr(pi, ["agent", "get", member.name]);
+          const agent = live.agent ?? live;
+          liveState = sameSession(agent.agent_session, member.session) ? agent.agent_status ?? "unknown" : "ownership-mismatch";
+        } catch { /* lifecycle unavailable */ }
+        const safeEvents = journal.lifecycleOnly
+          ? []
+          : journal.events.slice(-200).map((event) => {
+              const { v, runId, goalId, participantId, role, proof, ...bounded } = event;
+              return bounded;
+            });
+        return {
+          participantId: member.participantId,
+          role: member.role,
+          liveState,
+          herdr: member.herdr,
+          agentSession: member.session,
+          lifecycleOnly: journal.lifecycleOnly,
+          problem: journal.problem,
+          events: safeEvents,
+          successInferred: false,
+        };
+      }));
+      return result(
+        inspections.length
+          ? `Inspected ${inspections.length} Run-owned crew participant(s); no success was inferred.`
+          : `No active crew participants found for Run ${params.runId}.`,
+        { runId: params.runId, participants: inspections },
+      );
+    },
+  });
+}
+
+export type VaultHunterCrewLaunchInput = Static<typeof LaunchSchema>;
+export type VaultHunterCrewSendInput = Static<typeof SendSchema>;
+export type VaultHunterCrewReleaseInput = Static<typeof ReleaseSchema>;
+export type VaultHunterCrewInspectInput = Static<typeof InspectSchema>;


### PR DESCRIPTION
## Intent

Implement the accepted Proposal 1 Vault Hunter crew and driver pipeline. Keep the Run Registry adapter separate from a new production Herdr process-custody extension; use verifier-builder, convergence-engineer, and delivery-steward personas with fail-closed two-phase registration, exact Run/workspace ownership, one sequential writer lease, automatic reconnection, safe bounded telemetry journals, direct-steering hashes, persistent crew visibility, and persona-specific retention/closure. Update the Vault Hunter skill so No Mistakes owns independent review and a dedicated final verifier certification phase before push/PR/CI while the Hunter parent retains canonical vault checkpoint authority. Preserve the generic inline agents as distinct capabilities and do not merge the accepted throwaway prototype wholesale. The external No Mistakes binary does not yet implement certify, so encode that required boundary honestly rather than claiming certification support.

## What Changed

- Add a production Herdr crew extension with persona-specific custody, two-phase registration, sequential writer leasing, reconnection, bounded telemetry, and lifecycle cleanup.
- Extend the Run Registry adapter and tests for strict, idempotent crew observations and stale custody recovery.
- Update Vault Hunter guidance for parent-owned canonical checkpoints, independent No Mistakes review, and fail-closed final verifier certification.

## Risk Assessment

✅ Low: The fixes close the previously identified cleanup race and stale Registry custody path while preserving exact ownership and fail-closed behavior.

## Testing

The focused Registry append/replay and strict-input tests passed, both Crew extensions bundled successfully, acceptance-boundary text and patch integrity checks passed, and the worktree remained clean; however, no interactive Crew launch or visual evidence could be captured because this session is not Herdr-bound.

- Outcome: ⏭️ skipped across 1 run (57.5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `pi/.pi/agent/extensions/vault-hunter-crew.ts:792` - Journal cleanup races the child&#39;s shutdown handler. After `tab close` returns, `cleanupJournal` removes and verifies the files, but `vault-hunter-crew-child.ts:317` can subsequently handle `session_shutdown` and recreate the journal via `O_CREAT`. This violates the required durable cleanup proof and can leave telemetry after a reported successful closure. Wait for exact agent termination before cleanup, or disable/acknowledge the writer before deleting and recording proof.
- 🚨 `pi/.pi/agent/extensions/vault-hunter-crew.ts:943` - Recovery silently skips a Registry-active participant when its Herdr agent is no longer live. The active Registry observation remains, `runHasActiveRole` continues blocking every later launch, and the skipped participant is absent from `members`, so none of the crew tools can abort or reconcile it. A child crash or manual tab closure therefore permanently wedges the Run. Reconcile dead exact-owned participants at the recovery boundary by recording an interrupted terminal state and cleaning safe residual journals, or retain an actionable lifecycle-only member that can be explicitly aborted.

🔧 Fix: Fix crew termination cleanup and stale custody recovery
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- ⚠️ `pi/.pi/agent/extensions/vault-hunter-crew.ts:493` - End-to-end Crew launch, registration, reconnection, telemetry, and persona closure could not be demonstrated because this test session lacks HERDR_ENV and HERDR_PANE_ID. Reviewer-visible product evidence is therefore missing.
- `go test ./cmd/vault-hunter-registry -run 'TestAppendObservationCommandWritesStrictV2AndReplaysIdempotently|TestAdministrationRequestsAreStrictBeforeOpeningStorage' -v`
- `bun build pi/.pi/agent/extensions/vault-hunter-crew.ts pi/.pi/agent/extensions/vault-hunter-crew-child.ts --target=node --format=esm --external='*' --outdir=/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/no-mistakes-evidence/01KYNAM0AREFQEG46HNHE47Z34/build-check`
- <code>Focused `rg -q` acceptance checks for custody separation, parent canonical authority, generic-agent distinction, and honest certification blocking</code>
- `git diff --check 196b439748eb72f920b95566974baebfcc5cbe2a..78b023be230e225ff4616ea40c53e2bf72c69116 -- cmd/vault-hunter-registry/main.go cmd/vault-hunter-registry/main_test.go pi/.pi/agent/extensions/vault-hunter-crew.ts pi/.pi/agent/extensions/vault-hunter-crew-child.ts`
- <code>Checked `HERDR_ENV` and `HERDR_PANE_ID` availability for interactive product verification</code>
- <code>`git status --short` confirmed testing left the worktree unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
