### PR TITLE
feat(atlas): add hierarchical Run browser experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,14 @@ atlas run retire <id> --expected-revision 7
 atlas capabilities --output json
 ```
 
-The interactive browser skips active Runs whose Project, Feature, or Task preview cannot be rendered and emits one
-startup warning with the Run ID and work-reference path. Machine-readable Run listings remain unchanged.
+The interactive browser groups canonical work as Project → Feature → Task → Run, including not-started Tasks even
+when they have no Run or exceed machine collection byte limits. Done Tasks are hidden by default; select a Feature
+and press Ctrl-D to toggle only that Feature's completed work. Press `p`, `f`, `t`, or `r` to switch previews. Feature
+previews summarize Now/Next work with the crew journey (activate, baseline, converge, review, land, cleanup), while
+Run previews retain the detailed lifecycle journal.
+
+The browser skips active Runs whose Project, Feature, or Task preview cannot be rendered and emits one startup
+warning with the Run ID and work-reference path. Machine-readable Run listings remain unchanged.
 
 The checked-in Pi config intentionally excludes `auth.json`, sessions, caches, and runtime state. MCP credentials should be provided out of band.
 

--- a/cmd/atlas/browser.go
+++ b/cmd/atlas/browser.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 
 	atlaspkg "github.com/aviral/dotfiles/internal/atlas"
 	"github.com/aviral/dotfiles/internal/vaultregistry"
@@ -22,9 +25,34 @@ type browserEntry struct {
 	featureName    string
 	taskID         string
 	taskName       string
+	taskStatus     string
 	projectPreview string
 	featurePreview string
 	taskPreview    string
+}
+
+type browserStyles struct {
+	project, feature, tree, row, rowMeta, selected, selectedMeta lipgloss.Style
+	green, yellow, red, blue, badge                              lipgloss.Style
+}
+
+func newBrowserStyles() browserStyles {
+	renderer := lipgloss.NewRenderer(io.Discard)
+	renderer.SetColorProfile(termenv.TrueColor)
+	return browserStyles{
+		project:      renderer.NewStyle().Bold(true).Foreground(lipgloss.Color("#fbf1c7")),
+		feature:      renderer.NewStyle().Foreground(lipgloss.Color("#e9b143")),
+		tree:         renderer.NewStyle().Foreground(lipgloss.Color("#e9b143")),
+		row:          renderer.NewStyle().Foreground(lipgloss.Color("#ebdbb2")),
+		rowMeta:      renderer.NewStyle().Foreground(lipgloss.Color("#928374")),
+		selected:     renderer.NewStyle().Bold(true).Foreground(lipgloss.Color("#fbf1c7")).Background(lipgloss.Color("#45403d")),
+		selectedMeta: renderer.NewStyle().Foreground(lipgloss.Color("#80aa9e")).Background(lipgloss.Color("#45403d")),
+		green:        renderer.NewStyle().Foreground(lipgloss.Color("#b8bb26")),
+		yellow:       renderer.NewStyle().Foreground(lipgloss.Color("#e9b143")),
+		red:          renderer.NewStyle().Foreground(lipgloss.Color("#f2594b")),
+		blue:         renderer.NewStyle().Foreground(lipgloss.Color("#80aa9e")),
+		badge:        renderer.NewStyle().Bold(true).Foreground(lipgloss.Color("#80aa9e")).Padding(0, 1),
+	}
 }
 
 type browserPanel string
@@ -43,6 +71,7 @@ type browserModel struct {
 	width, height int
 	emptyNote     string
 	colorEnabled  bool
+	showDone      map[string]bool
 	reload        func() ([]browserEntry, error)
 }
 
@@ -52,7 +81,27 @@ type browserRefreshMsg struct {
 }
 
 func newBrowserModel(entries []browserEntry) browserModel {
-	return browserModel{entries: entries, panel: browserPanelRun, width: 120, height: 32, emptyNote: "no active Runs"}
+	return browserModel{entries: entries, panel: browserPanelRun, width: 120, height: 32, emptyNote: "no active or not-started Tasks", showDone: map[string]bool{}}
+}
+
+func featureKey(entry browserEntry) string { return entry.projectName + "/" + entry.featureName }
+func entryKey(entry browserEntry) string {
+	if entry.runID != "" {
+		return entry.runID
+	}
+	return entry.taskID
+}
+func (m browserModel) visibleEntries() []browserEntry {
+	visible := make([]browserEntry, 0, len(m.entries))
+	for _, entry := range m.entries {
+		if entry.taskStatus == "done" || entry.taskStatus == "completed" {
+			if !m.showDone[featureKey(entry)] {
+				continue
+			}
+		}
+		visible = append(visible, entry)
+	}
+	return visible
 }
 
 func (m browserModel) withReload(reload func() ([]browserEntry, error)) browserModel {
@@ -76,12 +125,13 @@ func (m browserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case browserRefreshMsg:
 		if msg.err == nil {
 			selectedID := ""
-			if len(m.entries) != 0 {
-				selectedID = m.entries[m.selected].runID
+			visible := m.visibleEntries()
+			if len(visible) != 0 {
+				selectedID = entryKey(visible[m.selected])
 			}
 			m.entries, m.selected = msg.entries, 0
-			for i, entry := range m.entries {
-				if entry.runID == selectedID {
+			for i, entry := range m.visibleEntries() {
+				if entryKey(entry) == selectedID {
 					m.selected = i
 					break
 				}
@@ -98,7 +148,7 @@ func (m browserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "j", "down":
-			if m.selected < len(m.entries)-1 {
+			if m.selected < len(m.visibleEntries())-1 {
 				m.selected++
 			}
 		case "k", "up":
@@ -110,8 +160,21 @@ func (m browserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.selected = 0
 			}
 		case "G":
-			if len(m.entries) != 0 {
-				m.selected = len(m.entries) - 1
+			if visible := m.visibleEntries(); len(visible) != 0 {
+				m.selected = len(visible) - 1
+			}
+		case "ctrl+d":
+			visible := m.visibleEntries()
+			if len(visible) != 0 {
+				key, selectedID := featureKey(visible[m.selected]), entryKey(visible[m.selected])
+				m.showDone[key] = !m.showDone[key]
+				m.selected = 0
+				for i, entry := range m.visibleEntries() {
+					if entryKey(entry) == selectedID {
+						m.selected = i
+						break
+					}
+				}
 			}
 		case "p":
 			m.panel = browserPanelProject
@@ -141,8 +204,8 @@ func (m browserModel) View() string {
 	left := m.leftPane(bodyRows)
 	right := m.rightPane(rightWidth, bodyRows)
 	rows := []string{
-		clipText(fmt.Sprintf("ATLAS · %d active Runs · %s preview", len(m.entries), strings.ToUpper(string(m.panel))), m.width),
-		clipText("j/k select · g/G ends · p project · f feature · t task · r run · q quit", m.width),
+		clipText(fmt.Sprintf("ATLAS · %d visible Tasks · %s preview", len(m.visibleEntries()), strings.ToUpper(string(m.panel))), m.width),
+		clipText("j/k select · g/G ends · Ctrl-D done · p project · f feature · t task · r run · q quit", m.width),
 	}
 	for i := 0; i < bodyRows; i++ {
 		rows = append(rows, padText(valueAt(left, i), leftWidth)+"│"+clipText(valueAt(right, i), rightWidth))
@@ -151,35 +214,342 @@ func (m browserModel) View() string {
 }
 
 func (m browserModel) leftPane(rows int) []string {
-	lines := []string{"RUNS", strings.Repeat("─", maxInt(m.width*32/100, 28))}
-	if len(m.entries) == 0 {
-		lines = append(lines, m.emptyNote)
-		return lines
+	width := maxInt(m.width*32/100, 28)
+	entries := m.visibleEntries()
+	if len(entries) == 0 {
+		return []string{"RUNS", strings.Repeat("─", width), m.emptyNote}
 	}
-	visible := maxInt((rows-len(lines))/2, 1)
-	start := maxInt(m.selected-visible/2, 0)
-	if start+visible > len(m.entries) {
-		start = maxInt(len(m.entries)-visible, 0)
-	}
-	for i := start; i < minInt(start+visible, len(m.entries)); i++ {
-		entry := m.entries[i]
-		marker := "  "
-		if i == m.selected {
-			marker = "> "
+	styles := newBrowserStyles()
+	lines := []string{"RUNS", strings.Repeat("─", width)}
+	selectedLine := 0
+	project, feature := "", ""
+	featureContinues := false
+	for i, entry := range entries {
+		if entry.projectName != project {
+			project, feature = entry.projectName, ""
+			line := project
+			if m.colorEnabled {
+				line = styles.project.Render(line)
+			}
+			lines = append(lines, line)
 		}
-		lines = append(lines, fmt.Sprintf("%s%s · %s", marker, entry.runID, entry.runName), fmt.Sprintf("  %s / %s / %s", entry.projectName, entry.featureName, entry.taskID))
+		if entry.featureName != feature {
+			feature = entry.featureName
+			featureContinues = laterFeatureInProject(entries, i)
+			branch := "└─ "
+			if featureContinues {
+				branch = "├─ "
+			}
+			line := branch + feature
+			if m.colorEnabled {
+				line = styles.tree.Render(branch) + styles.feature.Render(feature)
+			}
+			lines = append(lines, line)
+		}
+		if i == m.selected {
+			selectedLine = len(lines)
+		}
+		outer := "   "
+		if featureContinues {
+			outer = "│  "
+		}
+		taskContinues := laterTaskInFeature(entries, i)
+		taskBranch := outer + "└─ "
+		childBranch := outer + "   └─ "
+		if taskContinues {
+			taskBranch, childBranch = outer+"├─ ", outer+"│  └─ "
+		}
+		lines = append(lines, renderBrowserRun(entry, i == m.selected, width, m.colorEnabled, styles, taskBranch, childBranch)...)
 	}
+	start := maxInt(selectedLine-rows/2, 0)
+	if start+rows > len(lines) {
+		start = maxInt(len(lines)-rows, 0)
+	}
+	return lines[start:minInt(start+rows, len(lines))]
+}
+
+func laterFeatureInProject(entries []browserEntry, index int) bool {
+	current := entries[index]
+	for i := index + 1; i < len(entries) && entries[i].projectName == current.projectName; i++ {
+		if entries[i].featureName != current.featureName {
+			return true
+		}
+	}
+	return false
+}
+
+func laterTaskInFeature(entries []browserEntry, index int) bool {
+	current := entries[index]
+	return index+1 < len(entries) && entries[index+1].projectName == current.projectName && entries[index+1].featureName == current.featureName
+}
+
+func renderBrowserRun(entry browserEntry, selected bool, width int, color bool, styles browserStyles, taskBranch, childBranch string) []string {
+	taskState, taskBadge := "yellow", "in progress"
+	if entry.taskStatus == "pending-work" {
+		taskState, taskBadge = "blue", "not started"
+	}
+	if entry.taskStatus == "done" || entry.taskStatus == "completed" {
+		taskState, taskBadge = "green", "done"
+	}
+	title := entry.taskName
+	if title == "" {
+		title = entry.runName
+	}
+	first := treeRow(taskBranch, title, taskBadge, taskState, selected, width, color, styles)
+	if entry.runID == "" {
+		return []string{first, treeRow(childBranch, "no Run registered", "", "blue", selected, width, color, styles)}
+	}
+	runState, runBadge := browserRunStatus(entry)
+	runText := fmt.Sprintf("%s · rev %d", shortBrowserID(entry.runID), entry.run.Revision)
+	return []string{first, treeRow(childBranch, runText, runBadge, runState, selected, width, color, styles)}
+}
+
+func treeRow(branch, text, badge, state string, selected bool, width int, color bool, styles browserStyles) string {
+	marker := "● "
+	if state == "blue" {
+		marker = "○ "
+	}
+	badgeWidth := 0
+	if badge != "" {
+		badgeWidth = len([]rune(badge)) + 2
+	}
+	available := maxInt(width-ansi.StringWidth(branch)-2-badgeWidth, 1)
+	text = clipText(text, available)
+	gap := strings.Repeat(" ", maxInt(1, available-ansi.StringWidth(text)))
+	if !color {
+		return branch + marker + text + gap + badge
+	}
+	treeStyle, textStyle, badgeStyle := styles.tree, styles.row, styles.badge
+	dotStyle := styles.yellow
+	if state == "green" {
+		dotStyle = styles.green
+	}
+	if state == "red" {
+		dotStyle = styles.red
+	}
+	if state == "blue" {
+		dotStyle = styles.blue
+	}
+	if selected {
+		bg := lipgloss.Color("#45403d")
+		treeStyle, dotStyle, badgeStyle = treeStyle.Background(bg), dotStyle.Background(bg), badgeStyle.Background(bg)
+		textStyle = styles.selected
+	}
+	result := treeStyle.Render(branch) + dotStyle.Render(marker[:len([]byte(marker))-1]) + textStyle.Render(" "+text+gap)
+	if badge != "" {
+		result += badgeStyle.Render(badge)
+	}
+	return result
+}
+
+func browserRunStatus(entry browserEntry) (string, string) {
+	if entry.taskStatus == "done" {
+		return "green", "done"
+	}
+	goal, state := "", "active"
+	for i := len(entry.run.Lifecycle) - 1; i >= 0; i-- {
+		if entry.run.Lifecycle[i].GoalID != "" {
+			goal, state = entry.run.Lifecycle[i].GoalID, entry.run.Lifecycle[i].State
+			break
+		}
+	}
+	for i := len(entry.run.Observations) - 1; i >= 0 && goal == ""; i-- {
+		if entry.run.Observations[i].GoalID != "" {
+			goal, state = entry.run.Observations[i].GoalID, string(entry.run.Observations[i].State)
+		}
+	}
+	lower := strings.ToLower(state)
+	color := "yellow"
+	if strings.Contains(lower, "fail") || strings.Contains(lower, "block") || strings.Contains(lower, "reject") || lower == "red" {
+		color = "red"
+	}
+	if strings.Contains(lower, "complete") || strings.Contains(lower, "accept") || lower == "done" || lower == "passed" || lower == "green" {
+		color = "green"
+	}
+	badge := state
+	parts := strings.Split(goal, ".")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if strings.HasPrefix(parts[i], "V") {
+			badge = parts[i]
+			break
+		}
+	}
+	if badge == "" {
+		badge = "run"
+	}
+	return color, clipText(badge, 8)
+}
+
+type featureTask struct{ ID, LocalID, Name, Status string }
+
+func renderFeatureFocus(selected browserEntry, entries []browserEntry, width, rows int, color bool) string {
+	var envelope struct {
+		Data struct {
+			Name  string `json:"name"`
+			Tasks []struct {
+				ID      string `json:"id"`
+				LocalID string `json:"local_id"`
+				Name    string `json:"name"`
+				Status  string `json:"status"`
+			} `json:"tasks"`
+		} `json:"data"`
+	}
+	if json.Unmarshal([]byte(selected.featurePreview), &envelope) != nil {
+		return selected.featurePreview
+	}
+	active, next, done := []featureTask{}, []featureTask{}, 0
+	for _, task := range envelope.Data.Tasks {
+		item := featureTask{task.ID, task.LocalID, task.Name, task.Status}
+		switch task.Status {
+		case "in-progress":
+			active = append(active, item)
+		case "pending-work":
+			next = append(next, item)
+		default:
+			done++
+		}
+	}
+	styles := newBrowserStyles()
+	lines := []string{fmt.Sprintf("%s · %d now · %d next · %d complete", envelope.Data.Name, len(active), len(next), done), ""}
+	appendLane := func(label string, tasks []featureTask) {
+		if color {
+			label = styles.feature.Bold(true).Render(label)
+		}
+		lines = append(lines, label)
+		for _, task := range tasks {
+			var run *browserEntry
+			for i := range entries {
+				if entries[i].taskID == task.ID {
+					run = &entries[i]
+					break
+				}
+			}
+			lines = append(lines, renderFeatureTask(task, run, selected.runID, width, color, styles)...)
+		}
+	}
+	appendLane(fmt.Sprintf("NOW · %d", len(active)), active)
+	lines = append(lines, "")
+	appendLane(fmt.Sprintf("NEXT · %d", len(next)), next)
 	if len(lines) > rows {
 		lines = lines[:rows]
 	}
-	return lines
+	return strings.Join(lines, "\n")
+}
+
+func renderFeatureTask(task featureTask, run *browserEntry, selectedRunID string, width int, color bool, styles browserStyles) []string {
+	badge, dot, stateColor := "not started", "○", "blue"
+	selected := false
+	if run != nil {
+		stateColor, badge = browserRunStatus(*run)
+		dot, selected = "●", run.runID == selectedRunID
+	}
+	title := clipText(task.LocalID+" · "+task.Name, maxInt(width-len([]rune(badge))-6, 1))
+	gap := strings.Repeat(" ", maxInt(1, width-2-ansi.StringWidth(title)-len([]rune(badge))-2))
+	if !color {
+		return []string{"  " + dot + " " + title + gap + badge, "    " + featureStages(run)}
+	}
+	dotStyle := styles.yellow
+	if stateColor == "green" {
+		dotStyle = styles.green
+	}
+	if stateColor == "red" {
+		dotStyle = styles.red
+	}
+	if stateColor == "blue" {
+		dotStyle = styles.blue
+	}
+	primary, meta, badgeStyle := styles.row, styles.rowMeta, styles.badge
+	if selected {
+		primary, meta = styles.selected, styles.selectedMeta
+		dotStyle = dotStyle.Background(lipgloss.Color("#45403d"))
+		badgeStyle = badgeStyle.Background(lipgloss.Color("#45403d"))
+	}
+	prefix := "  "
+	if selected {
+		prefix = "▌ "
+	}
+	first := primary.Render(prefix) + dotStyle.Render(dot) + primary.Render(" "+title+gap) + badgeStyle.Render(badge)
+	stage := "    " + featureStages(run)
+	if selected {
+		stage = meta.Render(padText(stage, width))
+	}
+	return []string{first, stage}
+}
+
+func featureStages(entry *browserEntry) string {
+	phases := []string{"activate", "baseline", "converge", "review", "land", "cleanup"}
+	if entry == nil {
+		parts := make([]string, len(phases))
+		for i, phase := range phases {
+			parts[i] = phase + " ○"
+		}
+		return strings.Join(parts, " ─ ")
+	}
+	current, failed := 0, false
+	observe := func(goal, kind, state string) {
+		phase := crewPhase(goal + " " + kind)
+		if phase > current {
+			current, failed = phase, false
+		}
+		if phase == current {
+			lower := strings.ToLower(state)
+			failed = strings.Contains(lower, "fail") || strings.Contains(lower, "block") || strings.Contains(lower, "reject")
+		}
+	}
+	for _, life := range entry.run.Lifecycle {
+		observe(life.GoalID, life.Kind, life.State)
+	}
+	for _, observation := range entry.run.Observations {
+		observe(observation.GoalID, string(observation.Kind), string(observation.State))
+	}
+	parts := make([]string, len(phases))
+	for i, phase := range phases {
+		mark := "○"
+		if i < current {
+			mark = "✓"
+		}
+		if i == current {
+			mark = "●"
+			if failed {
+				mark = "!"
+			}
+		}
+		parts[i] = phase + " " + mark
+	}
+	return strings.Join(parts, " ─ ")
+}
+
+func crewPhase(value string) int {
+	value = strings.ToLower(value)
+	switch {
+	case strings.Contains(value, "cleanup"), strings.Contains(value, "checkpoint-two"):
+		return 5
+	case strings.Contains(value, "delivery"), strings.Contains(value, "merge"), strings.Contains(value, "pull-request"), strings.Contains(value, " ci"), strings.Contains(value, "land"):
+		return 4
+	case strings.Contains(value, "review"), strings.Contains(value, "refactor"):
+		return 3
+	case strings.Contains(value, "baseline"):
+		return 1
+	case strings.Contains(value, "implement"), strings.Contains(value, "convergence"), strings.Contains(value, "verifier"), strings.Contains(value, ".v"), strings.Contains(value, "worker"), strings.Contains(value, "subagent"):
+		return 2
+	default:
+		return 0
+	}
+}
+
+func shortBrowserID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
 }
 
 func (m browserModel) rightPane(width, rows int) []string {
-	if len(m.entries) == 0 {
-		return []string{"PREVIEW", strings.Repeat("─", maxInt(width, 1)), "No active Run selected."}
+	visible := m.visibleEntries()
+	if len(visible) == 0 {
+		return []string{"PREVIEW", strings.Repeat("─", maxInt(width, 1)), "No visible Task selected."}
 	}
-	entry := m.entries[m.selected]
+	entry := visible[m.selected]
 	heading := []string{
 		fmt.Sprintf("%s · %s", strings.ToUpper(string(m.panel)), entry.runID),
 		strings.Repeat("─", maxInt(width, 1)),
@@ -189,11 +559,15 @@ func (m browserModel) rightPane(width, rows int) []string {
 	case browserPanelProject:
 		body = entry.projectPreview
 	case browserPanelFeature:
-		body = entry.featurePreview
+		body = renderFeatureFocus(entry, m.entries, width, rows-len(heading), m.colorEnabled)
 	case browserPanelTask:
 		body = entry.taskPreview
 	default:
-		body = atlaspkg.NewJournalModel(entry.run, width, maxInt(rows-len(heading), 24)).ViewColor(m.colorEnabled)
+		if entry.runID == "" {
+			body = renderNotStartedTask(entry, width, m.colorEnabled)
+		} else {
+			body = atlaspkg.NewJournalModel(entry.run, width, maxInt(rows-len(heading), 24)).ViewColor(m.colorEnabled)
+		}
 	}
 	lines := append(heading, strings.Split(body, "\n")...)
 	if len(lines) > rows {
@@ -201,6 +575,36 @@ func (m browserModel) rightPane(width, rows int) []string {
 	}
 	return lines
 }
+
+func renderNotStartedTask(entry browserEntry, width int, color bool) string {
+	var envelope struct {
+		Data struct {
+			LocalID   string `json:"local_id"`
+			Name      string `json:"name"`
+			Status    string `json:"status"`
+			Intent    string `json:"intent"`
+			Verifiers []any  `json:"verifiers"`
+			Evidence  []any  `json:"evidence"`
+		} `json:"data"`
+	}
+	if json.Unmarshal([]byte(entry.taskPreview), &envelope) != nil {
+		return entry.taskPreview
+	}
+	styles := newBrowserStyles()
+	lines := []string{envelope.Data.LocalID + " · " + envelope.Data.Name, "status · " + envelope.Data.Status, "", "STAGES", "activate ○ ─ baseline ○ ─ converge ○ ─ review ○ ─ land ○ ─ cleanup ○", "", "PROVENANCE PREVIEW", "intent · " + envelope.Data.Intent, fmt.Sprintf("verifiers · %d · evidence · %d", len(envelope.Data.Verifiers), len(envelope.Data.Evidence)), "", "No Run has been registered for this Task."}
+	if color {
+		lines[0] = styles.feature.Bold(true).Render(lines[0])
+		lines[1] = styles.selectedMeta.Render(lines[1])
+		lines[3] = styles.feature.Render(lines[3])
+		lines[6] = styles.feature.Render(lines[6])
+	}
+	for i := range lines {
+		lines[i] = clipText(lines[i], width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func canonicalTaskID(id string) string { return strings.TrimPrefix(id, "/Users/aviral/vault/") }
 
 func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Reader, warnings io.Writer) ([]browserEntry, error) {
 	runs, err := reader.List()
@@ -225,6 +629,7 @@ func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Read
 		projectID, projectName := mapPair(item, "project")
 		featureID, featureName := mapPair(item, "feature")
 		taskID, taskName := mapPair(item, "task")
+		taskValue, _ := item["task"].(map[string]any)
 		projectPreview, err := previewEnvelope(vaultRoot, stateRoot, "projects", atlaspkg.MachineSelector{ID: projectID})
 		if err != nil {
 			warnUnrenderableRun(warnings, run, err)
@@ -248,11 +653,48 @@ func buildBrowserEntries(vaultRoot, stateRoot string, reader *vaultregistry.Read
 			featureName:    featureName,
 			taskID:         taskID,
 			taskName:       taskName,
+			taskStatus:     mapString(taskValue, "status"),
 			projectPreview: projectPreview,
 			featurePreview: featurePreview,
 			taskPreview:    taskPreview,
 		})
 	}
+	existing := map[string]bool{}
+	for _, entry := range entries {
+		existing[canonicalTaskID(entry.taskID)] = true
+	}
+	tasks, err := atlaspkg.BuildTaskSummaries(vaultRoot, stateRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, task := range tasks {
+		taskID := mapString(task, "id")
+		if existing[canonicalTaskID(taskID)] {
+			continue
+		}
+		projectID, projectName := mapPair(task, "project")
+		featureID, featureName := mapPair(task, "feature")
+		projectPreview, projectErr := previewEnvelope(vaultRoot, stateRoot, "projects", atlaspkg.MachineSelector{ID: projectID})
+		featurePreview, featureErr := previewEnvelope(vaultRoot, stateRoot, "features", atlaspkg.MachineSelector{ID: featureID})
+		taskPreview, taskErr := previewEnvelope(vaultRoot, stateRoot, "tasks", atlaspkg.MachineSelector{ID: taskID})
+		if projectErr != nil || featureErr != nil || taskErr != nil {
+			continue
+		}
+		entries = append(entries, browserEntry{runName: mapString(task, "name"), projectName: projectName, featureName: featureName, taskID: taskID, taskName: mapString(task, "name"), taskStatus: mapString(task, "status"), projectPreview: projectPreview, featurePreview: featurePreview, taskPreview: taskPreview})
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		left, right := entries[i], entries[j]
+		if left.projectName != right.projectName {
+			return left.projectName < right.projectName
+		}
+		if left.featureName != right.featureName {
+			return left.featureName < right.featureName
+		}
+		if left.taskName != right.taskName {
+			return left.taskName < right.taskName
+		}
+		return left.runID < right.runID
+	})
 	return entries, nil
 }
 

--- a/cmd/atlas/browser.go
+++ b/cmd/atlas/browser.go
@@ -91,16 +91,61 @@ func entryKey(entry browserEntry) string {
 	}
 	return entry.taskID
 }
+func isDoneStatus(status string) bool    { return status == "done" || status == "completed" }
+func isPendingStatus(status string) bool { return status == "pending" || status == "pending-work" }
+func browserTaskKey(entry browserEntry) string {
+	id := canonicalTaskID(entry.taskID)
+	if id == "" {
+		id = entry.taskName
+	}
+	if id == "" {
+		id = entry.runID
+	}
+	return featureKey(entry) + "/" + id
+}
+
 func (m browserModel) visibleEntries() []browserEntry {
 	visible := make([]browserEntry, 0, len(m.entries))
+	seenTasks, seenFeatures := map[string]bool{}, map[string]bool{}
 	for _, entry := range m.entries {
-		if entry.taskStatus == "done" || entry.taskStatus == "completed" {
-			if !m.showDone[featureKey(entry)] {
-				continue
-			}
+		key := featureKey(entry)
+		seenFeatures[key] = true
+		if isDoneStatus(entry.taskStatus) && !m.showDone[key] {
+			continue
 		}
+		taskKey := browserTaskKey(entry)
+		if seenTasks[taskKey] {
+			continue
+		}
+		seenTasks[taskKey] = true
 		visible = append(visible, entry)
 	}
+	for _, entry := range m.entries {
+		key := featureKey(entry)
+		if !seenFeatures[key] {
+			continue
+		}
+		hasVisibleTask := false
+		for _, item := range visible {
+			if featureKey(item) == key {
+				hasVisibleTask = true
+				break
+			}
+		}
+		if !hasVisibleTask {
+			visible = append(visible, browserEntry{projectName: entry.projectName, featureName: entry.featureName, featurePreview: entry.featurePreview})
+		}
+		delete(seenFeatures, key)
+	}
+	sort.SliceStable(visible, func(i, j int) bool {
+		if visible[i].projectName != visible[j].projectName {
+			return visible[i].projectName < visible[j].projectName
+		}
+		if visible[i].featureName != visible[j].featureName {
+			return visible[i].featureName < visible[j].featureName
+		}
+		return visible[i].taskID == ""
+	})
 	return visible
 }
 
@@ -241,13 +286,21 @@ func (m browserModel) leftPane(rows int) []string {
 				branch = "├─ "
 			}
 			line := branch + feature
+			featureSelected := i == m.selected && entry.taskID == ""
 			if m.colorEnabled {
-				line = styles.tree.Render(branch) + styles.feature.Render(feature)
+				if featureSelected {
+					line = styles.selected.Render(branch + feature)
+				} else {
+					line = styles.tree.Render(branch) + styles.feature.Render(feature)
+				}
 			}
 			lines = append(lines, line)
 		}
 		if i == m.selected {
-			selectedLine = len(lines)
+			selectedLine = len(lines) - 1
+		}
+		if entry.taskID == "" {
+			continue
 		}
 		outer := "   "
 		if featureContinues {
@@ -259,7 +312,7 @@ func (m browserModel) leftPane(rows int) []string {
 		if taskContinues {
 			taskBranch, childBranch = outer+"├─ ", outer+"│  └─ "
 		}
-		lines = append(lines, renderBrowserRun(entry, i == m.selected, width, m.colorEnabled, styles, taskBranch, childBranch)...)
+		lines = append(lines, renderBrowserTask(entry, m.taskRuns(entry), i == m.selected, width, m.colorEnabled, styles, taskBranch, childBranch)...)
 	}
 	start := maxInt(selectedLine-rows/2, 0)
 	if start+rows > len(lines) {
@@ -283,25 +336,42 @@ func laterTaskInFeature(entries []browserEntry, index int) bool {
 	return index+1 < len(entries) && entries[index+1].projectName == current.projectName && entries[index+1].featureName == current.featureName
 }
 
-func renderBrowserRun(entry browserEntry, selected bool, width int, color bool, styles browserStyles, taskBranch, childBranch string) []string {
+func (m browserModel) taskRuns(task browserEntry) []browserEntry {
+	runs := []browserEntry{}
+	for _, entry := range m.entries {
+		if browserTaskKey(entry) == browserTaskKey(task) && entry.runID != "" {
+			runs = append(runs, entry)
+		}
+	}
+	return runs
+}
+
+func renderBrowserTask(entry browserEntry, runs []browserEntry, selected bool, width int, color bool, styles browserStyles, taskBranch, childBranch string) []string {
 	taskState, taskBadge := "yellow", "in progress"
-	if entry.taskStatus == "pending-work" {
+	if isPendingStatus(entry.taskStatus) {
 		taskState, taskBadge = "blue", "not started"
 	}
-	if entry.taskStatus == "done" || entry.taskStatus == "completed" {
+	if isDoneStatus(entry.taskStatus) {
 		taskState, taskBadge = "green", "done"
 	}
 	title := entry.taskName
 	if title == "" {
 		title = entry.runName
 	}
-	first := treeRow(taskBranch, title, taskBadge, taskState, selected, width, color, styles)
-	if entry.runID == "" {
-		return []string{first, treeRow(childBranch, "no Run registered", "", "blue", selected, width, color, styles)}
+	lines := []string{treeRow(taskBranch, title, taskBadge, taskState, selected, width, color, styles)}
+	if len(runs) == 0 {
+		return append(lines, treeRow(childBranch, "no Run registered", "", "blue", false, width, color, styles))
 	}
-	runState, runBadge := browserRunStatus(entry)
-	runText := fmt.Sprintf("%s · rev %d", shortBrowserID(entry.runID), entry.run.Revision)
-	return []string{first, treeRow(childBranch, runText, runBadge, runState, selected, width, color, styles)}
+	for i, run := range runs {
+		branch := strings.TrimSuffix(childBranch, "└─ ") + "├─ "
+		if i == len(runs)-1 {
+			branch = childBranch
+		}
+		runState, runBadge := browserRunStatus(run)
+		runText := fmt.Sprintf("%s · rev %d", shortBrowserID(run.runID), run.run.Revision)
+		lines = append(lines, treeRow(branch, runText, runBadge, runState, false, width, color, styles))
+	}
+	return lines
 }
 
 func treeRow(branch, text, badge, state string, selected bool, width int, color bool, styles browserStyles) string {
@@ -403,7 +473,7 @@ func renderFeatureFocus(selected browserEntry, entries []browserEntry, width, ro
 		switch task.Status {
 		case "in-progress":
 			active = append(active, item)
-		case "pending-work":
+		case "pending", "pending-work":
 			next = append(next, item)
 		default:
 			done++
@@ -419,9 +489,8 @@ func renderFeatureFocus(selected browserEntry, entries []browserEntry, width, ro
 		for _, task := range tasks {
 			var run *browserEntry
 			for i := range entries {
-				if entries[i].taskID == task.ID {
+				if canonicalTaskID(entries[i].taskID) == canonicalTaskID(task.ID) && entries[i].runID != "" {
 					run = &entries[i]
-					break
 				}
 			}
 			lines = append(lines, renderFeatureTask(task, run, selected.runID, width, color, styles)...)
@@ -458,9 +527,9 @@ func renderFeatureTask(task featureTask, run *browserEntry, selectedRunID string
 	if stateColor == "blue" {
 		dotStyle = styles.blue
 	}
-	primary, meta, badgeStyle := styles.row, styles.rowMeta, styles.badge
+	primary, badgeStyle := styles.row, styles.badge
 	if selected {
-		primary, meta = styles.selected, styles.selectedMeta
+		primary = styles.selected
 		dotStyle = dotStyle.Background(lipgloss.Color("#45403d"))
 		badgeStyle = badgeStyle.Background(lipgloss.Color("#45403d"))
 	}
@@ -470,8 +539,8 @@ func renderFeatureTask(task featureTask, run *browserEntry, selectedRunID string
 	}
 	first := primary.Render(prefix) + dotStyle.Render(dot) + primary.Render(" "+title+gap) + badgeStyle.Render(badge)
 	stage := "    " + featureStages(run)
-	if selected {
-		stage = meta.Render(padText(stage, width))
+	if color {
+		stage = styles.rowMeta.Render(stage)
 	}
 	return []string{first, stage}
 }

--- a/cmd/atlas/browser_test.go
+++ b/cmd/atlas/browser_test.go
@@ -80,6 +80,81 @@ func TestT18V03BrowserNavigation(t *testing.T) {
 	}
 }
 
+func TestBrowserHierarchyRowsShowLifecycleStatus(t *testing.T) {
+	entries := []browserEntry{{
+		runID: "run-active-123", projectName: "pi-agent", featureName: "vault-hunter-atlas",
+		taskName: "Build Atlas Browser", run: vaultregistry.Run{Revision: 12, Lifecycle: []vaultregistry.Lifecycle{{GoalID: "T18.V02", State: "active"}}},
+	}, {
+		runID: "run-done-456", projectName: "pi-agent", featureName: "vault-hunter-atlas",
+		taskName: "Build Execution Journal", taskStatus: "done", run: vaultregistry.Run{Revision: 8},
+	}, {
+		runID: "run-failed-789", projectName: "neovim", featureName: "agent-context-management",
+		taskName: "Sync Context", run: vaultregistry.Run{Revision: 3, Lifecycle: []vaultregistry.Lifecycle{{GoalID: "T03.V04", State: "failed"}}},
+	}}
+	model := newBrowserModel(entries).withColor(true)
+	model.width, model.height = 140, 32
+	view := model.View()
+	for _, want := range []string{"pi-agent", "vault-hunter-atlas", "Build Atlas Browser", "V02", "done", "neovim", "Sync Context", "V04", "48;2;69;64;60m"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("view missing %q: %q", want, view)
+		}
+	}
+	if strings.Index(view, "pi-agent") > strings.Index(view, "vault-hunter-atlas") || strings.Index(view, "vault-hunter-atlas") > strings.Index(view, "Build Atlas Browser") {
+		t.Fatalf("hierarchy order is not Project, Feature, Run: %q", view)
+	}
+	if strings.Contains(view, "48;2;50;48;47m") || strings.Contains(view, "48;2;60;56;54m") {
+		t.Fatalf("unselected hierarchy rows use a background: %q", view)
+	}
+}
+
+func TestBrowserCtrlDTogglesDoneWithinSelectedFeature(t *testing.T) {
+	model := newBrowserModel([]browserEntry{
+		{taskID: "a-active", taskName: "A active", taskStatus: "in-progress", projectName: "p", featureName: "a"},
+		{taskID: "a-done", taskName: "A done", taskStatus: "done", projectName: "p", featureName: "a"},
+		{taskID: "a-next", taskName: "A next", taskStatus: "pending-work", projectName: "p", featureName: "a"},
+		{taskID: "b-done", taskName: "B done", taskStatus: "done", projectName: "p", featureName: "b"},
+	})
+	if got := model.visibleEntries(); len(got) != 2 || got[0].taskID != "a-active" || got[1].taskID != "a-next" {
+		t.Fatalf("default visible = %#v", got)
+	}
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	model = next.(browserModel)
+	got := model.visibleEntries()
+	if len(got) != 3 || got[1].taskID != "a-done" {
+		t.Fatalf("feature-local expanded visible = %#v", got)
+	}
+	for _, entry := range got {
+		if entry.taskID == "b-done" {
+			t.Fatalf("Ctrl-D expanded another Feature: %#v", got)
+		}
+	}
+}
+
+func TestPendingFeatureTaskIsUnfilledAndUnhighlighted(t *testing.T) {
+	lines := renderFeatureTask(featureTask{LocalID: "T14", Name: "Harden Journal", Status: "pending-work"}, nil, "selected-run", 80, true, newBrowserStyles())
+	view := strings.Join(lines, "\n")
+	if !strings.Contains(view, "○") {
+		t.Fatalf("pending Task lacks empty circle: %q", view)
+	}
+	if strings.Contains(view, "48;2;69;64;60m") {
+		t.Fatalf("pending Task inherited selected background: %q", view)
+	}
+}
+
+func TestFeaturePreviewFocusesNowNextAndStages(t *testing.T) {
+	featureJSON := `{"data":{"name":"vault-hunter-atlas","tasks":[{"id":"task-active","local_id":"T11","name":"Build Browser","status":"in-progress"},{"id":"task-next","local_id":"T14","name":"Harden Journal","status":"pending-work"},{"id":"task-done","local_id":"T08","name":"Execution Journal","status":"done"}]}}`
+	entries := []browserEntry{{runID: "run-11", taskID: "task-active", taskName: "Build Browser", featurePreview: featureJSON, run: vaultregistry.Run{Revision: 2, Lifecycle: []vaultregistry.Lifecycle{{GoalID: "T11.V01", State: "done"}, {GoalID: "T11.V02", State: "active"}}}}}
+	view := renderFeatureFocus(entries[0], entries, 80, 24, false)
+	for _, want := range []string{"1 now · 1 next · 1 complete", "NOW · 1", "T11 · Build Browser", "activate ✓ ─ baseline ✓ ─ converge ● ─ review ○ ─ land ○ ─ cleanup ○", "NEXT · 1", "T14 · Harden Journal", "activate ○ ─ baseline ○ ─ converge ○ ─ review ○ ─ land ○ ─ cleanup ○"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("feature view missing %q: %q", want, view)
+		}
+	}
+	if strings.Contains(view, "Execution Journal") {
+		t.Fatalf("completed Task was not collapsed: %q", view)
+	}
+}
+
 func TestT18V03WatchEmitsCompleteEnvelopes(t *testing.T) {
 	fixture := filepath.Join("..", "..", "scripts", "fixtures", "vault-hunter-atlas-t18-v02")
 	t.Setenv("ATLAS_VAULT_ROOT", filepath.Join(fixture, "vault"))
@@ -130,11 +205,13 @@ func TestT18V03BrowserCompletenessIgnoresMachineByteCap(t *testing.T) {
 	vaultRoot := t.TempDir()
 	stateRoot := t.TempDir()
 	const taskPath = "1_projects/pi-agent/themes/pi-customization/features/vault-hunter-atlas/tasks/18-build-atlas.md"
+	const pendingTaskPath = "1_projects/pi-agent/themes/pi-customization/features/vault-hunter-atlas/tasks/19-not-started.md"
 	const featurePath = "1_projects/pi-agent/themes/pi-customization/features/vault-hunter-atlas/feature.md"
 	writeBrowserFile(t, vaultRoot, "1_projects/pi-agent/README.md", "---\nworking_directory: /worktrees/dotfiles\nrepository: git@github.com:aviralmansingka/dotfiles\n---\n# pi-agent\n")
 	writeBrowserFile(t, vaultRoot, "1_projects/pi-agent/themes/pi-customization/theme.md", "---\ndescription: Customize Pi Agent and its surrounding workflows.\n---\n# pi-customization\n")
 	writeBrowserFile(t, vaultRoot, featurePath, "---\ndescription: Provide a unified Atlas interface.\n---\n# vault-hunter-atlas\n")
 	writeBrowserFile(t, vaultRoot, taskPath, "---\nstatus: in-progress\n---\n# T18: Build Atlas\n\n## Intent\nRender Atlas.\n")
+	writeBrowserFile(t, vaultRoot, pendingTaskPath, "---\nstatus: pending-work\n---\n# T19: Not Started\n\n## Intent\nShow pending work.\n")
 	producer, err := vaultregistry.OpenProducer(stateRoot)
 	if err != nil {
 		t.Fatal(err)
@@ -162,8 +239,17 @@ func TestT18V03BrowserCompletenessIgnoresMachineByteCap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 6 || entries[0].runID != "run-01" || entries[len(entries)-1].runID != "run-06" {
-		t.Fatalf("browser entries = %#v", entries)
+	if len(entries) != 7 {
+		t.Fatalf("browser entries = %d, want six Runs plus one unstarted Task: %#v", len(entries), entries)
+	}
+	foundPending := false
+	for _, entry := range entries {
+		if entry.taskID == pendingTaskPath && entry.runID == "" {
+			foundPending = true
+		}
+	}
+	if !foundPending {
+		t.Fatalf("browser omitted unstarted Task beyond machine byte cap: %#v", entries)
 	}
 }
 

--- a/cmd/atlas/browser_test.go
+++ b/cmd/atlas/browser_test.go
@@ -23,6 +23,7 @@ func TestT18V03BrowserNavigation(t *testing.T) {
 		projectName:    "pi-agent",
 		featureName:    "vault-hunter-atlas",
 		taskID:         "T09",
+		taskStatus:     "in-progress",
 		projectPreview: "project-preview",
 		featurePreview: "feature-preview",
 		taskPreview:    "task-preview",
@@ -34,8 +35,9 @@ func TestT18V03BrowserNavigation(t *testing.T) {
 		runName:     "pending-review",
 		projectName: "pi-agent",
 		featureName: "vault-hunter-atlas",
-		taskID:      "T09",
-		run:         vaultregistry.Run{RunID: "run-042", Task: vaultregistry.Task{ID: "T09", Title: "Pending review"}},
+		taskID:      "T10",
+		taskStatus:  "in-progress",
+		run:         vaultregistry.Run{RunID: "run-042", Task: vaultregistry.Task{ID: "T10", Title: "Pending review"}},
 	}})
 	model.width, model.height = 140, 32
 	if !strings.Contains(model.View(), "vault-hunter journal") {
@@ -82,14 +84,14 @@ func TestT18V03BrowserNavigation(t *testing.T) {
 
 func TestBrowserHierarchyRowsShowLifecycleStatus(t *testing.T) {
 	entries := []browserEntry{{
-		runID: "run-active-123", projectName: "pi-agent", featureName: "vault-hunter-atlas",
-		taskName: "Build Atlas Browser", run: vaultregistry.Run{Revision: 12, Lifecycle: []vaultregistry.Lifecycle{{GoalID: "T18.V02", State: "active"}}},
+		runID: "run-active-123", taskID: "task-browser", projectName: "pi-agent", featureName: "vault-hunter-atlas",
+		taskName: "Build Atlas Browser", taskStatus: "in-progress", run: vaultregistry.Run{Revision: 12, Lifecycle: []vaultregistry.Lifecycle{{GoalID: "T18.V02", State: "active"}}},
 	}, {
-		runID: "run-done-456", projectName: "pi-agent", featureName: "vault-hunter-atlas",
+		runID: "run-done-456", taskID: "task-journal", projectName: "pi-agent", featureName: "vault-hunter-atlas",
 		taskName: "Build Execution Journal", taskStatus: "done", run: vaultregistry.Run{Revision: 8},
 	}, {
-		runID: "run-failed-789", projectName: "neovim", featureName: "agent-context-management",
-		taskName: "Sync Context", run: vaultregistry.Run{Revision: 3, Lifecycle: []vaultregistry.Lifecycle{{GoalID: "T03.V04", State: "failed"}}},
+		runID: "run-failed-789", taskID: "task-sync", projectName: "neovim", featureName: "agent-context-management",
+		taskName: "Sync Context", taskStatus: "in-progress", run: vaultregistry.Run{Revision: 3, Lifecycle: []vaultregistry.Lifecycle{{GoalID: "T03.V04", State: "failed"}}},
 	}}
 	model := newBrowserModel(entries).withColor(true)
 	model.width, model.height = 140, 32

--- a/cmd/atlas/browser_test.go
+++ b/cmd/atlas/browser_test.go
@@ -94,7 +94,7 @@ func TestBrowserHierarchyRowsShowLifecycleStatus(t *testing.T) {
 	model := newBrowserModel(entries).withColor(true)
 	model.width, model.height = 140, 32
 	view := model.View()
-	for _, want := range []string{"pi-agent", "vault-hunter-atlas", "Build Atlas Browser", "V02", "done", "neovim", "Sync Context", "V04", "48;2;69;64;60m"} {
+	for _, want := range []string{"pi-agent", "vault-hunter-atlas", "Build Atlas Browser", "V02", "neovim", "Sync Context", "V04", "48;2;69;64;60m"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q: %q", want, view)
 		}
@@ -107,6 +107,36 @@ func TestBrowserHierarchyRowsShowLifecycleStatus(t *testing.T) {
 	}
 }
 
+func TestBrowserGroupsRunsUnderOneTask(t *testing.T) {
+	model := newBrowserModel([]browserEntry{
+		{runID: "run-1", taskID: "task", taskName: "Task", projectName: "p", featureName: "f"},
+		{runID: "run-2", taskID: "task", taskName: "Task", projectName: "p", featureName: "f"},
+	})
+	if got := model.visibleEntries(); len(got) != 1 {
+		t.Fatalf("visible task rows = %d, want 1", len(got))
+	}
+	view := strings.Join(model.leftPane(20), "\n")
+	if strings.Count(view, "Task") != 1 || !strings.Contains(view, "run-1") || !strings.Contains(view, "run-2") {
+		t.Fatalf("runs were not grouped beneath Task: %q", view)
+	}
+}
+
+func TestBrowserCtrlDTogglesDoneOnlyFeature(t *testing.T) {
+	model := newBrowserModel([]browserEntry{
+		{taskID: "a-done", taskName: "A done", taskStatus: "done", projectName: "p", featureName: "a"},
+		{taskID: "b-active", taskName: "B active", taskStatus: "in-progress", projectName: "p", featureName: "b"},
+	})
+	visible := model.visibleEntries()
+	if len(visible) != 2 || visible[0].taskID != "" || visible[0].featureName != "a" {
+		t.Fatalf("done-only Feature is not selectable: %#v", visible)
+	}
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	visible = next.(browserModel).visibleEntries()
+	if len(visible) != 2 || visible[0].taskID != "a-done" {
+		t.Fatalf("done-only Feature did not expand locally: %#v", visible)
+	}
+}
+
 func TestBrowserCtrlDTogglesDoneWithinSelectedFeature(t *testing.T) {
 	model := newBrowserModel([]browserEntry{
 		{taskID: "a-active", taskName: "A active", taskStatus: "in-progress", projectName: "p", featureName: "a"},
@@ -114,19 +144,32 @@ func TestBrowserCtrlDTogglesDoneWithinSelectedFeature(t *testing.T) {
 		{taskID: "a-next", taskName: "A next", taskStatus: "pending-work", projectName: "p", featureName: "a"},
 		{taskID: "b-done", taskName: "B done", taskStatus: "done", projectName: "p", featureName: "b"},
 	})
-	if got := model.visibleEntries(); len(got) != 2 || got[0].taskID != "a-active" || got[1].taskID != "a-next" {
+	if got := model.visibleEntries(); len(got) != 3 || got[0].taskID != "a-active" || got[1].taskID != "a-next" || got[2].featureName != "b" || got[2].taskID != "" {
 		t.Fatalf("default visible = %#v", got)
 	}
 	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
 	model = next.(browserModel)
 	got := model.visibleEntries()
-	if len(got) != 3 || got[1].taskID != "a-done" {
+	if len(got) != 4 || got[1].taskID != "a-done" {
 		t.Fatalf("feature-local expanded visible = %#v", got)
 	}
 	for _, entry := range got {
 		if entry.taskID == "b-done" {
 			t.Fatalf("Ctrl-D expanded another Feature: %#v", got)
 		}
+	}
+}
+
+func TestCanonicalPendingStatusIsNotStarted(t *testing.T) {
+	styles := newBrowserStyles()
+	view := strings.Join(renderBrowserTask(browserEntry{taskName: "Pending", taskStatus: "pending"}, nil, false, 80, false, styles, "└─ ", "   └─ "), "\n")
+	if !strings.Contains(view, "○ Pending") || !strings.Contains(view, "not started") {
+		t.Fatalf("canonical pending Task rendered incorrectly: %q", view)
+	}
+	featureJSON := `{"data":{"name":"feature","tasks":[{"id":"task","local_id":"T1","name":"Pending","status":"pending"}]}}`
+	focus := renderFeatureFocus(browserEntry{featurePreview: featureJSON}, nil, 80, 20, false)
+	if !strings.Contains(focus, "1 next") || strings.Contains(focus, "1 complete") {
+		t.Fatalf("canonical pending Task classified incorrectly: %q", focus)
 	}
 }
 

--- a/internal/atlas/api.go
+++ b/internal/atlas/api.go
@@ -254,6 +254,20 @@ func BuildRunSummaries(vaultRoot, stateRoot string, runs []vaultregistry.Run) ([
 	return buildRunSummaries(loaded, runs), nil
 }
 
+// BuildTaskSummaries returns the complete canonical Task collection for the
+// interactive browser; machine envelopes remain independently bounded.
+func BuildTaskSummaries(vaultRoot, stateRoot string) ([]map[string]any, error) {
+	loaded, err := loadStore(vaultRoot, stateRoot)
+	if err != nil {
+		return nil, err
+	}
+	tasks := make([]map[string]any, 0, len(loaded.tasks))
+	for _, task := range loaded.tasks {
+		tasks = append(tasks, loaded.taskObject(task))
+	}
+	return tasks, nil
+}
+
 func buildRunSummaries(loaded *store, runs []vaultregistry.Run) []map[string]any {
 	data := make([]map[string]any, 0, len(runs))
 	for _, run := range runs {

--- a/scripts/verifiers/vault-hunter-atlas-t18-v03
+++ b/scripts/verifiers/vault-hunter-atlas-t18-v03
@@ -116,7 +116,11 @@ status: in-progress
 Render the execution journal.
 """)
     for source in RUN_FIXTURES:
-        shutil.copy2(source, state / "runs" / source.name)
+        destination = state / "runs" / source.name
+        shutil.copy2(source, destination)
+        run = json.loads(destination.read_text(encoding="utf-8"))
+        run["task"]["feature_path"] = "1_projects/pi-agent/themes/pi-customization/features/vault-hunter-atlas/feature.md"
+        destination.write_text(json.dumps(run, indent=2) + "\n", encoding="utf-8")
     (state / "registry.lock").write_text("", encoding="utf-8")
     return state, vault
 
@@ -322,7 +326,7 @@ def main():
 
         artifacts = tmp / "artifacts"
         artifacts.mkdir()
-        sh("go", "test", "-count=1", "./cmd/atlas", "-run", "^TestT18V03")
+        sh("go", "test", "-count=1", "./cmd/atlas", "-run", "^(TestT18V03|TestFeaturePreviewFocusesNowNextAndStages)$")
         sh("go", "build", "-o", str(tmp / "atlas"), "./cmd/atlas")
         atlas = tmp / "atlas"
 
@@ -360,8 +364,8 @@ def main():
             40,
             [
                 {"name": "initial", "wait_for": b"vault-hunter journal", "send": b"p"},
-                {"name": "project", "wait_for": b'"kind": "Project"', "send": b"f"},
-                {"name": "feature", "wait_for": b'"kind": "Feature"', "send": b"t"},
+                {"name": "project", "wait_for": b"PROJECT \xc2\xb7", "require_growth": True, "send": b"f"},
+                {"name": "feature", "wait_for": b"NEXT", "require_growth": True, "send": b"t"},
                 {"name": "task", "wait_for": b'"kind": "Task"', "send": b"r"},
                 {"name": "run", "wait_for": b"vault-hunter journal", "send": b"j"},
                 {"name": "selection", "wait_for": b"j/k select", "require_growth": True},
@@ -370,12 +374,16 @@ def main():
         (artifacts / "session.ansi").write_bytes(raw)
         bare_initial = screenshot(checkpoints["initial"], 140, 40)
         (artifacts / "browser-screenshot.txt").write_text(bare_initial + "\n", encoding="utf-8")
-        transcript.append("bare atlas: initial browser, project/feature/task/run navigation, run selection, clean exit")
-        assert "ATLAS · 3 active Runs · RUN preview" in bare_initial
-        assert "atlas-journal-run · atlas-journal-run" in bare_initial
+        transcript.append("bare atlas: Option 2 hierarchy, project/feature/task/run navigation, run selection, clean exit")
+        assert "ATLAS · 3 visible Tasks · RUN preview" in bare_initial
+        assert "pi-agent" in bare_initial
+        assert "vault-hunter-atlas" in bare_initial
         assert "vault-hunter journal" in bare_initial
-        assert '"kind": "Project"' in screenshot(checkpoints["project"], 140, 40)
-        assert '"kind": "Feature"' in screenshot(checkpoints["feature"], 140, 40)
+        assert "PROJECT ·" in screenshot(checkpoints["project"], 140, 40)
+        feature_screen = screenshot(checkpoints["feature"], 140, 40)
+        assert "NOW · 0" in feature_screen
+        assert "NEXT · 0" in feature_screen
+        assert '"kind": "Feature"' not in feature_screen
         assert '"kind": "Task"' in screenshot(checkpoints["task"], 140, 40)
         selection_screen = screenshot(checkpoints["selection"], 140, 40)
         assert selection_screen != bare_initial


### PR DESCRIPTION
## Intent

Deliver the user-selected Option 2 Atlas Observe experience from the interactive prototypes and screenshot feedback. The Runs pane should use a Project → Feature → Task → Run hierarchy; hide done Tasks by default and toggle them only within the selected Feature with Ctrl-D; include canonical not-started Tasks even without Run records or beyond machine collection byte bounds; use empty circles for not-started work and highlight only the selected row; preserve one normal terminal background except for selection; keep tree connector colors consistent; show concise status/Goal badges; and render the Feature preview as Now/Next lanes with a short canonical Vault Hunter crew journey (activate, baseline, converge, review, land, cleanup) rather than raw verifier or Registry goal identifiers. Preserve detailed raw lifecycle information in the Run view. The selected design is Option 2 from the provided HTML prototypes. Validate, push, open the PR, and complete delivery through CI.

## What Changed
- Group the Runs pane into a selectable Project → Feature → Task → Run hierarchy, with Feature-scoped done-task toggling and canonical tasks without Runs.
- Add pending-work indicators, concise status and Goal badges, and single-row selection styling.
- Replace raw Feature details with Now/Next lanes and the canonical Vault Hunter crew journey while preserving detailed lifecycle data in Run views.

## Risk Assessment

🚨 High: The implementation leaves Runs in the required hierarchy unreachable and introduces selection-colored background outside the selected row, directly contradicting source-verifiable acceptance criteria.

## Testing

The focused unit and end-to-end PTY verifier passed, exercising the Option 2 hierarchy and Now/Next experience, canonical Tasks beyond collection bounds, detailed Run lifecycle navigation, and machine output while capturing terminal-session evidence; no source changes or transient worktree artifacts remained.

<details>
<summary>Evidence: Interactive Atlas terminal session</summary>

```text
]11;?\[6n[?25l[?1049h[2J[H[?25l[?2004h[HATLAS · 3 visible Tasks · RUN preview[K
j/k select · g/G ends · Ctrl-D done · p project · f feature · t task · r run · q quit[K
RUNS                                        │RUN · atlas-rich-run[K
────────────────────────────────────────────│───────────────────────────────────────────────────────────────────────────────────────────────
[1;38;2;251;241;199mpi-agent[0m                                    │[38;2;242;133;52mvault-hunter journal[0m[38;2;235;219;178m  T02 Build the Compact At[0m[38;2;235;219;178m…[0m                      [38;2;146;131;116mRun [0m[38;2;235;219;178matlas-rich-run[0m[38;2;146;131;116m · rev 7[0m
[38;2;233;177;67m└─ [0m[38;2;233;177;67mvault-hunter-atlas[0m                       │[38;2;251;241;199mselected recorded journey · projection, not au[0m[38;2;251;241;199m…[0m              [38;2;146;131;116m5 lifecycle · 2 evidence · 7 total[0m
[38;2;233;177;67;48;2;69;64;60m   ├─ [0m[38;2;233;177;67;48;2;69;64;60m●[0m[1;38;2;251;241;199;48;2;69;64;60m Build the Compact Atla… [0m[48;2;69;64;60m [0m[1;38;2;128;170;158;48;2;69;64;60min progres…[0m[48;2;69;64;60m[0m│[38;2;146;131;116m───────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;2;233;177;67m   │  └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m atlas-ri · rev 7            [0m [1;38;2;128;170;158mV01[0m │[38;2;242;133;52m/goal [0m[38;2;235;219;178mT02.V01[0m[38;2;146;131;116m · [0m[38;2;233;177;67mactive[0m                                                                         
[38;2;233;177;67m   ├─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m Build the Execution Jo… [0m [1;38;2;128;170;158min progres…[0m│[38;2;242;133;52mverifier[0m[38;2;146;131;116m · [0m[38;2;235;219;178mbaseline red captured; implementation is intentionally not present yet and this sen[0m[38;2;235;219;178m…[0m
[38;2;233;177;67m   │  └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m atlas-jo · rev 8        [0m [1;38;2;128;170;158mpending[0m │[38;2;146;131;116m───────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;2;233;177;67m   └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m Build the Expanded Ope… [0m [1;38;2;128;170;158min progres…[0m│[38;2;146;131;116mFeature [0m[38;2;235;219;178m1_projects/pi-agent/themes/pi-customiz[0m[38;2;235;219;178m…[0m [38;2;146;131;116mupdated_at 2026-07-26T12:09:00Z · timestamp ga[0m[38;2;146;131;116m…[0m
[38;2;233;177;67m      └─ [0m[38;2;184;187;38m●[0m[38;2;235;219;178m atlas-t0 · rev 10          [0m [1;38;2;128;170;158mdone[0m │      [38;2;146;131;116m└─ … 7 recorded journal events omitted (2 earlier, 0 later)[0m[K
                                            │      [38;2;184;187;38m●[0m[38;2;146;131;116m  Jul 26 12:01 UTC · [0m[38;2;242;133;52mL[0m[38;2;146;131;116m · [0m[38;2;242;133;52mreview[0m[38;2;146;131;116m · [0m[38;2;184;187;38mdone[0m[38;2;146;131;116m · +0s since prior[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;242;133;52mgoal[0m[38;2;146;131;116m · [0m[38;2;235;219;178mA-tie[0m[K
                                            │      [38;2;146;131;116m│  └─ detail · [0m[38;2;235;219;178mtie ordered by Goal ID[0m[K
                                            │      [38;2;146;131;116m●[0m[38;2;146;131;116m  Jul 26 12:04 UTC · [0m[38;2;242;133;52mL[0m[38;2;146;131;116m · [0m[38;2;146;131;116mfuture-kind[0m[38;2;146;131;116m ?[0m[38;2;146;131;116m · [0m[38;2;146;131;116mfuture-state[0m[38;2;146;131;116m ?[0m[38;2;146;131;116m · +3m since prior[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;242;133;52mgoal[0m[38;2;146;131;116m · [0m[38;2;235;219;178mfuture-goal[0m[K
                                            │      [38;2;146;131;116m│  └─ detail · [0m[38;2;235;219;178mnone recorded[0m[K
                                            │      [38;2;233;177;67m●[0m[38;2;146;131;116m  Jul 26 12:05 UTC · [0m[38;2;242;133;52mL[0m[38;2;146;131;116m · [0m[38;2;242;133;52mverifier[0m[38;2;146;131;116m · [0m[38;2;233;177;67mactive[0m[38;2;146;131;116m · +1m since prior[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;242;133;52mgoal[0m[38;2;146;131;116m · [0m[38;2;235;219;178mT02.V01[0m[K
                                            │      [38;2;146;131;116m│  └─ detail · [0m[38;2;235;219;178mbaseline red captured; implementation is intentionally not present[0m[38;2;235;219;178m…[0m[K
                                            │      [38;2;242;89;75m●[0m[38;2;146;131;116m  Jul 26 12:05 UTC · [0m[38;2;211;134;155mE[0m[38;2;146;131;116m · [0m[38;2;128;170;158mT02.V01[0m[38;2;146;131;116m · [0m[38;2;242;89;75mfailed[0m[38;2;146;131;116m · +0s since prior[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;211;134;155mverifier[0m[38;2;146;131;116m · [0m[38;2;128;170;158mT02.V01[0m[K
                                            │      [38;2;146;131;116m│  └─ detail · [0m[38;2;235;219;178mbaseline red[0m[K
                                            │      [38;2;146;131;116m●[0m[38;2;146;131;116m  Jul 26 12:07 UTC · [0m[38;2;211;134;155mE[0m[38;2;146;131;116m · [0m[38;2;128;170;158mevidence-only[0m[38;2;146;131;116m · [0m[38;2;146;131;116mrecorded[0m[38;2;146;131;116m · +2m since prior[0m[38;2;146;131;116m · [0m[38;2;251;241;199mselected[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;211;134;155mverifier[0m[38;2;146;131;116m · [0m[38;2;128;170;158mevidence-only[0m[K
                                            │      [38;2;146;131;116m│  └─ detail · [0m[38;2;235;219;178mnone recorded[0m[K
                                            │      [38;2;146;131;116m│  ┌─ [0m[38;2;251;241;199mselected recorded observation[0m[38;2;146;131;116m · [0m[38;2;211;134;155mevidence[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;211;134;155mtimestamp[0m[38;2;146;131;116m · [0m[38;2;146;131;116m2026-07-26T12:07:00Z[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;211;134;155mobservation ID[0m[38;2;146;131;116m · [0m[38;2;235;219;178mevidence-only[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;211;134;155mverifier ID[0m[38;2;146;131;116m · [0m[38;2;128;170;158mevidence-only[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;211;134;155mstate[0m[38;2;146;131;116m · [0m[38;2;146;131;116mrecorded[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;211;134;155mcommand[0m[38;2;146;131;116m · [0m[38;2;128;170;158mnone recorded[0m[K
                                            │      [38;2;146;131;116m│  ├─ [0m[38;2;211;134;155mexit status[0m[38;2;146;131;116m · [0m[

... [978 bytes truncated] ...

                                        │[38;2;146;131;116mg/G first/last · j/k/↑/↓ records · v/V verifier · e/E evidence · enter detail · q/Esc quit[0m[K[39;H[HATLAS · 3 visible Tasks · PROJECT preview[K

RUNS                                        │PROJECT · atlas-rich-run[K

[1;38;2;251;241;199mpi-agent[0m                                    │{[K
[38;2;233;177;67m└─ [0m[38;2;233;177;67mvault-hunter-atlas[0m                       │  "api_version": "atlas/v1",[K
[38;2;233;177;67;48;2;69;64;60m   ├─ [0m[38;2;233;177;67;48;2;69;64;60m●[0m[1;38;2;251;241;199;48;2;69;64;60m Build the Compact Atla… [0m[48;2;69;64;60m [0m[1;38;2;128;170;158;48;2;69;64;60min progres…[0m[48;2;69;64;60m[0m│  "kind": "Project",[K
[38;2;233;177;67m   │  └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m atlas-ri · rev 7            [0m [1;38;2;128;170;158mV01[0m │  "data": {[K
[38;2;233;177;67m   ├─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m Build the Execution Jo… [0m [1;38;2;128;170;158min progres…[0m│    "description": "",[K
[38;2;233;177;67m   │  └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m atlas-jo · rev 8        [0m [1;38;2;128;170;158mpending[0m │    "id": "",[K
[38;2;233;177;67m   └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m Build the Expanded Ope… [0m [1;38;2;128;170;158min progres…[0m│    "name": "",[K
[38;2;233;177;67m      └─ [0m[38;2;184;187;38m●[0m[38;2;235;219;178m atlas-t0 · rev 10          [0m [1;38;2;128;170;158mdone[0m │    "repository": "",[K
                                            │    "status": "",[K
                                            │    "themes": [],[K
                                            │    "working_directory": ""[K
                                            │  },[K
                                            │  "meta": {[K
                                            │    "observed_at": "2026-07-28T22:54:58Z",[K
                                            │    "truncated": true[K
                                            │  }[K
                                            │}[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K[39;H[HATLAS · 3 visible Tasks · FEATURE preview[K

RUNS                                        │FEATURE · atlas-rich-run[K

[1;38;2;251;241;199mpi-agent[0m                                    │ · 0 now · 0 next · 0 complete[K
[38;2;233;177;67m└─ [0m[38;2;233;177;67mvault-hunter-atlas[0m                       │[K
[38;2;233;177;67;48;2;69;64;60m   ├─ [0m[38;2;233;177;67;48;2;69;64;60m●[0m[1;38;2;251;241;199;48;2;69;64;60m Build the Compact Atla… [0m[48;2;69;64;60m [0m[1;38;2;128;170;158;48;2;69;64;60min progres…[0m[48;2;69;64;60m[0m│[1;38;2;233;177;67mNOW · 0[0m[K
[38;2;233;177;67m   │  └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m atlas-ri · rev 7            [0m [1;38;2;128;170;158mV01[0m │[K
[38;2;233;177;67m   ├─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m Build the Execution Jo… [0m [1;38;2;128;170;158min progres…[0m│[1;38;2;233;177;67mNEXT · 0[0m[K
[38;2;233;177;67m   │  └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m atlas-jo · rev 8        [0m [1;38;2;128;170;158mpending[0m │[K
[38;2;233;177;67m   └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m Build the Expanded Ope… [0m [1;38;2;128;170;158min progres…[0m│[K
[38;2;233;177;67m      └─ [0m[38;2;184;187;38m●[0m[38;2;235;219;178m atlas-t0 · rev 10          [0m [1;38;2;128;170;158mdone[0m │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K
                                            │[K

















[39;H[HATLAS · 3 visible Tasks · TASK preview[K

RUNS                                        │TASK · atlas-rich-run[K

[1;38;2;251;241;199mpi-agent[0m                                    │{[K
[38;2;233;177;67m└─ [0m[38;2;233;177;67mvault-hunter-atlas[0m                       │  "api_version": "atlas/v1",[K
[38;2;233;177;67;48;2;69;64;60m   ├─ [0m[38;2;233;177;67;48;2;69;64;60m●[0m[1;38;2;251;241;199;48;2;69;64;60m Build the Compact Atla… [0m[48;2;69;64;60m [0m[1;38;2;128;170;158;48;2;69;64;60min progres…[0m[48;2;69;64;60m[0m│  "kind": "Task",[K
[38;2;233;177;67m   │  └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m atlas-ri · rev 7            [0m [1;38;2;128;170;158mV01[0m │  "data": {[K
[38;2;233;177;67m   ├─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m Build the Execution Jo… [0m [1;38;2;128;170;158min progres…[0m│    "evidence": [],[K
[38;2;233;177;67m   │  └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m atlas-jo · rev 8        [0m [1;38;2;128;170;158mpending[0m │    "feature": {[K
[38;2;233;177;67m   └─ [0m[38;2;233;177;67m●[0m[38;2;235;219;178m Build the Expanded Ope… [0m [1;38;2;128;170;158min progres…[0m│      "id": "",[K
[38;2;233;177;67m      └─ [0m[38;2;184;187;38m●[0m[38;2;235;219;178m atlas-t0 · rev 10          [0m [1;38;2;128;170;158mdone[0m │      "name": "",[K
                                            │      "status": ""[K
                                            │    },[K
                                            │    "id": "",[K
                                            │    "intent": "",[K
                                            │    "local_id": "",[K
                                            │    "name": "",[K
                                            │    "project": {[K
                                            │      "id": "",[K
                                            │      "name": ""[K
                                            │    },[K
                                            │    "runs": [],[K
                                            │    "status": "",[K
                                            │    "theme": {[K
                                            │      "id": "",[K
                                            │      "name": "",[K
                                            │      "status": ""[K
                                            │    },[K
                                            │    "verifiers": [][K
                                            │  },[K
                                            │  "meta": {[K
                                            │    "observed_at": "2026-07-28T22:54:58Z",[K
                                            │    "truncated": true[K
                                            │  }[K
                                            │}[K


[39;H[2K[?2004l[?25h[?1002l[?1003l[?1006l[?1049l[?25h
```
</details>
<details>
<summary>Evidence: Rendered browser terminal screenshot</summary>

```text
ATLAS · 3 visible Tasks · RUN preview
j/k select · g/G ends · Ctrl-D done · p project · f feature · t task · r run · q quit
RUNS                                        │RUN · atlas-rich-run
────────────────────────────────────────────│───────────────────────────────────────────────────────────────────────────────────────────────
pi-agent                                    │vault-hunter journal  T02 Build the Compact At…                      Run atlas-rich-run · rev 7
└─ vault-hunter-atlas
```
</details>
- Evidence: Detailed Run observation terminal session (local file: <code>/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/no-mistakes-evidence/01KYNE1HSEFNTH68NBHSXST6YQ/observe-run.ansi</code>)
<details>
<summary>Evidence: Rendered detailed Run screenshot</summary>

```text
vault-hunter journal  T08 Build the Execution Jo…                      Run atlas-journal-run · rev 8
selected recorded journey · projection, not auth…                 5 lifecycle · 3 evidence · 8 total
────────────────────────────────────────────────────────────────────────────────────────────────────
/goal T08.REVIEW · active                                      shown later: T08.HIDDEN → T08.LANDING
review · tie-life-second
────────────────────────────────────────────────────────────────────────────────────────────────────
Feature 1_projects/pi-agent/themes/pi-customizat… updated_at 2026-07-26T10:04:00Z · timestamp gaps,…
         └─ … 8 recorded journal events omitted (4 earlier, 0 later)
         ●  Jul 26 10:01 UTC · E · T08.V02 · future-evidence-state ? · +0s since prior
         │  ├─ verifier · T08.V02
         │  └─ detail · tie-evidence-second
         ●  Jul 26 10:01 UTC · L · checkpoint · pending · +30s since prior
         │  ├─ goal · T08.HIDDEN
         │  └─ detail · visible-hidden
         ●  Jul 26 10:02 UTC · E · T08.V01 · passed · +30s since prior
         │  ├─ verifier · T08.V01
         │  └─ detail · instant-middle
         ●  Jul 26 10:03 UTC · L · landing · pending · +1m since prior · selected
         │  ├─ goal · T08.LANDING
         │  └─ detail · instant-later
         │  ┌─ selected recorded observation · lifecycle
         │  ├─ timestamp · 2026-07-26T10:03:00Z
         │  ├─ observation ID · life-later
         │  ├─ Goal ID · T08.LANDING
         │  ├─ kind · landing
         │  ├─ state · pending
         │  └─ detail · instant-later

────────────────────────────────────────────────────────────────────────────────────────────────────
g/G first/last · j/k/↑/↓ records · v/V verifier · e/E evidence · enter detail · q/Esc quit
```
</details>
<details>
<summary>Evidence: Semantic interaction transcript</summary>

```text
bare atlas: Option 2 hierarchy, project/feature/task/run navigation, run selection, clean exit
atlas observe: all-Runs browser matches bare atlas
atlas observe <run>: journal navigation, evidence jump, detail collapse, clean exit
```
</details>
<details>
<summary>Evidence: Watch-mode API output</summary>

```text
{"api_version":"atlas/v1","kind":"RunList","data":[],"meta":{"count":3,"observed_at":"2026-07-27T14:00:00Z","truncated":true}}
{"api_version":"atlas/v1","kind":"RunList","data":[],"meta":{"count":3,"observed_at":"2026-07-27T14:00:01Z","truncated":true}}
{"api_version":"atlas/v1","kind":"RunList","data":[],"meta":{"count":3,"observed_at":"2026-07-27T14:00:02Z","truncated":true}}
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (10m20s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 errors</summary>

- 🚨 `cmd/atlas/browser.go:403` - Intent requires canonical not-started Tasks and empty circles, but only status &#34;pending-work&#34; is treated as next/not-started. Canonical loader data defaults to and fixtures use &#34;pending&#34;, so those Tasks are counted as complete in Feature preview and rendered as filled/in-progress in the tree. Recognize canonical &#34;pending&#34; at the shared status classification boundary.
- 🚨 `cmd/atlas/browser.go:262` - Intent requires Project → Feature → Task → Run hierarchy, but each browserEntry represents one Run and renderBrowserRun emits a fresh Task row for every entry. A Task with multiple Runs is therefore shown as repeated Task → Run pairs instead of one Task with multiple Run children; Feature preview also selects only the first matching Run at lines 420-425. Group entries by Task before rendering and attach all Runs beneath that Task.
- 🚨 `cmd/atlas/browser.go:166` - Intent requires Ctrl-D to toggle done Tasks within the selected Feature, but Ctrl-D derives the Feature only from a visible Task entry. A Feature containing only done Tasks is entirely filtered out and can never be selected or expanded, so its done Tasks are unreachable. Preserve selectable Feature nodes independently of filtered Task rows.
- 🚨 `cmd/atlas/browser.go:298` - Intent says to &#34;highlight only the selected row&#34;, but the same selected flag is passed to both the Task row and its Run/no-Run child, applying the selection background to two rows. Give selection a single hierarchy-row owner rather than styling the whole Task/Run pair.

🔧 Fix: Fix Atlas task hierarchy and pending states
2 errors still open:
- 🚨 `cmd/atlas/browser.go:368` - The hierarchy renders every Run child but navigation still selects only the deduplicated Task entry, so a Task with multiple Runs always opens the first lexicographically sorted Run and its other Run children cannot be selected or inspected. This contradicts the required Project → Feature → Task → Run hierarchy and prevents preserving detailed raw lifecycle information for those Runs. Represent Run children as selectable hierarchy rows while retaining one grouped Task parent.
- 🚨 `cmd/atlas/browser.go:667` - The required normal terminal background except for selection is violated because the not-started Task preview renders its status line with selectedMeta, which unconditionally applies the selection background even though that status line is not the selected hierarchy row. Use a foreground-only metadata style here.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `scripts/verifiers/vault-hunter-atlas-t18-v03:364` - The end-to-end PTY verifier still waits for the former raw `&#34;kind&#34;: &#34;Feature&#34;` preview, so it times out against the new Now/Next Feature experience and cannot capture reviewer-visible terminal evidence. Update its checkpoints and assertions for the Option 2 hierarchy and preview.
- `go test ./cmd/atlas -run 'Test(BrowserHierarchyRowsShowLifecycleStatus|BrowserGroupsRunsUnderOneTask|BrowserCtrlDTogglesDoneOnlyFeature|BrowserCtrlDTogglesDoneWithinSelectedFeature|CanonicalPendingStatusIsNotStarted|PendingFeatureTaskIsUnfilledAndUnhighlighted|FeaturePreviewFocusesNowNextAndStages|T18V03BrowserCompletenessIgnoresMachineByteCap|T18V03BrowserNavigation)$'`
- `scripts/verifiers/vault-hunter-atlas-t18-v03`

🔧 Fix: Update interactive verifier for Option 2 preview
✅ Re-checked - no issues remain.
- `scripts/verifiers/vault-hunter-atlas-t18-v03`
- `Re-executed the focused verifier while exporting its generated artifacts to the required evidence directory`
- `Interactive PTY checks for Project → Feature → Task → Run navigation, Now/Next Feature preview, run selection, detailed lifecycle view, byte-capped collection behavior, watch output, and immutable fixtures`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
