### PR TITLE
ccgram-prototype: fix Pi transcript-binding race for reused worker sessions

### DIFF
--- a/ccgram-prototype/.local/bin/ccgram-pi-hook
+++ b/ccgram-prototype/.local/bin/ccgram-pi-hook
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""ccgram Pi hook shim for the local prototype.
+
+Pi's SessionStart hook can fire before the JSONL transcript file exists
+(observed ~4.2s delay on reused Firstmate/treehouse session directories).
+ccgram's patched resolver never falls back to the newest file in the
+directory, but binding is fastest when the hook payload already carries the
+exact transcript path. This shim waits for the session's OWN file — named
+``*_<session_id>.jsonl`` and non-empty — injects ``transcript_path`` when
+found, and then delegates to ccgram's hook processor.
+
+Safety invariants:
+  - NEVER injects a transcript whose filename does not contain the session
+    id. On timeout the payload is forwarded untouched; ccgram then defers
+    binding (pending) until the exact file appears instead of binding the
+    previous tenant's transcript.
+  - The wait is self-bounded: the cc-thingz hook runner exports
+    ``PI_HOOK_TIMEOUT_SEC`` and SIGTERMs stragglers, so the shim always
+    returns before that deadline. ``CCGRAM_PI_HOOK_WAIT_SECS`` overrides
+    the budget explicitly.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CCGRAM = "/home/avirus/.local/bin/ccgram"
+CCGRAM_DIR = "/home/avirus/.ccgram-prototype"
+
+# Absolute ceiling for the wait; the effective budget is the smallest of
+# the override, the runner timeout minus a safety margin, and this cap.
+_MAX_WAIT_SECS = 30.0
+_RUNNER_TIMEOUT_MARGIN_SECS = 0.5
+_DEFAULT_WAIT_SECS = 4.5
+
+
+def wait_budget() -> float:
+    """Effective wait deadline in seconds (never exceeds the runner's)."""
+    override = os.environ.get("CCGRAM_PI_HOOK_WAIT_SECS")
+    if override:
+        try:
+            return max(0.0, min(float(override), _MAX_WAIT_SECS))
+        except ValueError:
+            pass
+    hint = os.environ.get("PI_HOOK_TIMEOUT_SEC")
+    if hint:
+        try:
+            budget = float(hint) - _RUNNER_TIMEOUT_MARGIN_SECS
+        except ValueError:
+            budget = _DEFAULT_WAIT_SECS
+    else:
+        budget = _DEFAULT_WAIT_SECS
+    return max(1.0, min(budget, _MAX_WAIT_SECS))
+
+
+def encode_pi_cwd(cwd: str) -> str:
+    stripped = cwd.strip("/\\")
+    return "--" + stripped.replace("/", "-").replace("\\", "-").replace(":", "-") + "--"
+
+
+def find_transcript(cwd: str, session_id: str, deadline: float) -> str:
+    """Return the exact transcript for session_id once it exists and is
+    non-empty, or "" on timeout. Never returns another session's file."""
+    if not cwd or not session_id:
+        return ""
+    directory = Path.home() / ".pi" / "agent" / "sessions" / encode_pi_cwd(cwd)
+    end = time.time() + deadline
+    while True:
+        if directory.is_dir():
+            matches = sorted(
+                directory.glob(f"*_{session_id}.jsonl"),
+                key=lambda p: p.stat().st_mtime if p.exists() else 0,
+                reverse=True,
+            )
+            for match in matches:
+                try:
+                    if match.stat().st_size > 0:
+                        return str(match)
+                except OSError:
+                    continue
+        if time.time() >= end:
+            return ""
+        time.sleep(0.1)
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {}
+    if isinstance(payload, dict) and payload.get("hook_event_name") == "SessionStart" and not payload.get("transcript_path"):
+        transcript = find_transcript(
+            str(payload.get("cwd") or ""),
+            str(payload.get("session_id") or ""),
+            wait_budget(),
+        )
+        if transcript:
+            payload["transcript_path"] = transcript
+            raw = json.dumps(payload, separators=(",", ":"))
+    env = os.environ.copy()
+    env["CCGRAM_DIR"] = CCGRAM_DIR
+    proc = subprocess.run([CCGRAM, "hook", "--provider", "pi"], input=raw, text=True, env=env)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ccgram-prototype/.pi/agent/extensions/hooks.json
+++ b/ccgram-prototype/.pi/agent/extensions/hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/avirus/.local/bin/ccgram-pi-hook",
+            "timeout": 20,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/avirus/.local/bin/ccgram-pi-hook",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/avirus/.local/bin/ccgram-pi-hook",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -39,8 +39,12 @@ already publish agent sessions that ccgram discovers with zero code changes.
 | `.config/ccgram-prototype.env.example` | Env template (multiplexer, status mode, autoclose, low-noise notification knobs, placeholders for secrets, optional sidecar fallback tuning). |
 | `patches/ccgram-4.5.2-pi-renderer-parity.patch` | Tracked unified diff, layer 1: patches the installed ccgram 4.5.2 Pi renderer (thinking + tool-call + final-answer flow). Not deployed by stow. |
 | `patches/ccgram-4.5.2-low-noise-notifications.patch` | Tracked unified diff, layer 2 (applies on top of layer 1): final-answer-only notifications (silent thinking trace, quiet-progress mode). Not deployed by stow. |
+| `patches/ccgram-4.5.2-pi-transcript-binding.patch` | Tracked unified diff, layer 3 (disjoint files): fixes the SessionStart transcript-binding race for reused session directories (exact-match-only binding, deferred pending resolution, offset reset on path change). Not deployed by stow. |
+| `.local/bin/ccgram-pi-hook` | Pi hook shim: waits (self-bounded) for the session's OWN transcript file at SessionStart, injects the exact `transcript_path`, delegates to `ccgram hook --provider pi`. Deployed by stow. |
+| `.pi/agent/extensions/hooks.json` | cc-thingz hook-runner wiring (SessionStart/Stop/SessionEnd → shim, async; SessionStart timeout raised to 20s to cover slow transcript creation). Deployed by stow. |
 | `pi-renderer-patch.sh` | Idempotent `status`/`check`/`apply`/`rollback` for the whole patch stack, with file-level backups. Not deployed by stow. |
 | `pi-renderer/` | Patch-stack fixture tests (JSONL turn with thinking + tool calls + final text; low-noise notification behavior). Not deployed by stow. |
+| `transcript-binding/` | Transcript-binding race fixture tests (reused-directory/off-by-one reproduction; shim behavior). Not deployed by stow. |
 | `thinking-sidecar/` | Sidecar unit tests + JSONL/state fixtures (deprecated fallback). Not deployed by stow. |
 | `validate.sh` | Offline checks: systemd unit syntax + sidecar unit tests + renderer patch state and fixture tests + no committed secrets. Not deployed by stow. |
 | `README.md` | This guide. Not deployed by stow. |
@@ -188,6 +192,83 @@ Rollback (exact reverse of apply, whole stack in reverse order):
 ./pi-renderer-patch.sh rollback   # reverse-patches (idempotent)
 systemctl --user restart ccgram-prototype.service
 ```
+
+## Pi transcript-binding race — exact-match-or-defer (patch layer 3 + shim)
+
+The bug: Pi's SessionStart hook fires **before** Pi creates the session
+JSONL (observed ~4.2s on reused Firstmate/treehouse leases). Stock ccgram
+then fell back to the **newest existing transcript in the reused session
+directory** — the previous worker's file — so a new worker's topic watched
+its predecessor's transcript until a later hook event self-healed the
+binding (minutes late, with "Corrupted offset"/"File truncated" warnings
+and replay risk). A prior audit measured the off-by-one on 5/5 consecutive
+workers sharing one lease.
+
+Layer 3 (`patches/ccgram-4.5.2-pi-transcript-binding.patch`) plus the
+tracked hook shim close the race at every binding vector, without any
+launch/kill/recovery behavior (observe-only posture unchanged):
+
+| Vector | Fix |
+| ------ | --- |
+| `hook.py` SessionStart resolution | **Exact match only**: a Pi transcript is eligible only when its filename contains the session id. No newest-file fallback; a mismatched payload path is refused. When the file doesn't exist yet, the session_map entry records the session with an **empty transcript_path (pending)**. |
+| `session_monitor.py` poll loop | Pending Pi sessions are re-resolved **every poll** by exact session-id match; the session binds its own file as soon as Pi creates it (seconds, not minutes). |
+| `transcript_reader.py` offsets | Whenever a session's transcript **path changes**, the tracked byte offset is dropped and the session rebinds fresh — no mid-file corruption, no full stale replay. |
+| `session_map.py` primary preservation | The nested-session "preserve existing primary" guard (tmux/claude observer pattern) no longer pins **Pi** windows: a new Pi SessionStart is always the window's new primary. Claude behavior unchanged. Stale transcript paths are cleared from window state when the session changes without a replacement. |
+| `session_resolver.py` history reads | A persisted transcript path whose filename doesn't name the session is treated as absent for Pi, so `/last`/summary reads can't bind the prior tenant's file. |
+| `~/.local/bin/ccgram-pi-hook` (shim) | Waits for the session's OWN `*_<session_id>.jsonl` to exist **and be non-empty** before injecting `transcript_path` — fastest correct binding in the common case. The wait self-bounds to the hook runner's `PI_HOOK_TIMEOUT_SEC` (minus margin; `CCGRAM_PI_HOOK_WAIT_SECS` overrides; hard cap 30s) and **never** injects a prior tenant's file. |
+| `hooks.json` | SessionStart hook timeout raised 5s → 20s (still `async: true`, so Pi never blocks) to cover slow transcript creation; the shim exits well before the runner's SIGTERM. |
+
+Defense in depth: if the shim times out, ccgram defers (pending) instead
+of binding wrong, and the poll loop binds the exact file when it appears.
+If a later hook event re-resolves first, the offset reset keeps the handoff
+clean.
+
+### Deploy / redeploy the shim (tracked since this PR)
+
+The shim and `hooks.json` were previously untracked live files. stow will
+not overwrite real files, so redeploy once by hand:
+
+```sh
+rm -f ~/.local/bin/ccgram-pi-hook ~/.pi/agent/extensions/hooks.json
+cd ~/dotfiles && stow ccgram-prototype
+```
+
+### Live smoke plan for the race fix (only when explicitly authorized)
+
+Offline tests reproduce the race fully. To smoke live after applying layer
+3, redeploying the shim, and restarting the service:
+
+1. Let Firstmate dispatch two consecutive small worker tasks into the SAME
+   treehouse lease (the reused-directory case).
+2. `jq -r '.[] | [.session_id, .transcript_path] | @tsv' ~/.ccgram-prototype/session_map.json`
+   — the second worker's entry must name its OWN transcript from spawn
+   (filename contains its session id), or sit pending (`""`) for at most a
+   few seconds.
+3. `jq '.tracked_sessions' ~/.ccgram-prototype/monitor_state.json` — no
+   session id mapped to a file naming a different session id (the old
+   off-by-one pattern).
+4. `journalctl --user -u ccgram-prototype.service` shows zero "Corrupted
+   offset" / "File truncated" lines for the new worker; "Transcript path
+   changed … resetting read offset" may appear if a pending binding
+   hand-off happened (benign, one line).
+5. The second worker's topic shows thinking/final text from its own turn
+   within seconds of spawn — no multi-minute dead window.
+
+### Offline tests for the race
+
+```sh
+~/.local/share/uv/tools/ccgram/bin/python \
+    -m unittest discover -s ccgram-prototype/transcript-binding -v
+```
+
+The tests copy the installed package to a temp dir, apply the tracked
+patch stack there, redirect HOME to a fixture reused session directory
+containing only transcript A, and assert: SessionStart for B does not bind
+A (hook + monitor level), B binds its own file once it appears with a
+clean offset, a pre-seeded stale A→B binding resets without corruption or
+replay, primary preservation is skipped for pi but intact for claude, and
+the shim waits for the exact non-empty file and never returns a prior
+tenant's transcript.
 
 `apply` copies each pre-existing modified file to
 `~/.ccgram-prototype/renderer-patch-backup/4.5.2/` before patching; if

--- a/ccgram-prototype/patches/ccgram-4.5.2-pi-transcript-binding.patch
+++ b/ccgram-prototype/patches/ccgram-4.5.2-pi-transcript-binding.patch
@@ -1,0 +1,203 @@
+--- a/ccgram/hook.py
++++ b/ccgram/hook.py
+@@ -1034,8 +1034,17 @@
+ 
+ 
+ def _resolve_pi_transcript_path(session_id: str, cwd: str) -> str:
+-    """Find a Pi transcript path when hook-runner omitted it."""
+-    if not cwd:
++    """Find a Pi transcript path when hook-runner omitted it.
++
++    Exact match only: a transcript is eligible only when its filename
++    contains the session id. Pi's SessionStart hook can fire before the
++    session file exists; a newest-file fallback would bind the new session
++    to the PREVIOUS session's transcript in a reused session directory
++    (the off-by-one binding race). Returning "" defers binding — the
++    monitor re-resolves pending Pi sessions on every poll and binds the
++    exact file once it appears.
++    """
++    if not cwd or not session_id:
+         return ""
+     session_dir = (
+         Path.home() / ".pi" / "agent" / "sessions" / _encode_pi_cwd_dirname(cwd)
+@@ -1055,9 +1064,14 @@
+         return ""
+     candidates.sort(reverse=True)
+     for _mtime, path in candidates:
+-        if session_id and session_id in path.name:
++        if session_id in path.name:
+             return str(path)
+-    return str(candidates[0][1]) if candidates else ""
++    logger.info(
++        "No Pi transcript naming session %s in %s yet; deferring binding",
++        session_id,
++        session_dir,
++    )
++    return ""
+ 
+ 
+ def _resolve_transcript_path(
+@@ -1078,7 +1092,12 @@
+                 )
+             return resolved
+         if transcript_path:
+-            return transcript_path
++            logger.warning(
++                "Refusing Pi transcript path not naming session %s: %s",
++                session_id,
++                transcript_path,
++            )
++        return ""
+     elif transcript_path:
+         return transcript_path
+     return ""
+--- a/ccgram/transcript_reader.py
++++ b/ccgram/transcript_reader.py
+@@ -155,6 +155,21 @@
+         tracked = self._state.get_session(session_id)
+         provider = _resolve_provider_for_file(window_id, file_path)
+ 
++        if tracked is not None and tracked.file_path != str(file_path):
++            # The session's transcript moved (e.g. a deferred Pi binding
++            # reaching its real file, or a refreshed session_map entry).
++            # Drop the stale offset before it causes mid-file corruption
++            # or a full stale replay, then rebind fresh below.
++            logger.info(
++                "Transcript path changed for session %s: %s -> %s; "
++                "resetting read offset",
++                session_id,
++                tracked.file_path,
++                str(file_path),
++            )
++            self.clear_session(session_id)
++            tracked = None
++
+         if tracked is None:
+             tracked = self._adopt_tracking_for_file(session_id, file_path)
+ 
+--- a/ccgram/session_monitor.py
++++ b/ccgram/session_monitor.py
+@@ -29,6 +29,7 @@
+ from .idle_tracker import IdleTracker
+ from .monitor_state import MonitorState
+ from .providers import get_provider_for_window, registry  # noqa: F401 (used by test patches)
++from .providers.pi import resolve_session_transcript
+ from .session_map import parse_session_map, read_session_map_raw, session_map_prefix
+ from .session_lifecycle import session_lifecycle
+ from .multiplexer import multiplexer as tmux_manager
+@@ -153,6 +154,7 @@
+         """
+         new_messages: list[NewMessage] = []
+         sid_to_wid = {v["session_id"]: wid for wid, v in current_map.items()}
++        sid_to_details = {v["session_id"]: v for v in current_map.values()}
+ 
+         direct_sessions: list[tuple[str, Path]] = []
+         fallback_session_ids: set[str] = set()
+@@ -167,6 +169,23 @@
+                     continue
+             fallback_session_ids.add(session_id)
+ 
++        # Pending Pi bindings: SessionStart defers registration when the
++        # exact session file has not appeared yet (empty transcript_path).
++        # Retry exact-match resolution every poll so a reused session
++        # directory never binds the new session to the previous session's
++        # transcript, and the session binds its own file as soon as Pi
++        # creates it.
++        for session_id in list(fallback_session_ids):
++            details = sid_to_details.get(session_id) or {}
++            if details.get("provider_name", "").lower() != "pi":
++                continue
++            resolved = resolve_session_transcript(
++                session_id, details.get("cwd", "")
++            )
++            if resolved:
++                direct_sessions.append((session_id, Path(resolved)))
++                fallback_session_ids.discard(session_id)
++
+         for session_id, file_path in direct_sessions:
+             try:
+                 await self._process_session_file(
+--- a/ccgram/session_map.py
++++ b/ccgram/session_map.py
+@@ -146,6 +146,15 @@
+     if not incoming_sid or incoming_sid == state.session_id:
+         return None
+ 
++    # Pi sessions own their window outright: a new Pi SessionStart is
++    # always the window's new primary session (pi has no nested-observer
++    # pattern; the hook-side nested guard is tmux/claude-only). Preserving
++    # the prior tenant here would pin reused-session-directory windows to
++    # the previous session's transcript, so the nested-session
++    # preservation below does not apply to pi.
++    if (incoming.get("provider_name", "") or "").lower() == "pi":
++        return None
++
+     existing_mtime = _transcript_mtime(state.transcript_path)
+     incoming_mtime = _transcript_mtime(incoming.get("transcript_path", ""))
+     existing_is_fresh = _transcript_is_fresh(state.transcript_path)
+@@ -643,6 +652,7 @@
+         changed = False
+ 
+         state = window_store.get_window_state(window_id)
++        sid_changed = bool(state.session_id) and state.session_id != new_sid
+         if state.session_id != new_sid or state.cwd != new_cwd:
+             logger.info(
+                 "Session map: window_id %s updated sid=%s, cwd=%s",
+@@ -656,6 +666,13 @@
+         if new_transcript and state.transcript_path != new_transcript:
+             state.transcript_path = new_transcript
+             changed = True
++        elif not new_transcript and state.transcript_path and sid_changed:
++            # Session changed without a replacement transcript yet
++            # (deferred Pi binding): the stored path names the previous
++            # session's file — drop it so history reads and primary
++            # preservation can't bind the new session to it.
++            state.transcript_path = ""
++            changed = True
+         new_provider = effective["provider_name"].lower()
+         # Cross-check provider claim against the transcript path. session_map.json
+         # may carry a stale `provider_name` from a previous run in the same tmux
+--- a/ccgram/session_resolver.py
++++ b/ccgram/session_resolver.py
+@@ -61,6 +61,15 @@
+         transcript = identity.transcript_path
+         if not transcript:
+             return None
++        if (
++            identity.provider_name == "pi"
++            and identity.session_id
++            and identity.session_id not in transcript.name
++        ):
++            # Stale path from a previous session in this window (reused
++            # session directory): never bind a Pi session to a transcript
++            # whose filename does not name it.
++            return None
+         if not transcript.exists():
+             return None
+         summary = (
+--- a/ccgram/providers/pi.py
++++ b/ccgram/providers/pi.py
+@@ -92,6 +92,23 @@
+     return results
+ 
+ 
++def resolve_session_transcript(session_id: str, cwd: str) -> str:
++    """Return the transcript path whose filename names ``session_id``.
++
++    Exact match only — never falls back to the newest file in the
++    directory. Pi's SessionStart hook can fire before the session file
++    exists; a newest-file fallback would bind the new session to the
++    previous session's transcript in a reused session directory. Callers
++    treat "" as "not created yet" and retry on a later poll.
++    """
++    if not session_id or not cwd:
++        return ""
++    for _mtime, path in _candidate_transcripts(cwd):
++        if session_id in path.name:
++            return str(path)
++    return ""
++
++
+ def _parse_message_entry(
+     role: str,
+     msg: dict[str, Any],

--- a/ccgram-prototype/pi-renderer-patch.sh
+++ b/ccgram-prototype/pi-renderer-patch.sh
@@ -14,9 +14,18 @@
 #      user transcript echoes (Firstmate worker briefs) are sent with
 #      disable_notification=True. Tool calls need no patch — config
 #      (CCGRAM_HIDE_TOOL_CALLS=true) suppresses them upstream.
+#   3. ccgram-4.5.2-pi-transcript-binding.patch
+#      Transcript-binding race fix: Pi SessionStart never binds a transcript
+#      whose filename does not contain the session id (no newest-file
+#      fallback — deferred Pi bindings stay pending until the exact file
+#      appears and the monitor re-resolves them every poll), tracked read
+#      offsets reset whenever a session's transcript path changes, and the
+#      nested-session primary preservation no longer pins reused Pi windows
+#      to the previous tenant's transcript.
 #
 # Patch 2's context includes files added/edited by patch 1, so patch 2 only
-# applies on top of patch 1; rollback reverses the stack in reverse order.
+# applies on top of patch 1; patch 3 touches disjoint files and applies on
+# top of either. Rollback reverses the stack in reverse order.
 # This script makes the hot-patches tracked, idempotent, and reversible.
 #
 # Usage:
@@ -43,6 +52,7 @@ EXPECTED_VERSION="4.5.2"
 PATCH_NAMES=(
     ccgram-4.5.2-pi-renderer-parity.patch
     ccgram-4.5.2-low-noise-notifications.patch
+    ccgram-4.5.2-pi-transcript-binding.patch
 )
 
 patch_file() { printf '%s/patches/%s\n' "$PKG_DIR" "$1"; }
@@ -57,6 +67,12 @@ TARGET_FILES=(
     ccgram/handlers/messaging_pipeline/message_task.py
     ccgram/handlers/status/status_bubble.py
     ccgram/config.py
+    ccgram/hook.py
+    ccgram/providers/pi.py
+    ccgram/session_monitor.py
+    ccgram/session_map.py
+    ccgram/session_resolver.py
+    ccgram/transcript_reader.py
 )
 
 site_packages() {
@@ -130,11 +146,32 @@ has_no_markers_low_noise() {
             "$sp/ccgram/handlers/messaging_pipeline/message_task.py"
 }
 
+has_markers_transcript_binding() {
+    local sp="$1"
+    grep -q 'Refusing Pi transcript path' "$sp/ccgram/hook.py" \
+        && grep -q 'def resolve_session_transcript' "$sp/ccgram/providers/pi.py" \
+        && grep -q 'resolve_session_transcript' "$sp/ccgram/session_monitor.py" \
+        && grep -q 'Transcript path changed for session' "$sp/ccgram/transcript_reader.py" \
+        && grep -q 'pi has no nested-observer' "$sp/ccgram/session_map.py" \
+        && grep -q 'Stale path from a previous session' "$sp/ccgram/session_resolver.py"
+}
+
+has_no_markers_transcript_binding() {
+    local sp="$1"
+    ! grep -q 'Refusing Pi transcript path' "$sp/ccgram/hook.py" \
+        && ! grep -q 'def resolve_session_transcript' "$sp/ccgram/providers/pi.py" \
+        && ! grep -q 'resolve_session_transcript' "$sp/ccgram/session_monitor.py" \
+        && ! grep -q 'Transcript path changed for session' "$sp/ccgram/transcript_reader.py" \
+        && ! grep -q 'pi has no nested-observer' "$sp/ccgram/session_map.py" \
+        && ! grep -q 'Stale path from a previous session' "$sp/ccgram/session_resolver.py"
+}
+
 marker_fn() {
     # Echo the marker function base name for a patch file name.
     case "$1" in
         ccgram-4.5.2-pi-renderer-parity.patch) echo "renderer_parity" ;;
         ccgram-4.5.2-low-noise-notifications.patch) echo "low_noise" ;;
+        ccgram-4.5.2-pi-transcript-binding.patch) echo "transcript_binding" ;;
         *) echo "FAIL: no marker functions registered for patch '$1'" >&2; exit 2 ;;
     esac
 }

--- a/ccgram-prototype/transcript-binding/test_pi_transcript_binding.py
+++ b/ccgram-prototype/transcript-binding/test_pi_transcript_binding.py
@@ -1,0 +1,437 @@
+"""Offline fixture tests for the ccgram Pi transcript-binding patch.
+
+Reproduces the reused-directory / off-by-one race: Pi's SessionStart hook
+for session B fires while only session A's transcript exists in the shared
+session directory. Expected: ccgram NEVER binds B to A; B stays pending and
+binds its own transcript once the file appears, with a clean (reset) read
+offset — no mid-file corruption and no stale replay of A.
+
+Runs against a THROWAWAY COPY of the installed ccgram package with the
+tracked patch stack applied (the live uv tool is never touched). Requires
+the ccgram uv tool's python — validate.sh invokes this with
+`~/.local/share/uv/tools/ccgram/bin/python`. No tmux/Herdr/Telegram calls
+are made: the monitor's multiplexer lookup is stubbed and HOME is
+redirected to a temp dir per test.
+
+Coverage:
+  1. hook._resolve_pi_transcript_path / _resolve_transcript_path: exact
+     session-id match only — defer ("") while only A exists, refuse a
+     mismatched payload transcript, resolve B once B's file appears.
+  2. SessionMonitor.check_for_updates: a pending Pi session (empty
+     transcript_path) is not bound to A, then binds B's file on a later
+     poll with a fresh offset, and new content flows.
+  3. TranscriptReader: when a session's transcript path changes, the stale
+     tracked offset is dropped and the session rebinds fresh (no corrupted
+     offset, no replay of the previous file).
+  4. session_map._prefer_existing_primary: the nested-session primary
+     preservation no longer pins a Pi window to the prior tenant, while
+     the claude preservation behavior is unchanged.
+  5. Shim: find_transcript waits for the exact *_<session_id>.jsonl file
+     and never returns a prior tenant's transcript.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+PKG_DIR = Path(__file__).resolve().parent.parent
+# Patch stack, in apply order.
+PATCH_FILES = [
+    PKG_DIR / "patches" / "ccgram-4.5.2-pi-renderer-parity.patch",
+    PKG_DIR / "patches" / "ccgram-4.5.2-low-noise-notifications.patch",
+    PKG_DIR / "patches" / "ccgram-4.5.2-pi-transcript-binding.patch",
+]
+SHIM = PKG_DIR / ".local" / "bin" / "ccgram-pi-hook"
+
+# ccgram.config constructs at import time and requires a token; give it a
+# placeholder (never used — no Bot API calls happen here).
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "0:offline-fixture-placeholder")
+os.environ.setdefault("ALLOWED_USERS", "123")
+
+LEASE_CWD = "/tmp/lease"
+SID_A = "aaaaaaaa-1111-2222-3333-444444444444"
+SID_B = "bbbbbbbb-5555-6666-7777-888888888888"
+
+
+def _find_site_packages() -> Path:
+    candidates = glob.glob(
+        os.path.expanduser("~/.local/share/uv/tools/ccgram/lib/python*/site-packages")
+    )
+    for cand in candidates:
+        if (Path(cand) / "ccgram").is_dir():
+            return Path(cand)
+    raise unittest.SkipTest("ccgram uv tool not installed; cannot run patch tests")
+
+
+def _prepare_patched_copy() -> Path:
+    """Copy the installed ccgram package to a temp dir and apply the stack."""
+    sp = _find_site_packages()
+    tmp = Path(tempfile.mkdtemp(prefix="ccgram-patched-binding-"))
+    shutil.copytree(
+        sp / "ccgram",
+        tmp / "ccgram",
+        ignore=shutil.ignore_patterns("__pycache__"),
+    )
+
+    def renderer_parity_applied(root: Path) -> bool:
+        new_file = root / "ccgram/handlers/messaging_pipeline/pi_live_transcript.py"
+        fmt = root / "ccgram/providers/pi_format.py"
+        return new_file.exists() and 'phase="pi-live"' in fmt.read_text(
+            encoding="utf-8"
+        )
+
+    def low_noise_applied(root: Path) -> bool:
+        cfg = (root / "ccgram/config.py").read_text(encoding="utf-8")
+        task = (
+            root / "ccgram/handlers/messaging_pipeline/message_task.py"
+        ).read_text(encoding="utf-8")
+        return "CCGRAM_QUIET_PROGRESS" in cfg and "silent: bool = False" in task
+
+    def transcript_binding_applied(root: Path) -> bool:
+        hook = (root / "ccgram/hook.py").read_text(encoding="utf-8")
+        pi = (root / "ccgram/providers/pi.py").read_text(encoding="utf-8")
+        reader = (root / "ccgram/transcript_reader.py").read_text(encoding="utf-8")
+        return (
+            "Refusing Pi transcript path" in hook
+            and "def resolve_session_transcript" in pi
+            and "Transcript path changed for session" in reader
+        )
+
+    marker_checks = [
+        renderer_parity_applied,
+        low_noise_applied,
+        transcript_binding_applied,
+    ]
+
+    for patch_file, applied_check in zip(PATCH_FILES, marker_checks):
+        if applied_check(tmp):
+            continue  # live tool already patched; the copy is too
+        with open(patch_file, "rb") as fh:
+            dry = subprocess.run(
+                ["patch", "-p1", "--dry-run", "--batch", "-s", "-d", str(tmp)],
+                stdin=fh,
+                check=False,
+            )
+        if dry.returncode != 0:
+            raise unittest.SkipTest(
+                f"{patch_file.name} does not apply cleanly; installed ccgram "
+                "version differs from the patch target"
+            )
+        with open(patch_file, "rb") as fh:
+            subprocess.run(
+                ["patch", "-p1", "--batch", "-s", "-d", str(tmp)],
+                stdin=fh,
+                check=True,
+            )
+        if not applied_check(tmp):
+            raise RuntimeError(f"{patch_file.name} applied but markers missing")
+    return tmp
+
+
+def _session_dir(home: Path) -> Path:
+    return home / ".pi" / "agent" / "sessions" / "--tmp-lease--"
+
+
+def _write_transcript(path: Path, session_id: str, texts: list[str]) -> None:
+    """Write a minimal Pi v3 JSONL transcript: header + user/assistant turns."""
+    lines = [
+        json.dumps(
+            {"type": "session", "id": session_id, "cwd": LEASE_CWD, "version": 3}
+        )
+    ]
+    for i, text in enumerate(texts):
+        role = "user" if i % 2 == 0 else "assistant"
+        message: dict = {"role": role, "content": [{"type": "text", "text": text}]}
+        if role == "assistant":
+            message["stopReason"] = "stop"
+        lines.append(
+            json.dumps(
+                {
+                    "type": "message",
+                    "timestamp": f"2026-08-16T00:00:{i:02d}Z",
+                    "message": message,
+                }
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class TranscriptBindingTest(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmp = _prepare_patched_copy()
+        sys.path.insert(0, str(cls.tmp))
+        for mod in list(sys.modules):
+            if mod == "ccgram" or mod.startswith("ccgram."):
+                del sys.modules[mod]
+
+        from ccgram import hook
+        from ccgram import session_map
+        from ccgram.monitor_state import TrackedSession
+        from ccgram.session_monitor import SessionMonitor
+        from ccgram.window_state_store import (
+            WindowStateStore,
+            install_window_store,
+        )
+
+        cls.hook = hook
+        cls.session_map = session_map
+        cls.TrackedSession = TrackedSession
+        cls.SessionMonitor = SessionMonitor
+        cls.WindowStateStore = WindowStateStore
+        cls.install_window_store = install_window_store
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        sys.path.remove(str(cls.tmp))
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+
+    def setUp(self) -> None:
+        # Redirect HOME so Path.home()-based session-dir lookups land in a
+        # per-test temp dir; seed it with only transcript A (prior tenant).
+        self.home = Path(tempfile.mkdtemp(prefix="ccgram-binding-home-"))
+        self._old_home = os.environ.get("HOME")
+        os.environ["HOME"] = str(self.home)
+        session_dir = _session_dir(self.home)
+        session_dir.mkdir(parents=True)
+        self.a_path = session_dir / f"2026-08-15T21-00-00-000Z_{SID_A}.jsonl"
+        _write_transcript(
+            self.a_path, SID_A, ["previous tenant brief", "previous tenant final"]
+        )
+        self.b_path = session_dir / f"2026-08-15T21-05-00-000Z_{SID_B}.jsonl"
+        # Wire an empty window store so primary-preservation code paths run.
+        # (call via type(): plain functions stored as class attrs would bind)
+        type(self).install_window_store(
+            self.WindowStateStore(
+                schedule_save=lambda: None,
+                on_hookless_provider_switch=lambda window_id: None,
+            )
+        )
+
+    def tearDown(self) -> None:
+        if self._old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._old_home
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def _make_monitor(self) -> "SessionMonitor":
+        monitor = self.SessionMonitor(
+            projects_path=self.home / "no-projects",
+            poll_interval=1.0,
+            state_file=self.home / "monitor_state.json",
+        )
+
+        async def _no_active_cwds() -> set:
+            return set()
+
+        # No multiplexer in tests: the cwd-fallback discovery scan is a no-op.
+        monitor._get_active_cwds = _no_active_cwds
+        return monitor
+
+    def _pending_map(self) -> dict:
+        return {
+            "w1": {
+                "session_id": SID_B,
+                "cwd": LEASE_CWD,
+                "transcript_path": "",
+                "provider_name": "pi",
+                "window_name": "w1",
+            }
+        }
+
+    # ── 1. Hook resolver: exact match only ───────────────────────────────
+
+    def test_hook_resolver_defers_while_only_prior_transcript_exists(self):
+        self.assertEqual(self.hook._resolve_pi_transcript_path(SID_B, LEASE_CWD), "")
+        # A payload transcript that names a different session is refused too.
+        self.assertEqual(
+            self.hook._resolve_transcript_path(
+                "pi", SID_B, LEASE_CWD, str(self.a_path)
+            ),
+            "",
+        )
+
+    def test_hook_resolver_binds_exact_file_once_it_appears(self):
+        _write_transcript(self.b_path, SID_B, ["worker B brief"])
+        self.assertEqual(
+            self.hook._resolve_pi_transcript_path(SID_B, LEASE_CWD), str(self.b_path)
+        )
+        # Exact payload path is accepted.
+        self.assertEqual(
+            self.hook._resolve_transcript_path(
+                "pi", SID_B, LEASE_CWD, str(self.b_path)
+            ),
+            str(self.b_path),
+        )
+        # Stale payload path is overridden by the exact on-disk match.
+        self.assertEqual(
+            self.hook._resolve_transcript_path(
+                "pi", SID_B, LEASE_CWD, str(self.a_path)
+            ),
+            str(self.b_path),
+        )
+
+    # ── 2. Monitor: pending session never binds A, then binds B ──────────
+
+    async def test_monitor_pending_session_never_binds_prior_transcript(self):
+        monitor = self._make_monitor()
+
+        # Poll 1: SessionStart for B deferred (only A exists) — no binding.
+        messages = await monitor.check_for_updates(self._pending_map())
+        self.assertEqual(messages, [])
+        self.assertIsNone(monitor.state.get_session(SID_B))
+
+        # B's transcript appears (as Pi creates it, ~4s later live).
+        _write_transcript(self.b_path, SID_B, ["worker B brief"])
+
+        # Poll 2: pending resolution binds B's own file with a clean offset.
+        messages = await monitor.check_for_updates(self._pending_map())
+        tracked = monitor.state.get_session(SID_B)
+        self.assertIsNotNone(tracked, "pending Pi session did not bind its file")
+        self.assertEqual(tracked.file_path, str(self.b_path))
+        # Clean start: offset belongs to B's file, never carried over from A.
+        self.assertEqual(tracked.last_byte_offset, self.b_path.stat().st_size)
+        for msg in messages:
+            self.assertNotIn("previous tenant", msg.text)
+
+        # New content in B flows to the topic.
+        with self.b_path.open("a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "type": "message",
+                        "timestamp": "2026-08-15T21:05:30Z",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "worker B final"}],
+                            "stopReason": "stop",
+                        },
+                    }
+                )
+                + "\n"
+            )
+        messages = await monitor.check_for_updates(self._pending_map())
+        self.assertIn("worker B final", [m.text for m in messages])
+
+    # ── 3. Offset reset when a session's transcript path changes ─────────
+
+    async def test_offset_reset_on_transcript_path_change(self):
+        monitor = self._make_monitor()
+        # Pre-patch state reproduced: B tracked against A's file at A's EOF.
+        a_size = self.a_path.stat().st_size
+        monitor.state.update_session(
+            self.TrackedSession(
+                session_id=SID_B,
+                file_path=str(self.a_path),
+                last_byte_offset=a_size,
+            )
+        )
+        monitor._file_mtimes[SID_B] = self.a_path.stat().st_mtime
+
+        # B's real file appears, SHORTER than the stale offset — the exact
+        # case that used to fire "File truncated… Resetting" + full replay.
+        _write_transcript(self.b_path, SID_B, ["worker B brief"])
+        self.assertLess(self.b_path.stat().st_size, a_size)
+
+        bound_map = self._pending_map()
+        bound_map["w1"]["transcript_path"] = str(self.b_path)
+        messages = await monitor.check_for_updates(bound_map)
+
+        tracked = monitor.state.get_session(SID_B)
+        self.assertIsNotNone(tracked)
+        self.assertEqual(tracked.file_path, str(self.b_path))
+        # Fresh rebind: offset reset to B's clean start, not A's stale EOF.
+        self.assertEqual(tracked.last_byte_offset, self.b_path.stat().st_size)
+        # No replay of the previous tenant's transcript into the topic.
+        for msg in messages:
+            self.assertNotIn("previous tenant", msg.text)
+
+    # ── 4. Primary preservation no longer pins Pi windows ────────────────
+
+    def test_primary_preservation_skipped_for_pi(self):
+        from ccgram.window_state_store import window_store
+
+        state = window_store.get_window_state("w1")
+        state.session_id = SID_A
+        state.cwd = LEASE_CWD
+        state.transcript_path = str(self.a_path)
+        state.provider_name = "pi"
+        # A's transcript is "fresh" so the nested-session preservation WOULD
+        # fire for a claude window; for pi it must not pin the prior tenant.
+        incoming = {
+            "session_id": SID_B,
+            "cwd": LEASE_CWD,
+            "transcript_path": "",
+            "provider_name": "pi",
+            "window_name": "w1",
+        }
+        self.assertIsNone(self.session_map._prefer_existing_primary("w1", incoming))
+
+    def test_primary_preservation_still_applies_for_claude(self):
+        from ccgram.window_state_store import window_store
+
+        state = window_store.get_window_state("w2")
+        state.session_id = SID_A
+        state.cwd = LEASE_CWD
+        state.transcript_path = str(self.a_path)
+        state.provider_name = "claude"
+        incoming = {
+            "session_id": SID_B,
+            "cwd": LEASE_CWD,
+            "transcript_path": "",
+            "provider_name": "claude",
+            "window_name": "w2",
+        }
+        preferred = self.session_map._prefer_existing_primary("w2", incoming)
+        self.assertIsNotNone(preferred, "claude nested-session preservation regressed")
+        self.assertEqual(preferred["session_id"], SID_A)
+
+    # ── 5. Shim: exact-match wait, never a prior tenant ──────────────────
+
+    def _load_shim(self):
+        from importlib.machinery import SourceFileLoader
+
+        loader = SourceFileLoader("ccgram_pi_hook", str(SHIM))
+        spec = importlib.util.spec_from_loader("ccgram_pi_hook", loader)
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
+
+    def test_shim_never_returns_prior_tenant_transcript(self):
+        shim = self._load_shim()
+        # Only A exists and the deadline expires: empty, not A.
+        start = time.monotonic()
+        self.assertEqual(shim.find_transcript(LEASE_CWD, SID_B, 0.4), "")
+        self.assertGreaterEqual(time.monotonic() - start, 0.35)
+
+    def test_shim_returns_exact_transcript_once_present(self):
+        shim = self._load_shim()
+        _write_transcript(self.b_path, SID_B, ["worker B brief"])
+        self.assertEqual(
+            shim.find_transcript(LEASE_CWD, SID_B, 1.0), str(self.b_path)
+        )
+
+    def test_shim_ignores_empty_exact_file_until_written(self):
+        shim = self._load_shim()
+        self.b_path.touch()  # created but not yet written
+        self.assertEqual(shim.find_transcript(LEASE_CWD, SID_B, 0.3), "")
+        _write_transcript(self.b_path, SID_B, ["worker B brief"])
+        self.assertEqual(
+            shim.find_transcript(LEASE_CWD, SID_B, 0.5), str(self.b_path)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ccgram-prototype/validate.sh
+++ b/ccgram-prototype/validate.sh
@@ -49,7 +49,28 @@ else
     fail=1
 fi
 
-echo "==> Pi patch stack (renderer parity + low-noise): applies cleanly + offline fixture tests"
+echo "==> Pi hook shim: syntax + hooks.json parse (offline)"
+SHIM="$PKG_DIR/.local/bin/ccgram-pi-hook"
+HOOKS_JSON="$PKG_DIR/.pi/agent/extensions/hooks.json"
+if command -v python3 >/dev/null 2>&1; then
+    if python3 -m py_compile "$SHIM" \
+        && python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$HOOKS_JSON"; then
+        echo "    ok: shim compiles and hooks.json parses"
+    else
+        echo "    FAIL: shim compile or hooks.json parse failed"
+        fail=1
+    fi
+else
+    echo "    skipped: python3 not available on this host"
+fi
+if [[ -x "$SHIM" ]]; then
+    echo "    ok: shim is executable (stow will deploy it to ~/.local/bin)"
+else
+    echo "    FAIL: $SHIM is not executable"
+    fail=1
+fi
+
+echo "==> Pi patch stack (renderer parity + low-noise + transcript binding): applies cleanly + offline fixture tests"
 PATCH_SH="$PKG_DIR/pi-renderer-patch.sh"
 CCGRAM_PY="$HOME/.local/share/uv/tools/ccgram/bin/python"
 if [[ ! -x "$CCGRAM_PY" ]]; then
@@ -71,6 +92,14 @@ if [[ -x "$CCGRAM_PY" ]]; then
     else
         echo "    FAIL: patch-stack tests failed; run:"
         echo "        $CCGRAM_PY -m unittest discover -s ccgram-prototype/pi-renderer -v"
+        fail=1
+    fi
+    if "$CCGRAM_PY" -m unittest discover -s "$PKG_DIR/transcript-binding" \
+        -t "$PKG_DIR/transcript-binding" >/dev/null 2>&1; then
+        echo "    ok: transcript-binding race tests pass (patched copy, reused-directory fixture)"
+    else
+        echo "    FAIL: transcript-binding tests failed; run:"
+        echo "        $CCGRAM_PY -m unittest discover -s ccgram-prototype/transcript-binding -v"
         fail=1
     fi
 else


### PR DESCRIPTION
## Problem

New Firstmate/Pi workers on a **reused session directory** sometimes got a ccgram topic bound to the **previous worker's transcript**: Pi's SessionStart hook fires before the new JSONL exists (observed ~4.2s creation delay vs the shim's 3s wait), and ccgram fell back to the newest existing transcript in the directory. Prior audits measured the off-by-one on **5/5 consecutive workers** sharing one treehouse lease, with `Corrupted offset`/`File truncated` warnings and replay risk on every minutes-late self-heal.

## Fix — tracked patch layer 3 + tracked hook shim

`patches/ccgram-4.5.2-pi-transcript-binding.patch` (applied by the existing `pi-renderer-patch.sh` stack mechanism, disjoint files from layers 1–2) closes every binding vector:

| Vector | Fix |
| ------ | --- |
| `hook.py` | Exact-match-only Pi transcript resolution at SessionStart — no newest-file fallback; mismatched payload paths refused; sessions whose file doesn't exist yet register **pending** (empty `transcript_path`) |
| `session_monitor.py` | Pending Pi sessions re-resolve by exact session-id match **every poll**, binding their own file as soon as Pi creates it (seconds, not minutes) |
| `transcript_reader.py` | Tracked byte offsets **reset whenever a session's transcript path changes** — no mid-file corruption, no full stale replay |
| `session_map.py` | Nested-session primary preservation (tmux/claude observer pattern) no longer pins **Pi** windows to the prior tenant; claude behavior unchanged. Stale transcript paths cleared from window state on session change |
| `session_resolver.py` | History reads never bind a Pi session to a transcript whose filename doesn't name it |
| `.local/bin/ccgram-pi-hook` (now tracked) | Waits — self-bounded to the hook runner's `PI_HOOK_TIMEOUT_SEC` (`CCGRAM_PI_HOOK_WAIT_SECS` override, 30s cap) — for the session's OWN non-empty `*_<session_id>.jsonl`; **never** injects a prior tenant's file |
| `.pi/agent/extensions/hooks.json` (now tracked) | SessionStart hook timeout 5s → 20s (still `async: true`, so Pi never blocks) |

Defense in depth: if the shim times out, ccgram defers instead of binding wrong; the longer shim wait is **not** the only protection.

## Tests

New `ccgram-prototype/transcript-binding/` suite (9 tests) reproduces the reused-directory off-by-one against a patched temp copy of the installed tool: SessionStart for B while only A exists → **no binding to A**, then binding to B once B appears, with offset reset/clean start and no replay; primary preservation skipped for pi but intact for claude; shim exact-match/never-prior-tenant behavior.

`ccgram-prototype/validate.sh` (units, sidecar tests, patch-stack consistency, all fixture tests, secret scan) passes; `pi-renderer-patch.sh check` confirms layer 3 applies cleanly on the live tree.

## Deployment note

The shim and `hooks.json` were previously untracked live files; stow won't overwrite real files, so redeploy once by hand: `rm -f ~/.local/bin/ccgram-pi-hook ~/.pi/agent/extensions/hooks.json && cd ~/dotfiles && stow ccgram-prototype`, then `./pi-renderer-patch.sh apply` + restart the service. A live smoke plan (reused-lease drill) is in the README; **no Telegram messages were sent** and none should be until authorized.

Observe-only posture unchanged: no launch/kill/recovery/steering behavior added.