### PR TITLE
fix(atlas): preserve faithful journal projection by default

### DIFF
--- a/cmd/atlas/browser.go
+++ b/cmd/atlas/browser.go
@@ -635,7 +635,7 @@ func (m browserModel) rightPane(width, rows int) []string {
 		if entry.runID == "" {
 			body = renderNotStartedTask(entry, width, m.colorEnabled)
 		} else {
-			body = atlaspkg.NewJournalModel(entry.run, width, maxInt(rows-len(heading), 24)).ViewColor(m.colorEnabled)
+			body = atlaspkg.NewJournalModel(entry.run, width, maxInt(rows-len(heading), 24)).WithCrewTimeline().ViewColor(m.colorEnabled)
 		}
 	}
 	lines := append(heading, strings.Split(body, "\n")...)

--- a/cmd/atlas/main.go
+++ b/cmd/atlas/main.go
@@ -545,7 +545,7 @@ func runObserve(command observeCommand, stdout io.Writer) error {
 		return err
 	}
 	if characterDevice(os.Stdin) && characterDevice(os.Stdout) {
-		model := atlaspkg.NewJournalModel(run, 80, 24).WithColor(interactiveColorEnabled()).WithReload(func() (vaultregistry.Run, error) { return readActiveRun(reader, command.selector) })
+		model := atlaspkg.NewJournalModel(run, 80, 24).WithCrewTimeline().WithColor(interactiveColorEnabled()).WithReload(func() (vaultregistry.Run, error) { return readActiveRun(reader, command.selector) })
 		_, err := tea.NewProgram(model, tea.WithAltScreen()).Run()
 		return err
 	}

--- a/docs/vault-hunter-atlas-crew-timeline.md
+++ b/docs/vault-hunter-atlas-crew-timeline.md
@@ -1,6 +1,6 @@
 # Vault Hunter Atlas crew timeline
 
-Atlas renders the default run journal as a compact vertical crew timeline. The connected Parent, Verifier, Convergence, Delivery, and Parent closure stages each expose one deliverable and use `●`, `⟳`, `○`, or `×` for complete, active, waiting, and failed state.
+Atlas observe and browser run previews select a compact vertical crew timeline. The underlying `JournalModel` retains the complete recorded Journal projection by default; callers must opt into the crew timeline with `WithCrewTimeline`. The connected Parent, Verifier, Convergence, Delivery, and Parent closure stages each expose one deliverable and use `●`, `⟳`, `○`, or `×` for complete, active, waiting, and failed state.
 
 Verifier progress comes from canonical Task `VNN` checkboxes, falling back to normalized Registry verifier evidence when the Task cannot provide them. Delivery completes only from an implementation pull-request field or the Task's Pull Request Evidence section, and closure follows canonical Task status. Compatibility `crew_role` metadata takes precedence. Otherwise, recognized original participant roles are retained and marked `≈` as inferred v1 projections; roles outside Verifier Builder, Convergence Engineer, and Delivery Steward remain Unassigned.
 

--- a/internal/atlas/crew_timeline_test.go
+++ b/internal/atlas/crew_timeline_test.go
@@ -48,7 +48,7 @@ func TestCrewTimelineQualifiedRegistryFallbackAndFailureLegend(t *testing.T) {
 	if !signals.verifiersComplete || signals.completeVerifiers != 1 {
 		t.Fatalf("fallback = %#v", signals)
 	}
-	view := NewJournalModel(run, 100, 24).ViewColor(false)
+	view := NewJournalModel(run, 100, 24).WithCrewTimeline().ViewColor(false)
 	if !strings.Contains(view, "× failed") {
 		t.Fatalf("failure legend missing from %q", view)
 	}

--- a/internal/atlas/journal.go
+++ b/internal/atlas/journal.go
@@ -96,6 +96,7 @@ type JournalModel struct {
 	events        []journalEvent
 	selected      int
 	detailVisible bool
+	crewTimeline  bool
 	colorEnabled  bool
 	attached      bool
 	width         int
@@ -141,6 +142,11 @@ func NewJournalModel(run vaultregistry.Run, width, height int) JournalModel {
 
 // WithColor configures the attached-terminal View without changing the
 // journal projection.
+func (m JournalModel) WithCrewTimeline() JournalModel {
+	m.crewTimeline = true
+	return m
+}
+
 func (m JournalModel) WithColor(enabled bool) JournalModel {
 	m.colorEnabled = enabled
 	m.attached = true
@@ -168,7 +174,7 @@ func (m JournalModel) refreshed(run vaultregistry.Run) JournalModel {
 		selectedID = journalEventID(m.events[m.selected])
 	}
 	next := NewJournalModel(run, m.width, m.height)
-	next.colorEnabled, next.attached, next.detailVisible, next.reload = m.colorEnabled, m.attached, m.detailVisible, m.reload
+	next.colorEnabled, next.attached, next.detailVisible, next.crewTimeline, next.reload = m.colorEnabled, m.attached, m.detailVisible, m.crewTimeline, m.reload
 	if !followTail && selectedID != "" {
 		for i, event := range next.events {
 			if journalEventID(event) == selectedID {
@@ -269,8 +275,51 @@ func (m JournalModel) ViewColor(enabled bool) string {
 	if m.width < 80 || m.height < 24 {
 		return truncate("terminal too small; minimum 80×24", m.width)
 	}
-	return m.crewTimelineView(enabled)
+	if m.crewTimeline {
+		return m.crewTimelineView(enabled)
+	}
 
+	start, end, capped := m.journalWindow()
+	lines := m.headerLines(start, end)
+	margin := strings.Repeat(" ", (m.width-min(82, m.width-2))/2)
+	if len(m.events) == 0 {
+		lines = append(lines, m.journalRailLine(margin, journalLine{{text: margin}, {text: "no recorded journal events", style: journalOrdinary}}))
+	} else {
+		omission := m.journalRailLine(margin, journalLine{
+			{text: margin},
+			{text: fmt.Sprintf("└─ … %d recorded journal events omitted (%d earlier, %d later)", len(m.events), start, len(m.events)-end), style: journalMuted},
+		})
+		if capped {
+			lines = append(lines, omission)
+		}
+		for i := start; i < end; i++ {
+			lines = append(lines, m.journalRailLines(margin, m.eventLines(i, margin))...)
+		}
+		if m.detailVisible {
+			lines = append(lines, m.journalRailLines(margin, m.selectedCard(margin))...)
+		}
+	}
+
+	for len(lines) < m.height-2 {
+		lines = append(lines, nil)
+	}
+	if len(lines) > m.height-2 {
+		lines = lines[:m.height-2]
+	}
+	lines = append(lines,
+		journalLine{{text: strings.Repeat("─", m.width), style: journalMuted}},
+		journalLine{{text: journalFooter(m.width), style: journalMuted}},
+	)
+
+	var styles journalStyles
+	if enabled {
+		styles = newJournalStyles()
+	}
+	rendered := make([]string, len(lines))
+	for i, line := range lines {
+		rendered[i] = renderJournalLine(line, m.width, enabled, styles)
+	}
+	return strings.Join(rendered, "\n")
 }
 
 func (m JournalModel) journalWindow() (start, end int, capped bool) {

--- a/internal/atlas/journal.go
+++ b/internal/atlas/journal.go
@@ -140,13 +140,15 @@ func NewJournalModel(run vaultregistry.Run, width, height int) JournalModel {
 	}
 }
 
-// WithColor configures the attached-terminal View without changing the
-// journal projection.
+// WithCrewTimeline selects the compact crew timeline projection. By default,
+// JournalModel renders the complete recorded journal.
 func (m JournalModel) WithCrewTimeline() JournalModel {
 	m.crewTimeline = true
 	return m
 }
 
+// WithColor configures the attached-terminal View without changing the
+// journal projection.
 func (m JournalModel) WithColor(enabled bool) JournalModel {
 	m.colorEnabled = enabled
 	m.attached = true


### PR DESCRIPTION
## Intent

Urgent post-merge repair for Atlas T14 PR #123. The production crew timeline replacement left the established T08 faithful Journal tests red. Preserve the complete faithful Journal projection as the default internal JournalModel contract, add an explicit WithCrewTimeline projection mode, and make real atlas observe/browser product entrypoints select the new T14 crew timeline. Preserve refresh state, old navigation/detail tests, the new T14 canonical stage semantics, and all machine output. Validate the full relevant Go suites, push, open the follow-up PR, and complete CI so T14 can be truthfully closed.

## What Changed

- Restore the complete recorded Journal projection as the default `JournalModel` view.
- Add an explicit `WithCrewTimeline` mode, preserve it across refreshes, and select it for Atlas observe and browser entrypoints.
- Update crew timeline coverage and documentation to reflect the opt-in projection behavior.

## Risk Assessment

✅ Low: The change cleanly restores the faithful default JournalModel projection, explicitly opts product entrypoints into the crew timeline, and preserves projection mode across refreshes without altering machine output.

## Testing

Exercised the relevant Atlas Go packages, including faithful Journal snapshots and interaction/refresh behavior, crew timeline semantics, browser navigation, observe/machine output paths, and a product-level browser projection check; all succeeded, with a transcript showing the default faithful journal alongside the browser-selected crew timeline.

<details>
<summary>Evidence: Default faithful JournalModel and browser crew-timeline projections</summary>

```text
DEFAULT INTERNAL JOURNALMODEL PROJECTION
vault-hunter journal  T14 Preserve faithful Jour…                        Run run-t14-repair · rev 14
selected recorded journey · projection, not auth…                 1 lifecycle · 0 evidence · 1 total
────────────────────────────────────────────────────────────────────────────────────────────────────
/goal T14.V01 · active                                                                              
verifier · faithful journal repair
────────────────────────────────────────────────────────────────────────────────────────────────────
Feature none recorded                             updated_at none recorded · timestamp gaps, not du…
         ●  Aug 01 12:00 UTC · L · verifier · active · journey start · selected
         │  ├─ goal · T14.V01
         │  └─ detail · faithful journal repair
         │  ┌─ selected recorded observation · lifecycle
         │  ├─ timestamp · 2026-08-01T12:00:00Z
         │  ├─ observation ID · life-1
         │  ├─ Goal ID · T14.V01
         │  ├─ kind · verifier
         │  ├─ state · active
         │  └─ detail · faithful journal repair





────────────────────────────────────────────────────────────────────────────────────────────────────
g/G first/last · j/k/↑/↓ records · v/V verifier · e/E evidence · enter detail · q/Esc quit

BROWSER RUN PANE (PRODUCT ENTRYPOINT)
RUN · run-t14-repair
────────────────────────────────────────────────────────────────────────────────────────────────────
vault-hunter journal  T14 · Goal T14.V01                                 Run run-t14-repair · rev 14
faithful journal repair                                                                       ACTIVE
────────────────────────────────────────────────────────────────────────────────────────────────────

CREW TIMELINE
 ├─ ● Parent  · invoked
 │  └─ Task and Goal accepted · canonical context
 ├─ ⟳ Verifier ≈ · verifying
 │  └─ 0/0 verifiers complete · 0 evidence · commands · red evidence
 ├─ ○ Convergence  · waiting
 │  └─ candidate tree not reco · 0 participant observations
 ├─ ○ Delivery  · waiting
 │  └─ implementation PR not pushed · review · checks · PR/CI
 └─ ○ Parent closure  · waiting
    └─ accepted evidence checkpoint · canonical decision · cleanup

  └─ UNASSIGNED · 0 participant observations · outside crew custody
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/atlas ./cmd/atlas`
- <code>`ATLAS_EVIDENCE_PATH=/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/no-mistakes-evidence/01KYP2QJH40HGM28ZMXMEGZX31/atlas-journal-projections.txt go test ./cmd/atlas -run &#39;^TestEvidenceJournalProjectionRouting$&#39; -count=1` (temporary evidence-only test removed afterward)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
