### PR TITLE
feat(sidekick): distinguish main from worktree branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,11 @@ Treat repository, worktree, and session identity as three distinct concepts:
 
 - Group durable sessions as `repository -> worktree`.
 - Render one worktree row for its one durable session; do not repeat a session name that restates the worktree name.
-- Color the worktree name with the existing Sidekick backend color and retain the Herdr status glyph.
-- Show tracked line additions and removals against local `main` as `+<added> −<removed>`; show `clean` when both are
-  zero.
+- Prefix every non-`main` Git branch row with `` and color both the marker and branch name with the existing Gruvbox
+  pink `SidekickBranch` highlight; do not color branch identity by agent backend. Retain the Herdr status glyph.
+- Treat a `main` branch row as the neutral checkout: render it without the branch marker and without line-diff totals.
+- For non-`main` branches, show tracked line additions and removals against local `main` as `+<added> −<removed>`;
+  show `clean` when both are zero.
 - Keep the current-worktree row in the picker alongside the repository hierarchy. Selection, preview, rename, kill,
   and focus actions must continue to target the exact underlying Herdr agent identity.
 - Preserve exact cwd behavior for non-Git directories instead of inventing repository identity.

--- a/docs/adr/0002-share-herdr-workspace-per-repository.md
+++ b/docs/adr/0002-share-herdr-workspace-per-repository.md
@@ -11,5 +11,5 @@ beneath the owning session.
 
 Task cleanup therefore closes task-owned tabs, panes, bindings, and worktree views without closing a repository's
 shared Herdr Workspace while other worktree sessions remain. The Sidekick picker presents repository headings and
-backend-colored worktree rows with tracked line additions and removals against `main`; internal agent names remain
-routing identities rather than display identities.
+Gruvbox-pink `` branch rows with tracked line additions and removals against `main`; the neutral `main` checkout has
+neither marker nor diff totals. Internal agent names remain routing identities rather than display identities.

--- a/docs/evidence/sidekick-repository-worktree-picker/README.md
+++ b/docs/evidence/sidekick-repository-worktree-picker/README.md
@@ -1,8 +1,8 @@
 # Sidekick repository/worktree picker evidence
 
-This capture shows the implemented picker contract: repositories expand into worktrees, each worktree row represents
-its one durable Sidekick session, the worktree name uses the agent backend color, and tracked line changes against
-local `main` appear as `+added −removed`. The bottom-right pane shows only the current worktree.
+This original implementation capture shows repositories expanding into worktrees, with one durable Sidekick session
+per row and the current worktree isolated in the bottom-right pane. The current verifier supersedes its row styling:
+non-`main` branches use a Gruvbox-pink `` marker and diff totals, while `main` has neither marker nor diff totals.
 
 ![Rendered Sidekick repository/worktree picker](picker.svg)
 

--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -372,7 +372,9 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Sidekick cwd session picker keeps the ordinary conversation preview full-width above its input, with
   `Repositories / Worktrees` and `Current Worktree` panes across the bottom.
 - Repository headings expand into one row per durable worktree session. Rows use the Git branch as worktree identity,
-  retain backend color and Herdr state, and show tracked `+added −removed` totals against local `main`.
+  retain Herdr state, and prefix non-`main` branches with a Gruvbox-pink `` marker instead of backend color.
+- Non-`main` branch rows show tracked `+added −removed` totals against local `main`; the neutral `main` checkout row
+  has neither the branch marker nor diff totals.
 - The current-worktree pane shows only that worktree's one durable session. Internal Herdr agent names remain available
   for exact routing, rename, kill, and focus actions without being repeated in the row.
 - Ordinary preview polling and full-history scrolling continue while navigating either pane.

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -3,7 +3,6 @@
 -- Bound to <c-.> in plugins/sidekick.lua.
 local internal = require("plugins.sidekick.internal")
 local registry = require("plugins.sidekick.registry")
-local branding = require("plugins.sidekick.branding")
 local herdr = require("plugins.sidekick.herdr")
 
 local M = {}
@@ -15,6 +14,7 @@ local spinner_refresh_ms = 80
 local preview_debounce_ms = 400
 local preview_settle_ms = 16
 local full_preview_lines = 2147483647 -- Herdr clamps this to the available scrollback.
+local branch_glyph = ""
 local workspace_ns = vim.api.nvim_create_namespace("sidekick_workspace_picker")
 local status_rank = { working = 1, blocked = 2, done = 3, idle = 4 }
 local status_display = {
@@ -66,7 +66,7 @@ end
 ---@param cache table<string, { added: integer, removed: integer }|false>
 ---@return { added: integer, removed: integer }|nil
 local function diff_stats(context, cache)
-  if not context then
+  if not context or context.branch == "main" then
     return nil
   end
   if cache[context.worktree] == nil then
@@ -415,6 +415,7 @@ function M.list_items(metric_cache)
         cwd = entry.cwd,
         repository = context and context.repository or nil,
         worktree = context and context.worktree or entry.cwd,
+        branch = context and context.branch or nil,
         diff = diff_stats(context, stats_cache),
         working_since = metrics.working_since,
         running_seconds = metrics.running_seconds,
@@ -488,6 +489,7 @@ local function workspace_groups(first_repository, metric_cache)
         cwd = agent.foreground_cwd or agent.cwd,
         repository = context and context.repository or nil,
         worktree = context and context.worktree or nil,
+        branch = context and context.branch or nil,
         diff = diff_stats(context, stats_cache),
         working_since = metrics.working_since,
         running_seconds = metrics.running_seconds,
@@ -533,9 +535,13 @@ local function format_local(item)
     return { { item.text or "", "Comment" } }
   end
   local symbol, symbol_hl = status_icon(item.status)
-  local chunks = {
-    { symbol .. " ", symbol_hl },
-    { item.display_label or item.label or "", branding.hl_groups(branding.tool_of(item.tool)).title },
+  local chunks = { { symbol .. " ", symbol_hl } }
+  if item.branch and item.branch ~= "main" then
+    chunks[#chunks + 1] = { branch_glyph .. " ", "SidekickBranch" }
+  end
+  chunks[#chunks + 1] = {
+    item.display_label or item.label or "",
+    item.branch and item.branch ~= "main" and "SidekickBranch" or "Normal",
   }
   vim.list_extend(chunks, diff_chunks(item))
   return chunks
@@ -556,10 +562,13 @@ local function workspace_agent_chunks(item, last)
   local chunks = {
     { last and "  └─ " or "  ├─ ", "SnacksPickerTree" },
     { symbol .. " ", symbol_hl },
-    {
-      item.display_label or item.label or item.agent_name or "unknown",
-      branding.hl_groups(branding.tool_of(item.tool)).title,
-    },
+  }
+  if item.branch and item.branch ~= "main" then
+    chunks[#chunks + 1] = { branch_glyph .. " ", "SidekickBranch" }
+  end
+  chunks[#chunks + 1] = {
+    item.display_label or item.label or item.agent_name or "unknown",
+    item.branch and item.branch ~= "main" and "SidekickBranch" or "Normal",
   }
   vim.list_extend(chunks, diff_chunks(item))
   return chunks

--- a/nvim/.config/nvim/lua/plugins/sidekick/herdr.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/herdr.lua
@@ -41,6 +41,7 @@ end
 ---@field repository_label string
 ---@field worktree string
 ---@field worktree_label string
+---@field branch string
 
 ---@param cwd string
 ---@return SidekickGitContext|nil
@@ -78,6 +79,7 @@ function M.git_context(cwd)
     repository_label = vim.fn.fnamemodify(repository, ":t"),
     worktree = worktree,
     worktree_label = branch ~= "" and branch ~= "HEAD" and branch or vim.fn.fnamemodify(worktree, ":t"),
+    branch = branch,
   }
 end
 

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1046,7 +1046,7 @@ local function validate_sidekick_herdr()
         name = "sk-codex-deadbeef",
         agent = "codex",
         agent_status = "working",
-        cwd = "/worktrees/dotfiles/base",
+        cwd = "/worktrees/dotfiles/main",
         pane_id = "w1:p1",
         terminal_id = "term-base",
         workspace_id = "w1",
@@ -1071,15 +1071,18 @@ local function validate_sidekick_herdr()
         repository_label = "dotfiles",
         worktree = cwd,
         worktree_label = "feat/sidekick-repo-session-grouping",
+        branch = "feat/sidekick-repo-session-grouping",
       }
     end
     local dotfiles_worktree = path:match("^/worktrees/dotfiles/([^/]+)")
     if dotfiles_worktree then
+      local branch = dotfiles_worktree == "main" and "main" or "feature/" .. dotfiles_worktree
       return {
         repository = "/repos/dotfiles",
         repository_label = "dotfiles",
         worktree = "/worktrees/dotfiles/" .. dotfiles_worktree,
-        worktree_label = "feature/" .. dotfiles_worktree,
+        worktree_label = branch,
+        branch = branch,
       }
     end
     local vault_worktree = path:match("^/worktrees/vault/([^/]+)")
@@ -1089,6 +1092,7 @@ local function validate_sidekick_herdr()
         repository_label = "vault",
         worktree = "/worktrees/vault/" .. vault_worktree,
         worktree_label = "feature/" .. vault_worktree,
+        branch = "feature/" .. vault_worktree,
       }
     end
   end
@@ -1099,7 +1103,7 @@ local function validate_sidekick_herdr()
       ["/worktrees/dotfiles/working"] = { added = 88, removed = 12 },
       ["/worktrees/dotfiles/done"] = { added = 18, removed = 4 },
       ["/worktrees/dotfiles/workspace-only"] = { added = 7, removed = 0 },
-      ["/worktrees/dotfiles/base"] = { added = 0, removed = 0 },
+      ["/worktrees/dotfiles/main"] = { added = 999, removed = 999 },
       ["/worktrees/vault/journal"] = { added = 21, removed = 9 },
     }
     return values[path] or { added = 0, removed = 0 }
@@ -1343,6 +1347,14 @@ local function validate_sidekick_herdr()
       if not rendered:find(item.display_label, 1, true) or rendered:find(item.label, 1, true) then
         fail("picker rows should use worktree identity without repeating the session name: " .. vim.inspect(rendered))
       end
+      if not rendered:find(" " .. item.display_label, 1, true) then
+        fail("non-main picker rows should show the Git branch marker: " .. vim.inspect(rendered))
+      end
+      for _, chunk in ipairs(chunks) do
+        if (chunk[1] == " " or chunk[1] == item.display_label) and chunk[2] ~= "SidekickBranch" then
+          fail("branch marker and label should use Gruvbox pink instead of agent color: " .. vim.inspect(chunks))
+        end
+      end
       if not rendered:find(" · +142 −38", 1, true) then
         fail("picker rows should show added and removed lines against main: " .. vim.inspect(rendered))
       end
@@ -1534,13 +1546,19 @@ local function validate_sidekick_herdr()
     end
     if
       global_lines[1] ~= "▾ dotfiles · 6 worktrees"
-      or not vim.tbl_contains(global_lines, "  ├─ S feature/working · +88 −12")
-      or not vim.tbl_contains(global_lines, "  ├─ ! feat/sidekick-repo-session-grouping · +142 −38")
+      or not vim.tbl_contains(global_lines, "  ├─ S  feature/working · +88 −12")
+      or not vim.tbl_contains(global_lines, "  ├─ !  feat/sidekick-repo-session-grouping · +142 −38")
+      or not vim.iter(global_lines):any(function(line)
+        return line:find("S main", 1, true) ~= nil
+          and line:find(" main", 1, true) == nil
+          and line:find("+999", 1, true) == nil
+          and line:find("−999", 1, true) == nil
+      end)
       or not vim.tbl_contains(global_lines, "▾ vault · 1 worktree")
-      or not vim.tbl_contains(global_lines, "  └─ · feature/journal · +21 −9")
+      or not vim.tbl_contains(global_lines, "  └─ ·  feature/journal · +21 −9")
     then
       fail(
-        "repository rows should start locally, group worktrees, show main diff stats, and start expanded: "
+        "repository rows should mark non-main branches, suppress main diff stats, and start expanded: "
           .. vim.inspect(global_lines)
       )
     end
@@ -1619,7 +1637,7 @@ local function validate_sidekick_herdr()
       global_lines = vim.api.nvim_buf_get_lines(global_win.buf, 0, -1, false)
       if
         global_lines[1] ~= "▾ vault · 1 worktree"
-        or global_lines[2] ~= "  └─ · feature/journal · +21 −9"
+        or global_lines[2] ~= "  └─ ·  feature/journal · +21 −9"
         or vim.api.nvim_win_get_cursor(global_win.win)[1] ~= 2
       then
         fail("Ctrl-R/Ctrl-X verifier should highlight pi-other-workspace")
@@ -1786,7 +1804,7 @@ local function validate_sidekick_herdr()
     global_lines = vim.api.nvim_buf_get_lines(global_win.buf, 0, -1, false)
     if
       global_lines[1] ~= "▾ vault · 1 worktree"
-      or global_lines[2] ~= "  └─ · feature/journal · +21 −9"
+      or global_lines[2] ~= "  └─ ·  feature/journal · +21 −9"
       or vim.api.nvim_win_get_cursor(global_win.win)[1] ~= 2
     then
       fail(


### PR DESCRIPTION
## Summary

- render the `main` checkout without a Git marker or line-diff totals
- prefix every non-`main` branch with a Gruvbox-pink `` marker and branch label
- stop using the Sidekick agent backend color for picker branch identity
- carry the exact Git branch through picker items and update the repository contracts and verifier

## Why

The picker treated `main` like a code-change worktree and colored branch identity by agent backend. That blurred the distinction between the neutral primary checkout and worktrees intended for changes.

## Impact

Repository-to-Herdr-workspace mapping, one durable session per worktree, exact cwd scope, and hidden Herdr routing identity are unchanged.

## Validation

- `scripts/verify-nvim sidekick-herdr`
- `scripts/verify-nvim herdr-workspaces`
- `scripts/verify-nvim sidekick-herdr-compat`
- `scripts/verify-nvim sidekick-picker-actions`
- `git diff --check`
