### PR TITLE
fix(nvim): route sidekick picker kill/rename actions to the highlighted session

### DIFF
--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -508,6 +508,7 @@ local function workspace_groups(first_workspace_id, metric_cache)
         label = parsed and parsed.label
           or (agent.name and not agent.name:match("^sk%-") and agent.name)
           or tool,
+        slug = parsed and parsed.slug,
         toggle_name = parsed and parsed.label or tool,
         tool = tool,
         pane_id = agent.pane_id,
@@ -1276,6 +1277,30 @@ function M.open(opts)
     internal.toggle_tool_session(target, true, item.terminal_id)
   end
 
+  local function rename_item(active_picker, item)
+    if not item or item._empty or not item.agent_name or not item.tool then
+      return
+    end
+    local current_slug = internal.normalize_label(item.slug or item.label)
+    vim.ui.input({ prompt = item.tool .. " session label: ", default = item.slug or item.label }, function(input)
+      local slug = internal.normalize_label(input)
+      local name = item.tool .. "-" .. slug
+      if slug == "" or slug == current_slug then
+        return
+      end
+      local result, err = herdr.call({ "agent", "rename", item.terminal_id or item.agent_name, name }, true)
+      if not result then
+        vim.notify("Sidekick: session rename failed: " .. (err or "unknown error"), vim.log.levels.ERROR)
+        return
+      end
+      reopening = true
+      active_picker:close()
+      vim.schedule(function()
+        M.open(opts)
+      end)
+    end)
+  end
+
   local function kill_item(active_picker, item)
     if not item or item._empty or not item.pane_id then
       return
@@ -1283,16 +1308,33 @@ function M.open(opts)
     if vim.fn.confirm("Kill agent " .. item.label .. "?", "&Yes\n&No", 2) ~= 1 then
       return
     end
-    if herdr.close(item.pane_id) then
-      if opts.on_kill then
-        opts.on_kill(item)
-      end
-      reopening = true
-      active_picker:close()
-      vim.schedule(function()
-        M.open(opts)
-      end)
+    if not herdr.close(item.pane_id) then
+      vim.notify("Sidekick: session close failed: " .. item.label, vim.log.levels.ERROR)
+      return
     end
+    if opts.on_kill then
+      opts.on_kill(item)
+    end
+    reopening = true
+    active_picker:close()
+    vim.schedule(function()
+      M.open(opts)
+    end)
+  end
+
+  local function active_item()
+    if workspace_active and workspace_win and workspace_win:valid() then
+      return workspace_rows[vim.api.nvim_win_get_cursor(workspace_win.win)[1]]
+    end
+    return picker and picker:current() or nil
+  end
+
+  local function rename_active_item()
+    rename_item(picker, active_item())
+  end
+
+  local function kill_active_item()
+    kill_item(picker, active_item())
   end
 
   local function focus_input()
@@ -1313,10 +1355,6 @@ function M.open(opts)
     else
       activate(picker, item)
     end
-  end
-
-  local function workspace_delete()
-    kill_item(picker, workspace_rows[vim.api.nvim_win_get_cursor(workspace_win.win)[1]])
   end
 
   local function clear_input()
@@ -1381,7 +1419,7 @@ function M.open(opts)
       ["<cr>"] = workspace_enter,
       ["<c-w>"] = focus_input,
       ["<c-u>"] = clear_input,
-      ["<c-x>"] = workspace_delete,
+      ["<c-x>"] = kill_active_item,
       ["<c-b>"] = function()
         scroll_preview(true)
       end,
@@ -1563,8 +1601,8 @@ function M.open(opts)
           ["<c-u>"] = { clear_input, mode = { "n", "i" } },
           ["<c-b>"] = { "sidekick_preview_scroll_up", mode = { "n", "i" } },
           ["<c-f>"] = { "sidekick_preview_scroll_down", mode = { "n", "i" } },
-          ["<c-r>"] = { "sidekick_rename_session", mode = { "n", "i" } },
-          ["<c-x>"] = { "sidekick_kill_session", mode = { "n", "i" } },
+          ["<c-r>"] = { rename_active_item, mode = { "n", "i" } },
+          ["<c-x>"] = { kill_active_item, mode = { "n", "i" } },
         },
       },
       list = {
@@ -1575,8 +1613,8 @@ function M.open(opts)
           ["<c-u>"] = clear_input,
           ["<c-b>"] = "sidekick_preview_scroll_up",
           ["<c-f>"] = "sidekick_preview_scroll_down",
-          ["<c-r>"] = { "sidekick_rename_session", mode = { "n" } },
-          ["<c-x>"] = { "sidekick_kill_session", mode = { "n" } },
+          ["<c-r>"] = { rename_active_item, mode = { "n" } },
+          ["<c-x>"] = { kill_active_item, mode = { "n" } },
         },
       },
       preview = {
@@ -1595,26 +1633,7 @@ function M.open(opts)
         scroll_preview(false)
       end,
       sidekick_rename_session = function(active_picker, item)
-        if not item or item._empty or not item.agent_name or not item.tool then
-          return
-        end
-        vim.ui.input({ prompt = item.tool .. " session label: ", default = item.slug }, function(input)
-          local slug = internal.normalize_label(input)
-          local name = item.tool .. "-" .. slug
-          if slug == "" or name == item.agent_name then
-            return
-          end
-          local result, err = herdr.call({ "agent", "rename", item.terminal_id or item.agent_name, name }, true)
-          if not result then
-            vim.notify("Sidekick: session rename failed: " .. (err or "unknown error"), vim.log.levels.ERROR)
-            return
-          end
-          reopening = true
-          active_picker:close()
-          vim.schedule(function()
-            M.open(opts)
-          end)
-        end)
+        rename_item(active_picker, item)
       end,
       sidekick_kill_session = function(active_picker, item)
         kill_item(active_picker, item)

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -489,6 +489,7 @@ local function validate_sidekick_pi()
 end
 
 local function validate_sidekick_herdr()
+  local picker_actions_only = case == "sidekick-picker-actions"
   load_plugin("sidekick.nvim")
 
   local config = require("sidekick.config")
@@ -652,7 +653,11 @@ local function validate_sidekick_herdr()
   local start_calls = {}
   source_herdr.call = function(args)
     start_calls[#start_calls + 1] = args
-    if args[1] == "agent" and args[2] == "start" then
+    if args[1] == "pane" and args[2] == "list" then
+      return { panes = { { pane_id = "w-bound:p0", workspace_id = "w-bound" } } }
+    elseif args[1] == "pane" and args[2] == "split" then
+      return { pane = { pane_id = "w-bound:p1" } }
+    elseif args[1] == "agent" and args[2] == "start" then
       return {
         agent = {
           name = "codex-workspace-session",
@@ -677,15 +682,21 @@ local function validate_sidekick_herdr()
     { workspace_id = "w-bound" }
   )
   source_herdr.call = original_call
+  local pane_list
+  local pane_split
   local agent_start
   local tab_rename
   for _, call in ipairs(start_calls) do
-    if call[1] == "workspace" or (call[1] == "pane" and call[2] == "list") then
+    if call[1] == "workspace" then
       fail("an exact workspace ID should bypass cwd workspace lookup: " .. vim.inspect(start_calls))
     elseif call[1] == "tab" and call[2] == "create" then
       fail("worker start must not precreate a blank root tab: " .. vim.inspect(start_calls))
     elseif call[1] == "pane" and call[2] == "move" and vim.fn.index(call, "--split") >= 0 then
       fail("worker start must not use a split: " .. vim.inspect(start_calls))
+    elseif call[1] == "pane" and call[2] == "list" then
+      pane_list = call
+    elseif call[1] == "pane" and call[2] == "split" then
+      pane_split = call
     elseif call[1] == "agent" and call[2] == "start" then
       agent_start = call
     elseif call[1] == "tab" and call[2] == "rename" then
@@ -693,8 +704,16 @@ local function validate_sidekick_herdr()
     end
   end
   if not started
+    or not vim.deep_equal(pane_list, { "pane", "list", "--workspace", "w-bound" })
+    or not vim.deep_equal(
+      pane_split,
+      { "pane", "split", "w-bound:p0", "--direction", "right", "--cwd", cwd, "--no-focus" }
+    )
     or not agent_start
-    or agent_start[7] ~= "w-bound"
+    or not vim.deep_equal(
+      agent_start,
+      { "agent", "start", "codex-workspace-session", "--kind", "codex", "--pane", "w-bound:p1" }
+    )
     or vim.fn.index(agent_start, "--tab") >= 0
     or not tab_rename
     or tab_rename[3] ~= "w-bound:t1"
@@ -916,6 +935,8 @@ local function validate_sidekick_herdr()
   end
 
   local original_list_agents = herdr.list_agents
+  local other_agent_name = "pi-other-workspace"
+  local removed_pane_id
   local function named_agent(name, status, index, workspace_id, agent_cwd)
     return {
       name = name,
@@ -934,7 +955,7 @@ local function validate_sidekick_herdr()
     }
   end
   herdr.list_agents = function()
-    return {
+    local agents = {
       {
         name = "sk-codex-deadbeef",
         agent = "codex",
@@ -948,9 +969,12 @@ local function validate_sidekick_herdr()
       named_agent("pi-working", "working", 3),
       named_agent("pi-done", "done", 4),
       named_agent("pi-blocked", "blocked", 5),
-      named_agent("pi-other-workspace", "idle", 6, "w2"),
+      named_agent(other_agent_name, "idle", 6, "w2"),
       named_agent("pi-workspace-only", "idle", 7, "w1", cwd .. "-unrelated"),
     }
+    return vim.tbl_filter(function(agent)
+      return agent.pane_id ~= removed_pane_id
+    end, agents)
   end
 
   local source_registry = dofile(source_root .. "registry.lua")
@@ -1018,6 +1042,7 @@ local function validate_sidekick_herdr()
 
   local original_herdr_call = herdr.call
   local rename_args
+  local rename_succeeds = true
   herdr.call = function(args, quiet)
     if args[1] == "workspace" and args[2] == "list" then
       return {
@@ -1029,6 +1054,12 @@ local function validate_sidekick_herdr()
     end
     if args[1] == "agent" and args[2] == "rename" then
       rename_args = args
+      if not rename_succeeds then
+        return nil, "agent name already exists"
+      end
+      if picker_actions_only and args[3] == "term-6" then
+        other_agent_name = args[4]
+      end
       return { agent = { name = args[4] } }
     end
     return original_herdr_call(args, quiet)
@@ -1042,6 +1073,7 @@ local function validate_sidekick_herdr()
   local original_toggle = internal.toggle_tool_session
   local original_ui_input = vim.ui.input
   local original_confirm = vim.fn.confirm
+  local original_picker_notify = vim.notify
   local picker_opts
   local read_args
   local read_result = "\27[31mfirst logical line\27[0m"
@@ -1056,6 +1088,8 @@ local function validate_sidekick_herdr()
   local focused = {}
   local toggles = {}
   local closed_panes = {}
+  local close_succeeds = true
+  local killed_item
   Snacks.picker.pick = function(opts)
     picker_opts = opts
   end
@@ -1100,6 +1134,12 @@ local function validate_sidekick_herdr()
   end
   herdr.close = function(pane_id)
     closed_panes[#closed_panes + 1] = pane_id
+    if not close_succeeds then
+      return false
+    end
+    if picker_actions_only then
+      removed_pane_id = pane_id
+    end
     return true
   end
   internal.toggle_tool_session = function(name, focus, terminal_id)
@@ -1107,7 +1147,11 @@ local function validate_sidekick_herdr()
   end
 
   local picker_ok, picker_err = xpcall(function()
-    cwd_picker.open()
+    cwd_picker.open(picker_actions_only and {
+      on_kill = function(item)
+        killed_item = item
+      end,
+    } or nil)
     if not picker_opts then
       fail("cwd picker did not open Snacks picker")
     end
@@ -1164,12 +1208,6 @@ local function validate_sidekick_herdr()
       if item.label == "pi-done" and not rendered:find(" · 12s · 42.5%", 1, true) then
         fail("done rows should retain their completed run time: " .. vim.inspect(rendered))
       end
-    end
-    if
-      picker_opts.win.input.keys["<c-r>"][1] ~= "sidekick_rename_session"
-      or picker_opts.win.list.keys["<c-r>"][1] ~= "sidekick_rename_session"
-    then
-      fail("cwd picker should map <c-r> to session rename in its input and list")
     end
     if
       not picker_opts.win.input.keys["<c-w>"]
@@ -1236,14 +1274,9 @@ local function validate_sidekick_herdr()
         break
       end
     end
-    local kill_input = picker_opts.win.input.keys["<c-x>"]
-    local kill_list = picker_opts.win.list.keys["<c-x>"]
-    local kill_action = type(kill_input) == "table" and kill_input[1] or kill_input
-    local kill_list_action = type(kill_list) == "table" and kill_list[1] or kill_list
+    local kill_action = "sidekick_kill_session"
     if
       not kill_item
-      or type(kill_action) ~= "string"
-      or kill_list_action ~= kill_action
       or type(picker_opts.actions[kill_action]) ~= "function"
     then
       fail("cwd picker should expose one agent-kill action from input and list")
@@ -1355,6 +1388,9 @@ local function validate_sidekick_herdr()
           vim.api.nvim_set_current_win(input_win)
         end
       end,
+      close = function(self)
+        self.closed = true
+      end,
       action = function(_, action)
         confirmed_action = action
       end,
@@ -1379,6 +1415,234 @@ local function validate_sidekick_herdr()
     end
     if type(input_changed) ~= "function" then
       fail("agent picker input should update workspace fuzzy results")
+    end
+    if picker_actions_only then
+      removed_pane_id = nil
+
+      local function run_input_action(lhs)
+        local spec = picker_opts.win.input.keys[lhs]
+        local action = type(spec) == "table" and spec[1] or spec
+        if type(action) == "function" then
+          action()
+        elseif type(action) == "string" and type(picker_opts.actions[action]) == "function" then
+          -- Snacks resolves named actions with picker:current(), which is the
+          -- local list item even while the workspace selector is active.
+          picker_opts.actions[action](fake_picker, fake_picker:current())
+        else
+          fail("missing picker input action for " .. lhs)
+        end
+      end
+
+      for _, lhs in ipairs({ "<c-r>", "<c-x>" }) do
+        local spec = picker_opts.win.input.keys[lhs]
+        if
+          type(spec) ~= "table"
+          or not vim.tbl_contains(spec.mode or {}, "n")
+          or not vim.tbl_contains(spec.mode or {}, "i")
+        then
+          fail(lhs .. " should be available from picker normal and insert modes")
+        end
+      end
+
+      local rename_response
+      local rename_prompt
+      local kill_choice = 2
+      local kill_prompt
+      local notifications = {}
+      vim.ui.input = function(opts, callback)
+        rename_prompt = opts
+        callback(rename_response)
+      end
+      vim.fn.confirm = function(prompt)
+        kill_prompt = prompt
+        return kill_choice
+      end
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local toggle_selector = picker_opts.win.input.keys["<c-w>"][1]
+      toggle_selector()
+      rename_response = nil
+      rename_prompt = nil
+      rename_args = nil
+      run_input_action("<c-r>")
+      if
+        not rename_prompt
+        or rename_prompt.default ~= current_fake_item.slug
+        or rename_args
+        or fake_picker.closed
+      then
+        fail("local Ctrl-R should prompt for the selected local session and cancel without mutation")
+      end
+      kill_prompt = nil
+      closed_panes = {}
+      run_input_action("<c-x>")
+      if
+        not kill_prompt
+        or not kill_prompt:find(current_fake_item.label, 1, true)
+        or #closed_panes ~= 0
+        or fake_picker.closed
+      then
+        fail("local Ctrl-X should confirm the selected local session and cancel without mutation")
+      end
+      toggle_selector()
+
+      input_pattern = "pother"
+      input_changed()
+      global_lines = vim.api.nvim_buf_get_lines(global_win.buf, 0, -1, false)
+      if
+        global_lines[1] ~= "▾ Workspace Two · ● 0"
+        or global_lines[2] ~= "  └─ · pi-other-workspace · 42.5%"
+        or vim.api.nvim_win_get_cursor(global_win.win)[1] ~= 2
+      then
+        fail("Ctrl-R/Ctrl-X verifier should highlight pi-other-workspace")
+      end
+
+      local target_errors = {}
+      rename_prompt = nil
+      rename_args = nil
+      run_input_action("<c-r>")
+      if not rename_prompt or rename_prompt.default ~= "other-workspace" or rename_args then
+        target_errors[#target_errors + 1] = "Ctrl-R did not target pi-other-workspace (term-6)"
+      end
+      kill_prompt = nil
+      closed_panes = {}
+      run_input_action("<c-x>")
+      if not kill_prompt or not kill_prompt:find("pi-other-workspace", 1, true) or #closed_panes ~= 0 then
+        target_errors[#target_errors + 1] = "Ctrl-X did not target pi-other-workspace (w1:p6)"
+      end
+      if #target_errors > 0 then
+        fail(table.concat(target_errors, "; "))
+      end
+
+      input_pattern = ""
+      input_changed()
+      vim.api.nvim_win_set_cursor(global_win.win, { 1, 0 })
+      rename_prompt = nil
+      kill_prompt = nil
+      run_input_action("<c-r>")
+      run_input_action("<c-x>")
+      if rename_prompt or kill_prompt then
+        fail("Ctrl-R and Ctrl-X should do nothing on a workspace heading")
+      end
+
+      input_pattern = "pother"
+      input_changed()
+      for _, response in ipairs({ "   ", "other-workspace" }) do
+        rename_response = response
+        rename_prompt = nil
+        rename_args = nil
+        run_input_action("<c-r>")
+        if not rename_prompt or rename_args or fake_picker.closed then
+          fail("Ctrl-R should leave blank and unchanged workspace labels untouched")
+        end
+      end
+
+      notifications = {}
+      rename_succeeds = false
+      rename_response = "Taken Label"
+      rename_args = nil
+      run_input_action("<c-r>")
+      if
+        not vim.deep_equal(rename_args, { "agent", "rename", "term-6", "pi-taken-label" })
+        or fake_picker.closed
+        or not notifications[1]
+        or not notifications[1].message:find("session rename failed", 1, true)
+      then
+        fail("failed Ctrl-R should report the exact workspace-session rename without refreshing")
+      end
+
+      notifications = {}
+      close_succeeds = false
+      kill_choice = 1
+      kill_prompt = nil
+      closed_panes = {}
+      run_input_action("<c-x>")
+      if
+        not kill_prompt
+        or not kill_prompt:find("pi-other-workspace", 1, true)
+        or not vim.deep_equal(closed_panes, { "w1:p6" })
+        or fake_picker.closed
+        or removed_pane_id
+        or not notifications[1]
+        or not notifications[1].message:find("session close failed", 1, true)
+      then
+        fail("failed Ctrl-X should report the exact workspace pane without removing or refreshing it")
+      end
+
+      rename_succeeds = true
+      rename_response = "Workspace Renamed"
+      rename_args = nil
+      notifications = {}
+      local rename_picker_opts = picker_opts
+      run_input_action("<c-r>")
+      if global_win:valid() then
+        global_win:close()
+      end
+      vim.wait(200, function()
+        return picker_opts ~= rename_picker_opts
+      end, 5)
+      if
+        not vim.deep_equal(rename_args, { "agent", "rename", "term-6", "pi-workspace-renamed" })
+        or picker_opts == rename_picker_opts
+        or not fake_picker.closed
+      then
+        fail("successful Ctrl-R should rename the exact workspace session and refresh the picker")
+      end
+
+      fake_picker.closed = false
+      global_win = picker_opts.layout.wins.workspace
+      global_win:show()
+      picker_opts.on_show(fake_picker)
+      input_pattern = "prenamed"
+      input_changed()
+      global_lines = vim.api.nvim_buf_get_lines(global_win.buf, 0, -1, false)
+      if not vim.iter(global_lines):any(function(line)
+        return line:find("pi-workspace-renamed", 1, true) ~= nil
+      end) then
+        fail("successful Ctrl-R should display the renamed workspace session")
+      end
+
+      close_succeeds = true
+      kill_choice = 1
+      kill_prompt = nil
+      closed_panes = {}
+      local kill_picker_opts = picker_opts
+      run_input_action("<c-x>")
+      if global_win:valid() then
+        global_win:close()
+      end
+      vim.wait(200, function()
+        return picker_opts ~= kill_picker_opts
+      end, 5)
+      if
+        not kill_prompt
+        or not kill_prompt:find("pi-workspace-renamed", 1, true)
+        or not vim.deep_equal(closed_panes, { "w1:p6" })
+        or removed_pane_id ~= "w1:p6"
+        or not killed_item
+        or killed_item.terminal_id ~= "term-6"
+        or picker_opts == kill_picker_opts
+      then
+        fail("successful Ctrl-X should close the exact renamed workspace pane and refresh the picker")
+      end
+
+      fake_picker.closed = false
+      global_win = picker_opts.layout.wins.workspace
+      global_win:show()
+      picker_opts.on_show(fake_picker)
+      input_pattern = "prenamed"
+      input_changed()
+      global_lines = vim.api.nvim_buf_get_lines(global_win.buf, 0, -1, false)
+      if not vim.deep_equal(global_lines, { "(no matching workspace agents)" }) then
+        fail("successful Ctrl-X should remove the killed workspace session from refreshed results")
+      end
+
+      fake_picker.closed = true
+      picker_opts.on_close(fake_picker)
+      global_win:close()
+      return
     end
     input_pattern = "notfound"
     input_changed()
@@ -2539,10 +2803,15 @@ local function validate_sidekick_herdr()
   internal.toggle_tool_session = original_toggle
   vim.ui.input = original_ui_input
   vim.fn.confirm = original_confirm
+  vim.notify = original_picker_notify
   pcall(vim.api.nvim_tabpage_del_var, current_tab, "herdr_workspace_id")
   pcall(vim.api.nvim_tabpage_del_var, current_tab, "herdr_workspace_label")
   if not picker_ok then
     error(picker_err, 0)
+  end
+  if picker_actions_only then
+    herdr.list_agents = original_list_agents
+    return
   end
 
   local starship = require("plugins.sidekick.starship")
@@ -4934,6 +5203,7 @@ local cases = {
   ["sidekick-pi"] = validate_sidekick_pi,
   ["sidekick-herdr"] = validate_sidekick_herdr,
   ["sidekick-herdr-compat"] = validate_sidekick_herdr,
+  ["sidekick-picker-actions"] = validate_sidekick_herdr,
   ["herdr-workspaces"] = validate_herdr_workspaces,
   ["sidekick-herdr-live"] = validate_sidekick_herdr_live,
   ["vault-features"] = validate_vault_features,
@@ -4945,7 +5215,7 @@ if not fn then
   fail(
     "unknown VERIFY_NVIM_CASE "
       .. vim.inspect(case)
-      .. "; expected one of: agent-keymaps, weekly-backlog, markdown-formatting, markdown-ansi, inline-ask-edit, sidekick-pi, sidekick-herdr, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
+      .. "; expected one of: agent-keymaps, weekly-backlog, markdown-formatting, markdown-ansi, inline-ask-edit, sidekick-pi, sidekick-herdr, sidekick-picker-actions, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
   )
 end
 


### PR DESCRIPTION
## Intent

Ensure the Sidekick session picker Ctrl-X kill and Ctrl-R rename mappings always act on the visually highlighted session in the active local or workspace selector while input focus remains in search. Ctrl-X must no-op on headings, confirm the exact label, cancel safely, close only the exact Herdr pane, report failures, invoke lifecycle hooks, and refresh away the killed row. Ctrl-R must no-op on headings, default to the current human-readable label, treat cancel blank and unchanged input as no-ops, rename only the exact Herdr terminal identity, report collisions or failures, and refresh to the new label. Add a deterministic verifier at the configured key-action seam first and preserve unrelated work and retained Sidekick checks.

## What Changed

- Reworked the Sidekick session picker's Ctrl-X kill and Ctrl-R rename keymaps to resolve the visually highlighted row in whichever selector is active (local list or workspace window) instead of the input picker's current item, so actions land on the correct session while focus stays in search.
- Hardened the kill and rename flows: kill confirms the exact label, reports close failures, and only closes the targeted Herdr pane before refreshing; rename defaults to the current human-readable label, treats blank/cancel/unchanged input as no-ops via normalized-slug comparison, and renames the exact Herdr terminal identity with collision/failure reporting.
- Added a deterministic `sidekick-picker-actions` case to `scripts/verify-nvim.lua` asserting the key-action contract (heading no-ops, active-item routing, slug propagation), while retaining the existing `sidekick-herdr-compat` and `sidekick-pi` checks.

## Risk Assessment

✅ Low: The change is a well-bounded rerouting of two picker actions through a single active-selector seam with added failure reporting, covered by a new deterministic verifier case and consistent with every required behavior in the stated intent.

## Testing

Exercised the change end-to-end through the deterministic headless verifier the intent designates as the key-action seam: the new `sidekick-picker-actions` case drives the real Ctrl-X/Ctrl-R input mappings against a fake picker with an active workspace selector and asserts heading no-ops, exact-label confirmation and rename defaults, cancel/blank/unchanged no-ops, exact pane (w1:p6) and terminal (term-6) targeting, failure notifications without refresh, the on_kill hook payload, and post-action refresh showing the renamed label and removing the killed row; it passed twice, and retained `sidekick-herdr-compat` and unrelated `sidekick-pi` checks also passed. No screenshot/visual artifact exists because the picker is a headless-Neovim surface whose acceptance seam is this deterministic verifier; rendering it visually would require a live Herdr tmux server, which the intent explicitly supersedes by requiring the verifier at the key-action seam. The only failure observed is the pre-existing, unrelated T10 Atlas-layout assertion in the full `sidekick-herdr` case, which also fails at the base commit. The worktree was left clean with no transient artifacts.

<details>
<summary>Evidence: PASS output of the new deterministic key-action verifier</summary>

`PASS verify-nvim sidekick-picker-actions (exit 0; also reproduced identically on a second consecutive run)`

```text
PASS verify-nvim sidekick-picker-actions
```
</details>
<details>
<summary>Evidence: Ctrl-X/Ctrl-R key-action contract assertions exercised by the new verifier case</summary>

<code>- local Ctrl-R should prompt for the selected local session and cancel without mutation&#10;- local Ctrl-X should confirm the selected local session and cancel without mutation&#10;- Ctrl-R/Ctrl-X verifier should highlight pi-other-workspace&#10;- Ctrl-R and Ctrl-X should do nothing on a workspace heading&#10;- Ctrl-R should leave blank and unchanged workspace labels untouched&#10;- failed Ctrl-R should report the exact workspace-session rename without refreshing&#10;- failed Ctrl-X should report the exact workspace pane without removing or refreshing it&#10;- successful Ctrl-R should rename the exact workspace session and refresh the picker&#10;- successful Ctrl-R should display the renamed workspace session&#10;- successful Ctrl-X should close the exact renamed workspace pane and refresh the picker&#10;- successful Ctrl-X should remove the killed workspace session from refreshed results</code>

```text
Key-action contract assertions exercised by: VERIFY_NVIM_CASE=sidekick-picker-actions (scripts/verify-nvim sidekick-picker-actions)

- missing picker input action for 
- local Ctrl-R should prompt for the selected local session and cancel without mutation
- local Ctrl-X should confirm the selected local session and cancel without mutation
- Ctrl-R/Ctrl-X verifier should highlight pi-other-workspace
- Ctrl-R and Ctrl-X should do nothing on a workspace heading
- Ctrl-R should leave blank and unchanged workspace labels untouched
- failed Ctrl-R should report the exact workspace-session rename without refreshing
- failed Ctrl-X should report the exact workspace pane without removing or refreshing it
- successful Ctrl-R should rename the exact workspace session and refresh the picker
- successful Ctrl-R should display the renamed workspace session
- successful Ctrl-X should close the exact renamed workspace pane and refresh the picker
- successful Ctrl-X should remove the killed workspace session from refreshed results
```
</details>
<details>
<summary>Evidence: Retained compat check output</summary>

`PASS verify-nvim sidekick-herdr-compat (exit 0)`

```text
PASS verify-nvim sidekick-herdr-compat
```
</details>
<details>
<summary>Evidence: Pre-existing unrelated failure in the full sidekick-herdr case (also fails at base commit)</summary>

<code>T10 V01 picker layout at 100x30 should be full-width Preview, input, then Workspaces | Agents | Atlas Preview — fails because cwd_picker.lua has `workspace_preview_enabled = true` (unchanged by this diff; stale expectation predates the base commit)</code>

```text
T10 V01 picker layout at 100x30 should be full-width Preview, input, then Workspaces | Agents | Atlas Preview: { {
    border = "rounded",
    title = " Preview ",
    win = "preview"
  }, {
    border = "rounded",
    height = 1,
    win = "input"
  }, { {
      border = "rounded",
      footer = " <C-w> Agents · <Enter> Expand/Open ",
      footer_pos = "center",
      height = 12,
      title = " Workspaces ",
      width = 0.5,
      win = "workspace"
    }, {
      border = "rounded",
      footer = " <C-w> Workspaces ",
      footer_pos = "center",
      height = 12,
      title = " Agents / Run ",
      width = 0.5,
      win = "list"
    },
    box = "horizontal",
    height = 14
  },
  backdrop = false,
  border = "none",
  box = "vertical",
  height = 26,
  width = 82
}
stack traceback:
	[C]: in function 'error'
	scripts/verify-nvim.lua:33: in function 'fail'
	scripts/verify-nvim.lua:1952: in function 'verify_atlas_preview'
	scripts/verify-nvim.lua:2164: in function <scripts/verify-nvim.lua:1149>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:1149: in function <scripts/verify-nvim.lua:491>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:5222: in main chunk
stack traceback:
	[C]: in function 'error'
	scripts/verify-nvim.lua:2810: in function <scripts/verify-nvim.lua:491>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:5222: in main chunk
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m43s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua:1284` - The unchanged-input no-op now compares normalized slugs (`slug == current_slug` where current_slug = normalize_label(item.slug or item.label)) instead of exact session names (`name == item.agent_name`). For sessions created outside the sidekick flow with mixed-case names (e.g. `pi-Foo`), a case-only rename is swallowed as &#39;unchanged&#39; because normalize_label lowercases. Equivalent for all internally created sessions; noted only as a behavioral edge introduced by the change.
- ℹ️ `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua:1636` - The named actions `sidekick_rename_session`/`sidekick_kill_session` in the actions table are no longer referenced by any keymap (input/list/workspace keys now use the `rename_active_item`/`kill_active_item` closures); they are retained only for the verifier&#39;s retained-check assertion. Harmless, but they are effectively dead product code kept alive by a test.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `scripts/verify-nvim.lua:1952` - Pre-existing, unrelated failure: the full `sidekick-herdr` case fails at the T10 V01 picker-layout assertion, which expects a bottom &#39;Atlas Preview&#39; pane that only exists when `workspace_preview_enabled` is false; cwd_picker.lua has hard-coded `workspace_preview_enabled = true` since commit 2882ea6 (before base). This failure reproduces at base commit 78f8f32 (which fails even earlier, at the workspace-lookup mock around line 684), so it is not caused by this change; the targeted `sidekick-picker-actions` case added here and the retained `sidekick-herdr-compat`/`sidekick-pi` cases all pass. Fixing the stale T10 layout expectation is outside this change&#39;s intent.
- <code>`./scripts/verify-nvim sidekick-picker-actions` (new deterministic key-action contract case; PASS, run twice to confirm determinism)</code>
- <code>`./scripts/verify-nvim sidekick-herdr-compat` (retained Sidekick compat check; PASS)</code>
- <code>`./scripts/verify-nvim sidekick-pi` (unrelated Sidekick check; PASS)</code>
- <code>`./scripts/verify-nvim sidekick-herdr` (full case; FAILS at pre-existing, unrelated T10 V01 Atlas-preview layout assertion)</code>
- <code>Manual baseline check: temporarily restored base-commit versions of `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua` and `scripts/verify-nvim.lua` via `git show 78f8f32:...` and re-ran `./scripts/verify-nvim sidekick-herdr`; it also failed (earlier, at the workspace-lookup mock), confirming the full-case breakage pre-dates this change; files restored with `git checkout HEAD --` and `git status --porcelain` confirmed clean</code>
- <code>Manual history inspection: `git log -S workspace_preview_enabled` and `git show` across 2882ea6/703bc07/a1fb5fb confirmed the T10 layout expectation has been stale since 2882ea6, independent of this branch</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua` - Pre-existing stylua drift, not introduced by this change: stylua 2.4.0 (Mason) reformats large unchanged regions of nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua (stylua 2.x style vs the repo&#39;s older-stylua formatting), and scripts/verify-nvim.lua has no stylua.toml in scope so stylua defaults to tabs against the file&#39;s 2-space style. Both files fail `stylua --check` identically at the base commit; the change&#39;s added lines introduce no new violations and match surrounding style. Fixing requires a repo-wide stylua version pin or reformat, which is out of scope for this pass; propose a follow-up to pin the stylua version and either reformat or add config coverage for scripts/.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
