### PR TITLE
fix(sidekick): allow named sessions on main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,13 @@ Treat repository, worktree, and session identity as three distinct concepts:
   [color-safe live handoff procedure](README.md#herdr-server-handoff).
 - A Git repository owns exactly one Herdr Workspace. Resolve repository identity from Git's shared common directory,
   so the primary checkout and every linked worktree reuse that same Herdr Workspace.
-- A Git worktree owns at most one durable Sidekick session. The session runs with that worktree as its cwd, inside the
-  repository's Herdr Workspace.
-- If a user asks to launch a session in a worktree that already owns one, focus and reuse the existing session. Do not
-  create a differently named duplicate.
-- If a user needs another durable session, create or select a different worktree first. Short-lived subagents may run
-  beneath the owning session, but they do not become additional durable Sidekick picker sessions for that worktree.
+- A non-`main` Git worktree owns at most one durable Sidekick session. The session runs with that worktree as its cwd,
+  inside the repository's Herdr Workspace. The `main` checkout may own multiple named durable sessions.
+- If a user asks to launch a session in a non-`main` worktree that already owns one, focus and reuse the existing
+  session. On `main`, reuse only an exact session-name match.
+- If a user needs another durable session from a non-`main` worktree, create or select a different worktree first.
+  Short-lived subagents may run beneath the owning session, but they do not become additional durable Sidekick picker
+  sessions for that worktree.
 - Do not create one Herdr Workspace per worktree, branch, feature, task, backend, or session label.
 - Keep internal Herdr agent names available for routing and lifecycle operations, but do not use them as the primary
   picker identity.
@@ -27,7 +28,8 @@ Treat repository, worktree, and session identity as three distinct concepts:
 ## Sidekick picker presentation
 
 - Group durable sessions as `repository -> worktree`.
-- Render one worktree row for its one durable session; do not repeat a session name that restates the worktree name.
+- Render one row per durable session. Non-`main` worktrees have one row; `main` may have multiple session-named rows.
+  Do not repeat a session name that restates a non-`main` worktree name.
 - Prefix every non-`main` Git branch row with `` and color both the marker and branch name with the existing Gruvbox
   pink `SidekickBranch` highlight; do not color non-`main` branch identity by agent backend. Retain the Herdr status
   glyph.
@@ -36,6 +38,6 @@ Treat repository, worktree, and session identity as three distinct concepts:
   backend chrome.
 - For non-`main` branches, show tracked line additions and removals against local `main` as `+<added> −<removed>`;
   show `clean` when both are zero.
-- Keep the current-worktree row in the picker alongside the repository hierarchy. Selection, preview, rename, kill,
-  and focus actions must continue to target the exact underlying Herdr agent identity.
+- Keep the current-worktree session rows in the picker alongside the repository hierarchy. Selection, preview, rename,
+  kill, and focus actions must continue to target the exact underlying Herdr agent identity.
 - Preserve exact cwd behavior for non-Git directories instead of inventing repository identity.

--- a/docs/adr/0002-share-herdr-workspace-per-repository.md
+++ b/docs/adr/0002-share-herdr-workspace-per-repository.md
@@ -4,13 +4,13 @@ status: accepted
 
 # Share one Herdr workspace per repository
 
-All primary checkouts and linked worktrees from one Git repository share one Herdr Workspace, while each worktree owns
-at most one durable Sidekick session. This removes redundant repository/worktree/session names and keeps repository
-runtime identity stable; durable parallel sessions require separate worktrees, while transient child agents remain
-beneath the owning session.
+All primary checkouts and linked worktrees from one Git repository share one Herdr Workspace. Each non-`main` worktree
+owns at most one durable Sidekick session, while the `main` checkout may own multiple named durable sessions. This
+removes redundant repository/worktree/session names and keeps repository runtime identity stable; durable parallel
+sessions require separate worktrees outside `main`, while transient child agents remain beneath the owning session.
 
 Task cleanup therefore closes task-owned tabs, panes, bindings, and worktree views without closing a repository's
 shared Herdr Workspace while other worktree sessions remain. The Sidekick picker presents repository headings and
 Gruvbox-pink `` branch rows with tracked line additions and removals against `main`; the neutral `main` checkout shows
-its durable Sidekick session name with backend chrome but neither marker nor diff totals. Non-Git sessions also retain
+each durable Sidekick session name with backend chrome but neither marker nor diff totals. Non-Git sessions also retain
 backend chrome. Internal Herdr agent names remain routing identities rather than display identities.

--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -356,8 +356,8 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Sidekick can match existing tmux panes to tools.
 - Sidekick can rehydrate its registry from tmux panes.
 - Sidekick named sessions are stored and identified through session labels and tmux environment.
-- Sidekick named-session prompts reuse the current worktree's existing durable session instead of creating a second
-  session with a redundant label.
+- Sidekick named-session prompts reuse a non-`main` worktree's existing durable session. The `main` checkout permits
+  multiple named durable sessions and reuses only an exact session-name match.
 - Pi named sessions receive native `--name <slug>` command arguments.
 - Sidekick branch metadata is stored in tmux environment.
 - `<C-.>` toggles the last picker-selected Sidekick session, falling back to the cwd session picker.
@@ -372,11 +372,11 @@ workflow area rather than plugin files, Lua modules, or implementation structure
   `Repositories / Worktrees` and `Current Worktree` panes across the bottom.
 - Repository headings expand into one row per durable worktree session. Non-`main` rows use the Git branch as worktree
   identity, retain Herdr state, and prefix it with a Gruvbox-pink `` marker instead of backend color.
-- Non-`main` branch rows show tracked `+added −removed` totals against local `main`; the neutral `main` checkout row
-  shows its durable Sidekick session name with agent backend chrome but has neither the branch marker nor diff totals.
+- Non-`main` branch rows show tracked `+added −removed` totals against local `main`; neutral `main` checkout rows show
+  their durable Sidekick session names with agent backend chrome but have neither branch markers nor diff totals.
   Non-Git rows also retain backend chrome.
-- The current-worktree pane shows only that worktree's one durable session. Internal Herdr agent names remain available
-  for exact routing, rename, kill, and focus actions without being repeated in the row.
+- The current-worktree pane shows the worktree's durable sessions: one for non-`main`, potentially multiple for `main`.
+  Internal Herdr agent names remain available for exact routing, rename, kill, and focus actions.
 - Ordinary preview polling and full-history scrolling continue while navigating either pane.
 - Sidekick global named-session picker includes previews.
 - Sidekick session pickers support killing sessions.

--- a/nvim/.config/nvim/lua/helpers/vault_work_items.lua
+++ b/nvim/.config/nvim/lua/helpers/vault_work_items.lua
@@ -72,7 +72,8 @@ function M.send_to_backlog_agent(item, root)
   local slug = internal.normalize_label(item.day)
   local name = "pi-" .. slug
   local launch_cwd = root or vim.fn.expand("~/vault")
-  local agent, listed = herdr.agent_for_worktree(launch_cwd)
+  local context = herdr.git_context(launch_cwd)
+  local agent, listed = herdr.agent_for_worktree(launch_cwd, context and context.branch == "main" and name or nil)
   if listed == false then
     vim.notify("Could not verify the durable session for this worktree", vim.log.levels.ERROR)
     return nil

--- a/nvim/.config/nvim/lua/plugins/sidekick/herdr.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/herdr.lua
@@ -194,9 +194,10 @@ function M.workspace_for_repository(repository)
 end
 
 ---@param cwd string
+---@param name? string exact agent name to find
 ---@return table|nil agent
 ---@return boolean listed
-function M.agent_for_worktree(cwd)
+function M.agent_for_worktree(cwd, name)
   local wanted = M.git_context(cwd)
   local wanted_cwd = wanted and wanted.worktree or M.normalize_cwd(cwd)
   local result = M.call({ "agent", "list" }, true)
@@ -204,7 +205,7 @@ function M.agent_for_worktree(cwd)
     return nil, false
   end
   for _, agent in ipairs(result.agents) do
-    if M.is_durable_agent(agent) then
+    if M.is_durable_agent(agent) and (not name or agent.name == name) then
       local agent_cwd = agent.foreground_cwd or agent.cwd
       local context = M.git_context(agent_cwd)
       if (context and context.worktree == wanted_cwd) or (not context and M.normalize_cwd(agent_cwd) == wanted_cwd) then
@@ -344,7 +345,8 @@ end
 ---@return table|nil agent
 function M.start(name, cwd, command, env, scope, tab_label)
   local normalized = M.normalize_cwd(cwd)
-  local existing, listed = M.agent_for_worktree(normalized)
+  local context = M.git_context(normalized)
+  local existing, listed = M.agent_for_worktree(normalized, context and context.branch == "main" and name or nil)
   if listed == false then
     notify("could not verify whether this worktree already owns a durable session")
     return nil
@@ -353,7 +355,6 @@ function M.start(name, cwd, command, env, scope, tab_label)
     if existing.name == name then
       return existing
     end
-    local context = M.git_context(normalized)
     notify(
       string.format(
         "worktree %s already owns session %s; use a separate worktree for another durable session",

--- a/nvim/.config/nvim/lua/plugins/sidekick/internal.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick/internal.lua
@@ -202,9 +202,12 @@ end
 ---@param label string
 ---@param cwd? string
 function M.start_named_session(tool, label, cwd)
+  local slug = M.normalize_label(label)
+  local name = tool .. "-" .. slug
   local requested_cwd = M.normalize_cwd(cwd) or vim.fn.getcwd()
   local herdr = require("plugins.sidekick.herdr")
-  local existing, listed = herdr.agent_for_worktree(requested_cwd)
+  local context = herdr.git_context(requested_cwd)
+  local existing, listed = herdr.agent_for_worktree(requested_cwd, context and context.branch == "main" and name or nil)
   if listed == false then
     vim.notify("Sidekick: could not verify whether this worktree already owns a durable session", vim.log.levels.ERROR)
     return
@@ -226,12 +229,10 @@ function M.start_named_session(tool, label, cwd)
     vim.notify("Sidekick: this worktree already owns a session", vim.log.levels.WARN)
     return
   end
-  local slug = M.normalize_label(label)
   if slug == "" then
     vim.notify("Sidekick: session label cannot be empty", vim.log.levels.WARN)
     return
   end
-  local name = tool .. "-" .. slug
   local config = require("sidekick.config")
   local command = M.tool_command_for_named_session(tool, slug)
   local workspace_ok, workspace_id = pcall(

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -695,6 +695,25 @@ local function validate_sidekick_herdr()
     fail("durable Sidekick identity should exclude transient child agents")
   end
 
+  local original_lookup_call = source_herdr.call
+  source_herdr.git_context = function()
+    return { worktree = "/repos/dotfiles", branch = "main" }
+  end
+  source_herdr.call = function()
+    return {
+      agents = {
+        { agent = "codex", name = "codex-first", cwd = "/repos/dotfiles" },
+        { agent = "pi", name = "pi-second", cwd = "/repos/dotfiles" },
+      },
+    }
+  end
+  local exact_main_agent = source_herdr.agent_for_worktree("/repos/dotfiles", "pi-second")
+  source_herdr.call = original_lookup_call
+  source_herdr.git_context = original_git_context
+  if not exact_main_agent or exact_main_agent.name ~= "pi-second" then
+    fail("main session lookup should filter by exact agent name")
+  end
+
   local diff_command
   source_herdr.git_context = function()
     return {
@@ -785,6 +804,7 @@ local function validate_sidekick_herdr()
       repository_label = "dotfiles",
       worktree = "/worktrees/feature-one",
       worktree_label = "feature/one",
+      branch = "feature/one",
     }
   end
   source_herdr.call = function()
@@ -799,12 +819,36 @@ local function validate_sidekick_herdr()
     return nil, false
   end
   local unverified = source_herdr.start("pi-unverified", "/worktrees/feature-one", { "pi" })
+  local main_launch_attempts = 0
+  local original_ensure_workspace = source_herdr.ensure_workspace
+  source_herdr.git_context = function()
+    return {
+      repository = "/repos/dotfiles",
+      repository_label = "dotfiles",
+      worktree = "/repos/dotfiles",
+      worktree_label = "main",
+      branch = "main",
+    }
+  end
+  source_herdr.agent_for_worktree = function(_, name)
+    return name == occupied.name and occupied or nil, true
+  end
+  source_herdr.ensure_workspace = function()
+    main_launch_attempts = main_launch_attempts + 1
+    return nil
+  end
+  local reused_main = source_herdr.start("codex-existing", "/repos/dotfiles", { "codex" })
+  source_herdr.start("pi-spinoff", "/repos/dotfiles", { "pi" })
   vim.notify = original_invariant_notify
   source_herdr.agent_for_worktree = original_agent_for_worktree
   source_herdr.git_context = original_git_context
   source_herdr.call = original_call_for_invariant
+  source_herdr.ensure_workspace = original_ensure_workspace
   if reused ~= occupied or rejected ~= nil or unverified ~= nil or invariant_calls ~= 0 then
-    fail("a worktree should reuse its one session and reject durable or unverified spinoffs")
+    fail("a non-main worktree should reuse its one session and reject durable or unverified spinoffs")
+  end
+  if reused_main ~= occupied or main_launch_attempts ~= 1 then
+    fail("main should reuse an exact session name while allowing differently named durable sessions")
   end
   for _, name in ipairs({
     "workspace_cwd",
@@ -847,6 +891,9 @@ local function validate_sidekick_herdr()
   end
 
   local reused_named_target
+  source_herdr.git_context = function()
+    return { branch = "feature/test" }
+  end
   source_herdr.agent_for_worktree = function()
     return {
       name = "sk-codex-existing",
@@ -863,8 +910,6 @@ local function validate_sidekick_herdr()
   source_internal.start_named_session("pi", "must-not-start", cwd)
   vim.notify = original_named_notify
   source_internal.toggle_tool_session = original_toggle_named
-  source_herdr.agent_for_worktree = original_named_agent_for_worktree
-  package.loaded["plugins.sidekick.herdr"] = loaded_named_herdr
   if
     not vim.deep_equal(reused_named_target, {
       name = "codex",
@@ -873,7 +918,28 @@ local function validate_sidekick_herdr()
     })
     or config.cli.tools["pi-must-not-start"] ~= nil
   then
-    fail("named-session launch should reuse the worktree's existing durable session")
+    fail("named-session launch should reuse a non-main worktree's existing durable session")
+  end
+
+  local main_lookup
+  local main_target
+  source_herdr.git_context = function()
+    return { branch = "main" }
+  end
+  source_herdr.agent_for_worktree = function(_, name)
+    main_lookup = name
+    return nil, true
+  end
+  source_internal.toggle_tool_session = function(name)
+    main_target = name
+  end
+  source_internal.start_named_session("pi", "main parallel", cwd)
+  source_internal.toggle_tool_session = original_toggle_named
+  source_herdr.agent_for_worktree = original_named_agent_for_worktree
+  source_herdr.git_context = original_git_context
+  package.loaded["plugins.sidekick.herdr"] = loaded_named_herdr
+  if main_lookup ~= "pi-main-parallel" or main_target ~= "pi-main-parallel" then
+    fail("main should allow a differently named durable session")
   end
 
   local original_start = source_herdr.start


### PR DESCRIPTION
## Summary
- allow multiple differently named durable Sidekick sessions from the `main` checkout
- preserve exact-name reuse on `main` and one-session reuse elsewhere
- apply the same behavior to daily backlog agents and update documentation

## Tests
- `scripts/verify-nvim sidekick-herdr`
- `scripts/verify-nvim vault-work-items`