### PR TITLE
ccgram-prototype: fix mobile thinking tree — goal/thinking dedupe + 36-col wrap

### DIFF
--- a/ccgram-prototype/.config/ccgram-prototype.env.example
+++ b/ccgram-prototype/.config/ccgram-prototype.env.example
@@ -70,10 +70,13 @@ CCGRAM_PI_TRACE_EDIT_SECS=1.0
 # answer arrives for this long (default 600 = 10 minutes).
 # CCGRAM_PI_TRACE_IDLE_SECS=600
 # Mobile wrap-aware tree: goal/step lines word-wrap at this many columns
-# (default 48, a phone-width approximation) with a hanging indent under the
-# node prefix so the tree shape survives Telegram's own wrapping on phones.
+# (default 36) with a hanging indent under the node prefix so the tree
+# shape survives Telegram's own wrapping on phones. Telegram mobile wraps
+# by pixels in a proportional font; a phone bubble fits roughly 35-44
+# Latin chars, so 36 keeps intentional breaks ahead of Telegram's re-wrap
+# (48 was wider than a phone bubble and shattered the tree on mobile).
 # 0 disables intentional wrapping.
-# CCGRAM_PI_TRACE_WRAP_CHARS=48
+# CCGRAM_PI_TRACE_WRAP_CHARS=36
 
 # Default provider for NEW sessions is irrelevant in observe-only mode
 # (ccgram auto-detects pi from pane processes). Leave unset.

--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -40,7 +40,7 @@ already publish agent sessions that ccgram discovers with zero code changes.
 | `patches/ccgram-4.5.2-pi-renderer-parity.patch` | Tracked unified diff, layer 1: patches the installed ccgram 4.5.2 Pi renderer (thinking + tool-call + final-answer flow). Not deployed by stow. |
 | `patches/ccgram-4.5.2-low-noise-notifications.patch` | Tracked unified diff, layer 2 (applies on top of layer 1): final-answer-only notifications (silent thinking trace, quiet-progress mode). Not deployed by stow. |
 | `patches/ccgram-4.5.2-pi-transcript-binding.patch` | Tracked unified diff, layer 3 (disjoint files): fixes the SessionStart transcript-binding race for reused session directories (exact-match-only binding, deferred pending resolution, offset reset on path change). Not deployed by stow. |
-| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): thinking-tree liveness — live elapsed timer + ticker, `CCGRAM_PI_TRACE_*` cadence/idle knobs, mid-turn text folded into the tree as the goal line, idle-timeout bubble deletion. Not deployed by stow. |
+| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): thinking-tree liveness — live elapsed timer + ticker, `CCGRAM_PI_TRACE_*` cadence/idle/wrap knobs, mid-turn text folded into the tree as the goal line, same-message goal/thinking paraphrase dedupe, idle-timeout bubble deletion. Not deployed by stow. |
 | `.local/bin/ccgram-pi-hook` | Pi hook shim: waits (self-bounded) for the session's OWN transcript file at SessionStart, injects the exact `transcript_path`, delegates to `ccgram hook --provider pi`. Deployed by stow. |
 | `.pi/agent/extensions/hooks.json` | cc-thingz hook-runner wiring (SessionStart/Stop/SessionEnd → shim, async; SessionStart timeout raised to 20s to cover slow transcript creation). Deployed by stow. |
 | `pi-renderer-patch.sh` | Idempotent `status`/`check`/`apply`/`rollback` for the whole patch stack, with file-level backups. Not deployed by stow. |
@@ -296,9 +296,12 @@ notification while the final answer still notifies, and silent/notifying
 tasks never merge. Layer 4 adds liveness coverage: the header elapsed timer,
 the `CCGRAM_PI_TRACE_*` knobs, mid-turn text folding into the bold goal line
 (no separate message, no notification), ticker timer refresh with no new
-steps, edit-throttle respect, idle-timeout bubble deletion, and mobile
-wrap-aware rendering (long goal/step lines word-wrap with a hanging indent
-that preserves the tree shape; wrapping disabled at width 0).
+steps, edit-throttle respect, idle-timeout bubble deletion, same-message
+goal/thinking paraphrase dedupe (a line-14-style thinking+text paraphrase
+renders once, as the goal; a divergent thinking+text pair keeps both), and
+mobile wrap-aware rendering (long goal/step lines word-wrap with a hanging
+indent that preserves the tree shape at the 36-char phone-safe width;
+wrapping disabled at width 0).
 
 ### Live smoke plan (only when explicitly authorized)
 
@@ -377,10 +380,20 @@ ever contains complete messages — and stays out of scope):
 - **Idle-timeout deletion.** If a turn dies mid-thinking (kill -9, network
   drop) and no final answer arrives, the stale bubble is deleted after
   `CCGRAM_PI_TRACE_IDLE_SECS` (default `600` = 10 minutes).
+- **Same-message goal/thinking dedupe.** Some models emit a mid-turn
+  visible text block that paraphrases their own thinking block in the same
+  assistant message. `pi_format` compares the two blocks of each message
+  and drops a thinking block whose first line near-duplicates the goal
+  text (shared opening of 3+ words plus a shared 20+ char phrase), so the
+  tree shows the statement once — as the bold goal line — instead of as
+  adjacent goal + `├─` step twins. Thinking-only messages and genuinely
+  distinct thinking+text messages keep both entries.
 - **Mobile wrap-aware tree.** Goal and step lines are word-wrapped at
-  `CCGRAM_PI_TRACE_WRAP_CHARS` columns (default `48`, a phone-width
-  approximation — Telegram wraps by pixels with a proportional font) with a
-  hanging indent under the node prefix: a wrapped step continues aligned
+  `CCGRAM_PI_TRACE_WRAP_CHARS` columns (default `36`; Telegram mobile
+  wraps by pixels in a proportional font and a phone bubble fits roughly
+  35–44 Latin chars, so 36 keeps intentional breaks ahead of Telegram's
+  own re-wrap — 48 was wider than a phone bubble and shattered the tree)
+  with a hanging indent under the node prefix: a wrapped step continues aligned
   under its `├─` text column and a wrapped goal under its `▸` text column
   (bold per segment), so the tree shape survives Telegram's own line
   wrapping instead of breaking into ragged full-width lines. `0` disables
@@ -392,7 +405,7 @@ ever contains complete messages — and stays out of scope):
 | `CCGRAM_PI_TRACE_EDIT_SECS` | `2.0` | `1.0` | Minimum seconds between trace-bubble edits (applies to step/goal updates and the timer ticker). |
 | `CCGRAM_PI_TRACE_TICK_SECS` | `1.0` | unset | Liveness ticker period (timer refresh + idle sweep granularity). |
 | `CCGRAM_PI_TRACE_IDLE_SECS` | `600` | unset | Delete a trace bubble with no thinking/goal activity for this long (killed-turn cleanup). |
-| `CCGRAM_PI_TRACE_WRAP_CHARS` | `48` | unset | Soft word-wrap width (in characters) for goal/step lines, with hanging indent under the node prefix; `0` disables. |
+| `CCGRAM_PI_TRACE_WRAP_CHARS` | `36` | unset | Soft word-wrap width (in characters) for goal/step lines, with hanging indent under the node prefix; `0` disables. |
 
 ### Remaining parity gaps (vs the Pi TUI)
 

--- a/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
+++ b/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
@@ -1,6 +1,6 @@
 diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handlers/messaging_pipeline/message_routing.py
---- a/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-15 23:31:24.824132529 -0400
-+++ b/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-15 23:31:58.460833554 -0400
+--- a/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-16 11:01:54.968490468 -0400
++++ b/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-16 11:02:41.281276117 -0400
 @@ -28,8 +28,10 @@
  from .message_queue import enqueue_content_message, get_message_queue
  from .pi_live_transcript import (
@@ -31,9 +31,9 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handl
              stripped = (msg.text or "").strip()
              if len(stripped) < _MIN_THINKING_LENGTH:
 diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
---- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-15 23:31:24.824153468 -0400
-+++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-15 23:40:43.935912786 -0400
-@@ -13,17 +13,42 @@
+--- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 11:01:54.968652031 -0400
++++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 11:03:42.372474875 -0400
+@@ -13,17 +13,46 @@
  Messages are marked by the Pi formatter via ``AgentMessage.phase``:
  
  - ``PI_LIVE_PHASE``  — a thinking block; folded into the temporary tree.
@@ -60,10 +60,14 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +- ``CCGRAM_PI_TRACE_TICK_SECS`` — liveness ticker period (default 1.0).
 +- ``CCGRAM_PI_TRACE_IDLE_SECS`` — idle-timeout deletion (default 600 =
 +  10 minutes).
-+- ``CCGRAM_PI_TRACE_WRAP_CHARS`` — mobile wrap width (default 48).  Goal
++- ``CCGRAM_PI_TRACE_WRAP_CHARS`` — mobile wrap width (default 36).  Goal
 +  and step lines are word-wrapped to this many columns with a hanging
 +  indent under the node prefix, so the tree shape survives Telegram's
-+  phone-width line wrapping.  0 disables intentional wrapping.
++  phone-width line wrapping.  Telegram mobile lays text out in a
++  proportional font and wraps by pixels; a phone bubble fits roughly
++  35–44 Latin characters, so 36 keeps intentional breaks ahead of
++  Telegram's own re-wrap (48 was wider than a phone bubble and shattered
++  the tree on mobile).  0 disables intentional wrapping.
 +
 +State is in-memory per (user_id, thread_id): rendered steps, the current
 +goal label, and the Telegram message id of the temporary trace bubble.
@@ -78,7 +82,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  import time
  from dataclasses import dataclass, field
  
-@@ -38,15 +63,34 @@
+@@ -38,15 +67,34 @@
  logger = structlog.get_logger()
  
  PI_LIVE_PHASE = "pi-live"
@@ -95,7 +99,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +EDIT_MIN_SECS = float(os.getenv("CCGRAM_PI_TRACE_EDIT_SECS", "2.0"))
 +TICK_SECS = float(os.getenv("CCGRAM_PI_TRACE_TICK_SECS", "1.0"))
 +IDLE_SECS = float(os.getenv("CCGRAM_PI_TRACE_IDLE_SECS", "600"))
-+WRAP_CHARS = int(os.getenv("CCGRAM_PI_TRACE_WRAP_CHARS", "48"))
++WRAP_CHARS = int(os.getenv("CCGRAM_PI_TRACE_WRAP_CHARS", "36"))
  
  _TREE_HEADER = "\U0001f9e0 Thinking\u2026"
  _TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
@@ -114,7 +118,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  
  
  @dataclass
-@@ -54,14 +98,22 @@
+@@ -54,14 +102,22 @@
      """Per-topic temporary thinking trace state."""
  
      steps: list[str] = field(default_factory=list)
@@ -137,7 +141,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  
  def normalize_step(text: str, max_chars: int = MAX_STEP_CHARS) -> str:
      """Reduce a thinking block to one compact tree node (first line)."""
-@@ -71,77 +123,277 @@
+@@ -71,77 +127,277 @@
      return first_line
  
  
@@ -443,7 +447,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  async def clear_pi_thinking(
      client: TelegramClient,
      user_id: int,
-@@ -170,5 +422,9 @@
+@@ -170,5 +426,9 @@
  
  
  def clear_all_traces() -> None:
@@ -455,30 +459,139 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +        _tick_task.cancel()
 +    _tick_task = None
 diff -ruN a/ccgram/providers/pi_format.py b/ccgram/providers/pi_format.py
---- a/ccgram/providers/pi_format.py	2026-08-15 23:31:24.813745884 -0400
-+++ b/ccgram/providers/pi_format.py	2026-08-15 23:31:54.644833142 -0400
-@@ -22,6 +22,10 @@
+--- a/ccgram/providers/pi_format.py	2026-08-16 11:01:54.968744163 -0400
++++ b/ccgram/providers/pi_format.py	2026-08-16 11:03:36.800471735 -0400
+@@ -22,11 +22,20 @@
  stamped ``phase="pi-final"`` when the message carries a terminal stopReason
  (anything but ``toolUse``), which is the signal to delete that trace before
  the answer is delivered — matching Pi's own live-transcript behaviour.
 +Mid-turn assistant text (stopReason ``toolUse``) is stamped
 +``phase="pi-live-goal"`` so the pipeline folds it into the tree as the bold
 +goal/top line instead of a separate notifying progress message (dotfiles
-+thinking-tree-live patch).
++thinking-tree-live patch).  When the same message also carries a thinking
++block whose first line paraphrases that goal text, the thinking block is
++dropped here — the goal already narrates the step, so rendering both makes
++the mobile tree show the same statement twice, adjacently.
  """
  
  from __future__ import annotations
-@@ -205,9 +209,11 @@
+ 
++import difflib
+ import json
++import re
+ from typing import Any
+ 
+ from ccgram.expandable_quote import format_expandable_quote
+@@ -195,6 +204,83 @@
+     )
+ 
+ 
++# Same-message goal/thinking paraphrase dedupe thresholds (mobile tree
++# fix).  A thinking first line is a near-duplicate of the goal when the
++# normalized texts share an opening of at least this many words AND one
++# common phrase of at least this many characters.  Requiring both keeps
++# genuinely distinct thinking+text messages (different opening, or only a
++# short incidental overlap) rendering as separate goal + step.
++_DEDUPE_PREFIX_WORDS = 3
++_DEDUPE_COMMON_CHARS = 20
++_DEDUPE_NORM_RE = re.compile(r"[^a-z0-9]+")
++
++
++def _normalize_dedupe(text: str) -> str:
++    """Lowercase, alphanumeric-only, single-spaced text for comparison."""
++    return " ".join(_DEDUPE_NORM_RE.sub(" ", text.lower()).split())
++
++
++def _common_word_prefix(a: str, b: str) -> int:
++    """Count the leading words two normalized strings share."""
++    shared = 0
++    for x, y in zip(a.split(), b.split()):
++        if x != y:
++            break
++        shared += 1
++    return shared
++
++
++def _is_goal_thinking_duplicate(goal: str, thinking: str) -> bool:
++    """True when a thinking block's first line paraphrases the goal text.
++
++    Some models emit a mid-turn visible text block that is a compressed
++    paraphrase of their own thinking block in the same assistant message
++    (e.g. goal ``Now let me check the vault's current state…`` beside
++    thinking ``Now let me look at the vault's current state…``).  Folded
++    into the tree, the pair renders as a bold goal line immediately
++    followed by a near-identical ``├─`` step.  Only the thinking's first
++    line is compared because that is all the tree step ever shows.
++    """
++    g = _normalize_dedupe(goal)
++    first_line = thinking.splitlines()[0] if thinking else ""
++    t = _normalize_dedupe(first_line)
++    if not g or not t:
++        return False
++    if _common_word_prefix(g, t) < _DEDUPE_PREFIX_WORDS:
++        return False
++    match = difflib.SequenceMatcher(None, g, t).find_longest_match(
++        0, len(g), 0, len(t)
++    )
++    return match.size >= _DEDUPE_COMMON_CHARS
++
++
++def _drop_goal_thinking_duplicates(
++    messages: list[AgentMessage],
++) -> list[AgentMessage]:
++    """Suppress thinking steps that paraphrase a same-message goal text.
++
++    Runs on one assistant message's parsed blocks (the only place both
++    blocks are visible together), so thinking-only and text-only messages
++    are unaffected, and a thinking block whose first line diverges from
++    the goal is kept as its own tree step.
++    """
++    goals = [
++        m.text
++        for m in messages
++        if m.content_type == "text" and m.phase == "pi-live-goal"
++    ]
++    if not goals:
++        return messages
++    return [
++        m
++        for m in messages
++        if not (
++            m.content_type == "thinking"
++            and any(_is_goal_thinking_duplicate(g, m.text) for g in goals)
++        )
++    ]
++
++
+ def _parse_assistant_content(
+     content: Any,
+     pending: Pending,
+@@ -205,9 +291,14 @@
  
      ``final`` marks the message as turn-terminal (stopReason != "toolUse");
      text messages then carry ``phase="pi-final"`` so the pipeline can retire
 -    the temporary thinking trace before delivering the answer.
 +    the temporary thinking trace before delivering the answer.  Mid-turn
 +    text carries ``phase="pi-live-goal"`` so it folds into the tree as the
-+    goal/top line (thinking-tree-live patch).
++    goal/top line (thinking-tree-live patch).  A mid-turn thinking block
++    whose first line paraphrases the same message's goal text is dropped
++    (``_drop_goal_thinking_duplicates``) so the tree does not render the
++    same statement as both the bold goal line and an adjacent step.
      """
 -    text_phase = "pi-final" if final else None
 +    text_phase = "pi-final" if final else "pi-live-goal"
      if isinstance(content, str):
          if content.strip():
              return [
+@@ -253,6 +344,11 @@
+                 )
+         elif btype == "toolCall":
+             messages.append(_tool_call_block_to_message(block, pending, timestamp))
++    if not final:
++        # Same-message goal/thinking paraphrase dedupe (mobile tree fix):
++        # the goal already narrates this step, so a paraphrasing thinking
++        # block must not also render as an adjacent ``├─`` step.
++        messages = _drop_goal_thinking_duplicates(messages)
+     return messages
+ 
+ 

--- a/ccgram-prototype/pi-renderer-patch.sh
+++ b/ccgram-prototype/pi-renderer-patch.sh
@@ -26,10 +26,15 @@
 #      Thinking-tree liveness: live elapsed timer in the trace header plus a
 #      background ticker that re-renders the bubble at the edit cadence even
 #      when no new JSONL message arrived; CCGRAM_PI_TRACE_EDIT_SECS /
-#      _TICK_SECS / _IDLE_SECS env knobs; mid-turn assistant text
-#      (stopReason=toolUse) folds into the tree as the bold goal line
-#      instead of a separate notifying message; idle-timeout deletion of
-#      stale trace bubbles (default 10 min).
+#      _TICK_SECS / _IDLE_SECS / _WRAP_CHARS env knobs; mid-turn assistant
+#      text (stopReason=toolUse) folds into the tree as the bold goal line
+#      instead of a separate notifying message, with same-message
+#      goal/thinking paraphrase dedupe in pi_format (a thinking block whose
+#      first line near-duplicates the goal text is dropped so the pair does
+#      not render as adjacent twins); mobile-safe wrap default (36 columns —
+#      48 was wider than a phone bubble's pixel capacity and shattered the
+#      tree on Telegram mobile); idle-timeout deletion of stale trace
+#      bubbles (default 10 min).
 #
 # Patch 2's context includes files added/edited by patch 1, so patch 2 only
 # applies on top of patch 1; patch 3 touches disjoint files and applies on

--- a/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
+++ b/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
@@ -20,11 +20,14 @@ Coverage:
   4. Wiring: patched message_routing routes pi-live/pi-final phases and
      flags user echoes silent; the status bubble send honors quiet_progress.
   5. Thinking-tree liveness (patch layer 4): live elapsed timer in the
-     tree header; CCGRAM_PI_TRACE_EDIT_SECS/_TICK_SECS/_IDLE_SECS env knobs;
-     mid-turn assistant text (stopReason toolUse) stamped pi-live-goal and
-     folded into the tree as the bold goal line (no separate message, no
-     notification); ticker timer refresh without new steps; idle-timeout
-     deletion of stale trace bubbles.
+     tree header; CCGRAM_PI_TRACE_EDIT_SECS/_TICK_SECS/_IDLE_SECS/_WRAP_CHARS
+     env knobs; mid-turn assistant text (stopReason toolUse) stamped
+     pi-live-goal and folded into the tree as the bold goal line (no
+     separate message, no notification); same-message goal/thinking
+     paraphrase dedupe (a thinking block whose first line near-duplicates
+     the goal text is dropped, so the pair renders once); ticker timer
+     refresh without new steps; idle-timeout deletion of stale trace
+     bubbles; mobile-safe 36-column wrap.
 """
 
 from __future__ import annotations
@@ -61,7 +64,7 @@ os.environ.setdefault("CCGRAM_QUIET_PROGRESS", "true")
 # drive tick_once() directly); idle-timeout deletion stays at the default.
 os.environ.setdefault("CCGRAM_PI_TRACE_EDIT_SECS", "1.0")
 os.environ.setdefault("CCGRAM_PI_TRACE_TICK_SECS", "3600")
-os.environ.setdefault("CCGRAM_PI_TRACE_WRAP_CHARS", "48")
+os.environ.setdefault("CCGRAM_PI_TRACE_WRAP_CHARS", "36")
 
 
 def _find_site_packages() -> Path:
@@ -101,12 +104,18 @@ def _prepare_patched_copy() -> Path:
         return "CCGRAM_QUIET_PROGRESS" in cfg and "silent: bool = False" in task
 
     def thinking_tree_live_applied(root: Path) -> bool:
+        # The dedupe helper doubles as the revision marker: an installed
+        # tool carrying an OLDER layer-4 revision (goal folding without
+        # same-message goal/thinking dedupe) fails this check, so the copy
+        # is NOT mistaken for the tracked stack and the suite skips with a
+        # clear reason instead of silently testing stale code.
         live = root / "ccgram/handlers/messaging_pipeline/pi_live_transcript.py"
         fmt = root / "ccgram/providers/pi_format.py"
         return (
             live.exists()
             and "CCGRAM_PI_TRACE_EDIT_SECS" in live.read_text(encoding="utf-8")
             and "pi-live-goal" in fmt.read_text(encoding="utf-8")
+            and "_drop_goal_thinking_duplicates" in fmt.read_text(encoding="utf-8")
         )
 
     marker_checks = [
@@ -127,7 +136,9 @@ def _prepare_patched_copy() -> Path:
         if dry.returncode != 0:
             raise unittest.SkipTest(
                 f"{patch_file.name} does not apply cleanly; installed ccgram "
-                "version differs from the patch target"
+                "version differs from the patch target, or the installed "
+                "tool carries an older revision of this patch layer (apply "
+                "the updated patch stack to run these tests)"
             )
         with open(patch_file, "rb") as fh:
             subprocess.run(
@@ -364,13 +375,13 @@ class PiRendererParityTest(unittest.TestCase):
     # ── 5. Thinking-tree liveness (patch layer 4) ────────────────────────
 
     def test_liveness_env_knobs(self):
-        # CCGRAM_PI_TRACE_EDIT_SECS=1.0 / _TICK_SECS=3600 / _WRAP_CHARS=48
+        # CCGRAM_PI_TRACE_EDIT_SECS=1.0 / _TICK_SECS=3600 / _WRAP_CHARS=36
         # set at module import (top of file); the idle-timeout default is
         # 10 minutes.
         self.assertEqual(self.trace.EDIT_MIN_SECS, 1.0)
         self.assertEqual(self.trace.TICK_SECS, 3600.0)
         self.assertEqual(self.trace.IDLE_SECS, 600.0)
-        self.assertEqual(self.trace.WRAP_CHARS, 48)
+        self.assertEqual(self.trace.WRAP_CHARS, 36)
 
     def test_header_shows_live_elapsed_timer(self):
         tree = self.trace.render_thinking_tree(["step"], elapsed=42.7)
@@ -480,8 +491,10 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(len(client.edited), 1)
         self.assertEqual(client.edited[0]["message_id"], 1001)
         # convert_to_entities strips the markdown into bold entities, so
-        # the plain text carries the stripped goal…
-        self.assertIn("▸ I found the cause; patching it now.", client.edited[0]["text"])
+        # the plain text carries the stripped goal (word-wrapped at the
+        # 36-column mobile width)…
+        self.assertIn("▸ I found the cause; patching it", client.edited[0]["text"])
+        self.assertIn("now.", client.edited[0]["text"])
         # …and the goal line is rendered bold via entities.
         entities = client.edited[0].get("entities") or []
         self.assertTrue(
@@ -536,6 +549,212 @@ class PiRendererParityTest(unittest.TestCase):
         run(trace.tick_once())
         self.assertEqual(len(client.edited), 0)
         trace.clear_all_traces()
+
+    # ── 6. Same-message goal/thinking dedupe + mobile wrap width ───────
+
+    # The captain's 2026-08-16 mobile screenshot (scout report
+    # ccgram-tree-regression-scout): transcript line 14 of the
+    # fm-vault-next-work-scout session paired this visible text block…
+    _LINE14_GOAL = (
+        "Now let me check the vault's current state and recent activity "
+        "since the prior scouts."
+    )
+    # …with this thinking block in the SAME assistant message — a
+    # paraphrase ("check" vs "look at"), which the tree rendered as
+    # adjacent goal + step twins.
+    _LINE14_THINKING = (
+        "Now let me look at the vault's current state to verify whether "
+        "anything has changed since the prior scouts (auto-commits, weekly "
+        "backlog W33/W34). Today is Sun Aug 16, 2026 (W33).\nSecond line "
+        "of private reasoning the tree never shows."
+    )
+
+    def _parse_assistant_blocks(self, blocks, stop_reason="toolUse"):
+        line = json.dumps(
+            {
+                "type": "message",
+                "id": "mx",
+                "parentId": None,
+                "timestamp": "2026-08-16T04:17:27.100Z",
+                "message": {
+                    "role": "assistant",
+                    "content": blocks,
+                    "stopReason": stop_reason,
+                },
+            }
+        )
+        entry = self.provider.parse_transcript_line(line)
+        self.assertIsNotNone(entry)
+        messages, _pending = self.provider.parse_transcript_entries([entry], {})
+        return messages
+
+    def test_same_message_goal_thinking_paraphrase_deduped(self):
+        # Line-14 scenario: the paraphrasing thinking block is dropped at
+        # parse time; only the goal text survives (plus tool calls).
+        messages = self._parse_assistant_blocks(
+            [
+                {"type": "thinking", "thinking": self._LINE14_THINKING},
+                {"type": "text", "text": self._LINE14_GOAL},
+                {
+                    "type": "toolCall",
+                    "id": "call_x",
+                    "name": "read",
+                    "arguments": {"path": "note.md"},
+                },
+            ]
+        )
+        goals = [m for m in messages if m.phase == "pi-live-goal"]
+        thinking = [m for m in messages if m.content_type == "thinking"]
+        self.assertEqual([m.text for m in goals], [self._LINE14_GOAL])
+        self.assertEqual(thinking, [])  # paraphrase suppressed
+        tools = [m for m in messages if m.content_type == "tool_use"]
+        self.assertEqual(len(tools), 1)  # tool calls unaffected
+
+    def test_same_message_divergent_thinking_kept(self):
+        # Same shape as line 14, but the thinking's first line is genuinely
+        # different content: both the goal and the step must survive.
+        messages = self._parse_assistant_blocks(
+            [
+                {
+                    "type": "thinking",
+                    "thinking": "The reminder script state looks stale; the "
+                    "daemon may have skipped its tick.\nMore detail.",
+                },
+                {"type": "text", "text": self._LINE14_GOAL},
+            ]
+        )
+        self.assertEqual(
+            len([m for m in messages if m.phase == "pi-live-goal"]), 1
+        )
+        self.assertEqual(
+            len([m for m in messages if m.content_type == "thinking"]), 1
+        )
+
+    def test_dedupe_leaves_other_message_shapes_untouched(self):
+        # Thinking-only mid-turn messages still produce a step.
+        thinking_only = self._parse_assistant_blocks(
+            [{"type": "thinking", "thinking": self._LINE14_THINKING}]
+        )
+        self.assertEqual(
+            [m.phase for m in thinking_only if m.content_type == "thinking"],
+            ["pi-live"],
+        )
+        # Final answers (stopReason != toolUse) are never deduped: the
+        # text is the delivered answer, not a tree goal line.
+        final = self._parse_assistant_blocks(
+            [
+                {"type": "thinking", "thinking": self._LINE14_THINKING},
+                {"type": "text", "text": self._LINE14_GOAL},
+            ],
+            stop_reason="stop",
+        )
+        self.assertEqual(
+            len([m for m in final if m.content_type == "thinking"]), 1
+        )
+        self.assertEqual(
+            [m.phase for m in final if m.content_type == "text"], ["pi-final"]
+        )
+
+    def test_dedupe_heuristic_boundaries(self):
+        dup = self.pi_format._is_goal_thinking_duplicate
+        # The line-14 paraphrase pair.
+        self.assertTrue(dup(self._LINE14_GOAL, self._LINE14_THINKING))
+        # Exact prefix of a longer thinking line.
+        self.assertTrue(
+            dup(
+                "Now let me check the vault state.",
+                "Now let me check the vault state and then the trip plan.",
+            )
+        )
+        # Different opening: not a duplicate even with topical overlap.
+        self.assertFalse(
+            dup(
+                "Now I will run the test suite to verify the fix.",
+                "The parser probably races on the tmp dir; serializing.",
+            )
+        )
+        # Same opening but no substantial shared phrase.
+        self.assertFalse(
+            dup("Now let me see.", "Now let me try a completely different angle.")
+        )
+
+    def test_paraphrase_pair_renders_once_in_tree(self):
+        # End-to-end golden: line-14 blocks routed through the trace state
+        # machine render the statement once (bold goal), with no adjacent
+        # near-duplicate `├─` step.
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+
+        messages = self._parse_assistant_blocks(
+            [
+                {"type": "thinking", "thinking": self._LINE14_THINKING},
+                {"type": "text", "text": self._LINE14_GOAL},
+            ]
+        )
+        for msg in messages:
+            if msg.content_type == "thinking":
+                run(
+                    trace.handle_pi_thinking(client, 1, 42, -100999, msg.text)
+                )
+            elif msg.phase == "pi-live-goal":
+                run(trace.handle_pi_goal(client, 1, 42, -100999, msg.text))
+        self.assertEqual(len(client.sent), 1)
+        bubble = client.sent[0]["text"]
+        # The goal renders once, directly under the header (convert_to_entities
+        # turns the ** markers into bold entities, and the line word-wraps
+        # at the 36-column mobile width)…
+        self.assertIn("▸ Now let me check the vault's", bubble)
+        self.assertTrue(bubble.splitlines()[1].startswith("▸ "))
+        # …and no `├─` step echoes the paraphrase.
+        step_lines = [l for l in bubble.splitlines() if l.startswith("├─")]
+        self.assertEqual(step_lines, [])
+        self.assertNotIn("look at the vault", bubble)
+        trace.clear_all_traces()
+
+    def test_mobile_wrap_width_36_keeps_tree_shape(self):
+        # The 2026-08-16 screenshot regression: at 48 columns every
+        # intentional line outlived a phone bubble's pixel capacity and
+        # Telegram's re-wrap shattered the tree. 36 stays ahead of the
+        # client-side wrap on typical phones.
+        goal = (
+            "Now let me check the vault's current state and recent "
+            "activity since the prior scouts."
+        )
+        step = (
+            "Now check the trip plan note for the current state, the "
+            "reminder script state, and daemon health."
+        )
+        tree = self.trace.render_thinking_tree(
+            [step], goal=goal, elapsed=14, wrap_chars=36
+        )
+        lines = tree.splitlines()
+        self.assertEqual(lines[0], "🧠 Thinking… · 0:14")
+        for line in lines[1:]:
+            display = line.replace("**", "")  # ** renders as bold entities
+            self.assertLessEqual(len(display), 36, line)
+        # Wrapped continuation lines keep the hanging indent, and the
+        # connector prefixes survive on the first segment of each node.
+        goal_lines = [l for l in lines if "**" in l]
+        self.assertGreater(len(goal_lines), 1)
+        self.assertTrue(goal_lines[0].startswith("▸ **"))
+        for cont in goal_lines[1:]:
+            self.assertTrue(cont.startswith("  **"), cont)
+        step_lines = [
+            l for l in lines if l.startswith("├─") or l.startswith("   ")
+        ]
+        self.assertGreater(len(step_lines), 1)
+        self.assertTrue(step_lines[0].startswith("├─ "))
+        # No text lost across the wrap.
+        reassembled_goal = " ".join(
+            l.removeprefix("▸ ").strip().strip("*") for l in goal_lines
+        )
+        self.assertEqual(reassembled_goal, goal)
+        reassembled_step = " ".join(
+            l.removeprefix("├─ ").strip() for l in step_lines
+        )
+        self.assertEqual(reassembled_step, step)
 
     def test_idle_cleanup_deletes_stale_bubble(self):
         trace = self.trace


### PR DESCRIPTION
## Why

The captain's 2026-08-16 Telegram mobile screenshot (topic `firstmate ▸ fm-vault-next-work-scout`) showed the same progress statement twice in one thinking-trace bubble, and the tree shape shattered on the phone. The read-only scout (`ccgram-tree-regression-scout/report.md`) reconstructed the bubble line-for-line from live artifacts and pinned **two layer-4 design gaps** — not a renderer-logic bug, not a double-feed, not config drift:

1. **Repeated text = duplicate source content rendered adjacent.** The session's model (`kimi-k3-fast`) emitted a mid-turn visible text block that paraphrases its *own* thinking block in the same assistant message (transcript line 14: text `Now let me check the vault's current state…` beside thinking `Now let me look at the vault's current state…`). PR148's goal folding stamps the text `pi-live-goal` (bold `▸` top line) while the thinking independently becomes a `├─` step — one message, two adjacent near-identical tree lines. Pre-PR148 the pair was spatially separated (separate progress message + step), which is why this reads as a new regression.
2. **Broken tree = width-assumption miss.** `CCGRAM_PI_TRACE_WRAP_CHARS=48` counts characters, but Telegram mobile wraps by *pixels* in a proportional font; a phone bubble fits ~35–44 Latin chars. Every intentional 47–48-char line double-wrapped at Telegram's chosen column 0, orphaning the `├─` connectors and hanging indents. Exactly the deployment audit's blind spot #3.

## What changed (all in patch layer 4 + tracked config/docs)

- **Same-message goal/thinking dedupe** in `pi_format._parse_assistant_content` — the one place both blocks of a message are visible together. A mid-turn thinking block whose first line near-duplicates the same message's goal text (normalized comparison: shared opening of ≥3 words **and** a shared phrase of ≥20 chars) is dropped, so the statement renders once as the bold goal. Thinking-only messages, genuinely divergent thinking+text pairs, and final answers are untouched (verified against the existing fixture's m4 pair, which must keep both).
- **Wrap default 48 → 36** in `pi_live_transcript.WRAP_CHARS`, plus the tracked env template (`ccgram-prototype.env.example`) and README. 36 keeps intentional breaks ahead of Telegram's client-side re-wrap on typical phones; desktop is unaffected (wide bubbles fit either way).
- **Tests** (`test_pi_renderer_parity.py`): line-14 golden fixture (paraphrase pair deduped at parse; end-to-end render shows the goal once with zero `├─` steps), divergent-pair / thinking-only / final-message preservation, dedupe heuristic boundary cases, 36-column wrap shape + lossless reassembly, knob assertions at 36. The harness's layer-4 applied-marker now keys on the dedupe helper, so an installed tool carrying the *older* layer-4 revision **skips the suite with a clear reason** instead of silently testing stale code (the live install still runs the old layer — per task rules nothing outside the worktree was modified).
- README + `pi-renderer-patch.sh` header comments updated for both behaviors.

## Validation

- Full stack re-applied from pristine ccgram 4.5.2 reproduces the patched tree exactly (`diff -r` clean).
- **34/34 fixture tests pass** against a staged pristine site-packages where the harness applied the tracked patches itself (offline, fake Telegram client, no Bot API calls).
- `./pi-renderer-patch.sh status` / `check`: all four layers `applied`, stack consistent.
- `./validate.sh`: **passes** from the worktree (fixture suite skips on the stale live install with reason \"apply the updated patch stack to run these tests\", as designed; everything else green).
- No services restarted/stopped, no Telegram traffic, no live config edits.

## Post-merge deployment step (captain)

The live service (MainPID since 2026-08-16 00:11:10 EDT) still runs the old layer 4, and the untracked `~/.config/ccgram-prototype.env` explicitly sets `CCGRAM_PI_TRACE_WRAP_CHARS=48`, which overrides the new default. To deploy:

```bash
cd ~/dotfiles/ccgram-prototype
./pi-renderer-patch.sh rollback && ./pi-renderer-patch.sh apply
# set CCGRAM_PI_TRACE_WRAP_CHARS=36 (or delete the line) in ~/.config/ccgram-prototype.env
systemctl --user restart ccgram-prototype.service
```

After restart, `validate.sh`'s fixture suite runs in full (no skip) against the updated install.