### PR TITLE
ccgram-prototype: low-noise Pi patch layer — final-answer-only notifications

### DIFF
--- a/ccgram-prototype/.config/ccgram-prototype.env.example
+++ b/ccgram-prototype/.config/ccgram-prototype.env.example
@@ -37,6 +37,28 @@ AUTOCLOSE_DEAD_MINUTES=0
 # Herdr socket path. Only set if yours differs from the herdr CLI default.
 # HERDR_SOCKET_PATH=/home/YOURUSER/.config/herdr/herdr.sock
 
+# --- Low-noise notifications (captain preference: final-answer-only) ---
+# Goal: while a Firstmate worker runs, NOTHING in its topic notifies —
+# when the turn completes, ONE normal final-answer message notifies.
+#
+# Tool calls: hidden entirely (upstream config, no patch needed). With
+# this set, CCGRAM_EPHEMERAL_TOOLS below is moot. Caveat: a per-window
+# /verbose override (shown/hidden) beats this global default — don't set
+# per-window overrides on worker topics.
+CCGRAM_HIDE_TOOL_CALLS=true
+# Fallback posture if tool calls are ever un-hidden: ephemeral batching
+# collapses each tool-call run into one edited bubble, deleted on flush.
+CCGRAM_EPHEMERAL_TOOLS=true
+# Thinking: keep the live tree-style trace (renderer-parity patch), but it
+# is SILENT by patch — first send uses disable_notification=True, edits and
+# the final delete never notify. Set true to drop thinking entirely.
+CCGRAM_HIDE_THINKING=false
+# Quiet progress (low-noise patch): the per-topic status bubble and user
+# transcript echoes (the Firstmate launch brief) stay visible in the topic
+# but are sent with disable_notification=True. Only the final assistant
+# answer notifies. Requires the low-noise patch (see README).
+CCGRAM_QUIET_PROGRESS=true
+
 # Default provider for NEW sessions is irrelevant in observe-only mode
 # (ccgram auto-detects pi from pane processes). Leave unset.
 # CCGRAM_PROVIDER=pi

--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -36,10 +36,11 @@ already publish agent sessions that ccgram discovers with zero code changes.
 | `.config/systemd/user/ccgram-prototype.service` | User unit running ccgram against Herdr. Deployed by `stow ccgram-prototype`. |
 | `.config/systemd/user/ccgram-thinking-sidecar.service` | User unit for the **deprecated** thinking sidecar (see below). Deployed by stow; **not enabled by default**; do not enable alongside the renderer patch. |
 | `.local/bin/ccgram-thinking-sidecar` | Stdlib-only Python sidecar (deprecated fallback). Deployed by stow to `~/.local/bin`. |
-| `.config/ccgram-prototype.env.example` | Env template (multiplexer, status mode, autoclose, placeholders for secrets, optional sidecar fallback tuning). |
-| `patches/ccgram-4.5.2-pi-renderer-parity.patch` | Tracked unified diff that patches the installed ccgram 4.5.2 Pi renderer (thinking + tool-call + final-answer flow). Not deployed by stow. |
-| `pi-renderer-patch.sh` | Idempotent `status`/`check`/`apply`/`rollback` for the renderer patch, with file-level backups. Not deployed by stow. |
-| `pi-renderer/` | Renderer-parity fixture tests (JSONL turn with thinking + tool calls + final text). Not deployed by stow. |
+| `.config/ccgram-prototype.env.example` | Env template (multiplexer, status mode, autoclose, low-noise notification knobs, placeholders for secrets, optional sidecar fallback tuning). |
+| `patches/ccgram-4.5.2-pi-renderer-parity.patch` | Tracked unified diff, layer 1: patches the installed ccgram 4.5.2 Pi renderer (thinking + tool-call + final-answer flow). Not deployed by stow. |
+| `patches/ccgram-4.5.2-low-noise-notifications.patch` | Tracked unified diff, layer 2 (applies on top of layer 1): final-answer-only notifications (silent thinking trace, quiet-progress mode). Not deployed by stow. |
+| `pi-renderer-patch.sh` | Idempotent `status`/`check`/`apply`/`rollback` for the whole patch stack, with file-level backups. Not deployed by stow. |
+| `pi-renderer/` | Patch-stack fixture tests (JSONL turn with thinking + tool calls + final text; low-noise notification behavior). Not deployed by stow. |
 | `thinking-sidecar/` | Sidecar unit tests + JSONL/state fixtures (deprecated fallback). Not deployed by stow. |
 | `validate.sh` | Offline checks: systemd unit syntax + sidecar unit tests + renderer patch state and fixture tests + no committed secrets. Not deployed by stow. |
 | `README.md` | This guide. Not deployed by stow. |
@@ -170,27 +171,27 @@ default (or set it per window with `/verbose`) for the Pi-like presentation.
 
 ```sh
 cd ~/dotfiles/ccgram-prototype
-./pi-renderer-patch.sh status     # applied | not-applied | unknown
-./pi-renderer-patch.sh check      # dry-run against the installed tool
+./pi-renderer-patch.sh status     # per-patch: applied | not-applied | unknown
+./pi-renderer-patch.sh check      # verifies the missing layers apply cleanly
 
 # If the deprecated sidecar fallback is running, stop it FIRST — running
 # both would double the thinking output.
 systemctl --user disable --now ccgram-thinking-sidecar.service 2>/dev/null || true
 
-./pi-renderer-patch.sh apply      # backs up originals, then patches (idempotent)
+./pi-renderer-patch.sh apply      # backs up originals, applies missing layers in order (idempotent)
 systemctl --user restart ccgram-prototype.service
 ```
 
-Rollback (exact reverse of apply):
+Rollback (exact reverse of apply, whole stack in reverse order):
 
 ```sh
 ./pi-renderer-patch.sh rollback   # reverse-patches (idempotent)
 systemctl --user restart ccgram-prototype.service
 ```
 
-`apply` copies the two modified files to
+`apply` copies each pre-existing modified file to
 `~/.ccgram-prototype/renderer-patch-backup/4.5.2/` before patching; if
-`rollback` ever fails, restore those two paths by hand. The script refuses to
+`rollback` ever fails, restore those paths by hand. The script refuses to
 touch any ccgram version other than 4.5.2 (set `CCGRAM_PATCH_FORCE=1` to
 override after regenerating the patch) and refuses to patch a dirty tree.
 
@@ -202,9 +203,58 @@ Offline tests (no Telegram, no live state):
 ```
 
 The tests copy the installed package to a temp dir, apply the tracked patch
-there, and drive a synthetic JSONL turn (thinking + tool calls + final text +
-error) through the real parser and the trace state machine with a fake
-Telegram client.
+stack there, and drive a synthetic JSONL turn (thinking + tool calls + final
+text + error) through the real parser and the trace state machine with a fake
+Telegram client. They also assert the low-noise behavior: the trace bubble is
+sent with `disable_notification=True`, silent user-echo tasks send without
+notification while the final answer still notifies, and silent/notifying
+tasks never merge.
+
+### Live smoke plan (only when explicitly authorized)
+
+Offline validation never touches Telegram. To smoke the low-noise behavior
+live after applying the stack and restarting the service:
+
+1. Confirm env: `grep -E 'HIDE_TOOL_CALLS|QUIET_PROGRESS|HIDE_THINKING|EPHEMERAL' ~/.config/ccgram-prototype.env`.
+2. Let Firstmate dispatch one small worker task (or wait for the next one).
+3. Expected in the worker's topic: the 👤 brief echo appears **without a
+   notification**; the 🧠 thinking tree appears/updates **without a
+   notification**; no tool-call messages at all; the status bubble (if it
+   appears) is silent; when the turn ends, the trace bubble is deleted and
+   **exactly one final-answer message notifies**.
+4. `journalctl --user -u ccgram-prototype.service -f` shows no patch-related
+   tracebacks.
+
+### Low-noise notifications — final-answer-only (patch layer 2)
+
+Captain preference: **while a Firstmate worker runs, nothing in its topic
+notifies; when the turn completes, one normal final-answer message
+notifies.** `patches/ccgram-4.5.2-low-noise-notifications.patch` (applied
+by the same `pi-renderer-patch.sh`, on top of the renderer-parity layer)
+plus env config implement that:
+
+| Transcript element during a run | Behavior | Mechanism |
+| ------------------------------- | -------- | --------- |
+| Tool calls / results | **No message at all** | `CCGRAM_HIDE_TOOL_CALLS=true` (upstream config, no patch; `message_queue` drops `tool_use`/`tool_result` tasks before batching) |
+| Thinking trace (tree bubble) | Visible, **silent on first send**, edited in place, deleted on final | Patch: `disable_notification=True` in `pi_live_transcript.handle_pi_thinking` |
+| Status bubble ("working…") | Visible, **silent on first send**, edited in place, cleared on done | Patch + `CCGRAM_QUIET_PROGRESS=true`: `disable_notification` in `status_bubble.send_status_text` |
+| User transcript echoes (Firstmate launch brief) | Visible (👤), **silent** | Patch + `CCGRAM_QUIET_PROGRESS=true`: `ContentTask.silent` flag, set in `message_routing` for `role="user"` |
+| Final assistant answer | **Normal message — notifies** | Unchanged normal path |
+
+Notes:
+
+- Edits and deletes never notify in Telegram, so only first sends need
+  the flag.
+- The thinking trace is silent unconditionally (it is ephemeral by design);
+  the status bubble and user echoes are gated on `CCGRAM_QUIET_PROGRESS`
+  (default off upstream-style, set `true` in the prototype env).
+- Silent and notifying content tasks never merge (`_can_merge_tasks`
+  guard), so a silent user echo can never fold into — and mute — the
+  final answer.
+- Tool calls need no patch: `CCGRAM_HIDE_TOOL_CALLS=true` suppresses them
+  in stock ccgram. Caveat: a per-window `/verbose` override
+  (`shown`/`hidden`) beats the global default — don't set per-window
+  overrides on worker topics.
 
 ### Remaining parity gaps (vs the Pi TUI)
 
@@ -334,9 +384,9 @@ Offline checks only (no live services touched):
 ```
 
 Verifies the systemd units parse (`systemd-analyze verify`), the thinking
-sidecar compiles and its unit tests pass, the renderer patch is in a
-consistent state (`pi-renderer-patch.sh check`) and its offline fixture tests
-pass against a patched temp copy of the installed tool, and that no real
+sidecar compiles and its unit tests pass, the patch stack is in a consistent
+state (`pi-renderer-patch.sh check`) and its offline fixture tests pass
+against a patched temp copy of the installed tool, and that no real
 tokens/chat IDs are committed in this package.
 
 ## Known limitations (from the scout report)

--- a/ccgram-prototype/patches/ccgram-4.5.2-low-noise-notifications.patch
+++ b/ccgram-prototype/patches/ccgram-4.5.2-low-noise-notifications.patch
@@ -1,0 +1,160 @@
+diff -ruN a/ccgram/config.py b/ccgram/config.py
+--- a/ccgram/config.py
++++ b/ccgram/config.py
+@@ -173,6 +173,16 @@
+             "CCGRAM_EPHEMERAL_TOOLS", ""
+         ).lower() in ("1", "true", "yes")
+ 
++        # Low-noise "quiet progress" mode (dotfiles ccgram-prototype
++        # low-noise patch): while a run is in flight, progress chrome —
++        # the per-topic status bubble and user transcript echoes (e.g. the
++        # Firstmate worker brief) — is sent with disable_notification=True,
++        # so the ONLY message that notifies is the final assistant answer.
++        # Off by default; the prototype env sets CCGRAM_QUIET_PROGRESS=true.
++        self.quiet_progress: bool = os.getenv(
++            "CCGRAM_QUIET_PROGRESS", "false"
++        ).lower() in ("1", "true", "yes")
++
+         # Color mapping for the topic state emoji prefix.
+         # "system" (default): green=active, yellow=idle (system POV: green=working).
+         # "user": green=idle, yellow=active (user POV: green=ready for me).
+diff -ruN a/ccgram/handlers/messaging_pipeline/message_queue.py b/ccgram/handlers/messaging_pipeline/message_queue.py
+--- a/ccgram/handlers/messaging_pipeline/message_queue.py
++++ b/ccgram/handlers/messaging_pipeline/message_queue.py
+@@ -178,6 +178,11 @@
+     # different chats, and merged text is delivered to a single destination.
+     if base.thread_id != candidate.thread_id or base.chat_id != candidate.chat_id:
+         return False
++    # Never merge silent with notifying tasks (dotfiles low-noise patch):
++    # a merged message carries one notification setting — mixing a silent
++    # user echo into the final answer would mute the answer's notification.
++    if base.silent != candidate.silent:
++        return False
+     if base.content_type in ("tool_use", "tool_result"):
+         return False
+     return candidate.content_type not in ("tool_use", "tool_result")
+@@ -237,6 +242,7 @@
+             role=first.role,
+             thread_id=first.thread_id,
+             chat_id=first.chat_id,
++            silent=first.silent,
+         ),
+         merge_count,
+     )
+@@ -460,7 +466,11 @@
+             first_part = False
+ 
+         sent = await rate_limit_send_message(
+-            client, chat_id, part, **send_kwargs(task.thread_id)
++            client,
++            chat_id,
++            part,
++            disable_notification=task.silent,
++            **send_kwargs(task.thread_id),
+         )
+ 
+         if sent:
+@@ -490,6 +500,7 @@
+     role: MessageRole = "assistant",
+     thread_id: int | None = None,
+     chat_id: int | None = None,
++    silent: bool = False,
+ ) -> None:
+     """Enqueue a content message task."""
+     if _is_ghost_window_task_at_enqueue(window_id):
+@@ -505,6 +516,7 @@
+         role=role,
+         thread_id=thread_id,
+         chat_id=chat_id,
++        silent=silent,
+     )
+     queue.put_nowait(task)
+ 
+diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handlers/messaging_pipeline/message_routing.py
+--- a/ccgram/handlers/messaging_pipeline/message_routing.py
++++ b/ccgram/handlers/messaging_pipeline/message_routing.py
+@@ -11,6 +11,7 @@
+ import structlog
+ 
+ from ... import session_query
++from ...config import config
+ from ...session_monitor import NewMessage
+ from ...telegram_client import TelegramClient
+ from ...user_preferences import user_preferences
+@@ -137,6 +138,11 @@
+                 role=msg.role,  # type: ignore[arg-type]  # NewMessage.role is str, narrows at runtime
+                 thread_id=thread_id,
+                 chat_id=chat_id,
++                # Quiet-progress (dotfiles low-noise patch): user transcript
++                # echoes — e.g. the Firstmate brief that starts a worker
++                # run — stay visible in the topic but do not notify; only
++                # the final assistant answer does.
++                silent=config.quiet_progress and msg.role == "user",
+             )
+ 
+             session = await session_query.resolve_session_for_window(window_id)
+diff -ruN a/ccgram/handlers/messaging_pipeline/message_task.py b/ccgram/handlers/messaging_pipeline/message_task.py
+--- a/ccgram/handlers/messaging_pipeline/message_task.py
++++ b/ccgram/handlers/messaging_pipeline/message_task.py
+@@ -24,6 +24,10 @@
+     tool_name: str | None = None
+     thread_id: int | None = None
+     chat_id: int | None = None
++    # Quiet-progress (dotfiles low-noise patch): deliver with
++    # disable_notification=True. Used for user transcript echoes so a
++    # Firstmate worker brief does not notify — only the final answer does.
++    silent: bool = False
+ 
+ 
+ @dataclass(frozen=True, slots=True)
+diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
+--- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
++++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
+@@ -112,7 +112,17 @@
+     text = render_thinking_tree(trace.steps)
+ 
+     if trace.message_id is None:
+-        sent = await safe_send(client, chat_id, text, message_thread_id=thread_id)
++        # Silent on first send (dotfiles low-noise patch): the trace is
++        # ephemeral by design — edited in place, deleted when the final
++        # answer lands — so it must never notify. Edits and deletes do not
++        # notify either; only the final answer (normal path) may notify.
++        sent = await safe_send(
++            client,
++            chat_id,
++            text,
++            message_thread_id=thread_id,
++            disable_notification=True,
++        )
+         if sent is not None:
+             trace.message_id = sent.message_id
+             trace.last_edit_ts = time.monotonic()
+Binary files a/ccgram/handlers/messaging_pipeline/__pycache__/message_queue.cpython-314.pyc and b/ccgram/handlers/messaging_pipeline/__pycache__/message_queue.cpython-314.pyc differ
+Binary files a/ccgram/handlers/messaging_pipeline/__pycache__/message_routing.cpython-314.pyc and b/ccgram/handlers/messaging_pipeline/__pycache__/message_routing.cpython-314.pyc differ
+Binary files a/ccgram/handlers/messaging_pipeline/__pycache__/message_task.cpython-314.pyc and b/ccgram/handlers/messaging_pipeline/__pycache__/message_task.cpython-314.pyc differ
+Binary files a/ccgram/handlers/messaging_pipeline/__pycache__/pi_live_transcript.cpython-314.pyc and b/ccgram/handlers/messaging_pipeline/__pycache__/pi_live_transcript.cpython-314.pyc differ
+Binary files a/ccgram/handlers/status/__pycache__/status_bubble.cpython-314.pyc and b/ccgram/handlers/status/__pycache__/status_bubble.cpython-314.pyc differ
+diff -ruN a/ccgram/handlers/status/status_bubble.py b/ccgram/handlers/status/status_bubble.py
+--- a/ccgram/handlers/status/status_bubble.py
++++ b/ccgram/handlers/status/status_bubble.py
+@@ -18,6 +18,7 @@
+ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+ from telegram.error import TelegramError
+ 
++from ...config import config
+ from ...session_state_ports.live_session_state import get_task_snapshot, get_wait_header
+ from ...expandable_quote import format_expandable_quote
+ from ...telegram_client import TelegramClient
+@@ -341,6 +342,11 @@
+         text,
+         message_thread_id=thread_id,
+         reply_markup=keyboard,
++        # Quiet-progress (dotfiles low-noise patch): the status bubble is
++        # run-progress chrome — edited in place while the run continues,
++        # cleared when it ends — so under CCGRAM_QUIET_PROGRESS its first
++        # send must not notify; only the final answer does.
++        disable_notification=config.quiet_progress,
+     )
+     if msg is not None:
+         _status_msg_info[skey] = (msg.message_id, window_id, text, chat_id)
+Binary files a/ccgram/__pycache__/config.cpython-314.pyc and b/ccgram/__pycache__/config.cpython-314.pyc differ

--- a/ccgram-prototype/pi-renderer-patch.sh
+++ b/ccgram-prototype/pi-renderer-patch.sh
@@ -1,17 +1,29 @@
 #!/usr/bin/env bash
-# Apply / roll back the ccgram Pi renderer-parity patch.
+# Apply / roll back the ccgram Pi patch stack.
 #
-# The patch lives at patches/ccgram-4.5.2-pi-renderer-parity.patch and edits
-# the INSTALLED ccgram uv tool (4.5.2) so its own Pi rendering pipeline owns
-# thinking (temporary tree-style trace), tool-call display (existing
-# ephemeral batch), and final-answer delivery. This script makes that
-# hot-patch tracked, idempotent, and reversible.
+# The stack (applied IN ORDER) lives at patches/ and edits the INSTALLED
+# ccgram uv tool (4.5.2) so its own Pi rendering pipeline owns the whole
+# topic transcript flow:
+#
+#   1. ccgram-4.5.2-pi-renderer-parity.patch
+#      Thinking (temporary tree-style trace), tool-call display (existing
+#      ephemeral batch), final-answer delivery, phase stamping in pi_format.
+#   2. ccgram-4.5.2-low-noise-notifications.patch
+#      Final-answer-only notifications: the thinking trace bubble is silent
+#      on first send; under CCGRAM_QUIET_PROGRESS=true the status bubble and
+#      user transcript echoes (Firstmate worker briefs) are sent with
+#      disable_notification=True. Tool calls need no patch — config
+#      (CCGRAM_HIDE_TOOL_CALLS=true) suppresses them upstream.
+#
+# Patch 2's context includes files added/edited by patch 1, so patch 2 only
+# applies on top of patch 1; rollback reverses the stack in reverse order.
+# This script makes the hot-patches tracked, idempotent, and reversible.
 #
 # Usage:
-#   ./pi-renderer-patch.sh status     # applied | not-applied | unknown
-#   ./pi-renderer-patch.sh check      # dry-run: would the patch apply cleanly?
+#   ./pi-renderer-patch.sh status     # per-patch: applied | not-applied | unknown
+#   ./pi-renderer-patch.sh check      # dry-run: would the missing patches apply cleanly?
 #   ./pi-renderer-patch.sh apply      # backup originals, then patch (idempotent)
-#   ./pi-renderer-patch.sh rollback   # reverse the patch (idempotent)
+#   ./pi-renderer-patch.sh rollback   # reverse the whole stack (idempotent)
 #
 # Safety:
 #   - Refuses to touch a ccgram version other than 4.5.2 unless
@@ -25,13 +37,26 @@
 set -euo pipefail
 
 PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PATCH_FILE="$PKG_DIR/patches/ccgram-4.5.2-pi-renderer-parity.patch"
 EXPECTED_VERSION="4.5.2"
 
+# Patch stack, in apply order. Rollback walks this list in reverse.
+PATCH_NAMES=(
+    ccgram-4.5.2-pi-renderer-parity.patch
+    ccgram-4.5.2-low-noise-notifications.patch
+)
+
+patch_file() { printf '%s/patches/%s\n' "$PKG_DIR" "$1"; }
+
+# Files pre-existing in pristine ccgram that the stack modifies — backed up
+# before the first patch that touches them. (pi_live_transcript.py is ADDED
+# by patch 1, so there is no pristine original to back up.)
 TARGET_FILES=(
     ccgram/providers/pi_format.py
     ccgram/handlers/messaging_pipeline/message_routing.py
-    ccgram/handlers/messaging_pipeline/pi_live_transcript.py  # added by patch
+    ccgram/handlers/messaging_pipeline/message_queue.py
+    ccgram/handlers/messaging_pipeline/message_task.py
+    ccgram/handlers/status/status_bubble.py
+    ccgram/config.py
 )
 
 site_packages() {
@@ -67,34 +92,112 @@ check_version() {
     fi
 }
 
-has_markers() {
-    # Marker-based applied detection: `patch -R --dry-run` auto-detects
-    # unreversed patches and silently ignores -R, so it cannot distinguish
-    # applied from pristine. The patch's own fingerprints can.
+# --- Marker-based applied detection ---------------------------------------
+# `patch -R --dry-run` auto-detects unreversed patches and silently ignores
+# -R, so it cannot distinguish applied from pristine. Each patch's own
+# fingerprints can.
+
+has_markers_renderer_parity() {
     local sp="$1"
     [[ -f "$sp/ccgram/handlers/messaging_pipeline/pi_live_transcript.py" ]] \
         && grep -q 'phase="pi-live"' "$sp/ccgram/providers/pi_format.py" \
         && grep -q 'handle_pi_thinking' "$sp/ccgram/handlers/messaging_pipeline/message_routing.py"
 }
 
-has_no_markers() {
+has_no_markers_renderer_parity() {
     local sp="$1"
     [[ ! -e "$sp/ccgram/handlers/messaging_pipeline/pi_live_transcript.py" ]] \
         && ! grep -q 'phase="pi-live"' "$sp/ccgram/providers/pi_format.py" \
         && ! grep -q 'handle_pi_thinking' "$sp/ccgram/handlers/messaging_pipeline/message_routing.py"
 }
 
-is_applied() {
-    # 0 = applied, 1 = cleanly applicable (not applied), 2 = neither (dirty tree)
+has_markers_low_noise() {
     local sp="$1"
-    if has_markers "$sp"; then
+    grep -q 'CCGRAM_QUIET_PROGRESS' "$sp/ccgram/config.py" \
+        && grep -q 'disable_notification=True' \
+            "$sp/ccgram/handlers/messaging_pipeline/pi_live_transcript.py" 2>/dev/null \
+        && grep -q 'silent: bool = False' \
+            "$sp/ccgram/handlers/messaging_pipeline/message_task.py"
+}
+
+has_no_markers_low_noise() {
+    local sp="$1"
+    ! grep -q 'CCGRAM_QUIET_PROGRESS' "$sp/ccgram/config.py" \
+        && ! { [[ -f "$sp/ccgram/handlers/messaging_pipeline/pi_live_transcript.py" ]] \
+            && grep -q 'disable_notification=True' \
+                "$sp/ccgram/handlers/messaging_pipeline/pi_live_transcript.py"; } \
+        && ! grep -q 'silent: bool = False' \
+            "$sp/ccgram/handlers/messaging_pipeline/message_task.py"
+}
+
+marker_fn() {
+    # Echo the marker function base name for a patch file name.
+    case "$1" in
+        ccgram-4.5.2-pi-renderer-parity.patch) echo "renderer_parity" ;;
+        ccgram-4.5.2-low-noise-notifications.patch) echo "low_noise" ;;
+        *) echo "FAIL: no marker functions registered for patch '$1'" >&2; exit 2 ;;
+    esac
+}
+
+patch_state() {
+    # 0 = applied, 1 = not applied, 2 = partially applied (dirty tree)
+    local sp="$1" name="$2" base
+    base="$(marker_fn "$name")"
+    if "has_markers_$base" "$sp"; then
         return 0
     fi
-    if has_no_markers "$sp" \
-        && (cd "$sp" && patch -p1 --dry-run --batch -s < "$PATCH_FILE") >/dev/null 2>&1; then
+    if "has_no_markers_$base" "$sp"; then
         return 1
     fi
     return 2
+}
+
+stack_state() {
+    # Echoes per-patch state lines; overall rc 0 when every patch is in a
+    # definite state (applied or cleanly not-applied), 2 otherwise.
+    local sp="$1" rc=0 name st
+    for name in "${PATCH_NAMES[@]}"; do
+        st=0
+        patch_state "$sp" "$name" || st=$?
+        case "$st" in
+            0) echo "  $name: applied" ;;
+            1) echo "  $name: not-applied" ;;
+            *) echo "  $name: unknown (partial markers — dirty tree)"; rc=2 ;;
+        esac
+    done
+    return "$rc"
+}
+
+# Scratch-verify that the missing tail of the stack applies from the live
+# tree's current state: copy the affected files to a temp dir and really
+# apply the missing patches there (dry-run alone can't validate a sequence).
+verify_stack_applies() {
+    local sp="$1"
+    local tmp rel name st
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    for rel in "${TARGET_FILES[@]}" \
+        ccgram/handlers/messaging_pipeline/pi_live_transcript.py; do
+        if [[ -f "$sp/$rel" ]]; then
+            mkdir -p "$tmp/$(dirname "$rel")"
+            cp -p "$sp/$rel" "$tmp/$rel"
+        fi
+    done
+    for name in "${PATCH_NAMES[@]}"; do
+        st=0
+        patch_state "$tmp" "$name" || st=$?
+        if [[ $st -eq 0 ]]; then
+            continue  # already applied; skip
+        fi
+        if [[ $st -ne 1 ]]; then
+            echo "FAIL: $name is partially applied; tree is dirty" >&2
+            return 1
+        fi
+        if ! (cd "$tmp" && patch -p1 --batch -s < "$(patch_file "$name")"); then
+            echo "FAIL: $name does not apply cleanly from the current state" >&2
+            return 1
+        fi
+    done
 }
 
 cmd="${1:-}"
@@ -102,65 +205,82 @@ SP="$(site_packages)" || { echo "FAIL: cannot locate ccgram uv tool site-package
 
 case "$cmd" in
     status)
-        rc=0
-        is_applied "$SP" || rc=$?
-        case "$rc" in
-            0) echo "applied ($SP)" ;;
-            1) echo "not-applied ($SP)" ;;
-            *) echo "unknown ($SP — tree matches neither pristine nor patched)" ;;
-        esac
+        echo "patch stack state ($SP):"
+        stack_state "$SP"
         ;;
     check)
         check_version "$SP"
-        if has_markers "$SP"; then
-            echo "ok: patch is applied (markers present in $SP)"
-        elif (cd "$SP" && patch -p1 --dry-run --batch -s < "$PATCH_FILE") >/dev/null 2>&1; then
-            echo "ok: patch would apply cleanly to $SP"
+        rc=0
+        stack_state "$SP" >/dev/null || rc=$?
+        if [[ $rc -ne 0 ]]; then
+            stack_state "$SP" >&2
+            echo "FAIL: patch stack is in a partial/dirty state" >&2
+            exit 1
+        fi
+        if verify_stack_applies "$SP"; then
+            echo "ok: patch stack state is consistent; missing patches apply cleanly ($SP)"
         else
-            echo "FAIL: patch does not apply cleanly; tree is dirty or version-mismatched" >&2
             exit 1
         fi
         ;;
     apply)
         check_version "$SP"
         rc=0
-        is_applied "$SP" || rc=$?
-        if [[ $rc -eq 0 ]]; then
-            echo "ok: already applied; nothing to do"
-            exit 0
-        fi
-        if [[ $rc -ne 1 ]]; then
-            echo "FAIL: $SP matches neither pristine nor patched state; refusing to patch a dirty tree" >&2
+        stack_state "$SP" >/dev/null || rc=$?
+        if [[ $rc -ne 0 ]]; then
+            stack_state "$SP" >&2
+            echo "FAIL: $SP has a partially applied stack; refusing to patch a dirty tree" >&2
             exit 1
         fi
         backup_dir="$HOME/.ccgram-prototype/renderer-patch-backup/$(installed_version "$SP")"
-        for rel in "${TARGET_FILES[@]}"; do
-            if [[ -f "$SP/$rel" && ! -f "$backup_dir/$rel" ]]; then
-                mkdir -p "$backup_dir/$(dirname "$rel")"
-                cp -p "$SP/$rel" "$backup_dir/$rel"
+        applied_any=0
+        for name in "${PATCH_NAMES[@]}"; do
+            st=0
+            patch_state "$SP" "$name" || st=$?
+            if [[ $st -eq 0 ]]; then
+                echo "ok: $name already applied; skipping"
+                continue
             fi
+            for rel in "${TARGET_FILES[@]}"; do
+                if [[ -f "$SP/$rel" && ! -f "$backup_dir/$rel" ]]; then
+                    mkdir -p "$backup_dir/$(dirname "$rel")"
+                    cp -p "$SP/$rel" "$backup_dir/$rel"
+                fi
+            done
+            (cd "$SP" && patch -p1 --batch -s < "$(patch_file "$name")")
+            if ! "has_markers_$(marker_fn "$name")" "$SP"; then
+                echo "FAIL: $name ran but markers are missing; restore the backup:" >&2
+                echo "      $backup_dir" >&2
+                exit 1
+            fi
+            echo "applied: $name -> $SP"
+            applied_any=1
         done
-        echo "backup: $backup_dir"
-        (cd "$SP" && patch -p1 --batch -s < "$PATCH_FILE")
-        if ! has_markers "$SP"; then
-            echo "FAIL: patch ran but markers are missing; restore the backup:" >&2
-            echo "      $backup_dir" >&2
-            exit 1
+        if [[ $applied_any -eq 1 ]]; then
+            echo "backup: $backup_dir"
+            echo "restart: systemctl --user restart ccgram-prototype.service"
         fi
-        echo "applied: $PATCH_FILE -> $SP"
-        echo "restart: systemctl --user restart ccgram-prototype.service"
         ;;
     rollback)
-        if ! is_applied "$SP"; then
-            echo "ok: not applied; nothing to do"
-            exit 0
-        fi
-        (cd "$SP" && patch -R -p1 --batch -s < "$PATCH_FILE")
-        if ! has_no_markers "$SP"; then
-            echo "FAIL: reverse patch ran but markers remain; tree may be dirty" >&2
-            exit 1
-        fi
-        echo "rolled back: $SP"
+        for ((i=${#PATCH_NAMES[@]}-1; i>=0; i--)); do
+            name="${PATCH_NAMES[$i]}"
+            st=0
+            patch_state "$SP" "$name" || st=$?
+            if [[ $st -eq 1 ]]; then
+                echo "ok: $name not applied; skipping"
+                continue
+            fi
+            if [[ $st -ne 0 ]]; then
+                echo "FAIL: $name is partially applied; refusing to roll back a dirty tree" >&2
+                exit 1
+            fi
+            (cd "$SP" && patch -R -p1 --batch -s < "$(patch_file "$name")")
+            if ! "has_no_markers_$(marker_fn "$name")" "$SP"; then
+                echo "FAIL: reverse patch ran but markers remain; tree may be dirty" >&2
+                exit 1
+            fi
+            echo "rolled back: $name"
+        done
         echo "restart: systemctl --user restart ccgram-prototype.service"
         ;;
     *)

--- a/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
+++ b/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
@@ -1,9 +1,9 @@
 """Offline fixture tests for the ccgram Pi renderer-parity patch.
 
 Runs against a THROWAWAY COPY of the installed ccgram package with the
-tracked patch applied (the live uv tool is never touched). Requires the
-ccgram uv tool's python (deps: telegram, structlog, dotenv) — validate.sh
-invokes this with `~/.local/share/uv/tools/ccgram/bin/python`.
+tracked patch stack applied (the live uv tool is never touched). Requires
+the ccgram uv tool's python (deps: telegram, structlog, dotenv) —
+validate.sh invokes this with `~/.local/share/uv/tools/ccgram/bin/python`.
 
 Coverage:
   1. pi_format: thinking blocks -> content_type "thinking", phase "pi-live";
@@ -11,9 +11,14 @@ Coverage:
      (stopReason toolUse) and tool_use/tool_result stay phase-free so the
      existing ephemeral tool_batch keeps owning tool-call display.
   2. pi_live_transcript: tree rendering (folding, first-line nodes) and the
-     temporary-bubble state machine (send -> rate-limited edit -> delete)
-     against a fake TelegramClient. No Bot API calls are made.
-  3. Wiring: patched message_routing routes pi-live/pi-final phases.
+     temporary-bubble state machine (silent send -> rate-limited edit ->
+     delete) against a fake TelegramClient. No Bot API calls are made.
+  3. Low-noise notifications: the thinking trace is silent on first send;
+     under CCGRAM_QUIET_PROGRESS user-echo content tasks are delivered with
+     disable_notification=True while the final answer still notifies;
+     silent and notifying tasks never merge.
+  4. Wiring: patched message_routing routes pi-live/pi-final phases and
+     flags user echoes silent; the status bubble send honors quiet_progress.
 """
 
 from __future__ import annotations
@@ -30,13 +35,19 @@ import unittest
 from pathlib import Path
 
 PKG_DIR = Path(__file__).resolve().parent.parent
-PATCH_FILE = PKG_DIR / "patches" / "ccgram-4.5.2-pi-renderer-parity.patch"
+# Patch stack, in apply order (patch 2's context depends on patch 1).
+PATCH_FILES = [
+    PKG_DIR / "patches" / "ccgram-4.5.2-pi-renderer-parity.patch",
+    PKG_DIR / "patches" / "ccgram-4.5.2-low-noise-notifications.patch",
+]
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "pi_turn.jsonl"
 
 # ccgram.config constructs at import time and requires a token; give it a
 # placeholder (not a real token, never used — no Bot API calls happen here).
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "0:offline-fixture-placeholder")
 os.environ.setdefault("ALLOWED_USERS", "123")
+# Low-noise mode under test: user echoes + status bubble go silent.
+os.environ.setdefault("CCGRAM_QUIET_PROGRESS", "true")
 
 
 def _find_site_packages() -> Path:
@@ -59,7 +70,7 @@ def _prepare_patched_copy() -> Path:
         ignore=shutil.ignore_patterns("__pycache__"),
     )
 
-    def already_patched(root: Path) -> bool:
+    def renderer_parity_applied(root: Path) -> bool:
         # Marker-based detection: `patch -R --dry-run` auto-detects unreversed
         # patches and ignores -R, so it cannot tell applied from pristine.
         new_file = root / "ccgram/handlers/messaging_pipeline/pi_live_transcript.py"
@@ -68,10 +79,19 @@ def _prepare_patched_copy() -> Path:
             encoding="utf-8"
         )
 
-    if already_patched(tmp):
-        pass  # live tool already patched; the copy is too
-    else:
-        with open(PATCH_FILE, "rb") as fh:
+    def low_noise_applied(root: Path) -> bool:
+        cfg = (root / "ccgram/config.py").read_text(encoding="utf-8")
+        task = (
+            root / "ccgram/handlers/messaging_pipeline/message_task.py"
+        ).read_text(encoding="utf-8")
+        return "CCGRAM_QUIET_PROGRESS" in cfg and "silent: bool = False" in task
+
+    marker_checks = [renderer_parity_applied, low_noise_applied]
+
+    for patch_file, applied_check in zip(PATCH_FILES, marker_checks):
+        if applied_check(tmp):
+            continue  # live tool already patched; the copy is too
+        with open(patch_file, "rb") as fh:
             dry = subprocess.run(
                 ["patch", "-p1", "--dry-run", "--batch", "-s", "-d", str(tmp)],
                 stdin=fh,
@@ -79,17 +99,17 @@ def _prepare_patched_copy() -> Path:
             )
         if dry.returncode != 0:
             raise unittest.SkipTest(
-                "patch does not apply cleanly; installed ccgram version "
-                "differs from the patch target"
+                f"{patch_file.name} does not apply cleanly; installed ccgram "
+                "version differs from the patch target"
             )
-        with open(PATCH_FILE, "rb") as fh:
+        with open(patch_file, "rb") as fh:
             subprocess.run(
                 ["patch", "-p1", "--batch", "-s", "-d", str(tmp)],
                 stdin=fh,
                 check=True,
             )
-        if not already_patched(tmp):
-            raise RuntimeError("patch applied but markers missing")
+        if not applied_check(tmp):
+            raise RuntimeError(f"{patch_file.name} applied but markers missing")
     return tmp
 
 
@@ -131,10 +151,15 @@ class PiRendererParityTest(unittest.TestCase):
             if mod == "ccgram" or mod.startswith("ccgram."):
                 del sys.modules[mod]
 
+        from ccgram.config import config
+        from ccgram.handlers.messaging_pipeline import message_queue, message_task
         from ccgram.handlers.messaging_pipeline import pi_live_transcript
         from ccgram.providers import pi_format
         from ccgram.providers.pi import PiProvider
 
+        cls.config = config
+        cls.message_queue = message_queue
+        cls.message_task = message_task
         cls.pi_format = pi_format
         cls.trace = pi_live_transcript
         cls.provider = PiProvider()
@@ -227,6 +252,9 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(client.sent[0]["chat_id"], -100999)
         self.assertEqual(client.sent[0].get("message_thread_id"), 42)
         self.assertIn("├─ first step", client.sent[0]["text"])
+        # Low-noise: the temporary trace is silent on first send — it is
+        # edited in place and deleted on final, so it must never notify.
+        self.assertIs(client.sent[0].get("disable_notification"), True)
 
         # Rate limit: an immediate second step does not edit yet.
         run(trace.handle_pi_thinking(client, 1, 42, -100999, "second step"))
@@ -260,7 +288,51 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(len(client.deleted), 1)
         self.assertIn((1, 77), trace._traces)
 
-    # ── 3. Routing wiring ────────────────────────────────────────────────
+    # ── 3. Low-noise notifications ───────────────────────────────────────
+
+    def test_quiet_progress_config_flag(self):
+        # CCGRAM_QUIET_PROGRESS=true is set at module import (top of file).
+        self.assertTrue(self.config.quiet_progress)
+
+    def test_silent_user_echo_sends_without_notification(self):
+        client = _FakeClient()
+        task = self.message_task.ContentTask(
+            window_id="w1",
+            parts=("\U0001f464 FIRSTMATE_OP: launch-brief",),
+            role="user",
+            thread_id=42,
+            chat_id=-100999,
+            silent=True,
+        )
+        asyncio.run(self.message_queue._process_content_task(client, 1, task))
+        self.assertEqual(len(client.sent), 1)
+        self.assertIs(client.sent[0].get("disable_notification"), True)
+
+    def test_final_answer_still_notifies(self):
+        client = _FakeClient()
+        task = self.message_task.ContentTask(
+            window_id="w1",
+            parts=("Fixed the flaky parser test.",),
+            role="assistant",
+            thread_id=42,
+            chat_id=-100999,
+        )
+        asyncio.run(self.message_queue._process_content_task(client, 1, task))
+        self.assertEqual(len(client.sent), 1)
+        self.assertIn(client.sent[0].get("disable_notification"), (None, False))
+
+    def test_silent_and_notifying_tasks_never_merge(self):
+        ct = self.message_task.ContentTask
+        silent = ct(window_id="w", parts=("a",), silent=True)
+        notifying = ct(window_id="w", parts=("b",), silent=False)
+        # A silent user echo must never fold into the notifying final
+        # answer (that would mute the answer's notification).
+        self.assertFalse(self.message_queue._can_merge_tasks(silent, notifying))
+        self.assertFalse(self.message_queue._can_merge_tasks(notifying, silent))
+        other_silent = ct(window_id="w", parts=("c",), silent=True)
+        self.assertTrue(self.message_queue._can_merge_tasks(silent, other_silent))
+
+    # ── 4. Routing wiring ────────────────────────────────────────────────
 
     def test_routing_wires_pi_phases(self):
         src = (
@@ -270,6 +342,20 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertIn("clear_pi_thinking(client, user_id, thread_id)", src)
         self.assertIn('msg.phase == PI_LIVE_PHASE', src)
         self.assertIn('msg.phase == PI_FINAL_PHASE', src)
+
+    def test_routing_flags_user_echoes_silent_under_quiet_progress(self):
+        src = (
+            self.tmp / "ccgram/handlers/messaging_pipeline/message_routing.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn('silent=config.quiet_progress and msg.role == "user"', src)
+
+    def test_status_bubble_send_honors_quiet_progress(self):
+        # Functional coverage of send_status_text needs a wired SessionManager
+        # (thread_router); assert the wiring instead.
+        src = (self.tmp / "ccgram/handlers/status/status_bubble.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("disable_notification=config.quiet_progress", src)
 
 
 if __name__ == "__main__":

--- a/ccgram-prototype/validate.sh
+++ b/ccgram-prototype/validate.sh
@@ -49,7 +49,7 @@ else
     fail=1
 fi
 
-echo "==> Pi renderer patch: applies cleanly + offline fixture tests"
+echo "==> Pi patch stack (renderer parity + low-noise): applies cleanly + offline fixture tests"
 PATCH_SH="$PKG_DIR/pi-renderer-patch.sh"
 CCGRAM_PY="$HOME/.local/share/uv/tools/ccgram/bin/python"
 if [[ ! -x "$CCGRAM_PY" ]]; then
@@ -60,16 +60,16 @@ if [[ ! -x "$CCGRAM_PY" ]] && command -v uv >/dev/null 2>&1; then
 fi
 if [[ -x "$CCGRAM_PY" ]]; then
     if bash "$PATCH_SH" check >/dev/null 2>&1; then
-        echo "    ok: patch state is consistent (applied or cleanly applicable)"
+        echo "    ok: patch stack state is consistent (applied or cleanly applicable)"
     else
         echo "    FAIL: pi-renderer-patch.sh check failed (dirty tree or version mismatch)"
         fail=1
     fi
     if "$CCGRAM_PY" -m unittest discover -s "$PKG_DIR/pi-renderer" \
         -t "$PKG_DIR/pi-renderer" >/dev/null 2>&1; then
-        echo "    ok: renderer-parity fixture tests pass (patched copy, no Telegram)"
+        echo "    ok: patch-stack fixture tests pass (patched copy, no Telegram)"
     else
-        echo "    FAIL: renderer-parity tests failed; run:"
+        echo "    FAIL: patch-stack tests failed; run:"
         echo "        $CCGRAM_PY -m unittest discover -s ccgram-prototype/pi-renderer -v"
         fail=1
     fi


### PR DESCRIPTION
## What

Implements the captain's low-noise preference for ccgram's Pi/Firstmate topics: **while a worker runs, nothing in its topic notifies; when the turn completes, one normal final-answer message notifies.**

Adds a second tracked patch, `ccgram-4.5.2-low-noise-notifications.patch`, applied on top of the merged PR145 renderer-parity layer by the same `pi-renderer-patch.sh` (now a two-layer stack: per-patch markers, ordered apply, reverse-order rollback, backups).

## Behavior matrix (per worker run)

| Transcript element | Behavior | Mechanism |
| --- | --- | --- |
| Tool calls / results | No message at all | `CCGRAM_HIDE_TOOL_CALLS=true` (upstream config, no patch needed — `message_queue` drops `tool_use`/`tool_result` tasks before batching) |
| Thinking trace (tree bubble) | Visible, **silent on first send**, edited in place, deleted on final | Patch: `disable_notification=True` in `pi_live_transcript.handle_pi_thinking` |
| Status bubble ("working…") | Visible, **silent on first send**, edited in place, cleared on done | Patch + `CCGRAM_QUIET_PROGRESS=true` in `status_bubble.send_status_text` |
| User echoes (Firstmate brief) | Visible (👤), **silent** | Patch + `CCGRAM_QUIET_PROGRESS=true`: new `ContentTask.silent` flag set in `message_routing` for `role="user"` |
| Final assistant answer | Normal message — **notifies** | Unchanged normal path |

Requirement 5 evaluation: Firstmate brief echoes **did** create start-of-run notifications (pi `parse_user` → routing → normal send). Fixed by sending them silently under `CCGRAM_QUIET_PROGRESS`, preserving topic context. A merge guard (`_can_merge_tasks`) ensures a silent echo can never fold into and mute the notifying final answer.

## Tracked / repeatable

The fix is a tracked patch + updated apply script, not a live site-packages edit. Live rollout (not done here): `pi-renderer-patch.sh apply`, add the env knobs, restart `ccgram-prototype.service`.

## Validation

- `./ccgram-prototype/validate.sh` passes offline (unit syntax, sidecar tests, patch-stack check, 15 fixture tests incl. new notification-behavior assertions, secret scan). No Telegram messages sent.
- Live smoke plan documented in `ccgram-prototype/README.md` ("Live smoke plan") for when Telegram sends are authorized.

Observe-only posture preserved: no launch/kill/recovery/steering behavior added.