### PR TITLE
systemd: track flight-checkin-reminders timer, retire honeymoon timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ terraform -chdir=ops/devbox destroy \
 | `nvim`       | Neovim with LazyVim                                                         |
 | `ssh`        | SSH configuration                                                           |
 | `starship`   | Starship prompt                                                             |
-| `systemd`    | User systemd units (vault/dotfiles auto-sync, Pi/WhatsApp/Telegram bridges) |
+| `systemd`    | User systemd units (vault/dotfiles auto-sync, Pi/WhatsApp/Telegram bridges, flight check-in reminders) |
 | `pi`         | Pi agent config, packages, themes, and messaging daemons                    |
 | `terminfo`   | Custom terminfo entries                                                     |
 | `tmux`       | Tmux configuration                                                          |
@@ -162,6 +162,13 @@ For Pi over Telegram, create a bot with `@BotFather`, copy `~/.config/pi-telegra
 systemctl --user daemon-reload
 systemctl --user enable --now pi-telegram.service
 ```
+
+The `flight-checkin-reminders.timer` user unit (every 12h) scans Gmail for upcoming flight check-in windows via Pi and sends Telegram reminders. It runs `%h/vault/scripts/flight-checkin-reminders.py` through an explicit `/usr/bin/python3` because the vault checkout does not guarantee the executable bit; direct execution fails with `status=203/EXEC`. Enable it with `systemctl --user enable --now flight-checkin-reminders.timer`.
+
+Retired reminder timers, kept out of the tracked units on purpose:
+
+- `honeymoon-message-drafts.timer` — built for the July 2026 honeymoon message plan; the trip is over, so the live unit was retired (see the disable/remove commands in the PR that tracked these notes).
+- `aug18-trip-flight-reminder.timer` — its script self-disables after its 2026-08-18 cutoff; remove the live unit after that date.
 
 ## Infrastructure
 

--- a/systemd/.config/systemd/user/flight-checkin-reminders.service
+++ b/systemd/.config/systemd/user/flight-checkin-reminders.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Flight check-in Gmail scan and Telegram reminders
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/vault
+# Invoke the vault script through an explicit interpreter: the vault checkout
+# does not guarantee the executable bit, so direct execution fails with
+# status=203/EXEC.
+ExecStart=/usr/bin/python3 %h/vault/scripts/flight-checkin-reminders.py
+TimeoutStartSec=45min
+Environment=PATH=%h/.nvm/versions/node/v22.22.3/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-%h/.config/pi-telegram.env

--- a/systemd/.config/systemd/user/flight-checkin-reminders.timer
+++ b/systemd/.config/systemd/user/flight-checkin-reminders.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=12-hour timer for flight check-in Telegram reminders
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=12h
+AccuracySec=5m
+Persistent=true
+Unit=flight-checkin-reminders.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What this repairs

`flight-checkin-reminders.service` and `honeymoon-message-drafts.service` failed every run with `status=203/EXEC` (confirmed in `journalctl --user` for every trigger over the last 14 days). Both units executed the vault scripts directly (`ExecStart=/home/avirus/vault/scripts/*.py`), but the vault checkout does not guarantee the executable bit — the scripts are `-rw-rw-r--`, so systemd cannot exec them.

- **Tracked `flight-checkin-reminders.{service,timer}`** in the stow'd `systemd` package (previously live-only, untracked). The service now invokes the script through an explicit interpreter (`ExecStart=/usr/bin/python3 %h/vault/scripts/flight-checkin-reminders.py`), so executable-bit drift cannot silently break the timer again. This matches the working `aug18-trip-flight-reminder.service` pattern. Validated with `systemd-analyze --user verify` and `python3 <script> --help`.

## What this retires

- **`honeymoon-message-drafts.{service,timer}`** — retired, not tracked. The unit drafted honeymoon WhatsApp messages from the July 2026 honeymoon plan (`3_logs/2026-W28/honeymoon-message-plan.md`); that trip ended 2026-07-17, over a month ago. Retirement documented in README; live cleanup commands below.
- **`aug18-trip-flight-reminder.timer`** — not failing and out of scope for changes. Its script has a hard `CUTOFF = date(2026, 8, 18)` and stops reminding on its own; README now notes the live unit can be removed after that date.

## Post-merge live commands (run on homelab)

The live unit files are plain files; stow will conflict until they are replaced by symlinks:

```sh
# Retire the obsolete honeymoon timer
systemctl --user disable --now honeymoon-message-drafts.timer
rm ~/.config/systemd/user/honeymoon-message-drafts.{service,timer}

# Replace the untracked flight-checkin units with the tracked versions
systemctl --user disable --now flight-checkin-reminders.timer
rm ~/.config/systemd/user/flight-checkin-reminders.{service,timer}
cd ~/dotfiles && git pull && stow -d ~/dotfiles -t ~ systemd

systemctl --user daemon-reload
systemctl --user enable --now flight-checkin-reminders.timer

# After 2026-08-18, the aug18 reminder is moot:
systemctl --user disable --now aug18-trip-flight-reminder.timer
rm ~/.config/systemd/user/aug18-trip-flight-reminder.{service,timer}
systemctl --user daemon-reload
```

No live state was changed from the task worktree; all live inspection was read-only.
