### PR TITLE
feat(nvim): add transactional, resumable PR review agent workspaces

### DIFF
--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -242,8 +242,9 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - PR review picker includes recently merged or closed assigned PRs.
 - Opening a top-level PR (smart entry, PR list or review picker confirm, or `Octo pr edit`) creates or reopens an
   isolated Herdr worktree workspace with a local `review/<repo>-<number>` branch.
-- Refreshing an updated PR head commits local review edits and rebases them onto the new head; a conflicted rebase
-  is handed to the review agent for semantic resolution and validation, with a recovery ref preserved.
+- Refreshing an updated PR head commits local review edits, records the exact pending head plus a recovery ref, and
+  rebases onto it; the same pending head is resumable, a different head is blocked, and the refs remain until the
+  review agent finishes any semantic conflict resolution and validates the rebased tree.
 - The review workspace tab shows a fixed 60-column presentation-only wrapped Markdown PR description on the left
   and the dedicated Sidekick review agent on the right.
 - The review agent is primed with PR metadata, diff, checks, reviews, and comments and asked for a context summary

--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -244,12 +244,14 @@ workflow area rather than plugin files, Lua modules, or implementation structure
   isolated Herdr worktree workspace with a local `review/<repo>-<number>` branch.
 - Refreshing an updated PR head commits local review edits, records the exact pending head plus a recovery ref, and
   rebases onto it; the same pending head is resumable, a different head is blocked, and the refs remain until the
-  review agent finishes any semantic conflict resolution and validates the rebased tree.
+  review agent finishes any semantic conflict resolution and validates the rebased tree. An orphaned recovery ref
+  without a pending ref or active rebase resumes validation when the fetched head matches the rebased state.
 - The review workspace tab shows a fixed 60-column presentation-only wrapped Markdown PR description on the left
   and the dedicated Sidekick review agent on the right.
 - The review agent is primed with PR metadata, diff, checks, reviews, and comments and asked for a context summary
   of at most 30 lines.
-- Selecting a PR's review agent restores its two-column review view.
+- Selecting a PR's review agent restores its two-column review view when that view is missing; toggling an already
+  visible review agent hides it and preserves user-created splits, and unrelated tabs are left untouched.
 - Review thread picker lists review threads.
 - Review thread picker defaults to unresolved threads and marks resolved or outdated threads in display text.
 - Review thread picker can open a thread in the browser.

--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -224,7 +224,7 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Git toggles include current-line blame and deleted-line display.
 - Octo is namespaced under `<leader>O`.
 - LazyVim default Octo `<leader>g*` mappings are disabled.
-- Octo supports smart entry.
+- Octo smart entry opens the current branch's PR review-agent workspace instead of Octo's built-in review.
 - Octo supports PR list, search, my PRs, review picker, author picker, thread picker, checkout, create, browser open, and URL copy.
 - Octo browser open also copies the PR URL and can fall back to `gh pr view` outside Octo PR buffers.
 - Octo avoids Projects v2 token-scope failures by not defaulting to Projects v2.
@@ -240,6 +240,15 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Octo unified review view is reversible and changes the Gitsigns base to the PR base commit while active.
 - PR review picker searches PRs to review and assigned PRs.
 - PR review picker includes recently merged or closed assigned PRs.
+- Opening a top-level PR (smart entry, PR list or review picker confirm, or `Octo pr edit`) creates or reopens an
+  isolated Herdr worktree workspace with a local `review/<repo>-<number>` branch.
+- Refreshing an updated PR head commits local review edits and rebases them onto the new head; a conflicted rebase
+  is handed to the review agent for semantic resolution and validation, with a recovery ref preserved.
+- The review workspace tab shows a fixed 60-column presentation-only wrapped Markdown PR description on the left
+  and the dedicated Sidekick review agent on the right.
+- The review agent is primed with PR metadata, diff, checks, reviews, and comments and asked for a context summary
+  of at most 30 lines.
+- Selecting a PR's review agent restores its two-column review view.
 - Review thread picker lists review threads.
 - Review thread picker defaults to unresolved threads and marks resolved or outdated threads in display text.
 - Review thread picker can open a thread in the browser.
@@ -361,7 +370,9 @@ workflow area rather than plugin files, Lua modules, or implementation structure
   session with a redundant label.
 - Pi named sessions receive native `--name <slug>` command arguments.
 - Sidekick branch metadata is stored in tmux environment.
-- `<C-.>` toggles the last picker-selected Sidekick session, falling back to the cwd session picker.
+- `<C-.>` toggles the current tab's last picker-selected Sidekick session, falling back to the cwd session picker.
+- Named Sidekick sessions started or listed inside a linked worktree are anchored to that worktree's Herdr
+  workspace.
 - `<C-;>` opens the local session picker.
 - `<C-r>` renames the selected session in the picker.
 - `<C-x>` confirms before closing the selected agent from the local session picker.
@@ -570,8 +581,11 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Tabline shows tabs and the current tab's buffers with custom separators and modified indicators.
 - Workspace tabs own a folder identity independent of Herdr; launching Neovim binds the initial tab to the launch
   folder, reusing an existing workspace tab that matches by path, then name.
-- Launching an agent from a workspace tab resolves or creates its Herdr workspace from the tab's folder, then label,
-  and binds the tab to that Herdr workspace.
+- Launching an agent from a Git-backed workspace tab resolves or creates the repository's Herdr workspace from Git's
+  shared common directory, keeps the agent cwd on the exact worktree, and binds the tab to the repository workspace.
+- Multiple worktree-scoped Workspace Tabs may bind to the same repository-scoped Herdr Workspace.
+- Workspace tabs bound to a PR review show GitHub-style open/merged/closed/draft status and an unseen-activity
+  marker in the tabline.
 - `<leader>fw` opens a fresh, compact Herdr workspace picker titled `spaces`.
 - Herdr workspaces can be created, renamed, selected, and confirmed-closed from the picker; each selected workspace is
   represented by at most one runtime Neovim tab keyed by its Herdr workspace ID.
@@ -580,7 +594,9 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Entering a bound workspace tab focuses the corresponding Herdr workspace; ordinary tabs and manually closed tabs do
   not affect Herdr.
 - Workspace tabs initialize from stable Herdr pane cwd and preserve later tab-local cwd/layout changes.
-- Closing a Herdr workspace from the picker unbinds its Neovim tab, which keeps its folder identity.
+- Closing a Herdr workspace from the picker unbinds its Neovim tabs, which keep their folder identity.
+- Killing an agent from the session picker closes its workspace tab and closes the Herdr workspace once no agents
+  remain.
 - `<S-h>` and `<S-l>` cycle the current tab's buffers; `[b` and `]b` navigate global buffers.
 - `<S-q>` closes the current buffer.
 - Dashboard actions include finding files, creating a new file, restoring the last session, opening Herdr workspaces,

--- a/nvim/.config/nvim/lua/plugins/herdr/workspaces.lua
+++ b/nvim/.config/nvim/lua/plugins/herdr/workspaces.lua
@@ -235,6 +235,9 @@ local function unbind(tab)
   for _, name in pairs(vars) do
     tab_del(tab, name)
   end
+  pcall(function()
+    require("plugins.octo.review_agent").unbind_workspace(tab)
+  end)
   vim.cmd.redrawtabline()
 end
 

--- a/nvim/.config/nvim/lua/plugins/herdr/workspaces.lua
+++ b/nvim/.config/nvim/lua/plugins/herdr/workspaces.lua
@@ -218,6 +218,10 @@ local function bind_tab(workspace, reuse_empty)
     vim.cmd.redrawtabline()
   end
 
+  pcall(function()
+    require("plugins.octo.review_agent").bind_workspace(tab, workspace)
+  end)
+
   local current = vim.api.nvim_get_current_tabpage()
   if current == tab then
     focus_tab(tab)

--- a/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/nvim/.config/nvim/lua/plugins/octo.lua
@@ -16,7 +16,7 @@ local function html_to_markdown(text)
   text = text:gsub('<a[^>]-href="([^"]*)"[^>]*>(.-)</a>', "[%2](%1)")
 
   -- Standalone images: <img alt="text" ...>
-  text = text:gsub('<img[^>]-alt="([^"]*)"[^>]*/?>',"%1")
+  text = text:gsub('<img[^>]-alt="([^"]*)"[^>]*/?>', "%1")
 
   -- Bold
   text = text:gsub("<strong>(.-)</strong>", "**%1**")
@@ -42,7 +42,24 @@ local function html_to_markdown(text)
   text = text:gsub("<summary>(.-)</summary>", "**%1**")
 
   -- Strip container tags but keep content
-  for _, tag in ipairs({ "details", "div", "span", "table", "thead", "tbody", "tr", "t" .. "d", "th", "ul", "ol", "li", "section", "nav", "header", "footer" }) do
+  for _, tag in ipairs({
+    "details",
+    "div",
+    "span",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "t" .. "d",
+    "th",
+    "ul",
+    "ol",
+    "li",
+    "section",
+    "nav",
+    "header",
+    "footer",
+  }) do
     text = text:gsub("<" .. tag .. "[^>]*>", "")
     text = text:gsub("</" .. tag .. ">", "")
   end
@@ -206,24 +223,76 @@ return {
     { "<leader>gr", false },
     { "<leader>gS", false },
     -- <leader>O Octo namespace
-    { "<leader>O",  "",                                                                 desc = "+octo" },
-    { "<leader>OO", smart_entry,                                                        desc = "Smart entry (review/list)" },
-    { "<leader>Op", "<cmd>Octo pr list<CR>",                                            desc = "PR list" },
-    { "<leader>OP", "<cmd>Octo pr search<CR>",                                          desc = "PR search" },
-    { "<leader>Om", "<cmd>Octo pr search author:@me state:open<CR>",                    desc = "My PRs" },
-    { "<leader>Or", function() require("plugins.octo.pr_review_picker").open() end,    desc = "PRs to review + assigned (incl. merged <1w)" },
-    { "<leader>OA", prompt_author,                                                      desc = "PRs by author..." },
-    { "<leader>OT", function() require("plugins.octo.threads_picker").open() end,       desc = "Threads picker" },
-    { "<leader>Oc", "<cmd>Octo pr checkout<CR>",                                        desc = "Checkout PR" },
-    { "<leader>OC", "<cmd>Octo pr create<CR>",                                          desc = "Create PR from current branch" },
-    { "<leader>Ob", open_browser_and_copy,                                              desc = "Open PR in browser + copy URL" },
+    { "<leader>O", "", desc = "+octo" },
+    {
+      "<leader>OO",
+      smart_entry,
+      desc = "Smart entry (review/list)",
+    },
+    { "<leader>Op", "<cmd>Octo pr list<CR>", desc = "PR list" },
+    { "<leader>OP", "<cmd>Octo pr search<CR>", desc = "PR search" },
+    { "<leader>Om", "<cmd>Octo pr search author:@me state:open<CR>", desc = "My PRs" },
+    {
+      "<leader>Or",
+      function()
+        require("plugins.octo.pr_review_picker").open()
+      end,
+      desc = "PRs to review + assigned (incl. merged <1w)",
+    },
+    { "<leader>OA", prompt_author, desc = "PRs by author..." },
+    {
+      "<leader>OT",
+      function()
+        require("plugins.octo.threads_picker").open()
+      end,
+      desc = "Threads picker",
+    },
+    { "<leader>Oc", "<cmd>Octo pr checkout<CR>", desc = "Checkout PR" },
+    {
+      "<leader>OC",
+      "<cmd>Octo pr create<CR>",
+      desc = "Create PR from current branch",
+    },
+    {
+      "<leader>Ob",
+      open_browser_and_copy,
+      desc = "Open PR in browser + copy URL",
+    },
     -- Collapse review's two-pane split into the right buffer + gitsigns gutter
     { "<localleader>u", unify_review_view, desc = "unify review view (drop left, gitsigns the right)" },
     -- Comment-prefix templates (active when inside a review session; no-op otherwise)
-    { "<localleader>cn", function() require("plugins.octo.comment_templates").compose("nit") end, mode = { "n", "x" }, desc = "nit comment" },
-    { "<localleader>cq", function() require("plugins.octo.comment_templates").compose("q")   end, mode = { "n", "x" }, desc = "question comment" },
-    { "<localleader>cb", function() require("plugins.octo.comment_templates").compose("b")   end, mode = { "n", "x" }, desc = "blocker comment" },
-    { "<localleader>c+", function() require("plugins.octo.comment_templates").compose("+")   end, mode = { "n", "x" }, desc = "praise comment" },
+    {
+      "<localleader>cn",
+      function()
+        require("plugins.octo.comment_templates").compose("nit")
+      end,
+      mode = { "n", "x" },
+      desc = "nit comment",
+    },
+    {
+      "<localleader>cq",
+      function()
+        require("plugins.octo.comment_templates").compose("q")
+      end,
+      mode = { "n", "x" },
+      desc = "question comment",
+    },
+    {
+      "<localleader>cb",
+      function()
+        require("plugins.octo.comment_templates").compose("b")
+      end,
+      mode = { "n", "x" },
+      desc = "blocker comment",
+    },
+    {
+      "<localleader>c+",
+      function()
+        require("plugins.octo.comment_templates").compose("+")
+      end,
+      mode = { "n", "x" },
+      desc = "praise comment",
+    },
   },
   opts = {
     -- Disable Projects v2 fields in PR/issue queries; the gh token does not

--- a/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/nvim/.config/nvim/lua/plugins/octo.lua
@@ -68,7 +68,7 @@ local function html_to_markdown(text)
 end
 
 local function smart_entry()
-  require("octo.reviews").start_or_resume_review()
+  require("plugins.octo.review_agent").open_current()
 end
 
 --- Toggle the review between Octo's stock vertical split (base | head, both in
@@ -424,6 +424,15 @@ query(
             end
             return ret
           end
+          pick_opts.confirm = function(picker, item)
+            picker:close()
+            if item then
+              require("plugins.octo.review_agent").open({
+                repo = item.repository.nameWithOwner,
+                number = item.number,
+              })
+            end
+          end
         end
 
         -- Restore and call original
@@ -436,6 +445,8 @@ query(
 
     -- Also patch the picker module reference
     snacks_provider.picker.prs = snacks_provider.pull_requests
+
+    require("plugins.octo.review_agent").setup()
 
     -- Monkey-patch octo writers to convert HTML → markdown before rendering
     local writers = require("octo.ui.writers")

--- a/nvim/.config/nvim/lua/plugins/octo/pr_review_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/pr_review_picker.lua
@@ -105,7 +105,7 @@ local function show(items)
     confirm = function(picker, item)
       picker:close()
       if not item then return end
-      vim.cmd(string.format("Octo pr edit %d %s", item.number, item.repo))
+      require("plugins.octo.review_agent").open({ repo = item.repo, number = item.number })
     end,
     win = {
       input = {

--- a/nvim/.config/nvim/lua/plugins/octo/pr_review_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/pr_review_picker.lua
@@ -12,7 +12,9 @@ end
 ---@param cb fun(prs: table[])
 local function gh_search(flags, cb)
   local cmd = { "gh", "search", "prs" }
-  for _, f in ipairs(flags) do table.insert(cmd, f) end
+  for _, f in ipairs(flags) do
+    table.insert(cmd, f)
+  end
   table.insert(cmd, "--json")
   table.insert(cmd, JSON_FIELDS)
   table.insert(cmd, "--limit")
@@ -20,8 +22,10 @@ local function gh_search(flags, cb)
   vim.system(cmd, { text = true }, function(out)
     if out.code ~= 0 then
       vim.schedule(function()
-        vim.notify("pr_review_picker: gh search failed (" .. table.concat(flags, " ") ..
-          "): " .. (out.stderr or ""), vim.log.levels.ERROR)
+        vim.notify(
+          "pr_review_picker: gh search failed (" .. table.concat(flags, " ") .. "): " .. (out.stderr or ""),
+          vim.log.levels.ERROR
+        )
       end)
       return cb({})
     end
@@ -51,8 +55,8 @@ local function to_item(pr, reason)
 end
 
 local REASON_LABEL = {
-  ["review"]          = "review-requested",
-  ["assigned"]        = "assigned (open)",
+  ["review"] = "review-requested",
+  ["assigned"] = "assigned (open)",
   ["assigned-merged"] = "assigned (merged)",
 }
 
@@ -104,7 +108,9 @@ local function show(items)
     end,
     confirm = function(picker, item)
       picker:close()
-      if not item then return end
+      if not item then
+        return
+      end
       require("plugins.octo.review_agent").open({ repo = item.repo, number = item.number })
     end,
     win = {
@@ -127,8 +133,8 @@ end
 function M.open()
   local since = iso_days_ago(RECENT_DAYS)
   local queries = {
-    { reason = "review",          flags = { "--review-requested=@me", "--state=open" } },
-    { reason = "assigned",        flags = { "--assignee=@me", "--state=open" } },
+    { reason = "review", flags = { "--review-requested=@me", "--state=open" } },
+    { reason = "assigned", flags = { "--assignee=@me", "--state=open" } },
     { reason = "assigned-merged", flags = { "--assignee=@me", "--merged", "--merged-at=>=" .. since } },
   }
 
@@ -137,7 +143,9 @@ function M.open()
 
   local function done()
     pending = pending - 1
-    if pending > 0 then return end
+    if pending > 0 then
+      return
+    end
     vim.schedule(function()
       if #items == 0 then
         vim.notify("pr_review_picker: nothing to show", vim.log.levels.INFO)

--- a/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
@@ -237,13 +237,14 @@ function M.restore(context)
   return true
 end
 
-local function record_for_session(name)
-  local state = load_state()
-  for _, record in pairs(state.reviews) do
-    if record.agent_name == name then
-      return record
+local function review_view_present(context)
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    local ok, key = pcall(vim.api.nvim_buf_get_var, vim.api.nvim_win_get_buf(win), "octo_review_key")
+    if ok and key == context.key then
+      return true
     end
   end
+  return false
 end
 
 function M.restore_for_session(name)
@@ -251,11 +252,10 @@ function M.restore_for_session(name)
     return false
   end
   local tab = vim.api.nvim_get_current_tabpage()
-  local context = tab_context(tab) or record_for_session(name)
-  if not context then
+  local context = tab_context(tab)
+  if not context or context.agent_name ~= name or review_view_present(context) then
     return false
   end
-  set_tab_context(tab, context)
   return M.restore(context)
 end
 
@@ -402,8 +402,10 @@ local function sync_branch(context, new_head)
   if recovery.code == 0 or pending.code == 0 then
     local pending_head = trim(pending.stdout)
     local target = rebasing and rebase_target(cwd) or nil
+    local orphaned_recovery = pending_head == "" and not rebasing and recovery.code == 0
     local same_refresh = pending_head == new_head and (not rebasing or target == new_head)
       or pending_head == "" and target == new_head
+      or orphaned_recovery and git(cwd, { "merge-base", "--is-ancestor", new_head, "HEAD" }).code == 0
     if not same_refresh then
       notify("finish validating the pending PR refresh before applying a different PR head", vim.log.levels.WARN)
       return nil

--- a/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
@@ -392,10 +392,6 @@ local function sync_branch(context, new_head)
   if rebased.code ~= 0 then
     return true, base_ref, recovery_ref
   end
-  if git(cwd, { "diff", "--check" }).code ~= 0 then
-    notify("rebased branch failed git diff --check; recovery ref retained")
-    return nil
-  end
   git(cwd, { "update-ref", base_ref, new_head })
   git(cwd, { "update-ref", "-d", recovery_ref })
   return false, base_ref, recovery_ref

--- a/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
@@ -1,0 +1,713 @@
+local herdr = require("plugins.sidekick.herdr")
+
+local M = {}
+
+local state_path = vim.fn.stdpath("state") .. "/octo-review-agents.json"
+local context_var = "octo_review_context"
+
+local function notify(message, level)
+  vim.notify("Octo review: " .. message, level or vim.log.levels.ERROR)
+end
+
+local function trim(value)
+  return (value or ""):gsub("%s+$", "")
+end
+
+local function command(args, opts)
+  opts = opts or {}
+  opts.text = true
+  return vim.system(args, opts):wait()
+end
+
+local function git(cwd, args)
+  local cmd = { "git", "-C", cwd }
+  vim.list_extend(cmd, args)
+  return command(cmd)
+end
+
+local function ref_slug(repo, number)
+  return (repo .. "-" .. tostring(number)):lower():gsub("[^%w._-]+", "-")
+end
+
+local function branch_name(repo, number)
+  return "review/" .. ref_slug(repo, number)
+end
+
+local function tab_context(tab)
+  local ok, context = pcall(vim.api.nvim_tabpage_get_var, tab or 0, context_var)
+  return ok and type(context) == "table" and context or nil
+end
+
+local function set_tab_context(tab, context)
+  vim.api.nvim_tabpage_set_var(tab, context_var, context)
+  vim.api.nvim_tabpage_set_var(tab, "octo_review_state", context.state)
+  vim.api.nvim_tabpage_set_var(tab, "octo_review_unseen", context.unseen == true)
+  vim.cmd.redrawtabline()
+end
+
+local function load_state()
+  if vim.fn.filereadable(state_path) ~= 1 then
+    return { reviews = {} }
+  end
+  local ok, decoded = pcall(vim.json.decode, table.concat(vim.fn.readfile(state_path), "\n"))
+  if not ok or type(decoded) ~= "table" then
+    return { reviews = {} }
+  end
+  decoded.reviews = type(decoded.reviews) == "table" and decoded.reviews or {}
+  return decoded
+end
+
+local function save_state(state)
+  vim.fn.mkdir(vim.fn.fnamemodify(state_path, ":h"), "p")
+  local temporary = state_path .. ".tmp"
+  if vim.fn.writefile({ vim.json.encode(state) }, temporary) ~= 0 then
+    return false
+  end
+  return vim.uv.fs_rename(temporary, state_path) ~= nil
+end
+
+local function review_key(host, repo, number)
+  return string.format("%s/%s#%d", host or "github.com", repo:lower(), number)
+end
+
+local function review_state(pr)
+  if pr.isDraft then
+    return "draft"
+  end
+  if pr.mergedAt or pr.state == "MERGED" then
+    return "merged"
+  end
+  if pr.state == "CLOSED" then
+    return "closed"
+  end
+  return "open"
+end
+
+function M.fingerprint(pr)
+  local checks = {}
+  for _, check in ipairs(pr.statusCheckRollup or {}) do
+    checks[#checks + 1] = table.concat({
+      check.name or check.context or "",
+      check.conclusion or check.state or check.status or "",
+      check.completedAt or check.startedAt or "",
+    }, ":")
+  end
+  table.sort(checks)
+  return vim.fn.sha256(vim.json.encode({
+    head = pr.headRefOid,
+    updated = pr.updatedAt,
+    state = review_state(pr),
+    comments = #(pr.comments or {}),
+    reviews = #(pr.reviews or {}),
+    checks = checks,
+  }))
+end
+
+function M.agent_name(repo, number)
+  local name = repo:match("/([^/]+)$") or repo
+  name = name:lower():gsub("[^%w_-]+", "-"):sub(1, 15):gsub("-$", "")
+  return ("codex-pr-%s-%d"):format(name, number):sub(1, 32)
+end
+
+function M.is_session(name)
+  return type(name) == "string" and name:match("^codex%-pr%-") ~= nil
+end
+
+local function wrap_line(line, width)
+  local function display_width(value)
+    return vim.fn.strdisplaywidth(value)
+  end
+  if display_width(line) <= width then
+    return { line }
+  end
+  local prefix = line:match("^(%s*[%-%*+]%s+)") or line:match("^(%s*%d+[%.%)]%s+)") or line:match("^(%s*>%s*)") or ""
+  local content = line:sub(#prefix + 1)
+  local continuation = prefix:gsub("[^%s]", " ")
+  local available = math.max(width - display_width(prefix), 20)
+  local out, current = {}, prefix
+  for word in content:gmatch("%S+") do
+    if current ~= prefix and display_width(current .. " " .. word) > width then
+      out[#out + 1] = current
+      current = continuation .. word
+    elseif current == prefix then
+      current = current .. word
+    else
+      current = current .. " " .. word
+    end
+    if display_width(word) > available and display_width(current) > width then
+      out[#out + 1] = current
+      current = continuation
+    end
+  end
+  if current ~= prefix and current ~= continuation then
+    out[#out + 1] = current
+  end
+  return #out > 0 and out or { line }
+end
+
+function M.wrap_markdown(body, width)
+  width = width or 60
+  local out, fenced = {}, false
+  for _, line in ipairs(vim.split(body or "", "\n", { plain = true })) do
+    local fence = line:match("^%s*```") or line:match("^%s*~~~")
+    local preserve = fenced
+      or fence
+      or line:find("|", 1, true)
+      or line:match("^    ")
+      or line:match("^%s*<[%w/!]")
+      or line:match("^%s*#")
+    if fence then
+      fenced = not fenced
+    end
+    if preserve or line == "" then
+      out[#out + 1] = line
+    else
+      vim.list_extend(out, wrap_line(line, width))
+    end
+  end
+  return out
+end
+
+local function description_lines(context)
+  local lines = {
+    string.format("# %s", context.title),
+    "",
+    string.format("%s/%s#%d · %s", context.host, context.repo, context.number, context.state),
+    string.format("@%s · %s → %s", context.author, context.head_ref, context.base_ref),
+    "",
+  }
+  vim.list_extend(lines, M.wrap_markdown(context.body, 60))
+  return lines
+end
+
+local function review_buffer(context)
+  local name = string.format("octo-review://%s/%s/pull/%d", context.host, context.repo, context.number)
+  local bufnr = vim.fn.bufnr(name)
+  if bufnr < 0 then
+    bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, name)
+  end
+  vim.bo[bufnr].modifiable = true
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, description_lines(context))
+  vim.b[bufnr].octo_review_body = context.body
+  vim.b[bufnr].octo_review_key = context.key
+  vim.bo[bufnr].buftype = "nofile"
+  vim.bo[bufnr].bufhidden = "hide"
+  vim.bo[bufnr].swapfile = false
+  vim.bo[bufnr].buflisted = false
+  vim.bo[bufnr].filetype = "markdown"
+  vim.bo[bufnr].modifiable = false
+  return bufnr
+end
+
+function M.restore(context)
+  context = context or tab_context(vim.api.nvim_get_current_tabpage())
+  if not context then
+    return false
+  end
+  local win
+  for _, candidate in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    local is_sidekick = pcall(vim.api.nvim_win_get_var, candidate, "sidekick_cli")
+    if vim.api.nvim_win_get_config(candidate).relative == "" and not is_sidekick then
+      win = candidate
+      break
+    end
+  end
+  if not win then
+    vim.cmd("leftabove vnew")
+    win = vim.api.nvim_get_current_win()
+  end
+  vim.api.nvim_set_current_win(win)
+  pcall(vim.cmd, "silent! only")
+  vim.api.nvim_win_set_buf(win, review_buffer(context))
+  vim.api.nvim_win_set_width(win, math.min(60, math.max(vim.o.columns - 40, 20)))
+  vim.wo[win].winfixwidth = true
+  vim.wo[win].wrap = false
+  vim.wo[win].linebreak = false
+  vim.wo[win].number = false
+  vim.wo[win].relativenumber = false
+  vim.wo[win].signcolumn = "no"
+  vim.wo[win].winbar = "%#Title# PR description %#Comment#· <C-w>l agent "
+  return true
+end
+
+local function record_for_session(name)
+  local state = load_state()
+  for _, record in pairs(state.reviews) do
+    if record.agent_name == name then
+      return record
+    end
+  end
+end
+
+function M.restore_for_session(name)
+  if not M.is_session(name) then
+    return false
+  end
+  local tab = vim.api.nvim_get_current_tabpage()
+  local context = tab_context(tab) or record_for_session(name)
+  if not context then
+    return false
+  end
+  set_tab_context(tab, context)
+  return M.restore(context)
+end
+
+function M.configure_terminal(terminal)
+  if not terminal or not terminal.tool or not M.is_session(terminal.tool.name) then
+    return
+  end
+  terminal.opts.layout = "right"
+  terminal.opts.split.width = math.max(vim.o.columns - 61, 40)
+end
+
+function M.bind_workspace(tab, workspace)
+  if not workspace or not workspace.workspace_id then
+    return false
+  end
+  local state = load_state()
+  for _, record in pairs(state.reviews) do
+    if record.workspace_id == workspace.workspace_id then
+      set_tab_context(tab, record)
+      return true
+    end
+  end
+  return false
+end
+
+local function parse_remote(url)
+  url = trim(url):gsub("%.git$", "")
+  local host, repo = url:match("^git@([^:]+):(.+)$")
+  if not host then
+    host, repo = url:match("^ssh://[^@]+@([^/]+)/(.+)$")
+  end
+  if not host then
+    host, repo = url:match("^https?://([^/]+)/(.+)$")
+  end
+  return host, repo
+end
+
+local function matching_remote(path, host, repo)
+  local root = trim(git(path, { "rev-parse", "--show-toplevel" }).stdout)
+  if root == "" then
+    return nil
+  end
+  local remotes = git(root, { "remote" })
+  if remotes.code ~= 0 then
+    return nil
+  end
+  for _, remote in ipairs(vim.split(trim(remotes.stdout), "\n", { plain = true, trimempty = true })) do
+    local url = git(root, { "remote", "get-url", remote })
+    local remote_host, remote_repo = parse_remote(url.stdout)
+    if remote_host and remote_repo and remote_host:lower() == host:lower() and remote_repo:lower() == repo:lower() then
+      return root, remote
+    end
+  end
+end
+
+local function repository_candidates(cwd, repo)
+  local candidates, seen = {}, {}
+  local function add(path)
+    path = path and vim.fs.normalize(vim.fn.fnamemodify(path, ":p")) or nil
+    if path and not seen[path] and vim.fn.isdirectory(path) == 1 then
+      seen[path] = true
+      candidates[#candidates + 1] = path
+    end
+  end
+  add(cwd)
+  if vim.fn.executable("ghq") == 1 then
+    local ghq = command({ "ghq", "list", "-p" })
+    if ghq.code == 0 then
+      for _, path in ipairs(vim.split(trim(ghq.stdout), "\n", { plain = true, trimempty = true })) do
+        add(path)
+      end
+    end
+  end
+  local name = repo:match("/([^/]+)$")
+  local home = vim.fn.expand("~")
+  for _, parent in ipairs({ "", "projects", "tools", "playground", "modal-projects" }) do
+    add(vim.fs.joinpath(home, parent, name))
+  end
+  return candidates
+end
+
+local function resolve_repository(cwd, host, repo)
+  for _, path in ipairs(repository_candidates(cwd, repo)) do
+    local root, remote = matching_remote(path, host, repo)
+    if root then
+      return root, remote
+    end
+  end
+end
+
+local function has_rebase(cwd)
+  local git_dir = trim(git(cwd, { "rev-parse", "--git-dir" }).stdout)
+  if git_dir == "" then
+    return false
+  end
+  if not vim.startswith(git_dir, "/") then
+    git_dir = vim.fs.joinpath(cwd, git_dir)
+  end
+  return vim.fn.isdirectory(vim.fs.joinpath(git_dir, "rebase-merge")) == 1
+    or vim.fn.isdirectory(vim.fs.joinpath(git_dir, "rebase-apply")) == 1
+end
+
+local function preserve_local_changes(cwd)
+  local status = git(cwd, { "status", "--porcelain", "--untracked-files=all" })
+  if status.code ~= 0 or trim(status.stdout) == "" then
+    return status.code == 0
+  end
+  if git(cwd, { "add", "-A" }).code ~= 0 then
+    return false
+  end
+  return git(cwd, { "commit", "-m", "chore: preserve local PR review edits" }).code == 0
+end
+
+local function sync_branch(context, new_head)
+  local cwd = context.cwd
+  local slug = ref_slug(context.repo, context.number)
+  local base_ref = "refs/octo-review/base/" .. slug
+  local recovery_ref = "refs/octo-review/recovery/" .. slug
+  if has_rebase(cwd) then
+    return true, base_ref, recovery_ref
+  end
+  if not preserve_local_changes(cwd) then
+    notify("could not commit local changes before refreshing the PR")
+    return nil
+  end
+  local old_head = trim(git(cwd, { "rev-parse", "--verify", base_ref }).stdout)
+  if old_head == "" then
+    git(cwd, { "update-ref", base_ref, new_head })
+    return false, base_ref, recovery_ref
+  end
+  if old_head == new_head then
+    return false, base_ref, recovery_ref
+  end
+  local current = trim(git(cwd, { "rev-parse", "HEAD" }).stdout)
+  if git(cwd, { "update-ref", recovery_ref, current }).code ~= 0 then
+    notify("could not create the recovery ref before rebase")
+    return nil
+  end
+  local rebased = git(cwd, { "-c", "core.editor=true", "rebase", "--onto", new_head, old_head })
+  if rebased.code ~= 0 then
+    return true, base_ref, recovery_ref
+  end
+  if git(cwd, { "diff", "--check" }).code ~= 0 then
+    notify("rebased branch failed git diff --check; recovery ref retained")
+    return nil
+  end
+  git(cwd, { "update-ref", base_ref, new_head })
+  git(cwd, { "update-ref", "-d", recovery_ref })
+  return false, base_ref, recovery_ref
+end
+
+local function ensure_scope(root, remote, context)
+  local slug = ref_slug(context.repo, context.number)
+  local head_ref = "refs/octo-review/heads/" .. slug
+  local fetched = git(root, {
+    "fetch",
+    "--force",
+    remote,
+    string.format("+refs/pull/%d/head:%s", context.number, head_ref),
+  })
+  if fetched.code ~= 0 then
+    notify("could not fetch PR head: " .. trim(fetched.stderr))
+    return nil
+  end
+  local head = trim(git(root, { "rev-parse", head_ref }).stdout)
+  if head == "" then
+    notify("fetched PR head could not be resolved")
+    return nil
+  end
+
+  local branch = branch_name(context.repo, context.number)
+  local listed = herdr.call({ "worktree", "list", "--cwd", root })
+  local found
+  for _, worktree in ipairs(listed and listed.worktrees or {}) do
+    if worktree.branch == branch then
+      found = worktree
+      break
+    end
+  end
+  local workspace_id = found and found.open_workspace_id or nil
+  if not found or not workspace_id then
+    local action = found and "open" or "create"
+    local args = { "worktree", action, "--cwd", root, "--branch", branch }
+    if action == "create" then
+      vim.list_extend(args, { "--base", head_ref })
+    end
+    vim.list_extend(args, { "--label", context.label, "--no-focus" })
+    local result = herdr.call(args)
+    found = result and result.worktree or nil
+    workspace_id = result and result.workspace and result.workspace.workspace_id or nil
+  end
+  if not found or not workspace_id or not found.path then
+    notify("could not create or reopen the PR worktree workspace")
+    return nil
+  end
+  context.cwd = found.path
+  context.branch = branch
+  context.workspace_id = workspace_id
+  local conflict, base_ref, recovery_ref = sync_branch(context, head)
+  if conflict == nil then
+    return nil
+  end
+  return context, conflict, head, base_ref, recovery_ref
+end
+
+local function prompt_text(context, conflict, head, base_ref, recovery_ref)
+  local conflict_instructions = ""
+  local mutation_instructions = [[This first pass is read-only: do not edit files, post comments, push,
+approve, merge, or otherwise mutate GitHub unless the user explicitly asks.]]
+  if conflict then
+    conflict_instructions = string.format(
+      [[
+
+A git rebase is currently conflicted. Resolve every conflict semantically, stage the resolutions,
+and finish the rebase yourself with GIT_EDITOR=true git rebase --continue. Run relevant tests plus
+git diff --check. Only after they pass, run:
+  git update-ref %s %s
+  git update-ref -d %s
+If resolution or validation fails, leave the recovery ref intact and explain the blocker.]],
+      base_ref,
+      head,
+      recovery_ref
+    )
+    mutation_instructions = [[Apart from the required conflict resolution, do not make unrelated edits,
+post comments, push, approve, merge, or otherwise mutate GitHub unless the user explicitly asks.]]
+  end
+  return string.format(
+    [[You are the dedicated review agent for %s#%d in %s.
+
+Refresh the complete PR context before answering:
+- gh pr view %d --repo %s --json number,title,body,state,isDraft,mergedAt,author,baseRefName,headRefName,headRefOid,updatedAt,reviewDecision,mergeStateStatus,statusCheckRollup,comments,reviews,files,commits
+- gh pr diff %d --repo %s
+- gh pr checks %d --repo %s
+
+Read the full diff, checks, reviews, and comments. Then produce a compact context summary of at most
+30 lines covering intent, change map, checks, review signals, risks, and local branch state. After the
+summary, wait for instructions. %s%s]],
+    context.repo,
+    context.number,
+    context.cwd,
+    context.number,
+    context.repo,
+    context.number,
+    context.repo,
+    context.number,
+    context.repo,
+    mutation_instructions,
+    conflict_instructions
+  )
+end
+
+local function mark_seen(key, fingerprint, tab)
+  local state = load_state()
+  local record = state.reviews[key]
+  if not record then
+    return
+  end
+  record.seen_fingerprint = fingerprint
+  record.unseen = false
+  state.reviews[key] = record
+  save_state(state)
+  if tab and vim.api.nvim_tabpage_is_valid(tab) then
+    set_tab_context(tab, record)
+  end
+end
+
+local function start_agent(context, conflict, head, base_ref, recovery_ref)
+  local internal = require("plugins.sidekick.internal")
+  local slug = context.agent_name:sub(#"codex-" + 1)
+  internal.start_named_session("codex", slug, context.cwd)
+  local tab = vim.api.nvim_get_current_tabpage()
+  local prompt = prompt_text(context, conflict, head, base_ref, recovery_ref)
+  local function submit(remaining)
+    if not herdr.get_agent(context.agent_name) then
+      if remaining > 0 then
+        vim.defer_fn(function()
+          submit(remaining - 1)
+        end, 200)
+      else
+        notify("review agent did not become ready", vim.log.levels.WARN)
+      end
+      return
+    end
+    vim.system(
+      { "herdr", "agent", "prompt", context.agent_name, prompt, "--wait", "--timeout", "900000" },
+      { text = true },
+      vim.schedule_wrap(function(result)
+        local refreshed = result.code == 0
+        if refreshed and conflict then
+          local base = git(context.cwd, { "rev-parse", "--verify", base_ref })
+          local recovery = git(context.cwd, { "rev-parse", "--verify", recovery_ref })
+          refreshed = not has_rebase(context.cwd) and trim(base.stdout) == head and recovery.code ~= 0
+        end
+        if refreshed then
+          mark_seen(context.key, context.fingerprint, tab)
+        else
+          notify("context refresh did not finish; unseen status retained", vim.log.levels.WARN)
+        end
+      end)
+    )
+  end
+  submit(50)
+end
+
+local function activate(pr, opts)
+  local host = opts.host or "github.com"
+  local repo = opts.repo
+  local number = tonumber(opts.number)
+  local root, remote = resolve_repository(opts.cwd, host, repo)
+  if not root then
+    notify(string.format("no local clone for %s/%s; open the PR from a matching checkout", host, repo))
+    return
+  end
+
+  local name = repo:match("/([^/]+)$") or repo
+  local key = review_key(host, repo, number)
+  local state = load_state()
+  local previous = state.reviews[key]
+  local fingerprint = M.fingerprint(pr)
+  local context = {
+    key = key,
+    host = host,
+    repo = repo,
+    number = number,
+    label = string.format("%s · #%d", name, number),
+    title = pr.title or ("Pull request #" .. number),
+    body = pr.body or "",
+    author = pr.author and pr.author.login or "?",
+    base_ref = pr.baseRefName or "?",
+    head_ref = pr.headRefName or "?",
+    state = review_state(pr),
+    fingerprint = fingerprint,
+    seen_fingerprint = previous and previous.seen_fingerprint or nil,
+    unseen = previous ~= nil and previous.seen_fingerprint ~= fingerprint,
+    agent_name = M.agent_name(repo, number),
+  }
+
+  local scoped, conflict, head, base_ref, recovery_ref = ensure_scope(root, remote, context)
+  if not scoped then
+    return
+  end
+  state.reviews[key] = scoped
+  if not save_state(state) then
+    notify("could not persist review workspace state", vim.log.levels.WARN)
+  end
+  if not require("plugins.herdr.workspaces").focus(scoped.workspace_id) then
+    return
+  end
+  local tab = vim.api.nvim_get_current_tabpage()
+  set_tab_context(tab, scoped)
+  M.restore(scoped)
+  start_agent(scoped, conflict, head, base_ref, recovery_ref)
+end
+
+function M.open(opts)
+  opts = opts or {}
+  local repo = opts.repo
+  local number = tonumber(opts.number)
+  if not repo or not number then
+    notify("repository and PR number are required")
+    return
+  end
+  local cwd = opts.cwd or vim.fn.getcwd(-1, 0)
+  local host = opts.host or "github.com"
+  local fields = table.concat({
+    "number",
+    "title",
+    "body",
+    "state",
+    "isDraft",
+    "mergedAt",
+    "author",
+    "baseRefName",
+    "headRefName",
+    "headRefOid",
+    "updatedAt",
+    "reviewDecision",
+    "mergeStateStatus",
+    "statusCheckRollup",
+    "comments",
+    "reviews",
+    "files",
+    "commits",
+  }, ",")
+  local env = host ~= "github.com" and vim.tbl_extend("force", vim.fn.environ(), { GH_HOST = host }) or nil
+  vim.system(
+    { "gh", "pr", "view", tostring(number), "--repo", repo, "--json", fields },
+    { text = true, env = env },
+    vim.schedule_wrap(function(result)
+      if result.code ~= 0 then
+        notify("gh pr view failed: " .. trim(result.stderr))
+        return
+      end
+      local ok, pr = pcall(vim.json.decode, result.stdout or "")
+      if not ok or type(pr) ~= "table" then
+        notify("gh pr view returned invalid JSON")
+        return
+      end
+      activate(pr, { repo = repo, number = number, host = host, cwd = cwd })
+    end)
+  )
+end
+
+function M.open_current()
+  local cwd = vim.fn.getcwd(-1, 0)
+  vim.system(
+    { "gh", "pr", "view", "--json", "number,url" },
+    { cwd = cwd, text = true },
+    vim.schedule_wrap(function(result)
+      if result.code ~= 0 then
+        notify("current branch has no pull request", vim.log.levels.WARN)
+        return
+      end
+      local ok, value = pcall(vim.json.decode, result.stdout or "")
+      local host, repo, number = ok and value.url and value.url:match("^https?://([^/]+)/(.+)/pull/(%d+)")
+      if not host or not repo or not number then
+        notify("could not identify the current pull request")
+        return
+      end
+      M.open({ host = host, repo = repo, number = tonumber(number), cwd = cwd })
+    end)
+  )
+end
+
+function M.setup()
+  local octo = require("octo")
+  if octo._review_agent_setup then
+    return
+  end
+  octo._review_agent_setup = true
+
+  local utils = require("octo.utils")
+  local uri = require("octo.uri")
+  local original_get_pull_request = utils.get_pull_request
+  utils.get_pull_request = function(...)
+    local repo, number = uri.get_repo_number_from_varargs(...)
+    if repo and number then
+      M.open({ repo = repo, number = number })
+      return
+    end
+    return original_get_pull_request(...)
+  end
+
+  local original_load_buffer = octo.load_buffer
+  octo.load_buffer = function(opts)
+    local bufnr = opts and opts.bufnr or vim.api.nvim_get_current_buf()
+    local parsed = uri.parse(vim.api.nvim_buf_get_name(bufnr))
+    if parsed and parsed.kind == "pull" then
+      M.open({ host = parsed.hostname or "github.com", repo = parsed.repo, number = tonumber(parsed.id) })
+      vim.schedule(function()
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+        end
+      end)
+      return
+    end
+    return original_load_buffer(opts)
+  end
+end
+
+return M

--- a/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
@@ -2,8 +2,12 @@ local herdr = require("plugins.sidekick.herdr")
 
 local M = {}
 
-local state_path = vim.fn.stdpath("state") .. "/octo-review-agents.json"
+local default_state_path = vim.fn.stdpath("state") .. "/octo-review-agents.json"
 local context_var = "octo_review_context"
+
+local function state_path()
+  return vim.g.octo_review_agent_state_path or default_state_path
+end
 
 local function notify(message, level)
   vim.notify("Octo review: " .. message, level or vim.log.levels.ERROR)
@@ -46,10 +50,11 @@ local function set_tab_context(tab, context)
 end
 
 local function load_state()
-  if vim.fn.filereadable(state_path) ~= 1 then
+  local path = state_path()
+  if vim.fn.filereadable(path) ~= 1 then
     return { reviews = {} }
   end
-  local ok, decoded = pcall(vim.json.decode, table.concat(vim.fn.readfile(state_path), "\n"))
+  local ok, decoded = pcall(vim.json.decode, table.concat(vim.fn.readfile(path), "\n"))
   if not ok or type(decoded) ~= "table" then
     return { reviews = {} }
   end
@@ -58,12 +63,13 @@ local function load_state()
 end
 
 local function save_state(state)
-  vim.fn.mkdir(vim.fn.fnamemodify(state_path, ":h"), "p")
-  local temporary = state_path .. ".tmp"
+  local path = state_path()
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+  local temporary = path .. ".tmp"
   if vim.fn.writefile({ vim.json.encode(state) }, temporary) ~= 0 then
     return false
   end
-  return vim.uv.fs_rename(temporary, state_path) ~= nil
+  return vim.uv.fs_rename(temporary, path) ~= nil
 end
 
 local function review_key(host, repo, number)
@@ -340,16 +346,37 @@ local function resolve_repository(cwd, host, repo)
   end
 end
 
-local function has_rebase(cwd)
+local function git_directory(cwd)
   local git_dir = trim(git(cwd, { "rev-parse", "--git-dir" }).stdout)
   if git_dir == "" then
-    return false
+    return nil
   end
   if not vim.startswith(git_dir, "/") then
     git_dir = vim.fs.joinpath(cwd, git_dir)
   end
+  return git_dir
+end
+
+local function has_rebase(cwd)
+  local git_dir = git_directory(cwd)
+  if not git_dir then
+    return false
+  end
   return vim.fn.isdirectory(vim.fs.joinpath(git_dir, "rebase-merge")) == 1
     or vim.fn.isdirectory(vim.fs.joinpath(git_dir, "rebase-apply")) == 1
+end
+
+local function rebase_target(cwd)
+  local git_dir = git_directory(cwd)
+  if not git_dir then
+    return nil
+  end
+  for _, path in ipairs({ "rebase-merge/onto", "rebase-apply/onto" }) do
+    local target = vim.fs.joinpath(git_dir, path)
+    if vim.fn.filereadable(target) == 1 then
+      return trim(table.concat(vim.fn.readfile(target), "\n"))
+    end
+  end
 end
 
 local function preserve_local_changes(cwd)
@@ -368,8 +395,24 @@ local function sync_branch(context, new_head)
   local slug = ref_slug(context.repo, context.number)
   local base_ref = "refs/octo-review/base/" .. slug
   local recovery_ref = "refs/octo-review/recovery/" .. slug
-  if has_rebase(cwd) then
-    return true, base_ref, recovery_ref
+  local pending_ref = "refs/octo-review/pending/" .. slug
+  local rebasing = has_rebase(cwd)
+  local recovery = git(cwd, { "rev-parse", "--verify", recovery_ref })
+  local pending = git(cwd, { "rev-parse", "--verify", pending_ref })
+  if recovery.code == 0 or pending.code == 0 then
+    local pending_head = trim(pending.stdout)
+    local target = rebasing and rebase_target(cwd) or nil
+    local same_refresh = pending_head == new_head and (not rebasing or target == new_head)
+      or pending_head == "" and target == new_head
+    if not same_refresh then
+      notify("finish validating the pending PR refresh before applying a different PR head", vim.log.levels.WARN)
+      return nil
+    end
+    return true, rebasing, base_ref, recovery_ref, pending_ref
+  end
+  if rebasing then
+    notify("the review branch already has an unrelated rebase in progress", vim.log.levels.WARN)
+    return nil
   end
   if not preserve_local_changes(cwd) then
     notify("could not commit local changes before refreshing the PR")
@@ -377,24 +420,34 @@ local function sync_branch(context, new_head)
   end
   local old_head = trim(git(cwd, { "rev-parse", "--verify", base_ref }).stdout)
   if old_head == "" then
-    git(cwd, { "update-ref", base_ref, new_head })
-    return false, base_ref, recovery_ref
+    if git(cwd, { "update-ref", base_ref, new_head }).code ~= 0 then
+      notify("could not record the initial PR head")
+      return nil
+    end
+    return false, false, base_ref, recovery_ref, pending_ref
   end
   if old_head == new_head then
-    return false, base_ref, recovery_ref
+    return false, false, base_ref, recovery_ref, pending_ref
   end
   local current = trim(git(cwd, { "rev-parse", "HEAD" }).stdout)
+  if git(cwd, { "update-ref", pending_ref, new_head }).code ~= 0 then
+    notify("could not record the pending PR head before rebase")
+    return nil
+  end
   if git(cwd, { "update-ref", recovery_ref, current }).code ~= 0 then
+    git(cwd, { "update-ref", "-d", pending_ref })
     notify("could not create the recovery ref before rebase")
     return nil
   end
   local rebased = git(cwd, { "-c", "core.editor=true", "rebase", "--onto", new_head, old_head })
-  if rebased.code ~= 0 then
-    return true, base_ref, recovery_ref
-  end
-  git(cwd, { "update-ref", base_ref, new_head })
-  git(cwd, { "update-ref", "-d", recovery_ref })
-  return false, base_ref, recovery_ref
+  return true, rebased.code ~= 0, base_ref, recovery_ref, pending_ref
+end
+
+local function refresh_complete(context, head, base_ref, recovery_ref, pending_ref)
+  local base = git(context.cwd, { "rev-parse", "--verify", base_ref })
+  local recovery = git(context.cwd, { "rev-parse", "--verify", recovery_ref })
+  local pending = git(context.cwd, { "rev-parse", "--verify", pending_ref })
+  return not has_rebase(context.cwd) and trim(base.stdout) == head and recovery.code ~= 0 and pending.code ~= 0
 end
 
 local function ensure_scope(root, remote, context)
@@ -441,35 +494,47 @@ local function ensure_scope(root, remote, context)
     notify("could not create or reopen the PR worktree workspace")
     return nil
   end
+  if not herdr.call({ "workspace", "rename", workspace_id, context.label }) then
+    notify("could not update the PR workspace label")
+    return nil
+  end
   context.cwd = found.path
   context.branch = branch
   context.workspace_id = workspace_id
-  local conflict, base_ref, recovery_ref = sync_branch(context, head)
-  if conflict == nil then
+  local refresh, conflict, base_ref, recovery_ref, pending_ref = sync_branch(context, head)
+  if refresh == nil then
     return nil
   end
-  return context, conflict, head, base_ref, recovery_ref
+  return context, refresh, conflict, head, base_ref, recovery_ref, pending_ref
 end
 
-local function prompt_text(context, conflict, head, base_ref, recovery_ref)
-  local conflict_instructions = ""
+local function prompt_text(context, refresh, conflict, head, base_ref, recovery_ref, pending_ref)
+  local refresh_instructions = ""
   local mutation_instructions = [[This first pass is read-only: do not edit files, post comments, push,
 approve, merge, or otherwise mutate GitHub unless the user explicitly asks.]]
-  if conflict then
-    conflict_instructions = string.format(
+  if refresh then
+    local conflict_step = conflict
+        and [[Resolve every conflict semantically, stage the resolutions, and finish the rebase with
+GIT_EDITOR=true git rebase --continue. ]]
+      or ""
+    refresh_instructions = string.format(
       [[
 
-A git rebase is currently conflicted. Resolve every conflict semantically, stage the resolutions,
-and finish the rebase yourself with GIT_EDITOR=true git rebase --continue. Run relevant tests plus
-git diff --check. Only after they pass, run:
+The PR head changed and the local review branch was rebased. %sRun relevant tests plus git diff
+--check against the rebased tree. Only after the rebase is complete and every validation passes, run:
   git update-ref %s %s
   git update-ref -d %s
-If resolution or validation fails, leave the recovery ref intact and explain the blocker.]],
+  git update-ref -d %s
+If the rebase, resolution, or validation fails, leave the recovery and pending refs intact and explain
+the blocker.]],
+      conflict_step,
       base_ref,
       head,
-      recovery_ref
+      recovery_ref,
+      pending_ref
     )
-    mutation_instructions = [[Apart from the required conflict resolution, do not make unrelated edits,
+    mutation_instructions =
+      [[Apart from the required rebase validation and conflict resolution, do not make unrelated edits,
 post comments, push, approve, merge, or otherwise mutate GitHub unless the user explicitly asks.]]
   end
   return string.format(
@@ -493,7 +558,7 @@ summary, wait for instructions. %s%s]],
     context.number,
     context.repo,
     mutation_instructions,
-    conflict_instructions
+    refresh_instructions
   )
 end
 
@@ -512,12 +577,12 @@ local function mark_seen(key, fingerprint, tab)
   end
 end
 
-local function start_agent(context, conflict, head, base_ref, recovery_ref)
+local function start_agent(context, refresh, conflict, head, base_ref, recovery_ref, pending_ref)
   local internal = require("plugins.sidekick.internal")
   local slug = context.agent_name:sub(#"codex-" + 1)
   internal.start_named_session("codex", slug, context.cwd)
   local tab = vim.api.nvim_get_current_tabpage()
-  local prompt = prompt_text(context, conflict, head, base_ref, recovery_ref)
+  local prompt = prompt_text(context, refresh, conflict, head, base_ref, recovery_ref, pending_ref)
   local function submit(remaining)
     if not herdr.get_agent(context.agent_name) then
       if remaining > 0 then
@@ -534,10 +599,8 @@ local function start_agent(context, conflict, head, base_ref, recovery_ref)
       { text = true },
       vim.schedule_wrap(function(result)
         local refreshed = result.code == 0
-        if refreshed and conflict then
-          local base = git(context.cwd, { "rev-parse", "--verify", base_ref })
-          local recovery = git(context.cwd, { "rev-parse", "--verify", recovery_ref })
-          refreshed = not has_rebase(context.cwd) and trim(base.stdout) == head and recovery.code ~= 0
+        if refreshed and refresh then
+          refreshed = refresh_complete(context, head, base_ref, recovery_ref, pending_ref)
         end
         if refreshed then
           mark_seen(context.key, context.fingerprint, tab)
@@ -554,7 +617,10 @@ local function activate(pr, opts)
   local host = opts.host or "github.com"
   local repo = opts.repo
   local number = tonumber(opts.number)
-  local root, remote = resolve_repository(opts.cwd, host, repo)
+  local root, remote = opts.root, opts.remote
+  if not root then
+    root, remote = resolve_repository(opts.cwd, host, repo)
+  end
   if not root then
     notify(string.format("no local clone for %s/%s; open the PR from a matching checkout", host, repo))
     return
@@ -583,7 +649,7 @@ local function activate(pr, opts)
     agent_name = M.agent_name(repo, number),
   }
 
-  local scoped, conflict, head, base_ref, recovery_ref = ensure_scope(root, remote, context)
+  local scoped, refresh, conflict, head, base_ref, recovery_ref, pending_ref = ensure_scope(root, remote, context)
   if not scoped then
     return
   end
@@ -597,7 +663,7 @@ local function activate(pr, opts)
   local tab = vim.api.nvim_get_current_tabpage()
   set_tab_context(tab, scoped)
   M.restore(scoped)
-  start_agent(scoped, conflict, head, base_ref, recovery_ref)
+  start_agent(scoped, refresh, conflict, head, base_ref, recovery_ref, pending_ref)
 end
 
 function M.open(opts)
@@ -705,5 +771,12 @@ function M.setup()
     return original_load_buffer(opts)
   end
 end
+
+M._test = {
+  activate = activate,
+  prompt_text = prompt_text,
+  refresh_complete = refresh_complete,
+  sync_branch = sync_branch,
+}
 
 return M

--- a/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
+++ b/nvim/.config/nvim/lua/plugins/octo/review_agent.lua
@@ -267,6 +267,12 @@ function M.configure_terminal(terminal)
   terminal.opts.split.width = math.max(vim.o.columns - 61, 40)
 end
 
+function M.unbind_workspace(tab)
+  for _, name in ipairs({ context_var, "octo_review_state", "octo_review_unseen" }) do
+    pcall(vim.api.nvim_tabpage_del_var, tab, name)
+  end
+end
+
 function M.bind_workspace(tab, workspace)
   if not workspace or not workspace.workspace_id then
     return false
@@ -321,15 +327,18 @@ local function repository_candidates(cwd, repo)
     end
   end
   add(cwd)
-  if vim.fn.executable("ghq") == 1 then
+  local name = repo:match("/([^/]+)$")
+  if name and vim.fn.executable("ghq") == 1 then
     local ghq = command({ "ghq", "list", "-p" })
     if ghq.code == 0 then
       for _, path in ipairs(vim.split(trim(ghq.stdout), "\n", { plain = true, trimempty = true })) do
-        add(path)
+        local basename = (path:gsub("/+$", "")):match("([^/]+)$")
+        if basename and basename:lower() == name:lower() then
+          add(path)
+        end
       end
     end
   end
-  local name = repo:match("/([^/]+)$")
   local home = vim.fn.expand("~")
   for _, parent in ipairs({ "", "projects", "tools", "playground", "modal-projects" }) do
     add(vim.fs.joinpath(home, parent, name))
@@ -776,6 +785,7 @@ end
 
 M._test = {
   activate = activate,
+  candidates = repository_candidates,
   prompt_text = prompt_text,
   refresh_complete = refresh_complete,
   sync_branch = sync_branch,

--- a/nvim/.config/nvim/lua/plugins/sidekick.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick.lua
@@ -10,6 +10,7 @@ return {
     cli = {
       win = {
         config = function(terminal)
+          require("plugins.octo.review_agent").configure_terminal(terminal)
           require("plugins.sidekick.branding").apply(terminal)
         end,
         layout = "float",

--- a/nvim/.config/nvim/lua/plugins/sidekick/herdr.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/herdr.lua
@@ -213,6 +213,51 @@ function M.agent_for_worktree(cwd)
   return nil, true
 end
 
+---@param cwd string
+---@return table|nil worktree
+---@return string|nil path
+local function containing_linked_worktree(cwd)
+  local normalized = M.normalize_cwd(cwd)
+  if normalized == "" then
+    return nil
+  end
+  local listed = M.call({ "worktree", "list", "--cwd", normalized }, true)
+  if not listed then
+    return nil
+  end
+  local match, match_path
+  for _, worktree in ipairs(listed.worktrees or {}) do
+    local path = worktree.path and M.normalize_cwd(worktree.path) or ""
+    if
+      worktree.is_linked_worktree
+      and path ~= ""
+      and (normalized == path or vim.startswith(normalized, path .. "/"))
+      and (not match_path or #path > #match_path)
+    then
+      match, match_path = worktree, path
+    end
+  end
+  return match, match_path
+end
+
+---@param cwd string
+---@return table|nil scope { workspace_id: string, cwd: string }
+function M.worktree_scope(cwd)
+  local worktree, path = containing_linked_worktree(cwd)
+  if not worktree or not path then
+    return nil
+  end
+  local workspace_id = worktree.open_workspace_id
+  if not workspace_id then
+    local result = M.call({ "worktree", "open", "--path", path, "--no-focus" })
+    workspace_id = result and result.workspace and result.workspace.workspace_id or nil
+  end
+  if not workspace_id then
+    return nil
+  end
+  return { workspace_id = workspace_id, cwd = path }
+end
+
 local function env_args(env)
   local out = {}
   for key, value in pairs(env or {}) do
@@ -327,6 +372,70 @@ local function own_tab(agent, scope, tab_label)
     or placed.workspace_id ~= scope.workspace_id
     or not placed_tab
     or placed_tab.pane_count ~= 1
+  then
+    return nil
+  end
+  return placed
+end
+
+---@param agent table
+---@param scope table
+---@param tab_label string
+---@return table|nil agent
+function M.place_agent(agent, scope, tab_label)
+  if not full_agent(agent) then
+    notify("worker must be a full Herdr Codex session")
+    return nil
+  end
+  local owner, listed = M.agent_for_worktree(scope.cwd)
+  if listed == false then
+    notify("could not verify whether this worktree already owns a durable session")
+    return nil
+  end
+  if owner and owner.name ~= agent.name then
+    notify("feature worktree already owns a different durable session")
+    return nil
+  end
+  local cwd = M.normalize_cwd(agent.foreground_cwd or agent.cwd)
+  if cwd ~= M.normalize_cwd(scope.cwd) then
+    notify("existing agent cwd does not match its feature worktree")
+    return nil
+  end
+  return own_tab(agent, scope, tab_label)
+end
+
+---@param agent table
+---@return table|nil agent
+function M.anchor_agent_worktree(agent)
+  if not terminal_agent(agent) then
+    return nil
+  end
+  local scope = M.worktree_scope(agent.foreground_cwd or agent.cwd)
+  if not scope or scope.workspace_id == agent.workspace_id then
+    return agent
+  end
+  local moved = M.call({
+    "pane",
+    "move",
+    agent.pane_id,
+    "--new-tab",
+    "--workspace",
+    scope.workspace_id,
+    "--label",
+    agent.name,
+    "--no-focus",
+  })
+  if not moved then
+    return nil
+  end
+  local placed = M.get_agent(agent.name)
+  local require_session = full_agent(agent)
+  if
+    not terminal_agent(placed)
+    or placed.name ~= agent.name
+    or placed.terminal_id ~= agent.terminal_id
+    or placed.workspace_id ~= scope.workspace_id
+    or (require_session and (not full_agent(placed) or not same_session(agent.agent_session, placed.agent_session)))
   then
     return nil
   end

--- a/nvim/.config/nvim/lua/plugins/sidekick/herdr_backend.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/herdr_backend.lua
@@ -54,12 +54,25 @@ function M:init()
   self.priority = 50
 end
 
+---@param name any
+---@return boolean
+local function named_session(name)
+  if type(name) ~= "string" then
+    return false
+  end
+  local ok, registry = pcall(require, "plugins.sidekick.registry")
+  return ok and registry.parse_session_name(name) ~= nil
+end
+
 function M.sessions()
   local sessions = {}
   local tools = Config.tools()
   for _, agent in ipairs(Herdr.list_agents()) do
     local tool = (agent.name and tools[agent.name]) or (agent.agent and tools[agent.agent])
     if tool then
+      if named_session(agent.name) then
+        agent = Herdr.anchor_agent_worktree(agent) or agent
+      end
       sessions[#sessions + 1] = {
         id = "herdr:" .. agent.terminal_id,
         cwd = agent.foreground_cwd or agent.cwd,
@@ -87,6 +100,9 @@ function M:start()
         label = workspace.label,
       }
     or (self.tool.herdr_workspace_id and { workspace_id = self.tool.herdr_workspace_id } or nil)
+  if named_session(self.tool.name) then
+    scope = Herdr.worktree_scope(self.cwd) or scope
+  end
   local command = self.tool.raw_cmd or self.tool.cmd
   local agent = Herdr.start(self.herdr_agent_name, self.cwd, command, self.tool.env, scope)
   if not agent then

--- a/nvim/.config/nvim/lua/plugins/sidekick/internal.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/internal.lua
@@ -76,7 +76,16 @@ end
 ---@param terminal_id? string
 function M.toggle_tool_session(name, focus, terminal_id)
   M.hide_tool_sessions(name)
-  require("plugins.octo.review_agent").restore_for_session(name)
+  local terminal_open = false
+  for _, terminal in ipairs(require("sidekick.cli.terminal").sessions()) do
+    if terminal.tool.name == name and terminal:is_open() then
+      terminal_open = true
+      break
+    end
+  end
+  if not terminal_open then
+    require("plugins.octo.review_agent").restore_for_session(name)
+  end
   local filter = terminal_id and { session = "herdr:" .. terminal_id } or nil
   require("sidekick.cli").toggle({ name = name, focus = focus ~= false, filter = filter })
 end

--- a/nvim/.config/nvim/lua/plugins/sidekick/internal.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/internal.lua
@@ -235,11 +235,8 @@ function M.start_named_session(tool, label, cwd)
   local name = tool .. "-" .. slug
   local config = require("sidekick.config")
   local command = M.tool_command_for_named_session(tool, slug)
-  local workspace_ok, workspace_id = pcall(
-    vim.api.nvim_tabpage_get_var,
-    vim.api.nvim_get_current_tabpage(),
-    "herdr_workspace_id"
-  )
+  local workspace_ok, workspace_id =
+    pcall(vim.api.nvim_tabpage_get_var, vim.api.nvim_get_current_tabpage(), "herdr_workspace_id")
   local extra = {
     env = { [M.named_env_var] = slug },
     herdr_workspace_id = workspace_ok and type(workspace_id) == "string" and workspace_id or nil,

--- a/nvim/.config/nvim/lua/plugins/sidekick/internal.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/internal.lua
@@ -76,6 +76,7 @@ end
 ---@param terminal_id? string
 function M.toggle_tool_session(name, focus, terminal_id)
   M.hide_tool_sessions(name)
+  require("plugins.octo.review_agent").restore_for_session(name)
   local filter = terminal_id and { session = "herdr:" .. terminal_id } or nil
   require("sidekick.cli").toggle({ name = name, focus = focus ~= false, filter = filter })
 end

--- a/nvim/.config/nvim/lua/plugins/sidekick/last_session.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/last_session.lua
@@ -1,31 +1,41 @@
 -- nvim/.config/nvim/lua/plugins/sidekick/last_session.lua
--- Tracks the most recently created or picker-selected named session so <C-.>
--- can jump straight back to it. Direct tool-toggle keymaps
+-- Tracks the most recently created or picker-selected named session per tab so
+-- <C-.> follows the tab's workspace instead of one process-global target.
 -- Direct session toggles intentionally do not update this.
 local M = {}
 
----@type string|nil
-M.label = nil
----@type string|nil
-M.terminal_id = nil
+local label_var = "sidekick_last_session_label"
+local terminal_var = "sidekick_last_session_terminal_id"
+
+local function get(tab, name)
+  local ok, value = pcall(vim.api.nvim_tabpage_get_var, tab, name)
+  return ok and value or nil
+end
 
 ---@param label string|nil
 ---@param terminal_id? string
 function M.record(label, terminal_id)
   if type(label) == "string" and label ~= "" then
-    M.label = label
-    M.terminal_id = terminal_id
+    local tab = vim.api.nvim_get_current_tabpage()
+    vim.api.nvim_tabpage_set_var(tab, label_var, label)
+    if terminal_id then
+      vim.api.nvim_tabpage_set_var(tab, terminal_var, terminal_id)
+    else
+      pcall(vim.api.nvim_tabpage_del_var, tab, terminal_var)
+    end
   end
 end
 
 --- Open the last active named session. With no record yet, fall back to
 --- the cwd-scoped named-session picker so the keymap stays local by default.
 function M.open()
-  if not M.label or M.label == "" then
+  local tab = vim.api.nvim_get_current_tabpage()
+  local label = get(tab, label_var)
+  if type(label) ~= "string" or label == "" then
     require("plugins.sidekick.cwd_picker").open()
     return
   end
-  require("plugins.sidekick.internal").toggle_tool_session(M.label, true, M.terminal_id)
+  require("plugins.sidekick.internal").toggle_tool_session(label, true, get(tab, terminal_var))
 end
 
 return M

--- a/nvim/.config/nvim/lua/plugins/tabline.lua
+++ b/nvim/.config/nvim/lua/plugins/tabline.lua
@@ -81,6 +81,17 @@ return {
             line.tabs().foreach(function(tab)
               local hl = tab.is_current() and theme.current_tab or theme.tab
               local workspace = require("helpers.workspace").get(tab.id)
+              local state_ok, review_state = pcall(vim.api.nvim_tabpage_get_var, tab.id, "octo_review_state")
+              local unseen_ok, unseen = pcall(vim.api.nvim_tabpage_get_var, tab.id, "octo_review_unseen")
+              local review = state_ok
+                  and ({
+                    open = { "\u{f407}", colors.green },
+                    merged = { "\u{f419}", colors.purple },
+                    closed = { "\u{f4dc}", colors.red },
+                    draft = { "\u{f4dd}", colors.fg4 },
+                  })[review_state]
+                or nil
+              local tab_bg = tab.is_current() and colors.yellow or colors.bg1
               return {
                 line.sep(right_sep, hl, theme.fill),
                 tab.in_jump_mode() and tab.jump_key() or {
@@ -88,7 +99,9 @@ return {
                   tab.number(),
                   margin = " ",
                 },
+                review and { review[1] .. " ", hl = { fg = review[2], bg = tab_bg, style = "bold" } } or "",
                 workspace and workspace.label or tab.name(),
+                unseen_ok and unseen and { " ●", hl = { fg = colors.yellow, bg = tab_bg, style = "bold" } } or "",
                 tab.close_btn(close_icon),
                 line.sep(left_sep, hl, theme.fill),
                 hl = hl,

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -877,6 +877,8 @@ local function validate_sidekick_herdr()
   end
 
   local original_start = source_herdr.start
+  local original_call = source_herdr.call
+  local original_worktree_scope = source_herdr.worktree_scope
   local forwarded_scope
   local forwarded_starts = 0
   source_herdr.start = function(_, _, _, _, scope)
@@ -888,6 +890,9 @@ local function validate_sidekick_herdr()
       tab_id = "w-bound:t1",
       workspace_id = "w-bound",
     }
+  end
+  source_herdr.worktree_scope = function()
+    return nil
   end
   source_backend.start({
     herdr_agent_name = "codex-workspace-session",
@@ -913,8 +918,156 @@ local function validate_sidekick_herdr()
     fail("an unbound tab should retain cwd-based Herdr fallback: " .. vim.inspect(forwarded_scope))
   end
   source_herdr.start = original_start
+  source_herdr.worktree_scope = original_worktree_scope
   if forwarded_starts ~= 2 or forwarded_scope ~= nil then
     fail("unbound named sessions should not override cwd workspace resolution")
+  end
+
+  local worktree_scope_lookups = 0
+  source_herdr.worktree_scope = function(path)
+    worktree_scope_lookups = worktree_scope_lookups + 1
+    if path == cwd then
+      return { workspace_id = "w-worktree", cwd = cwd }
+    end
+  end
+  forwarded_scope = nil
+  source_herdr.start = function(_, _, _, _, scope)
+    forwarded_scope = vim.deepcopy(scope)
+    return {
+      terminal_id = "term-worktree",
+      pane_id = "w-worktree:p1",
+      tab_id = "w-worktree:t1",
+      workspace_id = "w-worktree",
+    }
+  end
+  source_backend.start({
+    herdr_agent_name = "codex-workspace-session",
+    cwd = cwd,
+    tool = require("sidekick.cli.tool").get("codex-workspace-session"),
+    attach = function()
+      return {}
+    end,
+  })
+  if not forwarded_scope or forwarded_scope.workspace_id ~= "w-worktree" then
+    fail("linked worktree workspace should override a mismatched tab binding: " .. vim.inspect(forwarded_scope))
+  end
+  forwarded_scope = nil
+  source_backend.start({
+    herdr_agent_name = "sk-codex-base",
+    cwd = cwd,
+    tool = require("sidekick.cli.tool").get("codex"),
+    attach = function()
+      return {}
+    end,
+  })
+  source_herdr.start = original_start
+  source_herdr.worktree_scope = original_worktree_scope
+  if forwarded_scope ~= nil or worktree_scope_lookups ~= 1 then
+    fail("base sessions should bypass the linked worktree override: " .. vim.inspect(forwarded_scope))
+  end
+
+  local scope_calls = {}
+  source_herdr.call = function(args)
+    scope_calls[#scope_calls + 1] = vim.deepcopy(args)
+    if args[1] == "worktree" and args[2] == "list" then
+      return {
+        worktrees = {
+          { path = cwd, is_linked_worktree = false },
+          { path = cwd .. "/feature", is_linked_worktree = true },
+        },
+      }
+    elseif args[1] == "worktree" and args[2] == "open" then
+      return { workspace = { workspace_id = "w-opened" } }
+    end
+    return {}
+  end
+  local opened_scope = source_herdr.worktree_scope(cwd .. "/feature/inner")
+  local main_scope = source_herdr.worktree_scope(cwd)
+  source_herdr.call = original_call
+  local open_call
+  for _, call in ipairs(scope_calls) do
+    if call[1] == "worktree" and call[2] == "open" then
+      open_call = call
+    end
+  end
+  if
+    not opened_scope
+    or opened_scope.workspace_id ~= "w-opened"
+    or opened_scope.cwd ~= cwd .. "/feature"
+    or not vim.deep_equal(open_call, { "worktree", "open", "--path", cwd .. "/feature", "--no-focus" })
+  then
+    fail("linked worktree scope should open the anchored workspace: " .. vim.inspect(scope_calls))
+  end
+  if main_scope ~= nil then
+    fail("main checkout cwd should keep tab and cwd workspace resolution: " .. vim.inspect(main_scope))
+  end
+
+  source_herdr.call = function()
+    return nil, "not a git worktree"
+  end
+  local non_git_scope = source_herdr.worktree_scope(cwd)
+  source_herdr.call = original_call
+  if non_git_scope ~= nil then
+    fail("non-Git cwd should keep existing workspace behavior: " .. vim.inspect(non_git_scope))
+  end
+
+  local moved = false
+  local move_calls = 0
+  local move_args
+  local function discovery_agent()
+    return {
+      name = "codex-workspace-session",
+      cwd = cwd,
+      foreground_cwd = cwd .. "/feature/inner",
+      terminal_id = "term-moved",
+      pane_id = "p-moved",
+      tab_id = moved and "t-new" or "t-old",
+      workspace_id = moved and "w-opened" or "w-bound",
+      agent_session = { source = "codex", kind = "thread", value = "thread-1" },
+    }
+  end
+  source_herdr.call = function(args)
+    local family, action = args[1], args[2]
+    if family == "agent" and action == "list" then
+      return { agents = { discovery_agent() } }
+    elseif family == "worktree" and action == "list" then
+      return {
+        worktrees = {
+          { path = cwd, is_linked_worktree = false },
+          { path = cwd .. "/feature", is_linked_worktree = true, open_workspace_id = "w-opened" },
+        },
+      }
+    elseif family == "pane" and action == "move" then
+      move_calls = move_calls + 1
+      move_args = vim.deepcopy(args)
+      moved = true
+      return { pane = { pane_id = "p-moved" } }
+    elseif family == "agent" and action == "get" then
+      return { agent = discovery_agent() }
+    end
+    return {}
+  end
+  local discovered = source_backend.sessions()
+  local anchored = source_backend.sessions()
+  source_herdr.call = original_call
+  if
+    move_calls ~= 1
+    or not vim.deep_equal(
+      move_args,
+      { "pane", "move", "p-moved", "--new-tab", "--workspace", "w-opened", "--label", "codex-workspace-session", "--no-focus" }
+    )
+  then
+    fail("discovery should move a drifted named session into its worktree workspace once: " .. vim.inspect(move_args))
+  end
+  if
+    #discovered ~= 1
+    or discovered[1].herdr_workspace_id ~= "w-opened"
+    or discovered[1].herdr_tab_id ~= "t-new"
+    or discovered[1].herdr_terminal_id ~= "term-moved"
+    or #anchored ~= 1
+    or anchored[1].herdr_workspace_id ~= "w-opened"
+  then
+    fail("discovery should preserve the moved session identity: " .. vim.inspect(discovered))
   end
 
   original_workspace_for_repository = source_herdr.workspace_for_repository
@@ -934,7 +1087,6 @@ local function validate_sidekick_herdr()
     fail("unbound named sessions should resolve their workspace from the repository")
   end
 
-  local original_call = source_herdr.call
   local start_calls = {}
   source_herdr.call = function(args)
     start_calls[#start_calls + 1] = args

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1055,7 +1055,17 @@ local function validate_sidekick_herdr()
     move_calls ~= 1
     or not vim.deep_equal(
       move_args,
-      { "pane", "move", "p-moved", "--new-tab", "--workspace", "w-opened", "--label", "codex-workspace-session", "--no-focus" }
+      {
+        "pane",
+        "move",
+        "p-moved",
+        "--new-tab",
+        "--workspace",
+        "w-opened",
+        "--label",
+        "codex-workspace-session",
+        "--no-focus",
+      }
     )
   then
     fail("discovery should move a drifted named session into its worktree workspace once: " .. vim.inspect(move_args))

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -499,6 +499,7 @@ end
 
 local function validate_sidekick_herdr()
   local picker_actions_only = case == "sidekick-picker-actions"
+  local anchoring_only = case == "sidekick-worktree-anchor"
   load_plugin("sidekick.nvim")
 
   local config_lua = vim.fn.getcwd() .. "/nvim/.config/nvim/lua"
@@ -1068,6 +1069,9 @@ local function validate_sidekick_herdr()
     or anchored[1].herdr_workspace_id ~= "w-opened"
   then
     fail("discovery should preserve the moved session identity: " .. vim.inspect(discovered))
+  end
+  if anchoring_only then
+    return
   end
 
   original_workspace_for_repository = source_herdr.workspace_for_repository
@@ -4855,10 +4859,26 @@ local function validate_octo_review_agent()
     reviews = {},
     statusCheckRollup = { { name = "test", conclusion = "SUCCESS" } },
   }
-  local changed_pr = vim.deepcopy(base_pr)
-  changed_pr.comments = { { id = "new" } }
-  if review.fingerprint(base_pr) == review.fingerprint(changed_pr) then
-    fail("new PR comments should change the unseen-activity fingerprint")
+  local fingerprint_changes = {
+    commits = function(pr)
+      pr.headRefOid = "def"
+    end,
+    checks = function(pr)
+      pr.statusCheckRollup[1].conclusion = "FAILURE"
+    end,
+    reviews = function(pr)
+      pr.reviews = { { id = "new-review" } }
+    end,
+    comments = function(pr)
+      pr.comments = { { id = "new-comment" } }
+    end,
+  }
+  for label, mutate in pairs(fingerprint_changes) do
+    local changed_pr = vim.deepcopy(base_pr)
+    mutate(changed_pr)
+    if review.fingerprint(base_pr) == review.fingerprint(changed_pr) then
+      fail("new PR " .. label .. " should change the unseen-activity fingerprint")
+    end
   end
 
   local terminal = {
@@ -4908,6 +4928,321 @@ local function validate_octo_review_agent()
   vim.api.nvim_win_set_var(sidekick_win, "sidekick_cli", { name = agent_name })
   if not review.restore(context) or vim.api.nvim_win_is_valid(sidekick_win) then
     fail("review re-entry should rebuild from a non-Sidekick window")
+  end
+
+  local function git(root, args, expected)
+    local command = { "git", "-C", root }
+    vim.list_extend(command, args)
+    local result = vim.system(command, { text = true }):wait()
+    if result.code ~= (expected or 0) then
+      fail(string.format("%s failed (%d): %s", table.concat(command, " "), result.code, result.stderr or ""))
+    end
+    return vim.trim(result.stdout or "")
+  end
+
+  local function commit(root, contents, message)
+    vim.fn.writefile(contents, root .. "/review.txt")
+    git(root, { "add", "review.txt" })
+    git(root, { "commit", "-q", "-m", message })
+    return git(root, { "rev-parse", "HEAD" })
+  end
+
+  local function repository()
+    local root = vim.fn.tempname() .. "-octo-review"
+    vim.fn.mkdir(root, "p")
+    git(root, { "init", "-q", "--initial-branch", "review" })
+    git(root, { "config", "user.name", "Octo verifier" })
+    git(root, { "config", "user.email", "octo-verifier@example.invalid" })
+    commit(root, { "base" }, "base")
+    vim.fn.writefile({ "seed" }, root .. "/local.txt")
+    git(root, { "add", "local.txt" })
+    git(root, { "commit", "-q", "--amend", "--no-edit" })
+    return root, git(root, { "rev-parse", "HEAD" })
+  end
+
+  local refresh_root, refresh_base = repository()
+  git(refresh_root, { "switch", "-q", "-c", "upstream", refresh_base })
+  local refresh_head = commit(refresh_root, { "base", "upstream addition" }, "upstream")
+  git(refresh_root, { "switch", "-q", "review" })
+  vim.fn.writefile({ "local review edit" }, refresh_root .. "/local.txt")
+  vim.fn.writefile({ "untracked review note" }, refresh_root .. "/note.txt")
+  git(refresh_root, { "update-ref", "refs/octo-review/base/owner-repo-42", refresh_base })
+  local refresh, conflict, base_ref, recovery_ref, pending_ref = review._test.sync_branch({
+    cwd = refresh_root,
+    repo = "owner/repo",
+    number = 42,
+  }, refresh_head)
+  if not refresh or conflict then
+    fail("clean PR-head advance should require validation without reporting a conflict")
+  end
+  if git(refresh_root, { "rev-parse", base_ref }) ~= refresh_base then
+    fail("clean refresh must not advance the accepted base before validation")
+  end
+  if git(refresh_root, { "rev-parse", pending_ref }) ~= refresh_head then
+    fail("clean refresh should record the exact pending PR head")
+  end
+  local recovery_head = git(refresh_root, { "rev-parse", recovery_ref })
+  if
+    git(refresh_root, { "show", recovery_head .. ":local.txt" }) ~= "local review edit"
+    or git(refresh_root, { "show", recovery_head .. ":note.txt" }) ~= "untracked review note"
+  then
+    fail("refresh should commit tracked and untracked local review edits before rebasing")
+  end
+  local refresh_context = { cwd = refresh_root, repo = "owner/repo", number = 42 }
+  if review._test.refresh_complete(refresh_context, refresh_head, base_ref, recovery_ref, pending_ref) then
+    fail("refresh must remain incomplete while its recovery ref is retained")
+  end
+  local pending_head = git(refresh_root, { "rev-parse", "HEAD" })
+  local resumed_refresh, resumed_conflict = review._test.sync_branch(refresh_context, refresh_head)
+  if not resumed_refresh or resumed_conflict or git(refresh_root, { "rev-parse", "HEAD" }) ~= pending_head then
+    fail("reopening a pending clean refresh should validate the existing rebase without replaying it")
+  end
+  git(refresh_root, { "switch", "-q", "upstream" })
+  local newer_head = commit(refresh_root, { "base", "newer upstream addition" }, "newer upstream")
+  git(refresh_root, { "switch", "-q", "review" })
+  local function blocked_refresh(head)
+    local original_notify = vim.notify
+    local notice
+    vim.notify = function(message)
+      notice = message
+    end
+    local result = review._test.sync_branch(refresh_context, head)
+    vim.notify = original_notify
+    return result, notice
+  end
+  local older_refresh, older_notice = blocked_refresh(refresh_base)
+  if older_refresh ~= nil or not (older_notice or ""):find("pending PR refresh", 1, true) then
+    fail("an older ancestor must not be mistaken for the exact pending PR head")
+  end
+  local newer_refresh, pending_notice = blocked_refresh(newer_head)
+  if newer_refresh ~= nil or not (pending_notice or ""):find("pending PR refresh", 1, true) then
+    fail("a newer PR head should wait until the pending refresh has been validated")
+  end
+  local refresh_prompt = review._test.prompt_text(
+    refresh_context,
+    true,
+    false,
+    refresh_head,
+    base_ref,
+    recovery_ref,
+    pending_ref
+  )
+  if
+    not refresh_prompt:find("Run relevant tests plus git diff", 1, true)
+    or not refresh_prompt:find("git update-ref " .. base_ref .. " " .. refresh_head, 1, true)
+    or not refresh_prompt:find("git update-ref -d " .. pending_ref, 1, true)
+  then
+    fail("clean refresh prompt should require validation before accepting the new PR head")
+  end
+  git(refresh_root, { "update-ref", base_ref, refresh_head })
+  git(refresh_root, { "update-ref", "-d", recovery_ref })
+  git(refresh_root, { "update-ref", "-d", pending_ref })
+  if not review._test.refresh_complete(refresh_context, refresh_head, base_ref, recovery_ref, pending_ref) then
+    fail("validated refresh should complete only after base advancement and recovery cleanup")
+  end
+  local unchanged, unchanged_conflict = review._test.sync_branch(refresh_context, refresh_head)
+  if unchanged or unchanged_conflict then
+    fail("an unchanged PR head should not enter refresh validation")
+  end
+
+  local conflict_root, conflict_base = repository()
+  commit(conflict_root, { "local" }, "local review edit")
+  git(conflict_root, { "switch", "-q", "-c", "upstream", conflict_base })
+  local conflict_head = commit(conflict_root, { "upstream" }, "upstream conflict")
+  git(conflict_root, { "switch", "-q", "review" })
+  git(conflict_root, { "update-ref", "refs/octo-review/base/owner-repo-42", conflict_base })
+  local needs_refresh, has_conflict, conflict_base_ref, conflict_recovery_ref, conflict_pending_ref =
+    review._test.sync_branch({
+      cwd = conflict_root,
+      repo = "owner/repo",
+      number = 42,
+    }, conflict_head)
+  if not needs_refresh or not has_conflict then
+    fail("conflicted PR-head advance should be handed to the review agent")
+  end
+  local resumed_conflicted_refresh, resumed_has_conflict = review._test.sync_branch({
+    cwd = conflict_root,
+    repo = "owner/repo",
+    number = 42,
+  }, conflict_head)
+  if not resumed_conflicted_refresh or not resumed_has_conflict then
+    fail("reopening a pending conflicted refresh should resume the existing rebase")
+  end
+  local conflict_prompt = review._test.prompt_text(
+    { cwd = conflict_root, repo = "owner/repo", number = 42 },
+    true,
+    true,
+    conflict_head,
+    conflict_base_ref,
+    conflict_recovery_ref,
+    conflict_pending_ref
+  )
+  if not conflict_prompt:find("Resolve every conflict semantically", 1, true) then
+    fail("conflicted refresh prompt should require semantic rebase completion")
+  end
+  git(conflict_root, { "rebase", "--abort" })
+  vim.fn.delete(refresh_root, "rf")
+  vim.fn.delete(conflict_root, "rf")
+
+  do
+    local verifier_cwd = vim.fn.getcwd(-1, 0)
+    local route_root, route_head = repository()
+    git(route_root, { "remote", "add", "origin", route_root })
+    git(route_root, { "update-ref", "refs/pull/42/head", route_head })
+    vim.g.octo_review_agent_state_path = route_root .. "/state.json"
+
+    local module_names = {
+      "plugins.octo.review_agent",
+      "plugins.sidekick.herdr",
+      "plugins.herdr.workspaces",
+      "plugins.sidekick.internal",
+      "octo",
+      "octo.utils",
+      "octo.uri",
+    }
+    local original_modules = {}
+    for _, name in ipairs(module_names) do
+      original_modules[name] = package.loaded[name]
+    end
+    local original_system = vim.system
+    local calls = { opens = {} }
+    local fake_herdr = {}
+    function fake_herdr.call(args)
+      if args[1] == "worktree" and args[2] == "list" then
+        return {
+          worktrees = {
+            {
+              branch = "review/owner-repo-42",
+              is_linked_worktree = true,
+              open_workspace_id = "w-review",
+              path = route_root,
+            },
+          },
+        }
+      end
+      if args[1] == "workspace" and args[2] == "rename" then
+        calls.rename = vim.deepcopy(args)
+        return {}
+      end
+      fail("unexpected fake Herdr call: " .. vim.inspect(args))
+    end
+    function fake_herdr.get_agent(name)
+      return name == "codex-pr-repo-42" and { name = name } or nil
+    end
+
+    package.loaded["plugins.octo.review_agent"] = nil
+    package.loaded["plugins.sidekick.herdr"] = fake_herdr
+    package.loaded["plugins.herdr.workspaces"] = {
+      focus = function(workspace_id)
+        calls.focus = workspace_id
+        vim.cmd("tcd " .. vim.fn.fnameescape(route_root))
+        return true
+      end,
+    }
+    package.loaded["plugins.sidekick.internal"] = {
+      start_named_session = function(tool, slug, cwd)
+        calls.start = { tool = tool, slug = slug, cwd = cwd }
+      end,
+    }
+    vim.system = function(command, opts, callback)
+      if command[1] == "herdr" and command[2] == "agent" and command[3] == "prompt" then
+        calls.prompt = vim.deepcopy(command)
+        local result = { code = 0, stdout = "", stderr = "" }
+        if callback then
+          callback(result)
+        end
+        return { wait = function() return result end }
+      end
+      return original_system(command, opts, callback)
+    end
+
+    local routed_review = require("plugins.octo.review_agent")
+    local route_pr = vim.deepcopy(base_pr)
+    route_pr.title = "Route verifier"
+    route_pr.body = "Review route body"
+    route_pr.author = { login = "author" }
+    route_pr.baseRefName = "main"
+    route_pr.headRefName = "feature"
+    routed_review._test.activate(route_pr, {
+      cwd = route_root,
+      root = route_root,
+      remote = "origin",
+      host = "github.com",
+      repo = "owner/repo",
+      number = 42,
+    })
+    if not vim.wait(1000, function() return calls.prompt ~= nil end, 10) then
+      fail("review route did not submit its initial context prompt")
+    end
+    local route_context = vim.api.nvim_tabpage_get_var(0, "octo_review_context")
+    if
+      calls.focus ~= "w-review"
+      or not vim.deep_equal(calls.rename, { "workspace", "rename", "w-review", "repo · #42" })
+      or not vim.deep_equal(calls.start, { tool = "codex", slug = "pr-repo-42", cwd = route_root })
+      or vim.uv.fs_realpath(vim.fn.getcwd(-1, 0)) ~= vim.uv.fs_realpath(route_root)
+      or route_context.workspace_id ~= "w-review"
+      or route_context.cwd ~= route_root
+      or not calls.prompt[5]:find("context summary of at most", 1, true)
+    then
+      fail("top-level PR route did not align workspace, tab cwd, review agent cwd, and prompt: " .. vim.inspect(calls))
+    end
+    local saved_review
+    local seen_persisted = vim.wait(1000, function()
+      local ok, saved = pcall(
+        vim.json.decode,
+        table.concat(vim.fn.readfile(vim.g.octo_review_agent_state_path), "\n")
+      )
+      saved_review = ok and saved.reviews and saved.reviews["github.com/owner/repo#42"] or nil
+      return saved_review
+        and saved_review.seen_fingerprint == saved_review.fingerprint
+        and not saved_review.unseen
+    end, 10)
+    if not seen_persisted then
+      fail("successful initial context refresh should persist the PR as seen")
+    end
+
+    local fake_octo = { load_buffer = function() calls.original_load = true end }
+    local fake_utils = { get_pull_request = function() calls.original_get = true end }
+    local fake_uri = {
+      get_repo_number_from_varargs = function() return "owner/repo", 42 end,
+      parse = function()
+        return { kind = "pull", hostname = "github.com", repo = "owner/repo", id = 42 }
+      end,
+    }
+    package.loaded["octo"] = fake_octo
+    package.loaded["octo.utils"] = fake_utils
+    package.loaded["octo.uri"] = fake_uri
+    local routed_open = routed_review.open
+    routed_review.open = function(opts)
+      calls.opens[#calls.opens + 1] = opts
+    end
+    routed_review.setup()
+    fake_utils.get_pull_request("owner/repo", 42)
+    local route_buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(route_buf, "octo://github.com/owner/repo/pull/42")
+    fake_octo.load_buffer({ bufnr = route_buf })
+    vim.wait(1000, function() return not vim.api.nvim_buf_is_valid(route_buf) end, 10)
+    if
+      #calls.opens ~= 2
+      or calls.opens[1].repo ~= "owner/repo"
+      or calls.opens[1].number ~= 42
+      or calls.opens[2].host ~= "github.com"
+      or calls.opens[2].repo ~= "owner/repo"
+      or calls.opens[2].number ~= 42
+      or calls.original_get
+      or calls.original_load
+    then
+      fail("Octo PR command and URI routes should both enter the review-agent flow: " .. vim.inspect(calls.opens))
+    end
+    routed_review.open = routed_open
+
+    vim.system = original_system
+    for _, name in ipairs(module_names) do
+      package.loaded[name] = original_modules[name]
+    end
+    vim.g.octo_review_agent_state_path = nil
+    vim.cmd("tcd " .. vim.fn.fnameescape(verifier_cwd))
+    vim.fn.delete(route_root, "rf")
   end
 
   local original_internal = package.loaded["plugins.sidekick.internal"]
@@ -4966,6 +5301,7 @@ local cases = {
   ["sidekick-pi"] = validate_sidekick_pi,
   ["sidekick-herdr"] = validate_sidekick_herdr,
   ["sidekick-herdr-compat"] = validate_sidekick_herdr,
+  ["sidekick-worktree-anchor"] = validate_sidekick_herdr,
   ["sidekick-picker-actions"] = validate_sidekick_herdr,
   ["herdr-workspaces"] = validate_herdr_workspaces,
   ["sidekick-herdr-live"] = validate_sidekick_herdr_live,
@@ -4978,7 +5314,7 @@ if not fn then
   fail(
     "unknown VERIFY_NVIM_CASE "
       .. vim.inspect(case)
-      .. "; expected one of: agent-keymaps, workspace-session, weekly-backlog, markdown-formatting, markdown-ansi, octo-review-agent, inline-ask-edit, sidekick-pi, sidekick-herdr, sidekick-picker-actions, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
+      .. "; expected one of: agent-keymaps, workspace-session, weekly-backlog, markdown-formatting, markdown-ansi, octo-review-agent, inline-ask-edit, sidekick-pi, sidekick-herdr, sidekick-worktree-anchor, sidekick-picker-actions, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
   )
 end
 

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -4930,6 +4930,45 @@ local function validate_octo_review_agent()
     fail("review re-entry should rebuild from a non-Sidekick window")
   end
 
+  local restore_context = vim.tbl_extend("force", context, { agent_name = agent_name })
+  vim.api.nvim_tabpage_set_var(0, "octo_review_context", restore_context)
+  vim.cmd("rightbelow vnew")
+  local extra_win = vim.api.nvim_get_current_win()
+  if review.restore_for_session(agent_name) or not vim.api.nvim_win_is_valid(extra_win) then
+    fail("toggle with the review view visible should leave the existing layout alone")
+  end
+  vim.api.nvim_win_close(extra_win, true)
+  vim.cmd("enew")
+  vim.cmd("rightbelow vnew")
+  local user_win = vim.api.nvim_get_current_win()
+  if
+    not review.restore_for_session(agent_name)
+    or vim.api.nvim_win_is_valid(user_win)
+    or vim.b[vim.api.nvim_get_current_buf()].octo_review_key ~= context.key
+  then
+    fail("toggle without the review view should rebuild the review layout")
+  end
+  vim.cmd("tabnew")
+  local plain_win = vim.api.nvim_get_current_win()
+  local unbound_ok = pcall(vim.api.nvim_tabpage_get_var, 0, "octo_review_context")
+  if
+    review.restore_for_session(agent_name)
+    or not vim.api.nvim_win_is_valid(plain_win)
+    or #vim.api.nvim_tabpage_list_wins(0) ~= 1
+    or pcall(vim.api.nvim_tabpage_get_var, 0, "octo_review_context") ~= unbound_ok
+  then
+    fail("toggling from an unrelated tab should not rebind or replace its layout")
+  end
+  vim.api.nvim_tabpage_set_var(
+    0,
+    "octo_review_context",
+    vim.tbl_extend("force", restore_context, { agent_name = "codex-pr-repo-43" })
+  )
+  if review.restore_for_session(agent_name) or not vim.api.nvim_win_is_valid(plain_win) then
+    fail("toggling another PR's agent should not replace this tab's review layout")
+  end
+  vim.cmd("tabclose!")
+
   local function git(root, args, expected)
     local command = { "git", "-C", root }
     vim.list_extend(command, args)
@@ -5017,6 +5056,15 @@ local function validate_octo_review_agent()
   local newer_refresh, pending_notice = blocked_refresh(newer_head)
   if newer_refresh ~= nil or not (pending_notice or ""):find("pending PR refresh", 1, true) then
     fail("a newer PR head should wait until the pending refresh has been validated")
+  end
+  git(refresh_root, { "update-ref", "-d", pending_ref })
+  local orphan_refresh, orphan_conflict = review._test.sync_branch(refresh_context, refresh_head)
+  if not orphan_refresh or orphan_conflict or git(refresh_root, { "rev-parse", "HEAD" }) ~= pending_head then
+    fail("an orphaned recovery ref should resume validation for the same PR head")
+  end
+  local orphan_newer, orphan_notice = blocked_refresh(newer_head)
+  if orphan_newer ~= nil or not (orphan_notice or ""):find("pending PR refresh", 1, true) then
+    fail("an orphaned recovery ref must still block a different PR head")
   end
   local refresh_prompt = review._test.prompt_text(
     refresh_context,

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -4659,12 +4659,157 @@ local function validate_workspace_session()
   vim.cmd("silent! %bwipeout!")
 end
 
+local function validate_octo_review_agent()
+  package.path = table.concat({
+    vim.fn.getcwd() .. "/nvim/.config/nvim/lua/?.lua",
+    vim.fn.getcwd() .. "/nvim/.config/nvim/lua/?/init.lua",
+    package.path,
+  }, ";")
+  local review = require("plugins.octo.review_agent")
+  local table_line = "workflow with a deliberately wide name | status | duration | required"
+  local code_line = "command " .. string.rep("argument ", 10)
+  local body = table.concat({
+    "This ordinary prose paragraph is deliberately long enough to need several presentation-only lines in the fixed review column.",
+    "",
+    table_line,
+    "",
+    "```sh",
+    code_line,
+    "```",
+  }, "\n")
+  local wrapped = review.wrap_markdown(body, 60)
+  if vim.fn.index(wrapped, table_line) < 0 or vim.fn.index(wrapped, code_line) < 0 then
+    fail("review presentation should leave Markdown tables and fenced code unchanged: " .. vim.inspect(wrapped))
+  end
+  for _, line in ipairs(wrapped) do
+    if line == "" then
+      break
+    end
+    if vim.fn.strdisplaywidth(line) > 60 then
+      fail("ordinary PR prose should be wrapped to 60 columns: " .. vim.inspect(line))
+    end
+  end
+
+  local agent_name = review.agent_name("owner/a-very-long-repository-name-for-review", 12345)
+  if #agent_name > 32 or not review.is_session(agent_name) then
+    fail("review agent name should be a valid, recognizable Herdr name: " .. vim.inspect(agent_name))
+  end
+
+  local base_pr = {
+    headRefOid = "abc",
+    updatedAt = "2026-08-13T12:00:00Z",
+    state = "OPEN",
+    comments = {},
+    reviews = {},
+    statusCheckRollup = { { name = "test", conclusion = "SUCCESS" } },
+  }
+  local changed_pr = vim.deepcopy(base_pr)
+  changed_pr.comments = { { id = "new" } }
+  if review.fingerprint(base_pr) == review.fingerprint(changed_pr) then
+    fail("new PR comments should change the unseen-activity fingerprint")
+  end
+
+  local terminal = {
+    tool = { name = agent_name },
+    opts = { layout = "float", split = { width = 1 } },
+  }
+  review.configure_terminal(terminal)
+  local expected_agent_width = math.max(vim.o.columns - 61, 40)
+  if terminal.opts.layout ~= "right" or terminal.opts.split.width ~= expected_agent_width then
+    fail("review agent should open as the flexible right split: " .. vim.inspect(terminal.opts))
+  end
+
+  local context = {
+    key = "github.com/owner/repo#42",
+    host = "github.com",
+    repo = "owner/repo",
+    number = 42,
+    title = "Review agent verifier",
+    state = "open",
+    author = "author",
+    head_ref = "feature",
+    base_ref = "main",
+    body = body,
+  }
+  if not review.restore(context) then
+    fail("review description pane did not open")
+  end
+  local buf = vim.api.nvim_get_current_buf()
+  if
+    vim.bo[buf].buflisted
+    or vim.bo[buf].modifiable
+    or vim.bo[buf].filetype ~= "markdown"
+    or vim.b[buf].octo_review_body ~= body
+    or vim.wo.wrap
+  then
+    fail("review description buffer contract is wrong: " .. vim.inspect({
+      buflisted = vim.bo[buf].buflisted,
+      modifiable = vim.bo[buf].modifiable,
+      filetype = vim.bo[buf].filetype,
+      body_matches = vim.b[buf].octo_review_body == body,
+      wrap = vim.wo.wrap,
+    }))
+  end
+
+  vim.cmd("rightbelow vnew")
+  local sidekick_win = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_var(sidekick_win, "sidekick_cli", { name = agent_name })
+  if not review.restore(context) or vim.api.nvim_win_is_valid(sidekick_win) then
+    fail("review re-entry should rebuild from a non-Sidekick window")
+  end
+
+  local original_internal = package.loaded["plugins.sidekick.internal"]
+  local original_picker = package.loaded["plugins.sidekick.cwd_picker"]
+  local opened, picker_opens = {}, 0
+  package.loaded["plugins.sidekick.internal"] = {
+    toggle_tool_session = function(label, _, terminal_id)
+      opened[#opened + 1] = { label, terminal_id }
+    end,
+  }
+  package.loaded["plugins.sidekick.cwd_picker"] = {
+    open = function()
+      picker_opens = picker_opens + 1
+    end,
+  }
+  local last_session = dofile("nvim/.config/nvim/lua/plugins/sidekick/last_session.lua")
+  local first_tab = vim.api.nvim_get_current_tabpage()
+  last_session.record("codex-pr-one-1", "term-one")
+  vim.cmd.tabnew()
+  local second_tab = vim.api.nvim_get_current_tabpage()
+  last_session.record("codex-pr-two-2", "term-two")
+  vim.api.nvim_set_current_tabpage(first_tab)
+  last_session.open()
+  vim.api.nvim_set_current_tabpage(second_tab)
+  last_session.open()
+  vim.cmd.tabnew()
+  last_session.open()
+  if
+    not vim.deep_equal(opened, {
+      { "codex-pr-one-1", "term-one" },
+      { "codex-pr-two-2", "term-two" },
+    })
+    or picker_opens ~= 1
+  then
+    fail("Sidekick last-session routing should be tab-scoped: " .. vim.inspect(opened))
+  end
+  package.loaded["plugins.sidekick.internal"] = original_internal
+  package.loaded["plugins.sidekick.cwd_picker"] = original_picker
+  vim.api.nvim_set_current_tabpage(first_tab)
+  for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+    if tab ~= first_tab then
+      vim.api.nvim_set_current_tabpage(tab)
+      vim.cmd.tabclose()
+    end
+  end
+end
+
 local cases = {
   ["agent-keymaps"] = validate_agent_keymaps,
   ["workspace-session"] = validate_workspace_session,
   ["weekly-backlog"] = validate_weekly_backlog,
   ["markdown-formatting"] = validate_markdown_formatting,
   ["markdown-ansi"] = validate_markdown_ansi,
+  ["octo-review-agent"] = validate_octo_review_agent,
   ["inline-ask-edit"] = validate_inline_ask_edit,
   ["sidekick-pi"] = validate_sidekick_pi,
   ["sidekick-herdr"] = validate_sidekick_herdr,
@@ -4681,7 +4826,7 @@ if not fn then
   fail(
     "unknown VERIFY_NVIM_CASE "
       .. vim.inspect(case)
-      .. "; expected one of: agent-keymaps, workspace-session, weekly-backlog, markdown-formatting, markdown-ansi, inline-ask-edit, sidekick-pi, sidekick-herdr, sidekick-picker-actions, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
+      .. "; expected one of: agent-keymaps, workspace-session, weekly-backlog, markdown-formatting, markdown-ansi, octo-review-agent, inline-ask-edit, sidekick-pi, sidekick-herdr, sidekick-picker-actions, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
   )
 end
 

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -4969,6 +4969,64 @@ local function validate_octo_review_agent()
   end
   vim.cmd("tabclose!")
 
+  vim.cmd("tabnew")
+  local teardown_tab = vim.api.nvim_get_current_tabpage()
+  vim.api.nvim_tabpage_set_var(teardown_tab, "octo_review_context", restore_context)
+  vim.api.nvim_tabpage_set_var(teardown_tab, "octo_review_state", "open")
+  vim.api.nvim_tabpage_set_var(teardown_tab, "octo_review_unseen", true)
+  review.unbind_workspace(teardown_tab)
+  for _, name in ipairs({ "octo_review_context", "octo_review_state", "octo_review_unseen" }) do
+    if pcall(vim.api.nvim_tabpage_get_var, teardown_tab, name) then
+      fail("unbind_workspace should clear the review tab variable " .. name)
+    end
+  end
+  vim.cmd("tabclose!")
+
+  local candidates_root = vim.fn.tempname() .. "-candidates"
+  local cwd_clone = candidates_root .. "/cwd"
+  local matching_clone = candidates_root .. "/ghq/github.com/owner/repo"
+  local renamed_clone = candidates_root .. "/ghq/github.com/owner/repo-fork"
+  local other_clone = candidates_root .. "/ghq/github.com/owner/notrepo"
+  for _, path in ipairs({ cwd_clone, matching_clone, renamed_clone, other_clone }) do
+    vim.fn.mkdir(path, "p")
+  end
+  local original_executable = vim.fn.executable
+  local original_system = vim.system
+  vim.fn.executable = function(binary)
+    if binary == "ghq" then
+      return 1
+    end
+    return original_executable(binary)
+  end
+  vim.system = function(args)
+    if args[1] == "ghq" then
+      return {
+        wait = function()
+          return { code = 0, stdout = table.concat({ matching_clone, renamed_clone, other_clone }, "\n") }
+        end,
+      }
+    end
+    return original_system(args)
+  end
+  local candidates_ok, candidates = pcall(review._test.candidates, cwd_clone, "owner/repo")
+  vim.fn.executable = original_executable
+  vim.system = original_system
+  if not candidates_ok then
+    fail("repository candidate enumeration failed: " .. tostring(candidates))
+  end
+  local function normalized(path)
+    return vim.fs.normalize(vim.fn.fnamemodify(path, ":p"))
+  end
+  if
+    candidates[1] ~= normalized(cwd_clone)
+    or not vim.tbl_contains(candidates, normalized(matching_clone))
+    or vim.tbl_contains(candidates, normalized(renamed_clone))
+    or vim.tbl_contains(candidates, normalized(other_clone))
+  then
+    fail("ghq clones should be pre-filtered to the repo basename: " .. vim.inspect(candidates))
+  end
+  vim.fn.delete(candidates_root, "rf")
+
   local function git(root, args, expected)
     local command = { "git", "-C", root }
     vim.list_extend(command, args)


### PR DESCRIPTION
## Summary

This adds a dedicated Octo PR review-agent workflow to Neovim. Opening a top-level pull request now creates or reopens an isolated Herdr linked-worktree workspace, presents the PR beside a named Sidekick/Codex agent, preserves review state across sessions, and safely refreshes the local review branch when the remote PR head changes.

The branch changes 12 files (+1,851/-51), centered on the new `plugins/octo/review_agent.lua` module and targeted verifier coverage.

## What changed

### Octo entry points and PR discovery

- `<leader>OO` now opens the current branch's PR in the review-agent workflow.
- Confirming a PR from Octo's PR list, `Octo pr edit`, an Octo PR URI, or the custom review picker enters the same workflow instead of Octo's stock top-level PR buffer.
- The review picker still combines review-requested PRs, open assigned PRs, and assigned PRs merged within the last week, but confirmation now opens the dedicated review workspace.
- Repository resolution checks the current checkout, fixed local project locations, and ghq clones whose directory basename matches the requested repository. The basename filter prevents running multiple synchronous Git probes across every ghq checkout.

### Isolated review workspaces

- Each PR gets a stable `review/<repo>-<number>` branch and a Herdr linked-worktree workspace labeled `<repo> · #<number>`.
- The PR head is fetched into a private `refs/octo-review/heads/*` ref before creating or reopening the workspace.
- The Neovim tab, Herdr workspace, Sidekick agent, worktree CWD, and prompt all use the same scoped review checkout.
- Review workspaces use a named `codex-pr-*` Sidekick session so they can be found and restored through the existing session picker.

### Review presentation and agent context

- The workspace opens a fixed-width Markdown PR description on the left and the review agent on the right.
- Ordinary prose is presentation-wrapped to 60 columns while fenced code, tables, headings, indented blocks, HTML, and the original PR body remain intact.
- The agent receives commands to refresh the complete PR metadata, diff, checks, reviews, comments, files, and commits, then produce a context summary of at most 30 lines.
- The first pass is explicitly read-only unless a PR-head refresh requires semantic conflict resolution and validation.
- Toggling a visible review agent hides it normally. A missing review view is rebuilt only in the tab already bound to that PR; user-created splits and unrelated tabs are preserved.

### Transactional, resumable PR-head refreshes

- Local tracked and untracked review edits are committed before rebasing onto a changed PR head.
- Three private refs separate accepted, recoverable, and pending state:
  - `refs/octo-review/base/*` records the last validated PR head.
  - `refs/octo-review/recovery/*` anchors the pre-rebase local review state.
  - `refs/octo-review/pending/*` records the exact incoming PR head being validated.
- Reopening the exact same pending head reuses the existing clean or conflicted rebase state instead of stacking another rebase.
- Any older, newer, or otherwise different head is blocked until the pending refresh finishes.
- An orphaned recovery ref with no pending ref or active rebase can resume validation when the requested head is already an ancestor of the rebased `HEAD`; a genuinely different head remains blocked.
- Conflicts are handed to the review agent with instructions to resolve them semantically and finish the rebase.
- The accepted base advances, and recovery/pending refs are deleted, only after the rebase is complete and validation succeeds. Failed validation leaves recovery state intact.

### Persistent review state and tab UI

- Review records are stored atomically in Neovim state, keyed by host/repository/PR.
- Fingerprints include the head SHA, update time, PR state, comment/review counts, and sorted check state.
- A review is marked seen only after the initial context prompt succeeds and any refresh has passed its ref-state validation.
- Workspace tabs show state-specific icons for open, draft, merged, and closed PRs plus an unseen-update marker.
- Binding a Herdr workspace restores its saved Octo review context. Unbinding clears the context, state, and unseen tab variables so a preserved folder tab cannot display or restore a dead review session.

### Sidekick and Herdr reconciliation

- The last selected Sidekick session is now stored per Neovim tab, so `<C-.>` follows the current Workspace Tab instead of one process-global session.
- Named sessions started inside a linked worktree use that worktree's Herdr workspace even when the current tab carries another binding.
- Existing named sessions are checked and, when necessary, moved into the Herdr workspace that owns their foreground CWD while preserving terminal and agent-session identity.
- The review-agent terminal uses the right split and integrates with the existing Sidekick branding/configuration path.
- Normal agent closure removes the Herdr binding while preserving the Workspace Tab's folder identity; the Herdr workspace is closed when its last agent is gone.

### Documentation and verifier coverage

- `docs/neovim-current-features.md` documents the review-agent workflow, refresh semantics, toggle behavior, tab-scoped session routing, linked-worktree anchoring, and workspace teardown.
- `scripts/verify-nvim.lua` adds:
  - `octo-review-agent` coverage for routing, layout, persisted seen/unseen state, repository filtering, clean/conflicted/orphaned refreshes, exact-head blocking, validation-gated cleanup, and tab-scoped session restore.
  - `sidekick-worktree-anchor` coverage for linked-worktree placement without depending on the unrelated broad picker-layout assertion.
  - Updated Workspace Tab/Herdr ownership assertions after reconciliation with current `main`.
- Touched Lua was Stylua-normalized, and the final verifier housekeeping expanded an over-width table literal.

## Validation

No-mistakes completed review, rebase, targeted tests, documentation, lint, push, PR creation, and CI.

Passing targeted routes:

- `scripts/verify-nvim octo-review-agent`
- `scripts/verify-nvim workspace-session`
- `scripts/verify-nvim herdr-workspaces`
- `scripts/verify-nvim sidekick-worktree-anchor`
- `scripts/verify-nvim sidekick-picker-actions`
- `scripts/verify-nvim sidekick-pi`

Additional local checks passed:

- Stylua `--check` across all changed Neovim Lua files
- `git diff origin/main...HEAD --check`

No-mistakes found and fixed four issues during review:

- orphaned recovery refs could permanently block future refreshes;
- toggling a review session could always reopen it and destroy unrelated layout;
- repository discovery could synchronously probe an unbounded ghq inventory;
- unbinding a review workspace could leave stale tab identity and unseen state.

Known non-regressions/follow-ups:

- The broad `sidekick-herdr` route's 100×30 picker-layout assertion fails identically on the base and target commits.
- `sidekick-herdr-live` remains timing-sensitive against the running Herdr server and flakes on both base and target.
- Named-session enumeration still performs synchronous Herdr worktree lookup per named session; this was recorded as an informational performance follow-up, not claimed as cached in this PR.
