### PR TITLE
ccgram-prototype: thinking-tree liveness patch layer (timer, 1s cadence, goal folding, idle cleanup)

### DIFF
--- a/ccgram-prototype/.config/ccgram-prototype.env.example
+++ b/ccgram-prototype/.config/ccgram-prototype.env.example
@@ -59,6 +59,17 @@ CCGRAM_HIDE_THINKING=false
 # answer notifies. Requires the low-noise patch (see README).
 CCGRAM_QUIET_PROGRESS=true
 
+# --- Thinking-tree liveness (thinking-tree-live patch, layer 4) ---
+# Minimum seconds between thinking-tree edits. 1.0 matches the Firstmate
+# frontdoor's coalescing interval and drives the live elapsed timer in the
+# tree header (upstream default 2.0). Requires the thinking-tree-live patch.
+CCGRAM_PI_TRACE_EDIT_SECS=1.0
+# Liveness ticker period (timer refresh + idle sweep granularity).
+# CCGRAM_PI_TRACE_TICK_SECS=1.0
+# Delete a stale thinking bubble when a turn dies mid-thinking and no final
+# answer arrives for this long (default 600 = 10 minutes).
+# CCGRAM_PI_TRACE_IDLE_SECS=600
+
 # Default provider for NEW sessions is irrelevant in observe-only mode
 # (ccgram auto-detects pi from pane processes). Leave unset.
 # CCGRAM_PROVIDER=pi

--- a/ccgram-prototype/.config/ccgram-prototype.env.example
+++ b/ccgram-prototype/.config/ccgram-prototype.env.example
@@ -69,6 +69,11 @@ CCGRAM_PI_TRACE_EDIT_SECS=1.0
 # Delete a stale thinking bubble when a turn dies mid-thinking and no final
 # answer arrives for this long (default 600 = 10 minutes).
 # CCGRAM_PI_TRACE_IDLE_SECS=600
+# Mobile wrap-aware tree: goal/step lines word-wrap at this many columns
+# (default 48, a phone-width approximation) with a hanging indent under the
+# node prefix so the tree shape survives Telegram's own wrapping on phones.
+# 0 disables intentional wrapping.
+# CCGRAM_PI_TRACE_WRAP_CHARS=48
 
 # Default provider for NEW sessions is irrelevant in observe-only mode
 # (ccgram auto-detects pi from pane processes). Leave unset.

--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -296,7 +296,9 @@ notification while the final answer still notifies, and silent/notifying
 tasks never merge. Layer 4 adds liveness coverage: the header elapsed timer,
 the `CCGRAM_PI_TRACE_*` knobs, mid-turn text folding into the bold goal line
 (no separate message, no notification), ticker timer refresh with no new
-steps, edit-throttle respect, and idle-timeout bubble deletion.
+steps, edit-throttle respect, idle-timeout bubble deletion, and mobile
+wrap-aware rendering (long goal/step lines word-wrap with a hanging indent
+that preserves the tree shape; wrapping disabled at width 0).
 
 ### Live smoke plan (only when explicitly authorized)
 
@@ -309,10 +311,11 @@ live after applying the stack and restarting the service:
    notification**; the 🧠 thinking tree appears/updates **without a
    notification**; its header timer (`· 0:42`) visibly advances at ~1s
    cadence even while no new step arrives; mid-turn narration text shows up
-   as the tree's bold `▸` goal line instead of a separate message; no
-   tool-call messages at all; the status bubble (if it appears) is silent;
-   when the turn ends, the trace bubble is deleted and **exactly one
-   final-answer message notifies**.
+   as the tree's bold `▸` goal line instead of a separate message; long
+   goal/step lines wrap with a hanging indent that keeps the tree shape
+   intact on a phone; no tool-call messages at all; the status bubble (if
+   it appears) is silent; when the turn ends, the trace bubble is deleted
+   and **exactly one final-answer message notifies**.
 4. Kill a worker mid-turn (`herdr` pane kill or `kill -9` its pi process):
    the orphaned trace bubble is deleted within `CCGRAM_PI_TRACE_IDLE_SECS`
    (default 10 min) without a new turn.
@@ -374,12 +377,22 @@ ever contains complete messages — and stays out of scope):
 - **Idle-timeout deletion.** If a turn dies mid-thinking (kill -9, network
   drop) and no final answer arrives, the stale bubble is deleted after
   `CCGRAM_PI_TRACE_IDLE_SECS` (default `600` = 10 minutes).
+- **Mobile wrap-aware tree.** Goal and step lines are word-wrapped at
+  `CCGRAM_PI_TRACE_WRAP_CHARS` columns (default `48`, a phone-width
+  approximation — Telegram wraps by pixels with a proportional font) with a
+  hanging indent under the node prefix: a wrapped step continues aligned
+  under its `├─` text column and a wrapped goal under its `▸` text column
+  (bold per segment), so the tree shape survives Telegram's own line
+  wrapping instead of breaking into ragged full-width lines. `0` disables
+  intentional wrapping. The 120-char per-node caps still apply as the hard
+  truncation ceiling above this soft wrap.
 
 | Env knob | Default | Prototype setting | Meaning |
 | -------- | ------- | ----------------- | ------- |
 | `CCGRAM_PI_TRACE_EDIT_SECS` | `2.0` | `1.0` | Minimum seconds between trace-bubble edits (applies to step/goal updates and the timer ticker). |
 | `CCGRAM_PI_TRACE_TICK_SECS` | `1.0` | unset | Liveness ticker period (timer refresh + idle sweep granularity). |
 | `CCGRAM_PI_TRACE_IDLE_SECS` | `600` | unset | Delete a trace bubble with no thinking/goal activity for this long (killed-turn cleanup). |
+| `CCGRAM_PI_TRACE_WRAP_CHARS` | `48` | unset | Soft word-wrap width (in characters) for goal/step lines, with hanging indent under the node prefix; `0` disables. |
 
 ### Remaining parity gaps (vs the Pi TUI)
 

--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -40,6 +40,7 @@ already publish agent sessions that ccgram discovers with zero code changes.
 | `patches/ccgram-4.5.2-pi-renderer-parity.patch` | Tracked unified diff, layer 1: patches the installed ccgram 4.5.2 Pi renderer (thinking + tool-call + final-answer flow). Not deployed by stow. |
 | `patches/ccgram-4.5.2-low-noise-notifications.patch` | Tracked unified diff, layer 2 (applies on top of layer 1): final-answer-only notifications (silent thinking trace, quiet-progress mode). Not deployed by stow. |
 | `patches/ccgram-4.5.2-pi-transcript-binding.patch` | Tracked unified diff, layer 3 (disjoint files): fixes the SessionStart transcript-binding race for reused session directories (exact-match-only binding, deferred pending resolution, offset reset on path change). Not deployed by stow. |
+| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): thinking-tree liveness — live elapsed timer + ticker, `CCGRAM_PI_TRACE_*` cadence/idle knobs, mid-turn text folded into the tree as the goal line, idle-timeout bubble deletion. Not deployed by stow. |
 | `.local/bin/ccgram-pi-hook` | Pi hook shim: waits (self-bounded) for the session's OWN transcript file at SessionStart, injects the exact `transcript_path`, delegates to `ccgram hook --provider pi`. Deployed by stow. |
 | `.pi/agent/extensions/hooks.json` | cc-thingz hook-runner wiring (SessionStart/Stop/SessionEnd → shim, async; SessionStart timeout raised to 20s to cover slow transcript creation). Deployed by stow. |
 | `pi-renderer-patch.sh` | Idempotent `status`/`check`/`apply`/`rollback` for the whole patch stack, with file-level backups. Not deployed by stow. |
@@ -165,6 +166,9 @@ What the patch does (all inside ccgram, against the installed uv tool):
    thinking into the trace (never to permanent "Thinking" messages) and
    retires the trace before delivering `pi-final` answers.
 
+Patch layer 4 (`patches/ccgram-4.5.2-pi-thinking-tree-live.patch`) extends
+the same three files — see "Thinking-tree liveness" below.
+
 Tool calls need no patch: ccgram's default `batch_mode=ephemeral` already
 collapses each run of tool calls into one compact bubble that is edited in
 place as results land and **deleted** when the turn's final content flushes —
@@ -289,22 +293,31 @@ text + error) through the real parser and the trace state machine with a fake
 Telegram client. They also assert the low-noise behavior: the trace bubble is
 sent with `disable_notification=True`, silent user-echo tasks send without
 notification while the final answer still notifies, and silent/notifying
-tasks never merge.
+tasks never merge. Layer 4 adds liveness coverage: the header elapsed timer,
+the `CCGRAM_PI_TRACE_*` knobs, mid-turn text folding into the bold goal line
+(no separate message, no notification), ticker timer refresh with no new
+steps, edit-throttle respect, and idle-timeout bubble deletion.
 
 ### Live smoke plan (only when explicitly authorized)
 
 Offline validation never touches Telegram. To smoke the low-noise behavior
 live after applying the stack and restarting the service:
 
-1. Confirm env: `grep -E 'HIDE_TOOL_CALLS|QUIET_PROGRESS|HIDE_THINKING|EPHEMERAL' ~/.config/ccgram-prototype.env`.
+1. Confirm env: `grep -E 'HIDE_TOOL_CALLS|QUIET_PROGRESS|HIDE_THINKING|EPHEMERAL|PI_TRACE' ~/.config/ccgram-prototype.env`.
 2. Let Firstmate dispatch one small worker task (or wait for the next one).
 3. Expected in the worker's topic: the 👤 brief echo appears **without a
    notification**; the 🧠 thinking tree appears/updates **without a
-   notification**; no tool-call messages at all; the status bubble (if it
-   appears) is silent; when the turn ends, the trace bubble is deleted and
-   **exactly one final-answer message notifies**.
-4. `journalctl --user -u ccgram-prototype.service -f` shows no patch-related
-   tracebacks.
+   notification**; its header timer (`· 0:42`) visibly advances at ~1s
+   cadence even while no new step arrives; mid-turn narration text shows up
+   as the tree's bold `▸` goal line instead of a separate message; no
+   tool-call messages at all; the status bubble (if it appears) is silent;
+   when the turn ends, the trace bubble is deleted and **exactly one
+   final-answer message notifies**.
+4. Kill a worker mid-turn (`herdr` pane kill or `kill -9` its pi process):
+   the orphaned trace bubble is deleted within `CCGRAM_PI_TRACE_IDLE_SECS`
+   (default 10 min) without a new turn.
+5. `journalctl --user -u ccgram-prototype.service -f` shows no patch-related
+   tracebacks and no `RetryAfter` over a soak turn.
 
 ### Low-noise notifications — final-answer-only (patch layer 2)
 
@@ -317,7 +330,8 @@ plus env config implement that:
 | Transcript element during a run | Behavior | Mechanism |
 | ------------------------------- | -------- | --------- |
 | Tool calls / results | **No message at all** | `CCGRAM_HIDE_TOOL_CALLS=true` (upstream config, no patch; `message_queue` drops `tool_use`/`tool_result` tasks before batching) |
-| Thinking trace (tree bubble) | Visible, **silent on first send**, edited in place, deleted on final | Patch: `disable_notification=True` in `pi_live_transcript.handle_pi_thinking` |
+| Thinking trace (tree bubble) | Visible, **silent on first send**, edited in place, deleted on final | Patch: `disable_notification=True` in `pi_live_transcript` |
+| Mid-turn assistant text (`stopReason=toolUse`) | Folded into the tree as the bold goal line — **no separate message, no notification** | Layer 4 patch: `phase="pi-live-goal"` in `pi_format`, routed to `handle_pi_goal` |
 | Status bubble ("working…") | Visible, **silent on first send**, edited in place, cleared on done | Patch + `CCGRAM_QUIET_PROGRESS=true`: `disable_notification` in `status_bubble.send_status_text` |
 | User transcript echoes (Firstmate launch brief) | Visible (👤), **silent** | Patch + `CCGRAM_QUIET_PROGRESS=true`: `ContentTask.silent` flag, set in `message_routing` for `role="user"` |
 | Final assistant answer | **Normal message — notifies** | Unchanged normal path |
@@ -337,13 +351,43 @@ Notes:
   (`shown`/`hidden`) beats the global default — don't set per-window
   overrides on worker topics.
 
+### Thinking-tree liveness — closer to the frontdoor on mobile (patch layer 4)
+
+`patches/ccgram-4.5.2-pi-thinking-tree-live.patch` closes the cheap
+presentation gaps vs the `avirus` Firstmate Telegram frontdoor identified in
+the tree-rendering audit (the token-streaming gap is structural — JSONL only
+ever contains complete messages — and stays out of scope):
+
+- **Live elapsed timer.** The trace header is `🧠 Thinking… · 0:42` and a
+  per-trace background ticker re-renders the bubble at the edit cadence even
+  when no new completed JSONL message has arrived, so the bubble always
+  looks alive. The ticker stops when no traces remain; edits never notify.
+- **1s edit cadence knob.** `CCGRAM_PI_TRACE_EDIT_SECS` (default `2.0`)
+  controls the minimum gap between trace edits; the prototype env sets
+  `1.0`, matching the frontdoor's coalescing interval.
+- **Mid-turn text folds into the tree.** Assistant text blocks from Pi
+  messages with `stopReason="toolUse"` are stamped `phase="pi-live-goal"`
+  and update the tree's bold goal/top line (`▸ **…**`, markdown-stripped)
+  instead of becoming separate — and notifying — progress messages. This
+  also removes the last interim-notification gap: during a worker turn,
+  only the final answer notifies.
+- **Idle-timeout deletion.** If a turn dies mid-thinking (kill -9, network
+  drop) and no final answer arrives, the stale bubble is deleted after
+  `CCGRAM_PI_TRACE_IDLE_SECS` (default `600` = 10 minutes).
+
+| Env knob | Default | Prototype setting | Meaning |
+| -------- | ------- | ----------------- | ------- |
+| `CCGRAM_PI_TRACE_EDIT_SECS` | `2.0` | `1.0` | Minimum seconds between trace-bubble edits (applies to step/goal updates and the timer ticker). |
+| `CCGRAM_PI_TRACE_TICK_SECS` | `1.0` | unset | Liveness ticker period (timer refresh + idle sweep granularity). |
+| `CCGRAM_PI_TRACE_IDLE_SECS` | `600` | unset | Delete a trace bubble with no thinking/goal activity for this long (killed-turn cleanup). |
+
 ### Remaining parity gaps (vs the Pi TUI)
 
-- **No idle-timeout deletion.** If a turn dies mid-thinking with no terminal
-  message (kill -9, network drop), the trace bubble stays until the next
-  turn's first thinking step overwrites it. ccgram's routing path has no
-  per-topic timer to hook; the retired sidecar's 600s idle sweep covered
-  this.
+- **No token streaming.** The JSONL only contains complete messages, so a
+  long thinking block appears only when its assistant message completes;
+  the timer ticker keeps the bubble visibly alive during those windows but
+  cannot show new content. Closing this needs an upstream streaming event
+  source (Pi-side partial entries or an attachable event subscription).
 - **Step-granularity trace.** Pi writes an assistant message to the JSONL
   when that step finishes, so tree nodes appear per completed step, not
   token-by-token (same limitation the sidecar had; it matches the

--- a/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
+++ b/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
@@ -32,8 +32,8 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handl
              if len(stripped) < _MIN_THINKING_LENGTH:
 diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
 --- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-15 23:31:24.824153468 -0400
-+++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-15 23:31:48.658832502 -0400
-@@ -13,17 +13,38 @@
++++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-15 23:40:43.935912786 -0400
+@@ -13,17 +13,42 @@
  Messages are marked by the Pi formatter via ``AgentMessage.phase``:
  
  - ``PI_LIVE_PHASE``  — a thinking block; folded into the temporary tree.
@@ -60,6 +60,10 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +- ``CCGRAM_PI_TRACE_TICK_SECS`` — liveness ticker period (default 1.0).
 +- ``CCGRAM_PI_TRACE_IDLE_SECS`` — idle-timeout deletion (default 600 =
 +  10 minutes).
++- ``CCGRAM_PI_TRACE_WRAP_CHARS`` — mobile wrap width (default 48).  Goal
++  and step lines are word-wrapped to this many columns with a hanging
++  indent under the node prefix, so the tree shape survives Telegram's
++  phone-width line wrapping.  0 disables intentional wrapping.
 +
 +State is in-memory per (user_id, thread_id): rendered steps, the current
 +goal label, and the Telegram message id of the temporary trace bubble.
@@ -74,7 +78,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  import time
  from dataclasses import dataclass, field
  
-@@ -38,30 +59,49 @@
+@@ -38,15 +63,34 @@
  logger = structlog.get_logger()
  
  PI_LIVE_PHASE = "pi-live"
@@ -91,18 +95,26 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +EDIT_MIN_SECS = float(os.getenv("CCGRAM_PI_TRACE_EDIT_SECS", "2.0"))
 +TICK_SECS = float(os.getenv("CCGRAM_PI_TRACE_TICK_SECS", "1.0"))
 +IDLE_SECS = float(os.getenv("CCGRAM_PI_TRACE_IDLE_SECS", "600"))
++WRAP_CHARS = int(os.getenv("CCGRAM_PI_TRACE_WRAP_CHARS", "48"))
  
  _TREE_HEADER = "\U0001f9e0 Thinking\u2026"
  _TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
- 
++_GOAL_PREFIX = "\u25b8 "  # ▸ + space
++_STEP_PREFIX = "\u251c\u2500 "  # ├─ + space
++# Hanging indents for wrapped continuation lines: same column width as the
++# node prefixes, so a wrapped line aligns under its node's text and the
++# tree shape survives Telegram's phone-width wrapping.
++_GOAL_INDENT = " " * len(_GOAL_PREFIX)
++_STEP_INDENT = " " * len(_STEP_PREFIX)
++
 +# Markdown metacharacters stripped from goal labels (mirrors the frontdoor
 +# daemon's _strip_markdown) so model markdown cannot leak literal markup or
 +# skew the bold entity offsets of the rendered goal line.
 +_MD_STRIP_RE = re.compile(r"(\*\*|__|~~|`)")
-+
+ 
  
  @dataclass
- class _LiveTrace:
+@@ -54,14 +98,22 @@
      """Per-topic temporary thinking trace state."""
  
      steps: list[str] = field(default_factory=list)
@@ -125,7 +137,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  
  def normalize_step(text: str, max_chars: int = MAX_STEP_CHARS) -> str:
      """Reduce a thinking block to one compact tree node (first line)."""
-@@ -71,13 +111,36 @@
+@@ -71,77 +123,277 @@
      return first_line
  
  
@@ -133,6 +145,33 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +def _strip_markdown(text: str) -> str:
 +    """Remove markdown emphasis/code markers from a goal label."""
 +    return _MD_STRIP_RE.sub("", text)
++
++
++def wrap_segments(prefix_width: int, text: str, width: int) -> list[str]:
++    """Word-wrap ``text`` so ``prefix_width + segment`` fits ``width``.
++
++    Continuation segments share the first line's available width because
++    the renderer hangs them under a same-width blank indent.  Breaks
++    prefer spaces; an unbreakable over-long word is hard-cut.  ``width``
++    <= 0 disables wrapping (single segment).  Width is counted in
++    characters — Telegram wraps by pixels with a proportional font, so
++    this is an intentional mobile-column approximation, not an exact fit.
++    """
++    if width <= 0:
++        return [text]
++    avail = max(1, width - prefix_width)
++    segments: list[str] = []
++    remaining = text
++    while remaining:
++        if len(remaining) <= avail:
++            segments.append(remaining)
++            break
++        cut = remaining.rfind(" ", 0, avail + 1)
++        if cut <= 0:
++            cut = avail
++        segments.append(remaining[:cut].rstrip())
++        remaining = remaining[cut:].lstrip()
++    return segments
 +
 +
 +def format_elapsed(seconds: float) -> str:
@@ -146,6 +185,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    goal: str | None = None,
 +    elapsed: float | None = None,
 +    max_steps: int = MAX_TREE_STEPS,
++    wrap_chars: int = WRAP_CHARS,
 +) -> str:
      """Render the trace as a compact tree, newest steps last.
  
@@ -154,7 +194,10 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    ``elapsed`` adds the liveness timer to the header (``· 0:42``); ``goal``
 +    renders as a bold top line under the header.  Overflow folds into a
 +    ``… (N earlier steps)`` node, matching the step-granularity live trace
-+    of the Pi TUI.
++    of the Pi TUI.  Goal and step lines are word-wrapped at ``wrap_chars``
++    with a hanging indent under their node prefix, so the tree shape
++    survives Telegram's phone-width wrapping (``wrap_chars`` <= 0 disables
++    intentional wrapping).
      """
 -    lines = [_TREE_HEADER]
 +    header = _TREE_HEADER
@@ -162,11 +205,22 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +        header = f"{header} \u00b7 {format_elapsed(elapsed)}"
 +    lines = [header]
 +    if goal:
-+        lines.append(f"\u25b8 **{goal}**")
++        # Bold each wrapped segment separately; the ``**`` markers are
++        # converted to entities (not displayed), so width is counted on
++        # the plain goal text.
++        for i, seg in enumerate(wrap_segments(len(_GOAL_PREFIX), goal, wrap_chars)):
++            prefix = _GOAL_PREFIX if i == 0 else _GOAL_INDENT
++            lines.append(f"{prefix}**{seg}**")
      shown = steps[-max_steps:] if max_steps > 0 else []
      hidden = len(steps) - len(shown)
      if hidden > 0:
-@@ -88,60 +151,199 @@
+         lines.append(f"\u251c\u2500 \u2026 ({hidden} earlier steps)")
+     for step in shown:
+-        lines.append(f"\u251c\u2500 {step}")
++        for i, seg in enumerate(wrap_segments(len(_STEP_PREFIX), step, wrap_chars)):
++            prefix = _STEP_PREFIX if i == 0 else _STEP_INDENT
++            lines.append(f"{prefix}{seg}")
+     lines.append(_TREE_SPINNER)
      return "\n".join(lines)
  
  
@@ -206,14 +260,14 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    trace.client = client
      trace.chat_id = chat_id
 +    return key, trace, now
-+
  
 -    text = render_thinking_tree(trace.steps)
+ 
 +async def _push_update(
 +    trace: _LiveTrace, thread_id: int | None, now: float
 +) -> None:
 +    """Send the trace bubble on first content, else edit it in place.
- 
++
 +    First send is silent (dotfiles low-noise patch): the trace is ephemeral
 +    by design — edited in place, deleted when the final answer lands — so it
 +    must never notify.  Edits are rate-limited by EDIT_MIN_SECS and skipped
@@ -389,7 +443,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  async def clear_pi_thinking(
      client: TelegramClient,
      user_id: int,
-@@ -170,5 +372,9 @@
+@@ -170,5 +422,9 @@
  
  
  def clear_all_traces() -> None:

--- a/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
+++ b/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
@@ -1,0 +1,430 @@
+diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handlers/messaging_pipeline/message_routing.py
+--- a/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-15 23:31:24.824132529 -0400
++++ b/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-15 23:31:58.460833554 -0400
+@@ -28,8 +28,10 @@
+ from .message_queue import enqueue_content_message, get_message_queue
+ from .pi_live_transcript import (
+     PI_FINAL_PHASE,
++    PI_GOAL_PHASE,
+     PI_LIVE_PHASE,
+     clear_pi_thinking,
++    handle_pi_goal,
+     handle_pi_thinking,
+ )
+ 
+@@ -90,6 +92,17 @@
+         ):
+             await clear_pi_thinking(client, user_id, thread_id)
+ 
++        # Pi mid-turn assistant text (stopReason="toolUse"): fold it into
++        # the thinking tree as the bold goal/top line instead of a separate
++        # (notifying) progress message (thinking-tree-live patch).
++        if (
++            msg.content_type == "text"
++            and msg.role == "assistant"
++            and msg.phase == PI_GOAL_PHASE
++        ):
++            await handle_pi_goal(client, user_id, thread_id, chat_id, msg.text)
++            continue
++
+         if msg.content_type == "thinking":
+             stripped = (msg.text or "").strip()
+             if len(stripped) < _MIN_THINKING_LENGTH:
+diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
+--- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-15 23:31:24.824153468 -0400
++++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-15 23:31:48.658832502 -0400
+@@ -13,17 +13,38 @@
+ Messages are marked by the Pi formatter via ``AgentMessage.phase``:
+ 
+ - ``PI_LIVE_PHASE``  — a thinking block; folded into the temporary tree.
++- ``PI_GOAL_PHASE``  — mid-turn assistant text (stopReason ``toolUse``);
++  folded into the tree as the bold goal/top line instead of becoming a
++  separate (notifying) progress message.
+ - ``PI_FINAL_PHASE`` — assistant text with a terminal stopReason (anything
+   but ``toolUse``); triggers deletion of the temporary trace before the
+   answer is delivered through the normal path.
+ 
+-State is in-memory per (user_id, thread_id): rendered steps plus the
+-Telegram message id of the temporary trace bubble.
++Liveness (dotfiles thinking-tree-live patch): the tree header carries a
++live elapsed timer (``🧠 Thinking… · 0:42``) and a per-trace background
++ticker re-renders the bubble at the edit cadence even when no new
++completed JSONL message has arrived, so the trace always looks alive.
++The same sweep deletes a stale bubble when no thinking/goal activity has
++arrived for ``IDLE_SECS`` (a killed turn leaves no orphan).
++
++Knobs (env, read at import):
++
++- ``CCGRAM_PI_TRACE_EDIT_SECS`` — minimum seconds between trace edits
++  (default 2.0; the prototype env sets 1.0, matching the frontdoor).
++- ``CCGRAM_PI_TRACE_TICK_SECS`` — liveness ticker period (default 1.0).
++- ``CCGRAM_PI_TRACE_IDLE_SECS`` — idle-timeout deletion (default 600 =
++  10 minutes).
++
++State is in-memory per (user_id, thread_id): rendered steps, the current
++goal label, and the Telegram message id of the temporary trace bubble.
+ """
+ 
+ from __future__ import annotations
+ 
++import asyncio
+ import contextlib
++import os
++import re
+ import time
+ from dataclasses import dataclass, field
+ 
+@@ -38,30 +59,49 @@
+ logger = structlog.get_logger()
+ 
+ PI_LIVE_PHASE = "pi-live"
++PI_GOAL_PHASE = "pi-live-goal"
+ PI_FINAL_PHASE = "pi-final"
+ 
+ # Tree presentation knobs (mirror the retired sidecar defaults).
+ MAX_TREE_STEPS = 8
+-EDIT_MIN_SECS = 2.0
+ MAX_STEP_CHARS = 120
++MAX_GOAL_CHARS = 120
++
++# Liveness knobs (dotfiles thinking-tree-live patch), env-configurable.
++EDIT_MIN_SECS = float(os.getenv("CCGRAM_PI_TRACE_EDIT_SECS", "2.0"))
++TICK_SECS = float(os.getenv("CCGRAM_PI_TRACE_TICK_SECS", "1.0"))
++IDLE_SECS = float(os.getenv("CCGRAM_PI_TRACE_IDLE_SECS", "600"))
+ 
+ _TREE_HEADER = "\U0001f9e0 Thinking\u2026"
+ _TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
+ 
++# Markdown metacharacters stripped from goal labels (mirrors the frontdoor
++# daemon's _strip_markdown) so model markdown cannot leak literal markup or
++# skew the bold entity offsets of the rendered goal line.
++_MD_STRIP_RE = re.compile(r"(\*\*|__|~~|`)")
++
+ 
+ @dataclass
+ class _LiveTrace:
+     """Per-topic temporary thinking trace state."""
+ 
+     steps: list[str] = field(default_factory=list)
++    goal: str | None = None
+     message_id: int | None = None
+     chat_id: int | None = None
++    client: TelegramClient | None = None
++    started_ts: float = 0.0
+     last_edit_ts: float = 0.0
++    last_activity_ts: float = 0.0
++    last_rendered: str = ""
+ 
+ 
+ # Active traces: (user_id, thread_id_or_0) -> _LiveTrace
+ _traces: dict[tuple[int, int], _LiveTrace] = {}
+ 
++# The single liveness ticker task (runs while any trace is active).
++_tick_task: asyncio.Task | None = None
++
+ 
+ def normalize_step(text: str, max_chars: int = MAX_STEP_CHARS) -> str:
+     """Reduce a thinking block to one compact tree node (first line)."""
+@@ -71,13 +111,36 @@
+     return first_line
+ 
+ 
+-def render_thinking_tree(steps: list[str], max_steps: int = MAX_TREE_STEPS) -> str:
++def _strip_markdown(text: str) -> str:
++    """Remove markdown emphasis/code markers from a goal label."""
++    return _MD_STRIP_RE.sub("", text)
++
++
++def format_elapsed(seconds: float) -> str:
++    """Format elapsed seconds as ``M:SS`` (frontdoor-style timer)."""
++    total = max(0, int(seconds))
++    return f"{total // 60}:{total % 60:02d}"
++
++
++def render_thinking_tree(
++    steps: list[str],
++    goal: str | None = None,
++    elapsed: float | None = None,
++    max_steps: int = MAX_TREE_STEPS,
++) -> str:
+     """Render the trace as a compact tree, newest steps last.
+ 
+-    Overflow folds into a ``\u2026 (N earlier steps)`` node, matching the
+-    step-granularity live trace of the Pi TUI.
++    ``elapsed`` adds the liveness timer to the header (``· 0:42``); ``goal``
++    renders as a bold top line under the header.  Overflow folds into a
++    ``… (N earlier steps)`` node, matching the step-granularity live trace
++    of the Pi TUI.
+     """
+-    lines = [_TREE_HEADER]
++    header = _TREE_HEADER
++    if elapsed is not None:
++        header = f"{header} \u00b7 {format_elapsed(elapsed)}"
++    lines = [header]
++    if goal:
++        lines.append(f"\u25b8 **{goal}**")
+     shown = steps[-max_steps:] if max_steps > 0 else []
+     hidden = len(steps) - len(shown)
+     if hidden > 0:
+@@ -88,60 +151,199 @@
+     return "\n".join(lines)
+ 
+ 
+-async def handle_pi_thinking(
++def _render(trace: _LiveTrace, now: float) -> str:
++    """Render a trace's current tree text, including the live timer."""
++    return render_thinking_tree(
++        trace.steps, goal=trace.goal, elapsed=now - trace.started_ts
++    )
++
++
++def _touch_trace(
+     client: TelegramClient,
+     user_id: int,
+     thread_id: int | None,
+     chat_id: int,
+-    step_text: str,
+-) -> None:
+-    """Fold one thinking block into the topic's temporary trace bubble.
+-
+-    First block sends the bubble; later blocks edit it in place, rate-limited
+-    by EDIT_MIN_SECS (the final delete is never rate-limited).
+-    """
+-    step = normalize_step(step_text)
+-    if not step:
+-        return
+-
++) -> tuple[tuple[int, int], _LiveTrace, float]:
++    """Fetch-or-create the topic trace and stamp liveness fields."""
+     key = (user_id, thread_key(thread_id))
+     trace = _traces.setdefault(key, _LiveTrace())
+-    trace.steps.append(step)
++    now = time.monotonic()
++    if trace.started_ts == 0.0:
++        trace.started_ts = now
++    trace.last_activity_ts = now
++    trace.client = client
+     trace.chat_id = chat_id
++    return key, trace, now
++
+ 
+-    text = render_thinking_tree(trace.steps)
++async def _push_update(
++    trace: _LiveTrace, thread_id: int | None, now: float
++) -> None:
++    """Send the trace bubble on first content, else edit it in place.
+ 
++    First send is silent (dotfiles low-noise patch): the trace is ephemeral
++    by design — edited in place, deleted when the final answer lands — so it
++    must never notify.  Edits are rate-limited by EDIT_MIN_SECS and skipped
++    when the rendered text is unchanged (the final delete is never
++    rate-limited).
++    """
++    text = _render(trace, now)
+     if trace.message_id is None:
+-        # Silent on first send (dotfiles low-noise patch): the trace is
+-        # ephemeral by design — edited in place, deleted when the final
+-        # answer lands — so it must never notify. Edits and deletes do not
+-        # notify either; only the final answer (normal path) may notify.
+         sent = await safe_send(
+-            client,
+-            chat_id,
++            trace.client,
++            trace.chat_id,
+             text,
+             message_thread_id=thread_id,
+             disable_notification=True,
+         )
+         if sent is not None:
+             trace.message_id = sent.message_id
+-            trace.last_edit_ts = time.monotonic()
++            trace.last_edit_ts = now
++            trace.last_rendered = text
+         return
+ 
+-    now = time.monotonic()
++    if text == trace.last_rendered:
++        return
+     if now - trace.last_edit_ts < EDIT_MIN_SECS:
+         return
+     edited = await edit_with_fallback(
+-        client, chat_id, trace.message_id, text
++        trace.client, trace.chat_id, trace.message_id, text
+     )
+     if edited:
+         trace.last_edit_ts = now
++        trace.last_rendered = text
+     else:
+         # Bubble vanished (topic cleaned, message deleted); resend fresh.
+         trace.message_id = None
+         trace.last_edit_ts = 0.0
+ 
+ 
++def _ensure_ticker() -> None:
++    """Start the liveness ticker if it is not running (needs a live loop)."""
++    global _tick_task
++    try:
++        loop = asyncio.get_running_loop()
++    except RuntimeError:
++        return
++    if _tick_task is None or _tick_task.done():
++        _tick_task = loop.create_task(_ticker())
++
++
++async def _ticker() -> None:
++    """Refresh live traces (timer) and sweep idle ones until none remain."""
++    global _tick_task
++    try:
++        while _traces:
++            await asyncio.sleep(TICK_SECS)
++            await tick_once()
++    except Exception:
++        logger.exception("Pi thinking trace ticker crashed")
++    finally:
++        _tick_task = None
++
++
++async def tick_once(now: float | None = None) -> None:
++    """One liveness sweep over all traces.
++
++    - Idle sweep: a trace with no thinking/goal activity for IDLE_SECS has
++      its bubble deleted and its state dropped (killed turns leave no
++      orphan bubble).
++    - Timer refresh: a live trace whose edit throttle has elapsed is
++      re-rendered (the header timer advances even when no new JSONL
++      message arrived).  Edits never notify.
++    """
++    now = time.monotonic() if now is None else now
++    for key, trace in list(_traces.items()):
++        if now - trace.last_activity_ts > IDLE_SECS:
++            _traces.pop(key, None)
++            if (
++                trace.client is not None
++                and trace.message_id is not None
++                and trace.chat_id is not None
++            ):
++                with contextlib.suppress(TelegramError):
++                    await trace.client.delete_message(
++                        chat_id=trace.chat_id, message_id=trace.message_id
++                    )
++            logger.info(
++                "Deleted idle Pi thinking trace",
++                user_id=key[0],
++                thread_id=key[1],
++            )
++            continue
++        if (
++            trace.client is None
++            or trace.message_id is None
++            or trace.chat_id is None
++        ):
++            continue
++        if now - trace.last_edit_ts < EDIT_MIN_SECS:
++            continue
++        text = _render(trace, now)
++        if text == trace.last_rendered:
++            continue
++        edited = await edit_with_fallback(
++            trace.client, trace.chat_id, trace.message_id, text
++        )
++        if edited:
++            trace.last_edit_ts = now
++            trace.last_rendered = text
++        else:
++            # Bubble vanished; the next activity resends it fresh.
++            trace.message_id = None
++            trace.last_edit_ts = 0.0
++
++
++async def handle_pi_thinking(
++    client: TelegramClient,
++    user_id: int,
++    thread_id: int | None,
++    chat_id: int,
++    step_text: str,
++) -> None:
++    """Fold one thinking block into the topic's temporary trace bubble.
++
++    First block sends the bubble; later blocks edit it in place, rate-limited
++    by EDIT_MIN_SECS (the final delete is never rate-limited).
++    """
++    step = normalize_step(step_text)
++    if not step:
++        return
++
++    _key, trace, now = _touch_trace(client, user_id, thread_id, chat_id)
++    trace.steps.append(step)
++    _ensure_ticker()
++    await _push_update(trace, thread_id, now)
++
++
++async def handle_pi_goal(
++    client: TelegramClient,
++    user_id: int,
++    thread_id: int | None,
++    chat_id: int,
++    goal_text: str,
++) -> None:
++    """Fold mid-turn assistant text into the tree as the bold goal line.
++
++    The text block of a ``stopReason="toolUse"`` assistant message is the
++    model narrating its current step; it updates the tree's top line
++    (markdown-stripped, single-line) instead of becoming a separate
++    notifying progress message.
++    """
++    goal = " ".join(_strip_markdown(goal_text or "").split())
++    if not goal:
++        return
++    if len(goal) > MAX_GOAL_CHARS:
++        goal = goal[:MAX_GOAL_CHARS].rstrip() + "\u2026"
++
++    _key, trace, now = _touch_trace(client, user_id, thread_id, chat_id)
++    if goal == trace.goal:
++        return
++    trace.goal = goal
++    _ensure_ticker()
++    await _push_update(trace, thread_id, now)
++
++
+ async def clear_pi_thinking(
+     client: TelegramClient,
+     user_id: int,
+@@ -170,5 +372,9 @@
+ 
+ 
+ def clear_all_traces() -> None:
+-    """Drop all trace state (called on shutdown / in tests)."""
++    """Drop all trace state and stop the ticker (shutdown / tests)."""
++    global _tick_task
+     _traces.clear()
++    if _tick_task is not None and not _tick_task.done():
++        _tick_task.cancel()
++    _tick_task = None
+diff -ruN a/ccgram/providers/pi_format.py b/ccgram/providers/pi_format.py
+--- a/ccgram/providers/pi_format.py	2026-08-15 23:31:24.813745884 -0400
++++ b/ccgram/providers/pi_format.py	2026-08-15 23:31:54.644833142 -0400
+@@ -22,6 +22,10 @@
+ stamped ``phase="pi-final"`` when the message carries a terminal stopReason
+ (anything but ``toolUse``), which is the signal to delete that trace before
+ the answer is delivered — matching Pi's own live-transcript behaviour.
++Mid-turn assistant text (stopReason ``toolUse``) is stamped
++``phase="pi-live-goal"`` so the pipeline folds it into the tree as the bold
++goal/top line instead of a separate notifying progress message (dotfiles
++thinking-tree-live patch).
+ """
+ 
+ from __future__ import annotations
+@@ -205,9 +209,11 @@
+ 
+     ``final`` marks the message as turn-terminal (stopReason != "toolUse");
+     text messages then carry ``phase="pi-final"`` so the pipeline can retire
+-    the temporary thinking trace before delivering the answer.
++    the temporary thinking trace before delivering the answer.  Mid-turn
++    text carries ``phase="pi-live-goal"`` so it folds into the tree as the
++    goal/top line (thinking-tree-live patch).
+     """
+-    text_phase = "pi-final" if final else None
++    text_phase = "pi-final" if final else "pi-live-goal"
+     if isinstance(content, str):
+         if content.strip():
+             return [

--- a/ccgram-prototype/pi-renderer-patch.sh
+++ b/ccgram-prototype/pi-renderer-patch.sh
@@ -22,10 +22,20 @@
 #      offsets reset whenever a session's transcript path changes, and the
 #      nested-session primary preservation no longer pins reused Pi windows
 #      to the previous tenant's transcript.
+#   4. ccgram-4.5.2-pi-thinking-tree-live.patch
+#      Thinking-tree liveness: live elapsed timer in the trace header plus a
+#      background ticker that re-renders the bubble at the edit cadence even
+#      when no new JSONL message arrived; CCGRAM_PI_TRACE_EDIT_SECS /
+#      _TICK_SECS / _IDLE_SECS env knobs; mid-turn assistant text
+#      (stopReason=toolUse) folds into the tree as the bold goal line
+#      instead of a separate notifying message; idle-timeout deletion of
+#      stale trace bubbles (default 10 min).
 #
 # Patch 2's context includes files added/edited by patch 1, so patch 2 only
 # applies on top of patch 1; patch 3 touches disjoint files and applies on
-# top of either. Rollback reverses the stack in reverse order.
+# top of either; patch 4 edits files from patch 1, so it applies on top of
+# patch 1 (with or without 2 and 3). Rollback reverses the stack in reverse
+# order.
 # This script makes the hot-patches tracked, idempotent, and reversible.
 #
 # Usage:
@@ -53,6 +63,7 @@ PATCH_NAMES=(
     ccgram-4.5.2-pi-renderer-parity.patch
     ccgram-4.5.2-low-noise-notifications.patch
     ccgram-4.5.2-pi-transcript-binding.patch
+    ccgram-4.5.2-pi-thinking-tree-live.patch
 )
 
 patch_file() { printf '%s/patches/%s\n' "$PKG_DIR" "$1"; }
@@ -166,12 +177,32 @@ has_no_markers_transcript_binding() {
         && ! grep -q 'Stale path from a previous session' "$sp/ccgram/session_resolver.py"
 }
 
+has_markers_thinking_tree_live() {
+    local sp="$1"
+    grep -q 'CCGRAM_PI_TRACE_EDIT_SECS' \
+            "$sp/ccgram/handlers/messaging_pipeline/pi_live_transcript.py" 2>/dev/null \
+        && grep -q 'pi-live-goal' "$sp/ccgram/providers/pi_format.py" \
+        && grep -q 'handle_pi_goal' \
+            "$sp/ccgram/handlers/messaging_pipeline/message_routing.py"
+}
+
+has_no_markers_thinking_tree_live() {
+    local sp="$1"
+    ! { [[ -f "$sp/ccgram/handlers/messaging_pipeline/pi_live_transcript.py" ]] \
+            && grep -q 'CCGRAM_PI_TRACE_EDIT_SECS' \
+                "$sp/ccgram/handlers/messaging_pipeline/pi_live_transcript.py"; } \
+        && ! grep -q 'pi-live-goal' "$sp/ccgram/providers/pi_format.py" \
+        && ! grep -q 'handle_pi_goal' \
+            "$sp/ccgram/handlers/messaging_pipeline/message_routing.py"
+}
+
 marker_fn() {
     # Echo the marker function base name for a patch file name.
     case "$1" in
         ccgram-4.5.2-pi-renderer-parity.patch) echo "renderer_parity" ;;
         ccgram-4.5.2-low-noise-notifications.patch) echo "low_noise" ;;
         ccgram-4.5.2-pi-transcript-binding.patch) echo "transcript_binding" ;;
+        ccgram-4.5.2-pi-thinking-tree-live.patch) echo "thinking_tree_live" ;;
         *) echo "FAIL: no marker functions registered for patch '$1'" >&2; exit 2 ;;
     esac
 }

--- a/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
+++ b/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
@@ -61,6 +61,7 @@ os.environ.setdefault("CCGRAM_QUIET_PROGRESS", "true")
 # drive tick_once() directly); idle-timeout deletion stays at the default.
 os.environ.setdefault("CCGRAM_PI_TRACE_EDIT_SECS", "1.0")
 os.environ.setdefault("CCGRAM_PI_TRACE_TICK_SECS", "3600")
+os.environ.setdefault("CCGRAM_PI_TRACE_WRAP_CHARS", "48")
 
 
 def _find_site_packages() -> Path:
@@ -363,11 +364,13 @@ class PiRendererParityTest(unittest.TestCase):
     # ── 5. Thinking-tree liveness (patch layer 4) ────────────────────────
 
     def test_liveness_env_knobs(self):
-        # CCGRAM_PI_TRACE_EDIT_SECS=1.0 / _TICK_SECS=3600 set at module
-        # import (top of file); the idle-timeout default is 10 minutes.
+        # CCGRAM_PI_TRACE_EDIT_SECS=1.0 / _TICK_SECS=3600 / _WRAP_CHARS=48
+        # set at module import (top of file); the idle-timeout default is
+        # 10 minutes.
         self.assertEqual(self.trace.EDIT_MIN_SECS, 1.0)
         self.assertEqual(self.trace.TICK_SECS, 3600.0)
         self.assertEqual(self.trace.IDLE_SECS, 600.0)
+        self.assertEqual(self.trace.WRAP_CHARS, 48)
 
     def test_header_shows_live_elapsed_timer(self):
         tree = self.trace.render_thinking_tree(["step"], elapsed=42.7)
@@ -392,6 +395,68 @@ class PiRendererParityTest(unittest.TestCase):
         lines = tree.splitlines()
         self.assertTrue(lines[1].startswith("▸ **"))
         self.assertTrue(lines[2].startswith("├─"))
+
+    def test_wrap_segments_word_wraps_and_hard_cuts(self):
+        ws = self.trace.wrap_segments
+        # Fits: single segment.
+        self.assertEqual(ws(3, "short", 48), ["short"])
+        # Word-boundary break: never splits a word that fits.
+        segs = ws(3, "alpha beta gamma delta epsilon", 14)
+        self.assertTrue(all(len(seg) <= 11 for seg in segs))
+        self.assertEqual(" ".join(segs), "alpha beta gamma delta epsilon")
+        # Unbreakable over-long word: hard-cut at the available width.
+        segs = ws(3, "x" * 30, 13)
+        self.assertEqual(segs, ["x" * 10, "x" * 10, "x" * 10])
+        # Width 0 disables wrapping.
+        self.assertEqual(ws(3, "a " * 50, 0), ["a " * 50])
+
+    def test_long_step_wraps_with_hanging_indent(self):
+        step = (
+            "Checking whether the transcript binding race fix holds for "
+            "reused session directories across consecutive worker spawns"
+        )
+        tree = self.trace.render_thinking_tree([step], wrap_chars=48)
+        step_lines = [l for l in tree.splitlines() if "Checking" in l or l.startswith("   ")]
+        self.assertGreater(len(step_lines), 1)  # actually wrapped
+        self.assertTrue(step_lines[0].startswith("├─ "))
+        for cont in step_lines[1:]:
+            # Continuation aligns under the node's text column, so the
+            # tree shape survives Telegram's phone-width wrapping.
+            self.assertTrue(cont.startswith("   "), cont)
+            self.assertNotIn("├─", cont)
+        for line in step_lines:
+            self.assertLessEqual(len(line), 48, line)
+        # No text lost: stripping prefixes/indent reassembles the step.
+        reassembled = " ".join(
+            l.removeprefix("├─ ").strip() for l in step_lines
+        )
+        self.assertEqual(reassembled, step)
+
+    def test_long_goal_wraps_bold_segments_with_hanging_indent(self):
+        goal = (
+            "Refactoring the message routing pipeline so mid-turn assistant "
+            "text folds into the thinking tree instead of notifying"
+        )
+        tree = self.trace.render_thinking_tree(["step"], goal=goal, wrap_chars=48)
+        goal_lines = [l for l in tree.splitlines() if "**" in l]
+        self.assertGreater(len(goal_lines), 1)
+        self.assertTrue(goal_lines[0].startswith("▸ **"))
+        for cont in goal_lines[1:]:
+            self.assertTrue(cont.startswith("  **"), cont)
+            self.assertNotIn("▸", cont)
+        for line in goal_lines:
+            # Displayed width excludes the non-rendering ** markers.
+            self.assertLessEqual(len(line) - 4, 48, line)
+        reassembled = " ".join(
+            l.removeprefix("▸ ").strip().strip("*") for l in goal_lines
+        )
+        self.assertEqual(reassembled, goal)
+
+    def test_wrap_disabled_keeps_single_lines(self):
+        tree = self.trace.render_thinking_tree(
+            ["s " * 60], goal="g " * 60, wrap_chars=0
+        )
+        self.assertEqual(len(tree.splitlines()), 4)  # header, goal, step, spinner
 
     def test_mid_turn_text_folds_into_goal_line_no_new_message(self):
         trace = self.trace

--- a/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
+++ b/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
@@ -19,6 +19,12 @@ Coverage:
      silent and notifying tasks never merge.
   4. Wiring: patched message_routing routes pi-live/pi-final phases and
      flags user echoes silent; the status bubble send honors quiet_progress.
+  5. Thinking-tree liveness (patch layer 4): live elapsed timer in the
+     tree header; CCGRAM_PI_TRACE_EDIT_SECS/_TICK_SECS/_IDLE_SECS env knobs;
+     mid-turn assistant text (stopReason toolUse) stamped pi-live-goal and
+     folded into the tree as the bold goal line (no separate message, no
+     notification); ticker timer refresh without new steps; idle-timeout
+     deletion of stale trace bubbles.
 """
 
 from __future__ import annotations
@@ -35,10 +41,12 @@ import unittest
 from pathlib import Path
 
 PKG_DIR = Path(__file__).resolve().parent.parent
-# Patch stack, in apply order (patch 2's context depends on patch 1).
+# Patch stack, in apply order (patch 2's context depends on patch 1;
+# patch 4 edits files added by patch 1).
 PATCH_FILES = [
     PKG_DIR / "patches" / "ccgram-4.5.2-pi-renderer-parity.patch",
     PKG_DIR / "patches" / "ccgram-4.5.2-low-noise-notifications.patch",
+    PKG_DIR / "patches" / "ccgram-4.5.2-pi-thinking-tree-live.patch",
 ]
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "pi_turn.jsonl"
 
@@ -48,6 +56,11 @@ os.environ.setdefault("TELEGRAM_BOT_TOKEN", "0:offline-fixture-placeholder")
 os.environ.setdefault("ALLOWED_USERS", "123")
 # Low-noise mode under test: user echoes + status bubble go silent.
 os.environ.setdefault("CCGRAM_QUIET_PROGRESS", "true")
+# Liveness knobs under test (layer 4): 1s edit cadence like the prototype
+# env; a long tick so the background ticker never fires mid-test (tests
+# drive tick_once() directly); idle-timeout deletion stays at the default.
+os.environ.setdefault("CCGRAM_PI_TRACE_EDIT_SECS", "1.0")
+os.environ.setdefault("CCGRAM_PI_TRACE_TICK_SECS", "3600")
 
 
 def _find_site_packages() -> Path:
@@ -86,7 +99,20 @@ def _prepare_patched_copy() -> Path:
         ).read_text(encoding="utf-8")
         return "CCGRAM_QUIET_PROGRESS" in cfg and "silent: bool = False" in task
 
-    marker_checks = [renderer_parity_applied, low_noise_applied]
+    def thinking_tree_live_applied(root: Path) -> bool:
+        live = root / "ccgram/handlers/messaging_pipeline/pi_live_transcript.py"
+        fmt = root / "ccgram/providers/pi_format.py"
+        return (
+            live.exists()
+            and "CCGRAM_PI_TRACE_EDIT_SECS" in live.read_text(encoding="utf-8")
+            and "pi-live-goal" in fmt.read_text(encoding="utf-8")
+        )
+
+    marker_checks = [
+        renderer_parity_applied,
+        low_noise_applied,
+        thinking_tree_live_applied,
+    ]
 
     for patch_file, applied_check in zip(PATCH_FILES, marker_checks):
         if applied_check(tmp):
@@ -134,7 +160,7 @@ class _FakeClient:
 
     async def edit_message_text(self, chat_id, message_id, text, **kwargs):
         self.edited.append(
-            {"chat_id": chat_id, "message_id": message_id, "text": text}
+            {"chat_id": chat_id, "message_id": message_id, "text": text, **kwargs}
         )
         return _FakeMessage(message_id)
 
@@ -198,7 +224,9 @@ class PiRendererParityTest(unittest.TestCase):
         # Terminal error notice also retires the trace.
         self.assertIn("⚠ API error: provider rate limited", texts)
 
-    def test_mid_turn_text_and_tool_calls_keep_no_phase(self):
+    def test_mid_turn_text_is_stamped_pi_live_goal(self):
+        # Layer 4: mid-turn assistant text (stopReason toolUse) folds into
+        # the thinking tree as the goal line instead of a separate message.
         msgs = self._parse_fixture()
         mid_turn = [
             m
@@ -206,7 +234,7 @@ class PiRendererParityTest(unittest.TestCase):
             if m.content_type == "text" and "I found the cause" in m.text
         ]
         self.assertEqual(len(mid_turn), 1)
-        self.assertIsNone(mid_turn[0].phase)
+        self.assertEqual(mid_turn[0].phase, "pi-live-goal")
 
         tool_msgs = [m for m in msgs if m.content_type in ("tool_use", "tool_result")]
         self.assertEqual(len(tool_msgs), 4)  # read+result, edit+result
@@ -332,6 +360,138 @@ class PiRendererParityTest(unittest.TestCase):
         other_silent = ct(window_id="w", parts=("c",), silent=True)
         self.assertTrue(self.message_queue._can_merge_tasks(silent, other_silent))
 
+    # ── 5. Thinking-tree liveness (patch layer 4) ────────────────────────
+
+    def test_liveness_env_knobs(self):
+        # CCGRAM_PI_TRACE_EDIT_SECS=1.0 / _TICK_SECS=3600 set at module
+        # import (top of file); the idle-timeout default is 10 minutes.
+        self.assertEqual(self.trace.EDIT_MIN_SECS, 1.0)
+        self.assertEqual(self.trace.TICK_SECS, 3600.0)
+        self.assertEqual(self.trace.IDLE_SECS, 600.0)
+
+    def test_header_shows_live_elapsed_timer(self):
+        tree = self.trace.render_thinking_tree(["step"], elapsed=42.7)
+        self.assertEqual(tree.splitlines()[0], "🧠 Thinking… · 0:42")
+        # Without elapsed the header is unchanged (static render).
+        bare = self.trace.render_thinking_tree(["step"])
+        self.assertEqual(bare.splitlines()[0], "🧠 Thinking…")
+        self.assertEqual(self.trace.format_elapsed(0), "0:00")
+        self.assertEqual(self.trace.format_elapsed(65), "1:05")
+        self.assertEqual(self.trace.format_elapsed(600), "10:00")
+
+    def test_goal_line_markdown_stripped_and_bold(self):
+        self.assertEqual(
+            self.trace._strip_markdown("Fix **parser** `race` ~~now~~"),
+            "Fix parser race now",
+        )
+        tree = self.trace.render_thinking_tree(
+            ["step"], goal="Fix parser race now", elapsed=1
+        )
+        self.assertIn("▸ **Fix parser race now**", tree)
+        # Goal sits directly under the header, above the step nodes.
+        lines = tree.splitlines()
+        self.assertTrue(lines[1].startswith("▸ **"))
+        self.assertTrue(lines[2].startswith("├─"))
+
+    def test_mid_turn_text_folds_into_goal_line_no_new_message(self):
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "first step"))
+        self.assertEqual(len(client.sent), 1)
+
+        # Mid-turn assistant text (stopReason toolUse) edits the SAME
+        # bubble's goal line: no separate message, no notification.
+        key = (1, 42)
+        trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(
+            trace.handle_pi_goal(
+                client, 1, 42, -100999, "I found the **cause**; patching it now."
+            )
+        )
+        self.assertEqual(len(client.sent), 1)  # no new message
+        self.assertEqual(len(client.edited), 1)
+        self.assertEqual(client.edited[0]["message_id"], 1001)
+        # convert_to_entities strips the markdown into bold entities, so
+        # the plain text carries the stripped goal…
+        self.assertIn("▸ I found the cause; patching it now.", client.edited[0]["text"])
+        # …and the goal line is rendered bold via entities.
+        entities = client.edited[0].get("entities") or []
+        self.assertTrue(
+            any(getattr(e, "type", None) == "bold" for e in entities),
+            f"expected a bold entity on the goal line, got {entities!r}",
+        )
+
+        # Final answer still retires the bubble.
+        run(trace.clear_pi_thinking(client, 1, 42))
+        self.assertEqual(client.deleted, [{"chat_id": -100999, "message_id": 1001}])
+        trace.clear_all_traces()
+
+    def test_goal_before_any_thinking_starts_the_bubble_silently(self):
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        asyncio.run(trace.handle_pi_goal(client, 1, 42, -100999, "working on it"))
+        self.assertEqual(len(client.sent), 1)
+        self.assertIn("▸ working on it", client.sent[0]["text"])
+        self.assertIs(client.sent[0].get("disable_notification"), True)
+        trace.clear_all_traces()
+
+    def test_ticker_advances_timer_without_new_steps(self):
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "first step"))
+        self.assertEqual(len(client.edited), 0)
+
+        # Simulate 65s passing with no new completed JSONL message: the
+        # ticker still re-renders so the header timer visibly advances.
+        tr = trace._traces[(1, 42)]
+        tr.started_ts -= 65
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.tick_once())
+        self.assertEqual(len(client.edited), 1)
+        self.assertEqual(client.edited[0]["message_id"], 1001)
+        self.assertIn("🧠 Thinking… · 1:05", client.edited[0]["text"])
+        trace.clear_all_traces()
+
+    def test_ticker_respects_edit_throttle(self):
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "first step"))
+
+        # Timer text would change, but the edit throttle has not elapsed.
+        tr = trace._traces[(1, 42)]
+        tr.started_ts -= 65
+        run(trace.tick_once())
+        self.assertEqual(len(client.edited), 0)
+        trace.clear_all_traces()
+
+    def test_idle_cleanup_deletes_stale_bubble(self):
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "first step"))
+
+        # Turn died mid-thinking: no activity for more than IDLE_SECS.
+        trace._traces[(1, 42)].last_activity_ts -= trace.IDLE_SECS + 1
+        run(trace.tick_once())
+        self.assertEqual(client.deleted, [{"chat_id": -100999, "message_id": 1001}])
+        self.assertNotIn((1, 42), trace._traces)
+
+        # A live trace in another topic is untouched by the same sweep.
+        run(trace.handle_pi_thinking(client, 1, 77, -100999, "fresh step"))
+        run(trace.tick_once())
+        self.assertIn((1, 77), trace._traces)
+        self.assertEqual(len(client.deleted), 1)
+        trace.clear_all_traces()
+
     # ── 4. Routing wiring ────────────────────────────────────────────────
 
     def test_routing_wires_pi_phases(self):
@@ -342,6 +502,15 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertIn("clear_pi_thinking(client, user_id, thread_id)", src)
         self.assertIn('msg.phase == PI_LIVE_PHASE', src)
         self.assertIn('msg.phase == PI_FINAL_PHASE', src)
+
+    def test_routing_folds_mid_turn_text_into_tree(self):
+        # Layer 4: pi-live-goal text routes into the tree (and continues,
+        # so it never becomes a separate progress message).
+        src = (
+            self.tmp / "ccgram/handlers/messaging_pipeline/message_routing.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("handle_pi_goal(client, user_id, thread_id, chat_id, msg.text)", src)
+        self.assertIn("msg.phase == PI_GOAL_PHASE", src)
 
     def test_routing_flags_user_echoes_silent_under_quiet_progress(self):
         src = (

--- a/ccgram-prototype/validate.sh
+++ b/ccgram-prototype/validate.sh
@@ -70,7 +70,7 @@ else
     fail=1
 fi
 
-echo "==> Pi patch stack (renderer parity + low-noise + transcript binding): applies cleanly + offline fixture tests"
+echo "==> Pi patch stack (renderer parity + low-noise + transcript binding + thinking-tree-live): applies cleanly + offline fixture tests"
 PATCH_SH="$PKG_DIR/pi-renderer-patch.sh"
 CCGRAM_PY="$HOME/.local/share/uv/tools/ccgram/bin/python"
 if [[ ! -x "$CCGRAM_PY" ]]; then


### PR DESCRIPTION
## Summary

Short-term local ccgram thinking-tree improvements from the mobile plan and the [tree-rendering audit](https://github.com/aviralmansingka/dotfiles) (`ccgram-tree-rendering-audit` report, §6 P1/P2/P3/P5). Goal: make ccgram's worker-topic thinking tree feel much closer to the `avirus` Firstmate Telegram frontdoor on mobile, while keeping the low-noise posture (no tool-call messages, no interim notifications, one normal final-answer notification).

Adds **patch layer 4** — `ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch` — on top of the existing PR145/146/147 stack:

1. **Live elapsed timer / liveness affordance** — trace header becomes `🧠 Thinking… · 0:42`; a per-trace background ticker re-renders the bubble at the edit cadence even when no new completed JSONL message has arrived. Ticker stops when no traces remain; edits never notify.
2. **1s edit cadence knob** — `CCGRAM_PI_TRACE_EDIT_SECS` (default `2.0`); prototype env example sets `1.0`, matching the frontdoor's coalescing interval. Also `CCGRAM_PI_TRACE_TICK_SECS` (default `1.0`) and `CCGRAM_PI_TRACE_IDLE_SECS` (default `600`).
3. **Mid-turn text folds into the tree** — assistant text blocks with `stopReason="toolUse"` are stamped `phase="pi-live-goal"` and update the tree's bold goal/top line (`▸ **…**`, markdown-stripped) instead of becoming separate notifying progress messages. Removes the last interim-notification gap.
4. **Idle cleanup** — a turn that dies mid-thinking with no final answer has its stale bubble deleted after `CCGRAM_PI_TRACE_IDLE_SECS` (default 10 min).
5. **Mobile wrap-aware tree** (captain review follow-up) — goal/step lines word-wrap at `CCGRAM_PI_TRACE_WRAP_CHARS` columns (default `48`, a phone-width approximation; `0` disables) with a hanging indent under the node prefix: wrapped steps continue aligned under their `├─` text column and wrapped goal segments under the `▸` text column (bold per segment), so the tree shape survives Telegram's own line wrapping. The 120-char node caps remain the hard truncation ceiling.

Tool calls stay suppressed/non-notifying (`CCGRAM_HIDE_TOOL_CALLS=true`), the final answer stays normal/notifying, and trace create/edit/delete stay silent. Observe-only posture unchanged — no launch/kill/recovery/steering behavior added.

## Patch mechanics

- `pi-renderer-patch.sh` registers layer 4 (`PATCH_NAMES`, marker functions); `status`/`check`/`apply`/`rollback` verified against the installed ccgram 4.5.2 tool: layers 1–3 show `applied`, layer 4 `not-applied`, `check` scratch-verifies layer 4 applies cleanly, and apply+rollback on a scratch copy round-trips byte-identical.
- `README.md` (files table, new "Thinking-tree liveness" section, updated low-noise matrix, smoke plan, parity gaps), `.config/ccgram-prototype.env.example`, `validate.sh` updated.
- Offline fixture tests extended (24 tests, all passing): timer header render, `format_elapsed`, env knobs, markdown-stripped bold goal line (entity asserted), mid-turn text folding with **no separate message**, goal-before-thinking silent first send, ticker timer advance without new steps, edit-throttle respect, idle-timeout deletion, mobile wrap-aware rendering (long goal/step hanging-indent wrap, lossless reassembly, width cap, disable-at-0), routing wiring. `ccgram-prototype/validate.sh` passes end-to-end (28 tests).

## Deploy steps (post-merge, not done here)

1. `cd ~/dotfiles/ccgram-prototype && ./pi-renderer-patch.sh apply`
2. Add `CCGRAM_PI_TRACE_EDIT_SECS=1.0` to `~/.config/ccgram-prototype.env`
3. `systemctl --user restart ccgram-prototype.service`

## Live smoke plan (only when explicitly authorized)

No Telegram messages were sent and nothing live was tested for this PR.

1. Confirm env: `grep -E 'HIDE_TOOL_CALLS|QUIET_PROGRESS|HIDE_THINKING|EPHEMERAL|PI_TRACE' ~/.config/ccgram-prototype.env`; `./pi-renderer-patch.sh status` shows all four layers applied.
2. Let Firstmate dispatch one small worker task (or wait for the next one).
3. Expected in the worker's topic: 👤 brief echo silent; 🧠 tree appears/updates silently; header timer visibly advances at ~1s cadence during dead windows; mid-turn narration appears as the bold `▸` goal line inside the tree (no separate message); long goal/step lines wrap with a hanging indent that keeps the tree shape intact on a phone; no tool-call messages; when the turn ends the bubble is deleted and **exactly one final-answer message notifies**.
4. Kill a worker mid-turn: orphaned trace bubble disappears within `CCGRAM_PI_TRACE_IDLE_SECS` (default 10 min).
5. `journalctl --user -u ccgram-prototype.service -f`: no patch tracebacks, no `RetryAfter` over a soak turn.

## Notes

- `fm-ensure-agents-md.sh` reports a **pre-existing** repo conflict (`AGENTS.md` and `CLAUDE.md` are both real files); left untouched as out of scope. Durable knowledge from this task lives in `ccgram-prototype/README.md`.
- Known structural gap carried unchanged: JSONL has only complete messages, so true token streaming (audit U1) remains upstream work; the timer ticker keeps the bubble visibly alive during long thinking blocks but cannot show new content.