### PR TITLE
fix(sidekick): show session names for main checkouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,9 @@ Treat repository, worktree, and session identity as three distinct concepts:
 - Prefix every non-`main` Git branch row with `` and color both the marker and branch name with the existing Gruvbox
   pink `SidekickBranch` highlight; do not color non-`main` branch identity by agent backend. Retain the Herdr status
   glyph.
-- Treat a `main` branch row as the neutral checkout: retain its agent backend chrome, but render it without the branch
-  marker and without line-diff totals. Non-Git session rows also retain their agent backend chrome.
+- Treat a `main` branch row as the neutral checkout: show its durable Sidekick session name with agent backend chrome,
+  but render it without the branch marker and without line-diff totals. Non-Git session rows also retain their agent
+  backend chrome.
 - For non-`main` branches, show tracked line additions and removals against local `main` as `+<added> −<removed>`;
   show `clean` when both are zero.
 - Keep the current-worktree row in the picker alongside the repository hierarchy. Selection, preview, rename, kill,

--- a/docs/adr/0002-share-herdr-workspace-per-repository.md
+++ b/docs/adr/0002-share-herdr-workspace-per-repository.md
@@ -11,6 +11,6 @@ beneath the owning session.
 
 Task cleanup therefore closes task-owned tabs, panes, bindings, and worktree views without closing a repository's
 shared Herdr Workspace while other worktree sessions remain. The Sidekick picker presents repository headings and
-Gruvbox-pink `` branch rows with tracked line additions and removals against `main`; the neutral `main` checkout has
-backend chrome but neither marker nor diff totals. Non-Git sessions also retain backend chrome. Internal agent names
-remain routing identities rather than display identities.
+Gruvbox-pink `` branch rows with tracked line additions and removals against `main`; the neutral `main` checkout shows
+its durable Sidekick session name with backend chrome but neither marker nor diff totals. Non-Git sessions also retain
+backend chrome. Internal Herdr agent names remain routing identities rather than display identities.

--- a/docs/evidence/sidekick-repository-worktree-picker/README.md
+++ b/docs/evidence/sidekick-repository-worktree-picker/README.md
@@ -1,12 +1,13 @@
 # Sidekick repository/worktree picker evidence
 
 This original implementation capture shows repositories expanding into worktrees, with one durable Sidekick session
-per row and the current worktree isolated in the bottom-right pane. The current verifier supersedes its row styling:
-non-`main` branches use a Gruvbox-pink `` marker and diff totals, while `main` has neither marker nor diff totals.
+per row and the current worktree isolated in the bottom-right pane. The authoritative current behavior is documented in
+[Neovim current features](../../neovim-current-features.md#agent-sessions-and-routing); the verifier supersedes the
+historical row labels and styling shown here.
 
 ![Rendered Sidekick repository/worktree picker](picker.svg)
 
-The ANSI row content and layout labels use the deterministic fixtures asserted by:
+Current behavior is asserted by:
 
 ```sh
 scripts/verify-nvim sidekick-herdr

--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -374,8 +374,8 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Repository headings expand into one row per durable worktree session. Rows use the Git branch as worktree identity,
   retain Herdr state, and prefix non-`main` branches with a Gruvbox-pink `` marker instead of backend color.
 - Non-`main` branch rows show tracked `+added −removed` totals against local `main`; the neutral `main` checkout row
-  retains agent backend chrome but has neither the branch marker nor diff totals. Non-Git rows also retain backend
-  chrome.
+  shows its durable Sidekick session name with agent backend chrome but has neither the branch marker nor diff totals.
+  Non-Git rows also retain backend chrome.
 - The current-worktree pane shows only that worktree's one durable session. Internal Herdr agent names remain available
   for exact routing, rename, kill, and focus actions without being repeated in the row.
 - Ordinary preview polling and full-history scrolling continue while navigating either pane.

--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -347,7 +347,6 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Sidekick floats use per-agent colored titles.
 - Sidekick splits use per-agent colored winbars.
 - Sidekick splits use per-agent colored window separators.
-- Sidekick session pickers render worktree names with matching per-agent colors.
 - Sidekick cwd session picker uses transparent picker backgrounds so terminal previews stay visible.
 - Sidekick CLI picker shows right-aligned cwd.
 
@@ -371,8 +370,8 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Sidekick keymaps include ask/edit/apply/reject/yank, context/prompt sending, the local picker, and named-session creation.
 - Sidekick cwd session picker keeps the ordinary conversation preview full-width above its input, with
   `Repositories / Worktrees` and `Current Worktree` panes across the bottom.
-- Repository headings expand into one row per durable worktree session. Rows use the Git branch as worktree identity,
-  retain Herdr state, and prefix non-`main` branches with a Gruvbox-pink `` marker instead of backend color.
+- Repository headings expand into one row per durable worktree session. Non-`main` rows use the Git branch as worktree
+  identity, retain Herdr state, and prefix it with a Gruvbox-pink `` marker instead of backend color.
 - Non-`main` branch rows show tracked `+added −removed` totals against local `main`; the neutral `main` checkout row
   shows its durable Sidekick session name with agent backend chrome but has neither the branch marker nor diff totals.
   Non-Git rows also retain backend chrome.

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -76,6 +76,10 @@ local function diff_stats(context, cache)
   return cache[context.worktree] or nil
 end
 
+local function session_display_label(context, label)
+  return context and context.branch ~= "main" and context.worktree_label or label
+end
+
 ---@param entry_cwd string|nil
 ---@param root string  already normalized
 ---@return boolean
@@ -401,9 +405,9 @@ function M.list_items(metric_cache)
       local context = git_context(entry.cwd, context_cache)
       local metrics = agent_metrics(entry.agent_name, entry.agent_session, entry.status, metric_cache)
       items[#items + 1] = {
-        text = string.format("%s  [%s]", context and context.worktree_label or label, entry.status),
+        text = string.format("%s  [%s]", session_display_label(context, label), entry.status),
         label = label,
-        display_label = context and context.worktree_label or label,
+        display_label = session_display_label(context, label),
         tool = entry.tool,
         slug = entry.slug,
         pane_id = entry.pane_id,
@@ -477,13 +481,13 @@ local function workspace_groups(first_repository, metric_cache)
       group.running = group.running + (status == "working" and 1 or 0)
       group.done = group.done + (status == "done" and 1 or 0)
       local worktree = context and context.worktree or (agent.foreground_cwd or agent.cwd or agent.name)
+      local label = parsed and parsed.label
+        or (agent.name and not agent.name:match("^sk%-") and agent.name)
+        or tool
       group.worktrees[worktree] = true
       group.agents[#group.agents + 1] = {
-        label = parsed and parsed.label
-          or (agent.name and not agent.name:match("^sk%-") and agent.name)
-          or tool,
-        display_label = context and context.worktree_label
-          or vim.fn.fnamemodify(agent.foreground_cwd or agent.cwd or agent.name or tool, ":t"),
+        label = label,
+        display_label = session_display_label(context, label),
         slug = parsed and parsed.slug,
         toggle_name = parsed and parsed.label or tool,
         tool = tool,

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -481,9 +481,7 @@ local function workspace_groups(first_repository, metric_cache)
       group.running = group.running + (status == "working" and 1 or 0)
       group.done = group.done + (status == "done" and 1 or 0)
       local worktree = context and context.worktree or (agent.foreground_cwd or agent.cwd or agent.name)
-      local label = parsed and parsed.label
-        or (agent.name and not agent.name:match("^sk%-") and agent.name)
-        or tool
+      local label = parsed and parsed.label or (agent.name and not agent.name:match("^sk%-") and agent.name) or tool
       group.worktrees[worktree] = true
       group.agents[#group.agents + 1] = {
         label = label,

--- a/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/cwd_picker.lua
@@ -76,8 +76,8 @@ local function diff_stats(context, cache)
   return cache[context.worktree] or nil
 end
 
-local function session_display_label(context, label)
-  return context and context.branch ~= "main" and context.worktree_label or label
+local function session_display_label(context, label, non_git_label)
+  return context and context.branch ~= "main" and context.worktree_label or context and label or non_git_label or label
 end
 
 ---@param entry_cwd string|nil
@@ -487,7 +487,11 @@ local function workspace_groups(first_repository, metric_cache)
       group.worktrees[worktree] = true
       group.agents[#group.agents + 1] = {
         label = label,
-        display_label = session_display_label(context, label),
+        display_label = session_display_label(
+          context,
+          label,
+          vim.fn.fnamemodify(agent.foreground_cwd or agent.cwd or agent.name or tool, ":t")
+        ),
         slug = parsed and parsed.slug,
         toggle_name = parsed and parsed.label or tool,
         tool = tool,

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1058,6 +1058,7 @@ local function validate_sidekick_herdr()
       named_agent(other_agent_name, "idle", 6, "w2", "/worktrees/vault/journal"),
       named_agent("pi-workspace-only", "idle", 7, "w1", "/worktrees/dotfiles/workspace-only"),
       named_agent("review-child", "working", 8, "w1", cwd),
+      named_agent("pi-non-git-session", "idle", 9, "w3", "/tmp/sidekick-non-git/exact-cwd"),
     }
     return vim.tbl_filter(function(agent)
       return agent.pane_id ~= removed_pane_id
@@ -1192,6 +1193,7 @@ local function validate_sidekick_herdr()
         workspaces = {
           { workspace_id = "w1", label = "Workspace One" },
           { workspace_id = "w2", label = "Workspace Two" },
+          { workspace_id = "w3", label = "Non-Git Workspace" },
         },
       }
     end
@@ -1556,9 +1558,11 @@ local function validate_sidekick_herdr()
       end)
       or not vim.tbl_contains(global_lines, "▾ vault · 1 worktree")
       or not vim.tbl_contains(global_lines, "  └─ ·  feature/journal · +21 −9")
+      or not vim.tbl_contains(global_lines, "▾ Non-Git Workspace · 1 worktree")
+      or not vim.tbl_contains(global_lines, "  └─ · exact-cwd")
     then
       fail(
-        "repository rows should mark non-main branches, show the main session name without diff stats, and start expanded: "
+        "repository rows should distinguish branch, main-session, and non-Git cwd labels: "
           .. vim.inspect(global_lines)
       )
     end

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1043,7 +1043,7 @@ local function validate_sidekick_herdr()
   herdr.list_agents = function()
     local agents = {
       {
-        name = "sk-codex-deadbeef",
+        name = "codex-main-hello",
         agent = "codex",
         agent_status = "working",
         cwd = "/worktrees/dotfiles/main",
@@ -1113,7 +1113,7 @@ local function validate_sidekick_herdr()
   package.loaded["plugins.sidekick.herdr"] = source_herdr
   local source_registry = dofile(source_root .. "registry.lua")
   local discovered = source_registry.discover()
-  if discovered["sk-codex-deadbeef"] then
+  if source_registry.parse_session_name("sk-codex-deadbeef") then
     fail("base Herdr sessions must not appear as named sessions")
   end
   local entry = discovered["pi-blocked"]
@@ -1549,8 +1549,8 @@ local function validate_sidekick_herdr()
       or not vim.tbl_contains(global_lines, "  ├─ S  feature/working · +88 −12")
       or not vim.tbl_contains(global_lines, "  ├─ !  feat/sidekick-repo-session-grouping · +142 −38")
       or not vim.iter(global_lines):any(function(line)
-        return line:find("S main", 1, true) ~= nil
-          and line:find(" main", 1, true) == nil
+        return line:find("S codex-main-hello", 1, true) ~= nil
+          and line:find(" codex-main-hello", 1, true) == nil
           and line:find("+999", 1, true) == nil
           and line:find("−999", 1, true) == nil
       end)
@@ -1558,19 +1558,19 @@ local function validate_sidekick_herdr()
       or not vim.tbl_contains(global_lines, "  └─ ·  feature/journal · +21 −9")
     then
       fail(
-        "repository rows should mark non-main branches, suppress main diff stats, and start expanded: "
+        "repository rows should mark non-main branches, show the main session name without diff stats, and start expanded: "
           .. vim.inspect(global_lines)
       )
     end
     local main_row
     for row, line in ipairs(global_lines) do
-      if line:find("S main", 1, true) then
+      if line:find("S codex-main-hello", 1, true) then
         main_row = row
         break
       end
     end
     local main_hl
-    local main_col = assert(global_lines[main_row]:find("main", 1, true)) - 1
+    local main_col = assert(global_lines[main_row]:find("codex-main-hello", 1, true)) - 1
     local workspace_ns = vim.api.nvim_get_namespaces().sidekick_workspace_picker
     for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(global_win.buf, workspace_ns, 0, -1, { details = true })) do
       local details = mark[4]

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -1292,6 +1292,65 @@ local function validate_sidekick_herdr()
   end
 
   local picker_ok, picker_err = xpcall(function()
+    local fixture_list_agents = herdr.list_agents
+    local fixture_git_context = herdr.git_context
+    local fixture_diff_stats = herdr.git_diff_stats
+    local main_diff_calls = 0
+    herdr.list_agents = function()
+      return {
+        {
+          name = "codex-main-hello",
+          agent = "codex",
+          agent_status = "working",
+          cwd = cwd,
+          pane_id = "w1:p1",
+          terminal_id = "term-main",
+          workspace_id = "w1",
+        },
+      }
+    end
+    herdr.git_context = function(path)
+      path = vim.fs.normalize(path or "")
+      if path == cwd or vim.startswith(path, cwd .. "/") then
+        return {
+          repository = "/repos/dotfiles",
+          repository_label = "dotfiles",
+          worktree = cwd,
+          worktree_label = "main",
+          branch = "main",
+        }
+      end
+    end
+    herdr.git_diff_stats = function()
+      main_diff_calls = main_diff_calls + 1
+      return { added = 999, removed = 999 }
+    end
+    cwd_picker.open()
+    local main_item = picker_opts and picker_opts.items[1]
+    local main_chunks = main_item and picker_opts.format(main_item) or {}
+    if
+      picker_opts.title ~= "Sidekick Session in Worktree: main"
+      or #picker_opts.items ~= 1
+      or main_item.display_label ~= "codex-main-hello"
+      or main_item.cwd ~= cwd
+      or main_item.diff ~= nil
+      or main_diff_calls ~= 0
+      or not vim.deep_equal(main_chunks, {
+        { "S ", "DiagnosticInfo" },
+        { "codex-main-hello", "SidekickTitleCodex" },
+      })
+    then
+      fail("main checkout local row should show the friendly session name with backend chrome only: " .. vim.inspect({
+        title = picker_opts and picker_opts.title,
+        item = main_item,
+        chunks = main_chunks,
+        diff_calls = main_diff_calls,
+      }))
+    end
+    herdr.list_agents = fixture_list_agents
+    herdr.git_context = fixture_git_context
+    herdr.git_diff_stats = fixture_diff_stats
+
     cwd_picker.open(picker_actions_only and {
       on_kill = function(item)
         killed_item = item
@@ -1562,8 +1621,7 @@ local function validate_sidekick_herdr()
       or not vim.tbl_contains(global_lines, "  └─ · exact-cwd")
     then
       fail(
-        "repository rows should distinguish branch, main-session, and non-Git cwd labels: "
-          .. vim.inspect(global_lines)
+        "repository rows should distinguish branch, main-session, and non-Git cwd labels: " .. vim.inspect(global_lines)
       )
     end
     local main_row


### PR DESCRIPTION
## Summary

- show the durable Sidekick session name for sessions launched from `main`
- retain agent-backend chrome while suppressing the `main` branch marker and diff totals
- leave non-`main` worktree branch labels, pink styling, and diff totals unchanged
- preserve cwd-basename labels for non-Git sessions

## Root cause

Picker items always preferred the Git worktree label whenever Git context existed, so a session named `codex-main-hello` was rendered as `main`.

## Invariants

Repository, worktree, session, and routing behavior are unchanged: one Herdr workspace per repository, at most one durable session per worktree, and exact agent cwd.

## Validation

- `scripts/verify-nvim sidekick-herdr`
- `scripts/verify-nvim herdr-workspaces`
- `scripts/verify-nvim sidekick-herdr-compat`
- `scripts/verify-nvim sidekick-picker-actions`
- `git diff --check`

All passed.
