### PR TITLE
fix(sidekick): restore neutral session chrome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,10 @@ Treat repository, worktree, and session identity as three distinct concepts:
 - Group durable sessions as `repository -> worktree`.
 - Render one worktree row for its one durable session; do not repeat a session name that restates the worktree name.
 - Prefix every non-`main` Git branch row with `` and color both the marker and branch name with the existing Gruvbox
-  pink `SidekickBranch` highlight; do not color branch identity by agent backend. Retain the Herdr status glyph.
-- Treat a `main` branch row as the neutral checkout: render it without the branch marker and without line-diff totals.
+  pink `SidekickBranch` highlight; do not color non-`main` branch identity by agent backend. Retain the Herdr status
+  glyph.
+- Treat a `main` branch row as the neutral checkout: retain its agent backend chrome, but render it without the branch
+  marker and without line-diff totals. Non-Git session rows also retain their agent backend chrome.
 - For non-`main` branches, show tracked line additions and removals against local `main` as `+<added> −<removed>`;
   show `clean` when both are zero.
 - Keep the current-worktree row in the picker alongside the repository hierarchy. Selection, preview, rename, kill,

--- a/docs/adr/0002-share-herdr-workspace-per-repository.md
+++ b/docs/adr/0002-share-herdr-workspace-per-repository.md
@@ -12,4 +12,5 @@ beneath the owning session.
 Task cleanup therefore closes task-owned tabs, panes, bindings, and worktree views without closing a repository's
 shared Herdr Workspace while other worktree sessions remain. The Sidekick picker presents repository headings and
 Gruvbox-pink `` branch rows with tracked line additions and removals against `main`; the neutral `main` checkout has
-neither marker nor diff totals. Internal agent names remain routing identities rather than display identities.
+backend chrome but neither marker nor diff totals. Non-Git sessions also retain backend chrome. Internal agent names
+remain routing identities rather than display identities.

--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -374,7 +374,8 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Repository headings expand into one row per durable worktree session. Rows use the Git branch as worktree identity,
   retain Herdr state, and prefix non-`main` branches with a Gruvbox-pink `` marker instead of backend color.
 - Non-`main` branch rows show tracked `+added −removed` totals against local `main`; the neutral `main` checkout row
-  has neither the branch marker nor diff totals.
+  retains agent backend chrome but has neither the branch marker nor diff totals. Non-Git rows also retain backend
+  chrome.
 - The current-worktree pane shows only that worktree's one durable session. Internal Herdr agent names remain available
   for exact routing, rename, kill, and focus actions without being repeated in the row.
 - Ordinary preview polling and full-history scrolling continue while navigating either pane.

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -3,6 +3,7 @@
 -- Bound to <c-.> in plugins/sidekick.lua.
 local internal = require("plugins.sidekick.internal")
 local registry = require("plugins.sidekick.registry")
+local branding = require("plugins.sidekick.branding")
 local herdr = require("plugins.sidekick.herdr")
 
 local M = {}
@@ -432,6 +433,13 @@ local function status_icon(status)
   return status == "working" and Snacks.util.spinner() or display[1], display[2]
 end
 
+local function identity_hl(item)
+  if item.branch and item.branch ~= "main" then
+    return "SidekickBranch"
+  end
+  return branding.hl_groups(branding.tool_of(item.tool)).title
+end
+
 local function workspace_groups(first_repository, metric_cache)
   local grouped = {}
   local context_cache = {}
@@ -541,7 +549,7 @@ local function format_local(item)
   end
   chunks[#chunks + 1] = {
     item.display_label or item.label or "",
-    item.branch and item.branch ~= "main" and "SidekickBranch" or "Normal",
+    identity_hl(item),
   }
   vim.list_extend(chunks, diff_chunks(item))
   return chunks
@@ -568,7 +576,7 @@ local function workspace_agent_chunks(item, last)
   end
   chunks[#chunks + 1] = {
     item.display_label or item.label or item.agent_name or "unknown",
-    item.branch and item.branch ~= "main" and "SidekickBranch" or "Normal",
+    identity_hl(item),
   }
   vim.list_extend(chunks, diff_chunks(item))
   return chunks

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1562,6 +1562,26 @@ local function validate_sidekick_herdr()
           .. vim.inspect(global_lines)
       )
     end
+    local main_row
+    for row, line in ipairs(global_lines) do
+      if line:find("S main", 1, true) then
+        main_row = row
+        break
+      end
+    end
+    local main_hl
+    local main_col = assert(global_lines[main_row]:find("main", 1, true)) - 1
+    local workspace_ns = vim.api.nvim_get_namespaces().sidekick_workspace_picker
+    for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(global_win.buf, workspace_ns, 0, -1, { details = true })) do
+      local details = mark[4]
+      if mark[2] == main_row - 1 and mark[3] == main_col then
+        main_hl = details.hl_group
+        break
+      end
+    end
+    if main_hl ~= "SidekickTitleCodex" then
+      fail("neutral main sessions should retain their agent backend chrome: " .. vim.inspect(main_hl))
+    end
     if type(input_changed) ~= "function" then
       fail("agent picker input should update workspace fuzzy results")
     end


### PR DESCRIPTION
## Summary

- keep non-`main` worktree rows Gruvbox pink with the Git branch marker
- restore agent-backend chrome for neutral `main` and non-Git session rows
- retain the rule that `main` shows neither a branch marker nor diff totals
- verify the rendered workspace-picker extmark uses the Codex title highlight

## Root cause

The branch-display change in #138 replaced the neutral-row backend highlight with `Normal`. The picker still rendered the right text, but `main` and non-Git sessions lost their backend chrome.

## Invariants

This does not change repository/worktree/session identity or routing. One repository still maps to one Herdr workspace, each worktree owns at most one durable session, and every agent retains its exact cwd.

## Validation

- `scripts/verify-nvim sidekick-herdr`
- `scripts/verify-nvim herdr-workspaces`
- `scripts/verify-nvim sidekick-herdr-compat`
- `scripts/verify-nvim sidekick-picker-actions`
- `git diff --cached --check`

All passed.
