### PR TITLE
Add scoped ccgram prototype package + captain onboarding guide

### DIFF
--- a/ccgram-prototype/.config/ccgram-prototype.env.example
+++ b/ccgram-prototype/.config/ccgram-prototype.env.example
@@ -1,0 +1,42 @@
+# ccgram PROTOTYPE env template — copy to the live path and fill in:
+#   cp ~/.config/ccgram-prototype.env.example ~/.config/ccgram-prototype.env
+#   chmod 600 ~/.config/ccgram-prototype.env
+# NEVER commit the filled-in file. Only this .example is tracked in git.
+
+# --- Secrets (fill in locally, never commit) ---
+
+# Token of the NEW, separate prototype bot from @BotFather.
+# Do NOT reuse the pi-telegram / Firstmate frontdoor bot token — Telegram
+# allows only one getUpdates consumer per token; sharing breaks both bots.
+TELEGRAM_BOT_TOKEN=123456789:replace-with-prototype-bot-token
+
+# Comma-separated numeric Telegram user IDs allowed to talk to the bot.
+# Captain only. Get yours from @userinfobot.
+ALLOWED_USERS=123456789
+
+# Numeric ID of the NEW topics-enabled test group (supergroups look like -100xxxxxxxxxx).
+# Must NOT be the live Firstmate frontdoor chat. ccgram only ever binds topics
+# in this group, which is what keeps the prototype away from the live channel.
+CCGRAM_GROUP_ID=-1001234567890
+
+# --- Prototype behavior (safe defaults, no secrets) ---
+
+# Watch Herdr (default session) instead of tmux. Homelab Herdr 0.7.5
+# (protocol 17) is inside ccgram's supported set.
+CCGRAM_MULTIPLEXER=herdr
+
+# "user" status mode: topic emoji mean "what needs the captain", not raw
+# process state. Easier to read the fleet from a phone.
+CCGRAM_STATUS_MODE=user
+
+# Evaluation posture: never auto-close topics so raw lifecycle behavior can be
+# observed. Revisit (e.g. 30/10) after the evaluation.
+AUTOCLOSE_DONE_MINUTES=0
+AUTOCLOSE_DEAD_MINUTES=0
+
+# Herdr socket path. Only set if yours differs from the herdr CLI default.
+# HERDR_SOCKET_PATH=/home/YOURUSER/.config/herdr/herdr.sock
+
+# Default provider for NEW sessions is irrelevant in observe-only mode
+# (ccgram auto-detects pi from pane processes). Leave unset.
+# CCGRAM_PROVIDER=pi

--- a/ccgram-prototype/.config/systemd/user/ccgram-prototype.service
+++ b/ccgram-prototype/.config/systemd/user/ccgram-prototype.service
@@ -1,0 +1,26 @@
+# PROTOTYPE — scoped ccgram observe-only evaluation. Delete with:
+#   systemctl --user disable --now ccgram-prototype.service
+#   stow -D ccgram-prototype   (from ~/dotfiles)
+#   rm -rf ~/.ccgram-prototype ~/.config/ccgram-prototype.env
+#   git rm -r ccgram-prototype (from ~/dotfiles)
+# See ccgram-prototype/README.md for onboarding and safety rules.
+[Unit]
+Description=ccgram prototype - Telegram fleet mirror for Herdr (observe-only evaluation)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# ccgram long-polls Telegram and watches the Herdr default session.
+# All behavior (multiplexer, group, autoclose, secrets) comes from the env file.
+# The env file is mandatory so a missing config fails loudly at start.
+Environment=PATH=%h/.local/bin:%h/.cargo/bin:/usr/local/bin:/usr/bin:/bin
+Environment=CCGRAM_DIR=%h/.ccgram-prototype
+EnvironmentFile=%h/.config/ccgram-prototype.env
+ExecStart=%h/.local/bin/ccgram
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+
+[Install]
+WantedBy=default.target

--- a/ccgram-prototype/.stow-local-ignore
+++ b/ccgram-prototype/.stow-local-ignore
@@ -1,0 +1,6 @@
+# Patterns are regex, matched against basenames unless anchored with /.
+# Keep the captain-facing guide and the validation script repo-only;
+# `stow ccgram-prototype` should only deploy the unit and env template.
+^README\.md$
+^validate\.sh$
+^\.stow-local-ignore$

--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -1,0 +1,172 @@
+# ccgram prototype — observe-only Telegram fleet mirror (scoped evaluation)
+
+A **scoped, deletable prototype** for evaluating [ccgram](https://github.com/alexei-led/ccgram)
+as a Telegram mirror of Herdr-managed Pi agent sessions (Firstmate workers). It gives the
+captain one Telegram topic per live agent session so the fleet is visible from a phone.
+
+This is **not production**. Everything tracked lives in this one directory
+(`ccgram-prototype/`) and everything local lives under two paths, so removal is a few
+commands (see [Rollback](#rollback--deleting-the-prototype)).
+
+Basis: `ccgram-firstmate-integration-scout` report (2026-08-15). Homelab has Herdr 0.7.5
+(protocol 17, supported by ccgram) and the Pi Herdr integration v6, so Firstmate workers
+already publish agent sessions that ccgram discovers with zero code changes.
+
+## Safety rules (read first)
+
+1. **Observe-only.** Do not use ccgram to launch, kill, steer, or recover Firstmate
+   workers. ccgram has no read-only mode; its Kill button and recovery flows act on *any*
+   bound window and would fight Firstmate's supervision. Don't tap Kill/Close/recovery
+   buttons, and don't use `/new`. Watching topics, screenshots, and `/last` is fine.
+2. **Firstmate remains the source of truth** for task identity, dispatch, supervision, and
+   cleanup. ccgram topics are a display layer only.
+3. **Separate bot, separate group.** The prototype uses its own BotFather bot and its own
+   topics-enabled test group. Never point it at the pi-telegram/Firstmate frontdoor bot
+   token or the live Telegram group.
+4. **Secrets stay local.** The filled-in env file is untracked, `chmod 600`, and never
+   committed. Only the `.example` template is in git.
+5. **Emoji may disagree with Firstmate.** ccgram derives status from Herdr native state and
+   transcripts; Firstmate has its own busy records. Occasional "ready" while Firstmate says
+   busy is cosmetic — trust Firstmate.
+
+## Files in this package
+
+| Path | Purpose |
+| ---- | ------- |
+| `.config/systemd/user/ccgram-prototype.service` | User unit running ccgram against Herdr. Deployed by `stow ccgram-prototype`. |
+| `.config/ccgram-prototype.env.example` | Env template (multiplexer, status mode, autoclose, placeholders for secrets). |
+| `validate.sh` | Offline checks: systemd unit syntax + no committed secrets. Not deployed by stow. |
+| `README.md` | This guide. Not deployed by stow. |
+
+Local (untracked) state the prototype creates:
+
+| Path | Purpose |
+| ---- | ------- |
+| `~/.config/ccgram-prototype.env` | Your filled-in env file (secrets). A real file, not a symlink — the filled-in secrets never live inside the repo tree. |
+| `~/.ccgram-prototype/` | ccgram state dir (`CCGRAM_DIR`): state.json, session_map.json, events.jsonl. Safe to wipe; topics rebind by discovery/name on restart. |
+
+## Onboarding
+
+### 1. Create a separate bot with BotFather
+
+In Telegram, open `@BotFather`:
+
+1. `/newbot` — pick a distinct name/username, e.g. `ccgram-prototype-bot`. This bot is
+   **only** for this prototype; do not reuse the Firstmate frontdoor bot.
+2. Copy the token it gives you — goes into `TELEGRAM_BOT_TOKEN` later.
+3. Optional hardening: `/setjoingroups` → select the bot → **Disable**, so nobody can add
+   it to other groups.
+
+### 2. Create a topics-enabled test group
+
+1. In Telegram: New Group, e.g. `ccgram-prototype-test`. Add only yourself.
+2. Group settings → **Topics** → enable (group becomes a forum).
+3. Add your new bot to the group and promote it to **admin** (admin rights let it read and
+   create topics; this group is throwaway, so full admin is fine).
+
+### 3. Collect IDs
+
+- **Your user ID** (`ALLOWED_USERS`): message `@userinfobot`, note the numeric `Id`.
+- **Group ID** (`CCGRAM_GROUP_ID`): with the bot in the group, post any message in the
+  group, then from a shell (this is the only Telegram API call in the whole setup):
+
+  ```sh
+  curl -s "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/getUpdates" | jq .
+  ```
+
+  Find `message.chat.id` — a negative number like `-100xxxxxxxxxx`. (If the result is
+  empty, make sure the bot is a group member and privacy mode isn't blocking reads —
+  admin status covers this.)
+
+### 4. Install ccgram (skip if already installed)
+
+```sh
+uv tool install ccgram
+# or straight from source: uv tool install git+https://github.com/alexei-led/ccgram
+command -v ccgram   # expect ~/.local/bin/ccgram
+```
+
+### 5. Deploy config and fill in secrets
+
+```sh
+cd ~/dotfiles
+stow ccgram-prototype
+
+cp ~/.config/ccgram-prototype.env.example ~/.config/ccgram-prototype.env
+chmod 600 ~/.config/ccgram-prototype.env
+$EDITOR ~/.config/ccgram-prototype.env
+```
+
+Fill in `TELEGRAM_BOT_TOKEN`, `ALLOWED_USERS`, `CCGRAM_GROUP_ID` from steps 1–3. The
+remaining defaults (`CCGRAM_MULTIPLEXER=herdr`, `CCGRAM_STATUS_MODE=user`,
+`AUTOCLOSE_*=0`) are the intended evaluation posture — leave them.
+
+### 6. Start and check the service
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now ccgram-prototype.service
+systemctl --user status ccgram-prototype.service
+journalctl --user -u ccgram-prototype.service -f
+```
+
+Healthy signs: no `Conflict` errors (would mean a shared token), no Herdr protocol
+errors, no restart loop.
+
+### 7. First smoke test
+
+1. **Topic adoption**: within a minute, the test group should show one topic per live
+   Herdr agent session in the default session — Firstmate workers appear as
+   `firstmate ▸ fm-<task-id>`. Unrelated agent sessions may also get topics (ccgram
+   adopts everything; known limitation, cosmetic).
+2. **Read-only peek**: open a topic, try `/last` and a screenshot. Confirm you're only
+   reading — never press Kill/recovery buttons.
+3. **Frontdoor untouched**: `systemctl --user status pi-telegram.service` is still
+   healthy, and nothing appeared in the live Firstmate group.
+4. **Lifecycle follow** (optional): when a Firstmate task spawns/tears down, its topic
+   appears/goes dead; with `AUTOCLOSE_*=0` topics persist so you can watch raw behavior.
+   Verify ccgram never creates a replacement tab itself.
+5. Done evaluating? Follow the rollback below.
+
+## Rollback — deleting the prototype
+
+Everything is scoped to one stow package plus two local paths:
+
+```sh
+# 1. Stop and remove the service
+systemctl --user disable --now ccgram-prototype.service
+systemctl --user daemon-reload
+
+# 2. Unstow (removes the unit + env example symlinks from ~)
+cd ~/dotfiles && stow -D ccgram-prototype
+
+# 3. Remove local state and secrets
+rm -rf ~/.ccgram-prototype
+rm -f ~/.config/ccgram-prototype.env
+
+# 4. Remove tracked material
+git rm -r ccgram-prototype && git commit -m "Remove ccgram prototype"
+
+# 5. Optional: Telegram cleanup — @BotFather /deletebot, delete the test group
+# 6. Optional: uv tool uninstall ccgram
+```
+
+## Validation
+
+Offline checks only (no live services touched):
+
+```sh
+./ccgram-prototype/validate.sh
+```
+
+Verifies the systemd unit parses (`systemd-analyze verify`) and that no real
+tokens/chat IDs are committed in this package.
+
+## Known limitations (from the scout report)
+
+- ccgram has no observe-only mode — safety is policy (rule 1), not enforcement.
+- ccgram auto-adopts every Herdr agent in the session; unrelated sessions get topics too.
+- Pi session rotation (`/new`, resume) can make a worker look like a "new window" and
+  spawn a duplicate topic; the old one goes dead. Cosmetic for observe-only.
+- If homelab Herdr is upgraded past protocol 17/19, re-check ccgram compatibility before
+  restarting the service.

--- a/ccgram-prototype/validate.sh
+++ b/ccgram-prototype/validate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Offline validation for the ccgram prototype package.
+# Touches no live state: parses the systemd unit syntax and scans the package
+# for accidentally committed secrets.
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT="$PKG_DIR/.config/systemd/user/ccgram-prototype.service"
+fail=0
+
+echo "==> systemd unit syntax: $UNIT"
+if command -v systemd-analyze >/dev/null 2>&1; then
+    # verify parses the unit offline; it does not start or inspect live units.
+    # Expected warning (not a syntax error): the ccgram binary is installed by
+    # the captain during onboarding, so it may not exist on this host yet.
+    verify_out="$(systemd-analyze verify "$UNIT" 2>&1)" || true
+    unexpected="$(printf '%s\n' "$verify_out" | grep -v '^$' \
+        | grep -vE 'Command /.*/\.local/bin/ccgram is not executable' || true)"
+    if [[ -n "$unexpected" ]]; then
+        echo "    FAIL: systemd-analyze verify reported problems:"
+        printf '%s\n' "$unexpected"
+        fail=1
+    else
+        echo "    ok (ccgram-binary-missing warning filtered: installed at onboarding step 4)"
+    fi
+else
+    echo "    skipped: systemd-analyze not available on this host"
+fi
+
+echo "==> secret scan: $PKG_DIR"
+# Telegram bot tokens look like 123456789:AAE... (digits:35+ url-safe chars).
+# Only placeholder-shaped values may appear in tracked files.
+secret_hits="$(grep -rEn '[0-9]{6,}:[A-Za-z0-9_-]{30,}' "$PKG_DIR" \
+    --exclude=validate.sh || true)"
+# Allow the documented placeholder in the env example.
+secret_hits="$(printf '%s\n' "$secret_hits" | grep -v '123456789:replace-with-prototype-bot-token' || true)"
+if [[ -n "$secret_hits" ]]; then
+    echo "    FAIL: possible bot token committed:"
+    printf '%s\n' "$secret_hits"
+    fail=1
+else
+    echo "    ok: no real tokens found"
+fi
+
+# The filled-in env file must never be tracked.
+if git -C "$PKG_DIR" ls-files --error-unmatch \
+    'ccgram-prototype/.config/ccgram-prototype.env' >/dev/null 2>&1; then
+    echo "    FAIL: ccgram-prototype.env (real secrets file) is tracked in git"
+    fail=1
+else
+    echo "    ok: real env file is not tracked"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+    echo "==> validation FAILED"
+    exit 1
+fi
+echo "==> validation passed"


### PR DESCRIPTION
## Summary

Scoped, **easy-to-delete prototype** for evaluating [ccgram](https://github.com/alexei-led/ccgram) as an observe-only Telegram fleet mirror of Herdr-managed Pi agent sessions (Firstmate workers), plus a captain onboarding guide. Implements the scout report's recommended stage-0 MVP (`ccgram-firstmate-integration-scout`, 2026-08-15). Homelab prerequisites (Herdr 0.7.5 / protocol 17, Pi Herdr integration v6) are already verified live.

Everything tracked lives in one new stow package, `ccgram-prototype/` — nothing else in the repo is touched:

| File | Purpose |
| ---- | ------- |
| `ccgram-prototype/.config/systemd/user/ccgram-prototype.service` | User unit: runs `~/.local/bin/ccgram` with isolated `CCGRAM_DIR=~/.ccgram-prototype`; all behavior from a mandatory untracked env file. |
| `ccgram-prototype/.config/ccgram-prototype.env.example` | Template with placeholders for `TELEGRAM_BOT_TOKEN`, `ALLOWED_USERS`, `CCGRAM_GROUP_ID`, optional `HERDR_SOCKET_PATH`, and safe prototype defaults: `CCGRAM_MULTIPLEXER=herdr`, `CCGRAM_STATUS_MODE=user`, `AUTOCLOSE_DONE/DEAD_MINUTES=0` (evaluation). |
| `ccgram-prototype/README.md` | Onboarding walkthrough + safety rules + rollback. Repo-only (not stowed). |
| `ccgram-prototype/validate.sh` | Offline validation: `systemd-analyze verify` on the unit + committed-secret scan. |
| `ccgram-prototype/.stow-local-ignore` | Keeps README/validate.sh out of the stow target. |

## Onboarding steps (in the guide)

1. Create a **separate** BotFather bot (`/newbot`, optionally disable `/setjoingroups`).
2. Create a **separate** topics-enabled test group; add the bot as admin.
3. Collect captain user ID (`@userinfobot`) and group ID (one `getUpdates` curl — the only Telegram API call in the setup).
4. `uv tool install ccgram` (skip if installed).
5. `stow ccgram-prototype`; copy env example to `~/.config/ccgram-prototype.env`, `chmod 600`, fill in secrets.
6. `systemctl --user daemon-reload && systemctl --user enable --now ccgram-prototype.service`; check status/journal.
7. Smoke test: topics appear per live Herdr agent (`firstmate ▸ fm-<task-id>`); read-only peek with `/last`; confirm `pi-telegram.service` stays healthy and the live group is untouched.

## Safety boundaries

- **Observe-only policy**: no ccgram-side launch/kill/steer/recover, no `/new` — ccgram has no read-only mode, so this is enforced by policy + captain-only group (documented prominently in the guide).
- **Firstmate remains source of truth** for identity, dispatch, supervision, cleanup; ccgram topics are display-only.
- **Separate bot + group + state dir** from the pi-telegram/Firstmate frontdoor; frontdoor token and live group are never referenced.
- **No secrets in git**: only the `.example` is tracked; the filled env file is a real file at `~/.config/ccgram-prototype.env` (never inside the repo tree), `chmod 600`.
- No lifecycle-changing Herdr/systemd/ccgram commands were run from the worktree; all service actions are post-merge captain commands.

## Validation run

```
$ ./ccgram-prototype/validate.sh
==> systemd unit syntax ... ok (ccgram-binary-missing warning filtered: installed at onboarding step 4)
==> secret scan ... ok: no real tokens found; real env file not tracked
==> validation passed
```

Also dry-ran `stow -n -v ccgram-prototype` against a populated fake home: deploys exactly two file symlinks (unit + env example), no directory folding.

## Rollback

```
systemctl --user disable --now ccgram-prototype.service && systemctl --user daemon-reload
cd ~/dotfiles && stow -D ccgram-prototype
rm -rf ~/.ccgram-prototype && rm -f ~/.config/ccgram-prototype.env
git rm -r ccgram-prototype
```

## Post-merge local commands (captain, on homelab)

```sh
cd ~/dotfiles && git pull
uv tool install ccgram                                  # if not installed
stow ccgram-prototype
cp ~/.config/ccgram-prototype.env.example ~/.config/ccgram-prototype.env
chmod 600 ~/.config/ccgram-prototype.env                # then fill in 3 values
systemctl --user daemon-reload
systemctl --user enable --now ccgram-prototype.service
journalctl --user -u ccgram-prototype.service -f        # then smoke test per README §7
```

Do not merge until the captain reviews — per dotfiles policy (yolo off).
