### PR TITLE
fix(sidekick): rename hovered agent by Herdr name instead of terminal ID

### DIFF
--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -1288,7 +1288,7 @@ function M.open(opts)
       if slug == "" or slug == current_slug then
         return
       end
-      local result, err = herdr.call({ "agent", "rename", item.terminal_id or item.agent_name, name }, true)
+      local result, err = herdr.call({ "agent", "rename", item.agent_name, name }, true)
       if not result then
         vim.notify("Sidekick: session rename failed: " .. (err or "unknown error"), vim.log.levels.ERROR)
         return

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1057,7 +1057,7 @@ local function validate_sidekick_herdr()
       if not rename_succeeds then
         return nil, "agent name already exists"
       end
-      if picker_actions_only and args[3] == "term-6" then
+      if picker_actions_only and args[3] == "pi-other-workspace" then
         other_agent_name = args[4]
       end
       return { agent = { name = args[4] } }
@@ -1260,11 +1260,11 @@ local function validate_sidekick_herdr()
       not rename_closed
       or not vim.deep_equal(
         rename_args,
-        { "agent", "rename", rename_item.terminal_id, rename_item.tool .. "-renamed-session" }
+        { "agent", "rename", rename_item.agent_name, rename_item.tool .. "-renamed-session" }
       )
       or picker_opts == rename_picker_opts
     then
-      fail("session rename should rename the selected Herdr agent and reopen the picker")
+      fail("session rename should target the selected Herdr agent name: " .. vim.inspect(rename_args))
     end
 
     local kill_item
@@ -1504,7 +1504,7 @@ local function validate_sidekick_herdr()
       rename_args = nil
       run_input_action("<c-r>")
       if not rename_prompt or rename_prompt.default ~= "other-workspace" or rename_args then
-        target_errors[#target_errors + 1] = "Ctrl-R did not target pi-other-workspace (term-6)"
+        target_errors[#target_errors + 1] = "Ctrl-R did not target agent pi-other-workspace"
       end
       kill_prompt = nil
       closed_panes = {}
@@ -1545,7 +1545,7 @@ local function validate_sidekick_herdr()
       rename_args = nil
       run_input_action("<c-r>")
       if
-        not vim.deep_equal(rename_args, { "agent", "rename", "term-6", "pi-taken-label" })
+        not vim.deep_equal(rename_args, { "agent", "rename", "pi-other-workspace", "pi-taken-label" })
         or fake_picker.closed
         or not notifications[1]
         or not notifications[1].message:find("session rename failed", 1, true)
@@ -1584,7 +1584,7 @@ local function validate_sidekick_herdr()
         return picker_opts ~= rename_picker_opts
       end, 5)
       if
-        not vim.deep_equal(rename_args, { "agent", "rename", "term-6", "pi-workspace-renamed" })
+        not vim.deep_equal(rename_args, { "agent", "rename", "pi-other-workspace", "pi-workspace-renamed" })
         or picker_opts == rename_picker_opts
         or not fake_picker.closed
       then


### PR DESCRIPTION
## Intent

Ensure Ctrl-R in the Sidekick picker renames exactly the hovered active agent session and never sends Herdr a terminal ID, while preserving the already-correct Ctrl-X close behavior. Reproduce the reported agent_not_found error pattern in the focused picker verifier, require the selected Herdr agent name for local, global, failed, and successful rename paths, and keep the production fix minimal.

## What Changed

- Fixed the Sidekick picker's Ctrl-R rename action in `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua` to always pass the hovered agent's Herdr name to `agent rename`, removing the terminal-ID fallback that caused Herdr `agent_not_found` failures; Ctrl-X close behavior is unchanged.
- Updated the focused `scripts/verify-nvim.lua` picker-actions assertions to require the selected Herdr agent name (`pi-other-workspace`) as the rename target across local, global, failed (name taken), and successful rename paths, and improved the failure message to report the actual rename arguments.

## Risk Assessment

✅ Low: The production fix is a single-line change in cwd_picker.lua:1291 that passes item.agent_name (guaranteed non-nil by the existing guard at line 1281) to herdr agent rename instead of preferring terminal_id, and the verifier now strictly asserts the agent-name target across local, global, failed, and successful rename paths while leaving the Ctrl-X pane_id close behavior and its assertions untouched.

## Testing

Ran the focused picker verifier on the fix (pass: all four rename paths send the Herdr agent name, close still uses terminal ID), reproduced the reported agent_not_found-causing behavior by failing the same verifier against base-commit picker code, and confirmed the only other failure (T10 layout in sidekick-herdr) pre-exists at the base commit in this environment.

<details>
<summary>Evidence: Bug reproduction: focused verifier fails against base-commit picker code, showing Ctrl-R sent terminal ID term-3 to herdr agent rename</summary>

```text
session rename should target the selected Herdr agent name: { "agent", "rename", "term-3", "pi-renamed-session" }
stack traceback:
	[C]: in function 'error'
	scripts/verify-nvim.lua:33: in function 'fail'
	scripts/verify-nvim.lua:1267: in function <scripts/verify-nvim.lua:1149>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:1149: in function <scripts/verify-nvim.lua:491>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:5222: in main chunk
stack traceback:
	[C]: in function 'error'
	scripts/verify-nvim.lua:2810: in function <scripts/verify-nvim.lua:491>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:5222: in main chunk
exit=1
```
</details>
<details>
<summary>Evidence: Focused picker verifier passing on the fix (rename-by-agent-name across local/global/failed/success paths)</summary>

`PASS verify-nvim sidekick-picker-actions`

```text
PASS verify-nvim sidekick-picker-actionsexit=0
```
</details>
<details>
<summary>Evidence: Pre-existing T10 V01 layout failure in broader sidekick-herdr case (identical at base commit d35d36b)</summary>

```text
T10 V01 picker layout at 100x30 should be full-width Preview, input, then Workspaces | Agents | Atlas Preview: { {
    border = "rounded",
    title = " Preview ",
    win = "preview"
  }, {
    border = "rounded",
    height = 1,
    win = "input"
  }, { {
      border = "rounded",
      footer = " <C-w> Agents · <Enter> Expand/Open ",
      footer_pos = "center",
      height = 12,
      title = " Workspaces ",
      width = 0.5,
      win = "workspace"
    }, {
      border = "rounded",
      footer = " <C-w> Workspaces ",
      footer_pos = "center",
      height = 12,
      title = " Agents / Run ",
      width = 0.5,
      win = "list"
    },
    box = "horizontal",
    height = 14
  },
  backdrop = false,
  border = "none",
  box = "vertical",
  height = 26,
  width = 82
}
stack traceback:
	[C]: in function 'error'
	scripts/verify-nvim.lua:33: in function 'fail'
	scripts/verify-nvim.lua:1952: in function 'verify_atlas_preview'
	scripts/verify-nvim.lua:2164: in function <scripts/verify-nvim.lua:1149>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:1149: in function <scripts/verify-nvim.lua:491>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:5222: in main chunk
stack traceback:
	[C]: in function 'error'
	scripts/verify-nvim.lua:2810: in function <scripts/verify-nvim.lua:491>
	[C]: in function 'xpcall'
	scripts/verify-nvim.lua:5222: in main chunk
exit=1
```
</details>
- Outcome: ⚠️ 1 info across 1 run (2m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `scripts/verify-nvim.lua:1952` - The broader `scripts/verify-nvim sidekick-herdr` case fails on a pre-existing T10 V01 picker-layout assertion (expects a 100x30 full-width layout) that fails identically at the base commit d35d36b in this headless Neovim 0.11.6 environment; it is unrelated to the rename change. The focused `sidekick-picker-actions` case that covers this change passes.
- <code>`./scripts/verify-nvim sidekick-picker-actions` (target commit d099957) — PASS; asserts rename args are `{&#34;agent&#34;,&#34;rename&#34;,&#34;pi-other-workspace&#34;,...}` for local, global, failed (name taken), and successful rename paths, plus Ctrl-X close via terminal_id term-6</code>
- <code>Bug reproduction: temporarily restored base-commit `nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua` (d35d36b) and re-ran `./scripts/verify-nvim sidekick-picker-actions` — FAILS with `rename_args = {&#34;agent&#34;,&#34;rename&#34;,&#34;term-3&#34;,&#34;pi-renamed-session&#34;}`, demonstrating the terminal-ID/agent_not_found pattern; fixed file restored and worktree confirmed clean at d099957</code>
- <code>`./scripts/verify-nvim sidekick-herdr` (target commit) — fails on pre-existing T10 V01 layout assertion</code>
- <code>`git worktree add --detach .tmp-base-check d35d36b &amp;&amp; ./scripts/verify-nvim sidekick-herdr` — identical T10 V01 failure at base commit, confirming it is not a regression; temporary worktree removed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
