### PR TITLE
fix(pi): restore semantic terminal rendering in agent output

### DIFF
--- a/nvim/.config/nvim/lua/plugins/sidekick/herdr_backend.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/herdr_backend.lua
@@ -44,9 +44,8 @@ function M.mark_seen(buf)
 end
 
 function M:init()
-  -- Herdr forwards the attached program's native mouse protocol. Let Pi own
-  -- transcript scrolling instead of replacing the live terminal with Sidekick's
-  -- terminal-normal scrollback buffer on the first wheel event.
+  -- Keep native PTY scrollback during the P0 rollback. Pi's custom transcript
+  -- scroller is disabled; moving history ownership to Sidekick remains P1.
   self.tool.native_scroll = true
   self.herdr_agent_name = self.herdr_agent_name or Herdr.agent_name(self.tool.name, self.cwd)
   self.mux_session = self.herdr_agent_name

--- a/pi/.pi/agent/APPEND_SYSTEM.md
+++ b/pi/.pi/agent/APPEND_SYSTEM.md
@@ -1,75 +1,13 @@
-# ANSI Gruvbox response rendering
-
-Render every assistant-authored, user-visible answer as raw ANSI SGR text using the Gruvbox Material palette below. This applies to all final responses, including short confirmations and errors. Do not rely on Markdown alone for color.
-
-Use 24-bit ANSI sequences. In the notation below, `ESC` means the actual U+001B escape byte; emit that byte, not the literal text `ESC` or `\x1b`.
-
-### Emitting the escape byte (critical)
-
-The #1 failure mode is writing the SGR opener as literal ASCII characters with no escape byte in front of it. This includes three sub-cases, all wrong: (a) the four characters `ESC[` (or `\u001b[`, `\x1b[`, `\e[`), (b) a bare `[` immediately followed by SGR params like `[1;38;2;242;133;52m`, `[38;2;235;219;178m`, `[48;2;60;56;54m`, or the reset `[0m`, with no preceding U+001B byte. In every case the user sees raw unrendered text like `[1;38;2;242;133;52m## Heading[0m` — the `[` and the param digits are visible on screen. You must emit the single control byte U+001B directly in your output stream, immediately followed by `[38;2;...m`, and again emit U+001B before the closing `[0m`.
-
-- ✗ WRONG (literal text the user sees unrendered): `ESC[38;2;242;89;75mError textESC[0m`
-- ✗ WRONG (the actual negative example from this repo): `[1;38;2;242;133;52m## Heading[0m` — a bare `[` with no U+001B before it; the whole `[1;38;2;...m` shows as literal text. The reset `[0m` is also missing its U+001B.
-- ✓ CORRECT: the byte `<U+001B>` then `[38;2;242;89;75mError text` then the byte `<U+001B>` then `[0m`. For a bold heading: `<U+001B>[1;38;2;242;133;52m## Heading<U+001B>[0m`.
-
-Self-check before sending: scan every visible answer line for any of these substrings and treat each as a defect unless immediately preceded by the U+001B byte: `ESC[`, `\x1b[`, `\u001b[`, `\e[`, `[0m`, `[1;38;2`, `[38;2`, `[48;2`, or any `[` followed by one or more digits/semicolons ending in `m`. The most common miss is the reset `[0m` and the bold-heading opener `[1;38;2;…m` — both still require a U+001B byte before the `[`. If you find any, stop and rewrite that line with the real control byte before every `[`.
-
-A correctly rendered answer looks exactly like this (real escape bytes; in a terminal it shows colored, with no visible codes):
-
-```
-[1;38;2;242;133;52m## ANSI render test — Gruvbox Material[0m
-[38;2;235;219;178mDefault prose text (#ebdbb2) — this is what normal answer text should look like.[0m
-[1;38;2;233;177;67m### Secondary heading (#e9b143)[0m
-[38;2;250;189;47mWarning (#fabd2f) — e.g. "fits at avg, oversubscribed at peak".[0m
-[38;2;184;187;38mSuccess (#b8bb26) — e.g. "consistent with the expected build".[0m
-[38;2;242;89;75mError (#f2594b) — e.g. "inconsistent — contradicts the locked spec".[0m
-[38;2;211;134;155mSpecial value (#d3869b) — e.g. 8× ConnectX-8 @ 800G, SYS-821GE-TNHR.[0m
-[38;2;128;170;158mInfo/link (#80aa9e) — file paths and references.[0m
-[38;2;146;131;116mMuted (#928374) — caveats and secondary detail.[0m
-[38;2;235;219;178;48;2;60;56;54m raised callout: default fg on message bg (#3c3836) [0m
-```
-
-Every visible line starts with an SGR sequence and ends with `<U+001B>[0m`; style never leaks across lines.
-
-| Role | Hex | ANSI foreground | ANSI background |
-|---|---:|---|---|
-| Default text | `#ebdbb2` | `ESC[38;2;235;219;178m` | — |
-| Bright text | `#fbf1c7` | `ESC[38;2;251;241;199m` | — |
-| Accent / heading | `#f28534` | `ESC[38;2;242;133;52m` | — |
-| Secondary heading | `#e9b143` | `ESC[38;2;233;177;67m` | — |
-| Warning | `#fabd2f` | `ESC[38;2;250;189;47m` | — |
-| Success | `#b8bb26` | `ESC[38;2;184;187;38m` | — |
-| String / positive detail | `#b0b846` | `ESC[38;2;176;184;70m` | — |
-| Info / link | `#80aa9e` | `ESC[38;2;128;170;158m` | — |
-| Auxiliary info | `#89b482` | `ESC[38;2;137;180;130m` | — |
-| Special value | `#d3869b` | `ESC[38;2;211;134;155m` | — |
-| Error | `#f2594b` | `ESC[38;2;242;89;75m` | — |
-| Muted text | `#928374` | `ESC[38;2;146;131;116m` | — |
-| Dim text | `#665c54` | `ESC[38;2;102;92;84m` | — |
-| Base background | `#282828` | — | `ESC[48;2;40;40;40m` |
-| Raised background | `#32302f` | — | `ESC[48;2;50;48;47m` |
-| User/message background | `#3c3836` | — | `ESC[48;2;60;56;54m` |
-| Selected background | `#45403d` | — | `ESC[48;2;69;64;61m` |
-| Success background | `#353d25` | — | `ESC[48;2;53;61;37m` |
-| Error background | `#3d1f1f` | — | `ESC[48;2;61;31;31m` |
-
-Formatting rules:
-
-1. Start every visible line with an appropriate foreground sequence and end every line with reset `ESC[0m`; never allow style state to leak across lines.
-2. Use default text for prose, bold accent for headings (`ESC[1;38;2;242;133;52m`), blue for links/references, green for success, yellow for warnings, red for errors, purple for special values, and muted/dim colors for secondary information.
-3. Use backgrounds sparingly for callouts or message blocks; do not fill trailing terminal width unless a block is intentional.
-4. Keep content readable without color. ANSI styling supplements wording and structure.
-5. The ANSI requirement applies only to assistant-authored display text. Never inject escape bytes into tool arguments, commands, patches, JSON, or files unless the user explicitly asks those artifacts to contain ANSI.
-
 # Response shape
+
+Write semantic Markdown only; Pi's theme owns presentation.
 
 Keep final answers to 30 lines or less, and wrap prose near 100 characters per line. The 30-line limit is a hard cap: if a complete answer would run longer, fit the most important part into the cap and defer the rest to the suggested follow-up questions at the end.
 
 Prefer structure over walls of text:
-- Use Markdown headings (`##`, `###`) for sections, styled with bold accent color so the color scheme carries through.
+- Use Markdown headings (`##`, `###`) for sections.
 - Use bullet points for lists, enumerations, and multi-item findings.
 - Lead with the direct answer or outcome; push context, caveats, and evidence below it.
-- Keep the same Gruvbox Material palette and reset-per-line discipline as the rest of this file — headings, bullets, and prose all participate in the color scheme.
 
 End every response with a `## Suggested follow-up questions` section: 2–4 concrete, self-contained one-liners the user could send verbatim to continue the thread — the pieces that did not fit in the 30-line cap, or the natural next decisions. Skip the section only for trivial acknowledgements (e.g. a bare "Done.").
 

--- a/pi/.pi/agent/settings.json
+++ b/pi/.pi/agent/settings.json
@@ -7,6 +7,9 @@
     },
     "git/github.com/amosblomqvist/pi-config/extensions/youtube-search/index.ts"
   ],
+  "extensions": [
+    "-extensions/transcript-scroll.ts"
+  ],
   "lastChangelogVersion": "0.82.1",
   "defaultProvider": "openai-codex",
   "defaultModel": "gpt-5.6-sol",

--- a/scripts/verify-pi-work-step-ui
+++ b/scripts/verify-pi-work-step-ui
@@ -6,8 +6,11 @@ export COLORTERM=truecolor
 export TERM=xterm-256color
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+p0_only=false
 if [[ "${1:-}" == "T22.V02" ]]; then
 	exec "$repo_root/scripts/verifiers/pi-work-step-ui-t22-v02"
+elif [[ "${1:-}" == "P0" ]]; then
+	p0_only=true
 fi
 verify_dir="$(mktemp -d)"
 tmux_socket="pi-work-step-ui-verify-$$"
@@ -125,6 +128,72 @@ clock_invalidation_marker="$verify_dir/clock-invalidation"
 if grep -Fq '# Visible thinking updates' "$repo_root/pi/.pi/agent/APPEND_SYSTEM.md"; then
 	echo "Visible-thinking prompt customization is still installed" >&2
 	exit 1
+fi
+
+append_system="$repo_root/pi/.pi/agent/APPEND_SYSTEM.md"
+if LC_ALL=C grep -q $'\033' "$append_system" || grep -Eiq 'ANSI|U\+001B|escape byte|SGR|terminal control' "$append_system"; then
+	echo "Semantic prompt safety failure: ANSI-generation guidance remains in APPEND_SYSTEM.md" >&2
+	exit 1
+fi
+for heading in '# Response shape' '# Tool-call activity titles'; do
+	if ! grep -Fqx "$heading" "$append_system"; then
+		echo "Semantic prompt safety failure: required section missing: $heading" >&2
+		exit 1
+	fi
+done
+
+node - \
+	"$repo_root/pi/.pi/agent/settings.json" \
+	"$repo_root/pi/.pi/agent/extensions/transcript-scroll.ts" <<'NODE'
+const fs = require("node:fs");
+const [settingsPath, extensionPath] = process.argv.slice(2);
+const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+const exclusion = "-extensions/transcript-scroll.ts";
+if (!(settings.extensions ?? []).includes(exclusion)) {
+	console.error(`Pi extension safety failure: missing exact force-exclude ${exclusion}`);
+	process.exit(1);
+}
+if (!fs.existsSync(extensionPath)) {
+	console.error(`Pi extension safety failure: explicit-load fixture source missing: ${extensionPath}`);
+	process.exit(1);
+}
+console.log("Pi P0 terminal safety verified: semantic prompt and transcript-scroll exclusion present.");
+NODE
+
+pi_cli="$(realpath "$(command -v pi)")"
+pi_package_root="$(cd "$(dirname "$pi_cli")/.." && pwd)"
+PI_OFFLINE=1 node --input-type=module - \
+	"$repo_root" \
+	"$verify_dir/p0-resolver" \
+	"$pi_package_root" <<'NODE'
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const [repoRoot, sandboxRoot, piRoot] = process.argv.slice(2);
+const sourceAgentDir = `${repoRoot}/pi/.pi/agent`;
+const agentDir = `${sandboxRoot}/agent`;
+const cwd = `${sandboxRoot}/cwd`;
+mkdirSync(agentDir, { recursive: true });
+mkdirSync(cwd, { recursive: true });
+symlinkSync(`${sourceAgentDir}/extensions`, `${agentDir}/extensions`);
+const sourceSettings = JSON.parse(readFileSync(`${sourceAgentDir}/settings.json`, "utf8"));
+writeFileSync(`${agentDir}/settings.json`, `${JSON.stringify({ extensions: sourceSettings.extensions })}\n`);
+
+const { DefaultPackageManager } = await import(pathToFileURL(`${piRoot}/dist/core/package-manager.js`).href);
+const { SettingsManager } = await import(pathToFileURL(`${piRoot}/dist/core/settings-manager.js`).href);
+const settings = SettingsManager.create(cwd, agentDir);
+await settings.reload();
+const manager = new DefaultPackageManager({ cwd, agentDir, settingsManager: settings });
+const matches = (await manager.resolve()).extensions.filter(({ path }) => path.endsWith("/transcript-scroll.ts"));
+if (matches.length !== 1 || matches[0].enabled !== false) {
+	console.error(`Pi extension safety failure: expected one disabled transcript-scroll resource, got ${JSON.stringify(matches)}`);
+	process.exit(1);
+}
+console.log(`Pi transcript-scroll resolver verified: enabled=${matches[0].enabled}.`);
+NODE
+
+if [[ "$p0_only" == true ]]; then
+	exit 0
 fi
 
 subagent_entry_relative="pi/.pi/agent/extensions/subagent.ts"

--- a/scripts/verify-pi-work-step-ui
+++ b/scripts/verify-pi-work-step-ui
@@ -160,16 +160,22 @@ if (!fs.existsSync(extensionPath)) {
 console.log("Pi P0 terminal safety verified: semantic prompt and transcript-scroll exclusion present.");
 NODE
 
-pi_cli="$(realpath "$(command -v pi)")"
+if ! pi_bin="$(command -v pi)"; then
+	echo "Pi extension safety failure: pi is not on PATH; this verifier requires an installed pi CLI" >&2
+	exit 1
+fi
+pi_cli="$(realpath "$pi_bin")"
 pi_package_root="$(cd "$(dirname "$pi_cli")/.." && pwd)"
+pi_version="$(pi --version 2>/dev/null)" || pi_version="unknown"
 PI_OFFLINE=1 node --input-type=module - \
 	"$repo_root" \
 	"$verify_dir/p0-resolver" \
-	"$pi_package_root" <<'NODE'
+	"$pi_package_root" \
+	"$pi_version" <<'NODE'
 import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-const [repoRoot, sandboxRoot, piRoot] = process.argv.slice(2);
+const [repoRoot, sandboxRoot, piRoot, piVersion] = process.argv.slice(2);
 const sourceAgentDir = `${repoRoot}/pi/.pi/agent`;
 const agentDir = `${sandboxRoot}/agent`;
 const cwd = `${sandboxRoot}/cwd`;
@@ -179,12 +185,34 @@ symlinkSync(`${sourceAgentDir}/extensions`, `${agentDir}/extensions`);
 const sourceSettings = JSON.parse(readFileSync(`${sourceAgentDir}/settings.json`, "utf8"));
 writeFileSync(`${agentDir}/settings.json`, `${JSON.stringify({ extensions: sourceSettings.extensions })}\n`);
 
-const { DefaultPackageManager } = await import(pathToFileURL(`${piRoot}/dist/core/package-manager.js`).href);
-const { SettingsManager } = await import(pathToFileURL(`${piRoot}/dist/core/settings-manager.js`).href);
-const settings = SettingsManager.create(cwd, agentDir);
-await settings.reload();
-const manager = new DefaultPackageManager({ cwd, agentDir, settingsManager: settings });
-const matches = (await manager.resolve()).extensions.filter(({ path }) => path.endsWith("/transcript-scroll.ts"));
+function failLayout(error) {
+	console.error(
+		`Pi extension safety failure: installed pi internals changed or failed to load ` +
+			`(pi version ${piVersion}, package root ${piRoot}): ${error instanceof Error ? error.message : String(error)}. ` +
+			`Update scripts/verify-pi-work-step-ui to the new pi internal layout or to a supported pi interface.`,
+	);
+	process.exit(1);
+}
+
+let DefaultPackageManager;
+let SettingsManager;
+try {
+	({ DefaultPackageManager } = await import(pathToFileURL(`${piRoot}/dist/core/package-manager.js`).href));
+	({ SettingsManager } = await import(pathToFileURL(`${piRoot}/dist/core/settings-manager.js`).href));
+} catch (error) {
+	failLayout(error);
+}
+if (typeof DefaultPackageManager !== "function" || typeof SettingsManager?.create !== "function")
+	failLayout(new Error("DefaultPackageManager or SettingsManager.create export is missing"));
+let matches;
+try {
+	const settings = SettingsManager.create(cwd, agentDir);
+	await settings.reload();
+	const manager = new DefaultPackageManager({ cwd, agentDir, settingsManager: settings });
+	matches = (await manager.resolve()).extensions.filter(({ path }) => path.endsWith("/transcript-scroll.ts"));
+} catch (error) {
+	failLayout(error);
+}
 if (matches.length !== 1 || matches[0].enabled !== false) {
 	console.error(`Pi extension safety failure: expected one disabled transcript-scroll resource, got ${JSON.stringify(matches)}`);
 	process.exit(1);


### PR DESCRIPTION
## Intent

The developer was working through a Pi terminal-rendering audit in their dotfiles repo, having approved a P0 rollback that removes raw-ANSI/Gruvbox generation guidance from APPEND_SYSTEM.md and disables the transcript-scroll.ts Pi extension via settings.json, while leaving the renderer source untouched. They asked for confirmation that no Pi behavior accidentally spills over to Codex beyond the pre-existing shared Sidekick/Herdr transport paths, wanted the live audit artifact reopened to review status, and sought next steps: complete P0.3 subagent capability enforcement and implement attachment leases for session-aware ownership. They then directed the agent to use the no-mistakes pipeline to isolate only the four intended P0 file changes into a clean branch (excluding unrelated provider, model, and Neovim edits), validate, push, and open PR #131, and finally to merge that PR if not already merged, accepting the prescribed rerun/rebase path when branch protection blocked merging a behind head.

## What Changed

- Removed raw ANSI/escape-byte/SGR generation guidance from `pi/.pi/agent/APPEND_SYSTEM.md` so the rollback prompt leads with semantic-Markdown response-shape guidance instead of terminal escape codes.
- Force-disabled the auto-discovered `transcript-scroll.ts` extension via a `-extensions/transcript-scroll.ts` exclusion in `pi/.pi/agent/settings.json` (explicit CLI `--extension` loads still resolve through a separate path).
- Added a P0 mode to `scripts/verify-pi-work-step-ui` that checks the prompt no longer contains ANSI/SGR guidance, required sections exist, the exact force-exclude entry is present, and the real installed pi resolver reports transcript-scroll as `enabled=false`; includes a comment-only clarification in `nvim/.config/nvim/lua/plugins/sidekick/herdr_backend.lua` with `native_scroll = true` behavior unchanged.

## Risk Assessment

✅ Low: The change is a well-bounded P0 rollback (prompt guidance removal, settings force-exclude, comment-only Lua edit) plus verifier checks that fail closed with hardened diagnostics, and the round-1 concerns about unguarded discovery and opaque internal-import failures are resolved.

## Testing

Ran the change's own targeted P0 verifier (`scripts/verify-pi-work-step-ui P0`), which passed: it statically confirmed the ANSI-generation guidance is gone from APPEND_SYSTEM.md and dynamically exercised the installed pi 0.82.1 SettingsManager/PackageManager resolver in a sandbox to prove transcript-scroll.ts resolves disabled; I additionally confirmed the settings.json exclusion, the comment-only herdr_backend.lua edit, branch isolation to exactly the four intended P0 files, and a clean worktree, capturing a full transcript as evidence.

<details>
<summary>Evidence: P0 rollback verification transcript (verifier run, settings.json, APPEND_SYSTEM.md head, herdr_backend context)</summary>

```text
== scripts/verify-pi-work-step-ui P0 ==
Pi P0 terminal safety verified: semantic prompt and transcript-scroll exclusion present.
Pi transcript-scroll resolver verified: enabled=false.
exit=0

== pi/.pi/agent/settings.json ==
{
  "packages": [
    "npm:pi-mcp-adapter",
    {
      "source": "https://github.com/amosblomqvist/pi-config",
      "extensions": []
    },
    "git/github.com/amosblomqvist/pi-config/extensions/youtube-search/index.ts"
  ],
  "extensions": [
    "-extensions/transcript-scroll.ts"
  ],
  "lastChangelogVersion": "0.82.1",
  "defaultProvider": "openai-codex",
  "defaultModel": "gpt-5.6-sol",
  "defaultThinkingLevel": "high",
  "theme": "gruvbox-material",
  "transport": "websocket-cached"
}

== head of pi/.pi/agent/APPEND_SYSTEM.md ==
# Response shape

Write semantic Markdown only; Pi's theme owns presentation.

Keep final answers to 30 lines or less, and wrap prose near 100 characters per line. The 30-line limit is a hard cap: if a complete answer would run longer, fit the most important part into the cap and defer the rest to the suggested follow-up questions at the end.

Prefer structure over walls of text:
- Use Markdown headings (`##`, `###`) for sections.
- Use bullet points for lists, enumerations, and multi-item findings.
- Lead with the direct answer or outcome; push context, caveats, and evidence below it.

End every response with a `## Suggested follow-up questions` section: 2–4 concrete, self-contained one-liners the user could send verbatim to continue the thread — the pieces that did not fit in the 30-line cap, or the natural next decisions. Skip the section only for trivial acknowledgements (e.g. a bare "Done.").

== grep ANSI guidance in APPEND_SYSTEM.md ==
0
no ANSI-generation guidance found

== herdr_backend.lua native_scroll context ==
47-  -- Keep native PTY scrollback during the P0 rollback. Pi's custom transcript
48-  -- scroller is disabled; moving history ownership to Sidekick remains P1.
49:  self.tool.native_scroll = true
50-  self.herdr_agent_name = self.herdr_agent_name or Herdr.agent_name(self.tool.name, self.cwd)
51-  self.mux_session = self.herdr_agent_name
```
</details>
<details>
<summary>Evidence: P0 verifier result against installed pi 0.82.1</summary>

```text
$ scripts/verify-pi-work-step-ui P0
Pi P0 terminal safety verified: semantic prompt and transcript-scroll exclusion present.
Pi transcript-scroll resolver verified: enabled=false.
exit=0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `scripts/verify-pi-work-step-ui:182` - The new P0 resolver check imports pi&#39;s internal build artifacts (`dist/core/package-manager.js`, `dist/core/settings-manager.js`) from the globally installed package. These paths are not a stable public API; a routine pi upgrade that restructures dist internals will fail this verifier with an opaque module-resolution error even while the P0 invariant (transcript-scroll disabled) still holds. Given pi ships frequently (settings pin lastChangelogVersion 0.82.1), consider pinning the check to a supported interface (e.g. a `pi` CLI listing command) or at minimum wrapping the import with a clear &#39;pi internal layout changed&#39; diagnostic.
- ℹ️ `scripts/verify-pi-work-step-ui:163` - `pi_cli=&#34;$(realpath &#34;$(command -v pi)&#34;)&#34;` is unguarded under `set -euo pipefail`: if pi is not on PATH the script dies with a bare realpath error instead of a clear precondition message. The rest of the script already requires pi, so this is only a diagnostics-quality nit.
- ℹ️ `pi/.pi/agent/settings.json:11` - Confirmed the `-extensions/transcript-scroll.ts` force-exclude is a supported pi mechanism: SettingsManager surfaces top-level `extensions`, DefaultPackageManager marks the auto-discovered file `enabled: false`, and resource-loader filters disabled resources. Explicit CLI `--extension` loads (used by scripts/verifiers/pi-transcript-links-v03 via scripts/fixtures/pi-transcript-links-v03-harness.lua) resolve through a separate path and intentionally still work, so the P1 fixture remains functional. No action needed; noted so the exclusion is not later assumed to block explicit loads.

🔧 Fix: Harden P0 verifier pi discovery and resolver diagnostics
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`scripts/verify-pi-work-step-ui P0` — new P0-only verifier mode: checks APPEND_SYSTEM.md has no ANSI/U+001B/SGR guidance, required sections present, settings.json contains the exact `-extensions/transcript-scroll.ts` force-exclude, and loads the real installed pi DefaultPackageManager/SettingsManager in a sandbox to confirm transcript-scroll resolves with `enabled=false` (exit 0)</code>
- <code>`pi --version` / `node --version` — confirmed verifier prerequisites (pi 0.82.1 on PATH, node v25.8.0)</code>
- <code>`cat pi/.pi/agent/settings.json` — confirmed valid JSON with the force-exclusion entry and trailing-newline fix</code>
- <code>`grep -Eicn &#39;ANSI|U\+001B|escape byte|SGR&#39; pi/.pi/agent/APPEND_SYSTEM.md` — zero matches; rollback prompt now leads with semantic-Markdown response-shape guidance</code>
- <code>`grep -n -B2 -A2 &#39;native_scroll&#39; nvim/.config/nvim/lua/plugins/sidekick/herdr_backend.lua` — confirmed the herdr_backend.lua change is comment-only; `self.tool.native_scroll = true` behavior unchanged</code>
- <code>`git status --porcelain` and `git diff --name-only ea5f358..76a3da8` — clean worktree and exactly the four intended P0 files (APPEND_SYSTEM.md, settings.json, herdr_backend.lua, verify-pi-work-step-ui); no unrelated provider/model edits</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `pi/.pi/agent/APPEND_SYSTEM.md:5` - Four pre-existing markdownlint violations remain under the repo&#39;s configured rules (nvim/.markdownlint-cli2.yaml): AV001 visual-line-length at lines 5 and 12, MD032 blanks-around-lists at line 8, and MD025 multiple top-level headings at line 14. All are carried over unchanged from the base commit (which had 27 errors; this change reduced them to 4) and none were introduced by this change. Left unresolved because the file is an agent system prompt whose two-H1 structure and long-line prose are deliberate; reflowing or re-heading would alter prompt content rather than perform a safe mechanical fix.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
