### PR TITLE
ccgram-prototype: match Pi Telegram frontdoor ▸/✓ goal-line live status bubble (+ PR150 dedupe fix)

### DIFF
--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -40,7 +40,7 @@ already publish agent sessions that ccgram discovers with zero code changes.
 | `patches/ccgram-4.5.2-pi-renderer-parity.patch` | Tracked unified diff, layer 1: patches the installed ccgram 4.5.2 Pi renderer (thinking + tool-call + final-answer flow). Not deployed by stow. |
 | `patches/ccgram-4.5.2-low-noise-notifications.patch` | Tracked unified diff, layer 2 (applies on top of layer 1): final-answer-only notifications (silent thinking trace, quiet-progress mode). Not deployed by stow. |
 | `patches/ccgram-4.5.2-pi-transcript-binding.patch` | Tracked unified diff, layer 3 (disjoint files): fixes the SessionStart transcript-binding race for reused session directories (exact-match-only binding, deferred pending resolution, offset reset on path change). Not deployed by stow. |
-| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): thinking-tree liveness — live elapsed timer + ticker, `CCGRAM_PI_TRACE_*` cadence/idle/wrap knobs, mid-turn text folded into the tree as the goal line, same-message goal/thinking paraphrase dedupe, idle-timeout bubble deletion. Not deployed by stow. |
+| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): no-tree live status bubble — live elapsed timer + ticker, `CCGRAM_PI_TRACE_*` cadence/idle/wrap knobs, mid-turn text folded into the bubble as the bold goal line, goal/thinking paraphrase dedupe (parse-level + render-level), no tree connectors, idle-timeout bubble deletion. Not deployed by stow. |
 | `.local/bin/ccgram-pi-hook` | Pi hook shim: waits (self-bounded) for the session's OWN transcript file at SessionStart, injects the exact `transcript_path`, delegates to `ccgram hook --provider pi`. Deployed by stow. |
 | `.pi/agent/extensions/hooks.json` | cc-thingz hook-runner wiring (SessionStart/Stop/SessionEnd → shim, async; SessionStart timeout raised to 20s to cover slow transcript creation). Deployed by stow. |
 | `pi-renderer-patch.sh` | Idempotent `status`/`check`/`apply`/`rollback` for the whole patch stack, with file-level backups. Not deployed by stow. |
@@ -156,18 +156,19 @@ What the patch does (all inside ccgram, against the installed uv tool):
    with a terminal `stopReason` (anything but `toolUse`, including errors) is
    stamped `phase="pi-final"`. Tool calls/results are untouched.
 2. **`handlers/messaging_pipeline/pi_live_transcript.py`** (new) — owns the
-   temporary thinking trace: one message per topic, rendered as a compact
-   tree (`├─` node per thinking step, first line only, overflow folded into
-   `… (N earlier steps)`, `└─ ⏳ still thinking…` spinner), edited in place
-   with a 2s rate limit, and **deleted** when the final answer (or terminal
-   error) arrives — the same temporary-render semantics as Pi's tree-style
-   live transcript.
+   temporary thinking trace: one message per topic, edited in place with a
+   2s rate limit, and **deleted** when the final answer (or terminal
+   error) arrives. Patch layer 4 replaces layer 1's compact-tree rendering
+   with a **no-tree live status bubble** (see "No-tree live status bubble"
+   below): header with live elapsed timer, one bold goal line, an optional
+   latest-step summary line, and a plain `⏳ still thinking…` footer — no
+   `├─`/`└─`/`▸` connectors.
 3. **`handlers/messaging_pipeline/message_routing.py`** — routes `pi-live`
    thinking into the trace (never to permanent "Thinking" messages) and
    retires the trace before delivering `pi-final` answers.
 
 Patch layer 4 (`patches/ccgram-4.5.2-pi-thinking-tree-live.patch`) extends
-the same three files — see "Thinking-tree liveness" below.
+the same three files — see "No-tree live status bubble" below.
 
 Tool calls need no patch: ccgram's default `batch_mode=ephemeral` already
 collapses each run of tool calls into one compact bubble that is edited in
@@ -293,15 +294,19 @@ text + error) through the real parser and the trace state machine with a fake
 Telegram client. They also assert the low-noise behavior: the trace bubble is
 sent with `disable_notification=True`, silent user-echo tasks send without
 notification while the final answer still notifies, and silent/notifying
-tasks never merge. Layer 4 adds liveness coverage: the header elapsed timer,
-the `CCGRAM_PI_TRACE_*` knobs, mid-turn text folding into the bold goal line
-(no separate message, no notification), ticker timer refresh with no new
-steps, edit-throttle respect, idle-timeout bubble deletion, same-message
-goal/thinking paraphrase dedupe (a line-14-style thinking+text paraphrase
-renders once, as the goal; a divergent thinking+text pair keeps both), and
-mobile wrap-aware rendering (long goal/step lines word-wrap with a hanging
-indent that preserves the tree shape at the 36-char phone-safe width;
-wrapping disabled at width 0).
+tasks never merge. Layer 4 adds status-bubble coverage: the header elapsed
+timer, the `CCGRAM_PI_TRACE_*` knobs, mid-turn text folding into the bold
+goal line (no separate message, no notification), ticker timer refresh with
+no new steps, edit-throttle respect, idle-timeout bubble deletion,
+goal/thinking paraphrase dedupe with the EXACT line-14 transcript text
+(the paraphrasing thinking block is dropped at parse time; a render-level
+check also suppresses a latest step that paraphrases the current goal; a
+divergent thinking+text pair keeps both), and no-tree mobile rendering
+(long goal/step lines word-wrap plain at the 36-char phone-safe width
+with no connector prefixes or hanging indents; wrapping disabled at
+width 0). The fixture suite builds its patched copy from the pristine
+4.5.2 wheel in the uv cache when available, so it always exercises the
+tracked stack even when the live install carries an older patch revision.
 
 ### Live smoke plan (only when explicitly authorized)
 
@@ -311,14 +316,16 @@ live after applying the stack and restarting the service:
 1. Confirm env: `grep -E 'HIDE_TOOL_CALLS|QUIET_PROGRESS|HIDE_THINKING|EPHEMERAL|PI_TRACE' ~/.config/ccgram-prototype.env`.
 2. Let Firstmate dispatch one small worker task (or wait for the next one).
 3. Expected in the worker's topic: the 👤 brief echo appears **without a
-   notification**; the 🧠 thinking tree appears/updates **without a
+   notification**; the 🧠 status bubble appears/updates **without a
    notification**; its header timer (`· 0:42`) visibly advances at ~1s
    cadence even while no new step arrives; mid-turn narration text shows up
-   as the tree's bold `▸` goal line instead of a separate message; long
-   goal/step lines wrap with a hanging indent that keeps the tree shape
-   intact on a phone; no tool-call messages at all; the status bubble (if
-   it appears) is silent; when the turn ends, the trace bubble is deleted
-   and **exactly one final-answer message notifies**.
+   as the bubble's bold goal line instead of a separate message; the same
+   statement never appears twice (a paraphrasing thinking block is
+   suppressed); long goal/step lines wrap plain (no tree connectors, no
+   hanging indents) so nothing shatters on a phone; no tool-call messages
+   at all; the status bubble (if it appears) is silent; when the turn
+   ends, the trace bubble is deleted and **exactly one final-answer
+   message notifies**.
 4. Kill a worker mid-turn (`herdr` pane kill or `kill -9` its pi process):
    the orphaned trace bubble is deleted within `CCGRAM_PI_TRACE_IDLE_SECS`
    (default 10 min) without a new turn.
@@ -336,8 +343,8 @@ plus env config implement that:
 | Transcript element during a run | Behavior | Mechanism |
 | ------------------------------- | -------- | --------- |
 | Tool calls / results | **No message at all** | `CCGRAM_HIDE_TOOL_CALLS=true` (upstream config, no patch; `message_queue` drops `tool_use`/`tool_result` tasks before batching) |
-| Thinking trace (tree bubble) | Visible, **silent on first send**, edited in place, deleted on final | Patch: `disable_notification=True` in `pi_live_transcript` |
-| Mid-turn assistant text (`stopReason=toolUse`) | Folded into the tree as the bold goal line — **no separate message, no notification** | Layer 4 patch: `phase="pi-live-goal"` in `pi_format`, routed to `handle_pi_goal` |
+| Thinking trace (status bubble) | Visible, **silent on first send**, edited in place, deleted on final | Patch: `disable_notification=True` in `pi_live_transcript` |
+| Mid-turn assistant text (`stopReason=toolUse`) | Folded into the status bubble as the bold goal line — **no separate message, no notification** | Layer 4 patch: `phase="pi-live-goal"` in `pi_format`, routed to `handle_pi_goal` |
 | Status bubble ("working…") | Visible, **silent on first send**, edited in place, cleared on done | Patch + `CCGRAM_QUIET_PROGRESS=true`: `disable_notification` in `status_bubble.send_status_text` |
 | User transcript echoes (Firstmate launch brief) | Visible (👤), **silent** | Patch + `CCGRAM_QUIET_PROGRESS=true`: `ContentTask.silent` flag, set in `message_routing` for `role="user"` |
 | Final assistant answer | **Normal message — notifies** | Unchanged normal path |
@@ -357,47 +364,54 @@ Notes:
   (`shown`/`hidden`) beats the global default — don't set per-window
   overrides on worker topics.
 
-### Thinking-tree liveness — closer to the frontdoor on mobile (patch layer 4)
+### No-tree live status bubble — closer to the frontdoor on mobile (patch layer 4)
 
 `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` closes the cheap
 presentation gaps vs the `avirus` Firstmate Telegram frontdoor identified in
 the tree-rendering audit (the token-streaming gap is structural — JSONL only
-ever contains complete messages — and stays out of scope):
+ever contains complete messages — and stays out of scope). The bubble is
+deliberately **not a tree**: Telegram mobile wraps by pixels in a
+proportional font, so connector columns (`├─`/`└─`/`▸`) and hanging
+indents shattered on phone-width bubbles. It renders a header with a live
+elapsed timer, one bold goal line, an optional latest-step summary line
+(suppressed when it paraphrases the goal), and a plain `⏳ still
+thinking…` footer.
 
-- **Live elapsed timer.** The trace header is `🧠 Thinking… · 0:42` and a
+- **Live elapsed timer.** The bubble header is `🧠 Thinking… · 0:42` and a
   per-trace background ticker re-renders the bubble at the edit cadence even
   when no new completed JSONL message has arrived, so the bubble always
   looks alive. The ticker stops when no traces remain; edits never notify.
 - **1s edit cadence knob.** `CCGRAM_PI_TRACE_EDIT_SECS` (default `2.0`)
   controls the minimum gap between trace edits; the prototype env sets
   `1.0`, matching the frontdoor's coalescing interval.
-- **Mid-turn text folds into the tree.** Assistant text blocks from Pi
+- **Mid-turn text folds into the bubble.** Assistant text blocks from Pi
   messages with `stopReason="toolUse"` are stamped `phase="pi-live-goal"`
-  and update the tree's bold goal/top line (`▸ **…**`, markdown-stripped)
+  and update the bubble's bold goal line (`**…**`, markdown-stripped)
   instead of becoming separate — and notifying — progress messages. This
   also removes the last interim-notification gap: during a worker turn,
   only the final answer notifies.
 - **Idle-timeout deletion.** If a turn dies mid-thinking (kill -9, network
   drop) and no final answer arrives, the stale bubble is deleted after
   `CCGRAM_PI_TRACE_IDLE_SECS` (default `600` = 10 minutes).
-- **Same-message goal/thinking dedupe.** Some models emit a mid-turn
-  visible text block that paraphrases their own thinking block in the same
-  assistant message. `pi_format` compares the two blocks of each message
-  and drops a thinking block whose first line near-duplicates the goal
-  text (shared opening of 3+ words plus a shared 20+ char phrase), so the
-  tree shows the statement once — as the bold goal line — instead of as
-  adjacent goal + `├─` step twins. Thinking-only messages and genuinely
-  distinct thinking+text messages keep both entries.
-- **Mobile wrap-aware tree.** Goal and step lines are word-wrapped at
+- **Goal/thinking paraphrase dedupe, two layers.** Some models emit a
+  mid-turn visible text block that paraphrases their own thinking block in
+  the same assistant message. At parse time, `pi_format` drops a thinking
+  block whose first line near-duplicates the same message's goal text
+  (token-based rule: shared opening of 3+ words plus a shared 4+ word
+  contiguous phrase — the earlier character-level SequenceMatcher rule
+  silently collapsed on long thinking lines via difflib autojunk, which is
+  why the exact line-14 transcript pair slipped through PR150). At render
+  time, `pi_live_transcript` additionally hides the latest step when it
+  paraphrases the current goal (covers a paraphrase arriving in an earlier
+  message than the goal). Thinking-only messages and genuinely distinct
+  thinking+text messages keep both entries.
+- **No-tree mobile wrap.** Goal and step lines are word-wrapped at
   `CCGRAM_PI_TRACE_WRAP_CHARS` columns (default `36`; Telegram mobile
   wraps by pixels in a proportional font and a phone bubble fits roughly
   35–44 Latin chars, so 36 keeps intentional breaks ahead of Telegram's
-  own re-wrap — 48 was wider than a phone bubble and shattered the tree)
-  with a hanging indent under the node prefix: a wrapped step continues aligned
-  under its `├─` text column and a wrapped goal under its `▸` text column
-  (bold per segment), so the tree shape survives Telegram's own line
-  wrapping instead of breaking into ragged full-width lines. `0` disables
-  intentional wrapping. The 120-char per-node caps still apply as the hard
+  own re-wrap) with NO connector prefix and NO hanging indent — there is
+  no tree shape left for Telegram's re-wrap to shatter. `0` disables
+  intentional wrapping. The 120-char per-line caps still apply as the hard
   truncation ceiling above this soft wrap.
 
 | Env knob | Default | Prototype setting | Meaning |
@@ -405,7 +419,7 @@ ever contains complete messages — and stays out of scope):
 | `CCGRAM_PI_TRACE_EDIT_SECS` | `2.0` | `1.0` | Minimum seconds between trace-bubble edits (applies to step/goal updates and the timer ticker). |
 | `CCGRAM_PI_TRACE_TICK_SECS` | `1.0` | unset | Liveness ticker period (timer refresh + idle sweep granularity). |
 | `CCGRAM_PI_TRACE_IDLE_SECS` | `600` | unset | Delete a trace bubble with no thinking/goal activity for this long (killed-turn cleanup). |
-| `CCGRAM_PI_TRACE_WRAP_CHARS` | `36` | unset | Soft word-wrap width (in characters) for goal/step lines, with hanging indent under the node prefix; `0` disables. |
+| `CCGRAM_PI_TRACE_WRAP_CHARS` | `36` | unset | Soft word-wrap width (in characters) for goal/step lines, plain column-0 wrap (no connectors/indents); `0` disables. |
 
 ### Remaining parity gaps (vs the Pi TUI)
 
@@ -415,9 +429,9 @@ ever contains complete messages — and stays out of scope):
   cannot show new content. Closing this needs an upstream streaming event
   source (Pi-side partial entries or an attachable event subscription).
 - **Step-granularity trace.** Pi writes an assistant message to the JSONL
-  when that step finishes, so tree nodes appear per completed step, not
-  token-by-token (same limitation the sidecar had; it matches the
-  temporary-render goal).
+  when that step finishes, so the status bubble's step line updates per
+  completed step, not token-by-token (same limitation the sidecar had; it
+  matches the temporary-render goal).
 - **Tool calls vanish rather than collapse.** In the Pi TUI, finished tool
   calls stay in scrollback as collapsed lines; ccgram's ephemeral batch
   deletes the bubble entirely on flush. Switch a window to `batched` mode

--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -40,7 +40,7 @@ already publish agent sessions that ccgram discovers with zero code changes.
 | `patches/ccgram-4.5.2-pi-renderer-parity.patch` | Tracked unified diff, layer 1: patches the installed ccgram 4.5.2 Pi renderer (thinking + tool-call + final-answer flow). Not deployed by stow. |
 | `patches/ccgram-4.5.2-low-noise-notifications.patch` | Tracked unified diff, layer 2 (applies on top of layer 1): final-answer-only notifications (silent thinking trace, quiet-progress mode). Not deployed by stow. |
 | `patches/ccgram-4.5.2-pi-transcript-binding.patch` | Tracked unified diff, layer 3 (disjoint files): fixes the SessionStart transcript-binding race for reused session directories (exact-match-only binding, deferred pending resolution, offset reset on path change). Not deployed by stow. |
-| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): no-tree live status bubble — live elapsed timer + ticker, `CCGRAM_PI_TRACE_*` cadence/idle/wrap knobs, mid-turn text folded into the bubble as the bold goal line, goal/thinking paraphrase dedupe (parse-level + render-level), no tree connectors, idle-timeout bubble deletion. Not deployed by stow. |
+| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): frontdoor-style live status bubble — live elapsed timer + ticker, one bold goal line per goal (`▸` active / `✓` done, matching the Pi Telegram frontdoor daemon; thinking blocks derive labels but never render as lines), `CCGRAM_PI_TRACE_*` cadence/idle/wrap knobs, same-message goal/thinking paraphrase dedupe, idle-timeout bubble deletion. Not deployed by stow. |
 | `.local/bin/ccgram-pi-hook` | Pi hook shim: waits (self-bounded) for the session's OWN transcript file at SessionStart, injects the exact `transcript_path`, delegates to `ccgram hook --provider pi`. Deployed by stow. |
 | `.pi/agent/extensions/hooks.json` | cc-thingz hook-runner wiring (SessionStart/Stop/SessionEnd → shim, async; SessionStart timeout raised to 20s to cover slow transcript creation). Deployed by stow. |
 | `pi-renderer-patch.sh` | Idempotent `status`/`check`/`apply`/`rollback` for the whole patch stack, with file-level backups. Not deployed by stow. |
@@ -159,16 +159,18 @@ What the patch does (all inside ccgram, against the installed uv tool):
    temporary thinking trace: one message per topic, edited in place with a
    2s rate limit, and **deleted** when the final answer (or terminal
    error) arrives. Patch layer 4 replaces layer 1's compact-tree rendering
-   with a **no-tree live status bubble** (see "No-tree live status bubble"
-   below): header with live elapsed timer, one bold goal line, an optional
-   latest-step summary line, and a plain `⏳ still thinking…` footer — no
-   `├─`/`└─`/`▸` connectors.
+   with a **frontdoor-style goal-line status bubble** (see "Frontdoor-style
+   live status bubble" below): header with live elapsed timer, then one
+   bold line per goal — `▸ **label**` while active, `✓ **label**` when
+   done. Thinking blocks never render as lines of their own (no `├─`/`└─`
+   tree connectors, no prose paragraphs); a thinking-only turn derives
+   the active goal's label from its first thinking block.
 3. **`handlers/messaging_pipeline/message_routing.py`** — routes `pi-live`
    thinking into the trace (never to permanent "Thinking" messages) and
    retires the trace before delivering `pi-final` answers.
 
 Patch layer 4 (`patches/ccgram-4.5.2-pi-thinking-tree-live.patch`) extends
-the same three files — see "No-tree live status bubble" below.
+the same three files — see "Frontdoor-style live status bubble" below.
 
 Tool calls need no patch: ccgram's default `batch_mode=ephemeral` already
 collapses each run of tool calls into one compact bubble that is edited in
@@ -295,18 +297,21 @@ Telegram client. They also assert the low-noise behavior: the trace bubble is
 sent with `disable_notification=True`, silent user-echo tasks send without
 notification while the final answer still notifies, and silent/notifying
 tasks never merge. Layer 4 adds status-bubble coverage: the header elapsed
-timer, the `CCGRAM_PI_TRACE_*` knobs, mid-turn text folding into the bold
-goal line (no separate message, no notification), ticker timer refresh with
-no new steps, edit-throttle respect, idle-timeout bubble deletion,
-goal/thinking paraphrase dedupe with the EXACT line-14 transcript text
-(the paraphrasing thinking block is dropped at parse time; a render-level
-check also suppresses a latest step that paraphrases the current goal; a
-divergent thinking+text pair keeps both), and no-tree mobile rendering
-(long goal/step lines word-wrap plain at the 36-char phone-safe width
-with no connector prefixes or hanging indents; wrapping disabled at
-width 0). The fixture suite builds its patched copy from the pristine
-4.5.2 wheel in the uv cache when available, so it always exercises the
-tracked stack even when the live install carries an older patch revision.
+timer, the `CCGRAM_PI_TRACE_*` knobs, mid-turn text folding into the `▸`
+goal label (no separate message, no notification), `✓` completion when a
+newer text goal supersedes the active one, thinking-derived labels
+(sticky until text arrives; thinking never renders as a prose line),
+ticker timer refresh with no new steps, edit-throttle respect,
+idle-timeout bubble deletion, goal/thinking paraphrase dedupe with the
+EXACT line-14 transcript text (the paraphrasing thinking block is
+dropped at parse time so the screenshot case shows the concise goal
+once; a divergent thinking+text pair keeps both), and mobile rendering
+(long goal labels word-wrap at the 36-char phone-safe width with a blank
+hanging indent under the bullet — visually subordinate, no tree
+connectors; wrapping disabled at width 0). The fixture suite builds its
+patched copy from the pristine 4.5.2 wheel in the uv cache when
+available, so it always exercises the tracked stack even when the live
+install carries an older patch revision.
 
 ### Live smoke plan (only when explicitly authorized)
 
@@ -319,11 +324,12 @@ live after applying the stack and restarting the service:
    notification**; the 🧠 status bubble appears/updates **without a
    notification**; its header timer (`· 0:42`) visibly advances at ~1s
    cadence even while no new step arrives; mid-turn narration text shows up
-   as the bubble's bold goal line instead of a separate message; the same
-   statement never appears twice (a paraphrasing thinking block is
-   suppressed); long goal/step lines wrap plain (no tree connectors, no
-   hanging indents) so nothing shatters on a phone; no tool-call messages
-   at all; the status bubble (if it appears) is silent; when the turn
+   as the bubble's bold `▸` goal line instead of a separate message; the
+   same statement never appears twice (a paraphrasing thinking block is
+   suppressed); completed goals show as `✓` lines above the active `▸`;
+   long goal labels wrap with a blank hanging indent under the bullet
+   (no tree connectors) so nothing shatters on a phone; no tool-call
+   messages at all; the status bubble (if it appears) is silent; when the turn
    ends, the trace bubble is deleted and **exactly one final-answer
    message notifies**.
 4. Kill a worker mid-turn (`herdr` pane kill or `kill -9` its pi process):
@@ -364,18 +370,29 @@ Notes:
   (`shown`/`hidden`) beats the global default — don't set per-window
   overrides on worker topics.
 
-### No-tree live status bubble — closer to the frontdoor on mobile (patch layer 4)
+### Frontdoor-style live status bubble (patch layer 4)
 
-`patches/ccgram-4.5.2-pi-thinking-tree-live.patch` closes the cheap
-presentation gaps vs the `avirus` Firstmate Telegram frontdoor identified in
-the tree-rendering audit (the token-streaming gap is structural — JSONL only
-ever contains complete messages — and stays out of scope). The bubble is
-deliberately **not a tree**: Telegram mobile wraps by pixels in a
-proportional font, so connector columns (`├─`/`└─`/`▸`) and hanging
-indents shattered on phone-width bubbles. It renders a header with a live
-elapsed timer, one bold goal line, an optional latest-step summary line
-(suppressed when it paraphrases the goal), and a plain `⏳ still
-thinking…` footer.
+`patches/ccgram-4.5.2-pi-thinking-tree-live.patch` mirrors the Pi Telegram
+frontdoor daemon's live status rendering (`pi/bin/pi-telegram-daemon.py`,
+`ThinkingTreeBuilder.render`): a header with a live elapsed timer, then
+**one bold goal line per goal** — `▸ **label**` while the goal is active,
+`✓ **label**` once a newer goal supersedes it. Thinking blocks are
+tracked but **never rendered as lines of their own** (no `├─`/`└─` tree
+connectors, no prose thinking-summary paragraphs): a thinking-only turn
+derives the active goal's label from its first thinking block, exactly
+like the frontdoor's `label_derived` path (sticky until a text block in
+the same turn replaces it). Up to 8 goal lines are retained; older
+completed ones drop off.
+
+```
+🧠 Thinking… · 0:14
+✓ **Now let me check the vault's**
+  **current state and recent activity**
+  **since the prior scouts.**
+▸ **All prior findings remain**
+  **unresolved. Let me read the**
+  **completion-gate skill…**
+```
 
 - **Live elapsed timer.** The bubble header is `🧠 Thinking… · 0:42` and a
   per-trace background ticker re-renders the bubble at the edit cadence even
@@ -384,42 +401,43 @@ thinking…` footer.
 - **1s edit cadence knob.** `CCGRAM_PI_TRACE_EDIT_SECS` (default `2.0`)
   controls the minimum gap between trace edits; the prototype env sets
   `1.0`, matching the frontdoor's coalescing interval.
-- **Mid-turn text folds into the bubble.** Assistant text blocks from Pi
+- **Mid-turn text becomes the goal label.** Assistant text blocks from Pi
   messages with `stopReason="toolUse"` are stamped `phase="pi-live-goal"`
-  and update the bubble's bold goal line (`**…**`, markdown-stripped)
-  instead of becoming separate — and notifying — progress messages. This
-  also removes the last interim-notification gap: during a worker turn,
-  only the final answer notifies.
+  and become the active `▸` label (markdown-stripped, single-line)
+  instead of becoming separate — and notifying — progress messages. A
+  text block in the same turn as a thinking-derived label replaces it;
+  a text block following a text-set goal completes it (`✓`) and starts
+  a new goal line. This also removes the last interim-notification gap:
+  during a worker turn, only the final answer notifies.
 - **Idle-timeout deletion.** If a turn dies mid-thinking (kill -9, network
   drop) and no final answer arrives, the stale bubble is deleted after
   `CCGRAM_PI_TRACE_IDLE_SECS` (default `600` = 10 minutes).
-- **Goal/thinking paraphrase dedupe, two layers.** Some models emit a
+- **Same-message goal/thinking paraphrase dedupe.** Some models emit a
   mid-turn visible text block that paraphrases their own thinking block in
-  the same assistant message. At parse time, `pi_format` drops a thinking
-  block whose first line near-duplicates the same message's goal text
-  (token-based rule: shared opening of 3+ words plus a shared 4+ word
-  contiguous phrase — the earlier character-level SequenceMatcher rule
-  silently collapsed on long thinking lines via difflib autojunk, which is
-  why the exact line-14 transcript pair slipped through PR150). At render
-  time, `pi_live_transcript` additionally hides the latest step when it
-  paraphrases the current goal (covers a paraphrase arriving in an earlier
-  message than the goal). Thinking-only messages and genuinely distinct
-  thinking+text messages keep both entries.
-- **No-tree mobile wrap.** Goal and step lines are word-wrapped at
+  the same assistant message. `pi_format` drops a thinking block whose
+  first line near-duplicates the same message's goal text (token-based
+  rule: shared opening of 3+ words plus a shared 4+ word contiguous
+  phrase — the earlier character-level SequenceMatcher rule silently
+  collapsed on long thinking lines via difflib autojunk, which is why
+  the exact line-14 transcript pair slipped through PR150), so the
+  screenshot case displays the concise goal once. Thinking-only messages
+  and genuinely distinct thinking+text messages keep both entries.
+- **Mobile bullet-safe wrap.** Goal labels are word-wrapped at
   `CCGRAM_PI_TRACE_WRAP_CHARS` columns (default `36`; Telegram mobile
   wraps by pixels in a proportional font and a phone bubble fits roughly
   35–44 Latin chars, so 36 keeps intentional breaks ahead of Telegram's
-  own re-wrap) with NO connector prefix and NO hanging indent — there is
-  no tree shape left for Telegram's re-wrap to shatter. `0` disables
-  intentional wrapping. The 120-char per-line caps still apply as the hard
-  truncation ceiling above this soft wrap.
+  own re-wrap) with a blank hanging indent under the bullet: wrapped
+  continuations align under the label text, visually subordinate to the
+  `▸`/`✓` marker, with no tree connector to shatter. `0` disables
+  intentional wrapping. The 120-char per-label caps still apply as the
+  hard truncation ceiling above this soft wrap.
 
 | Env knob | Default | Prototype setting | Meaning |
 | -------- | ------- | ----------------- | ------- |
 | `CCGRAM_PI_TRACE_EDIT_SECS` | `2.0` | `1.0` | Minimum seconds between trace-bubble edits (applies to step/goal updates and the timer ticker). |
 | `CCGRAM_PI_TRACE_TICK_SECS` | `1.0` | unset | Liveness ticker period (timer refresh + idle sweep granularity). |
 | `CCGRAM_PI_TRACE_IDLE_SECS` | `600` | unset | Delete a trace bubble with no thinking/goal activity for this long (killed-turn cleanup). |
-| `CCGRAM_PI_TRACE_WRAP_CHARS` | `36` | unset | Soft word-wrap width (in characters) for goal/step lines, plain column-0 wrap (no connectors/indents); `0` disables. |
+| `CCGRAM_PI_TRACE_WRAP_CHARS` | `36` | unset | Soft word-wrap width (in characters) for goal labels, blank hanging indent under the bullet; `0` disables. |
 
 ### Remaining parity gaps (vs the Pi TUI)
 
@@ -429,7 +447,7 @@ thinking…` footer.
   cannot show new content. Closing this needs an upstream streaming event
   source (Pi-side partial entries or an attachable event subscription).
 - **Step-granularity trace.** Pi writes an assistant message to the JSONL
-  when that step finishes, so the status bubble's step line updates per
+  when that step finishes, so the status bubble's goal lines update per
   completed step, not token-by-token (same limitation the sidecar had; it
   matches the temporary-render goal).
 - **Tool calls vanish rather than collapse.** In the Pi TUI, finished tool

--- a/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
+++ b/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
@@ -32,8 +32,8 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handl
              if len(stripped) < _MIN_THINKING_LENGTH:
 diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
 --- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 12:23:28.800045847 -0400
-+++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 12:24:12.614650215 -0400
-@@ -1,29 +1,67 @@
++++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 12:39:33.157817656 -0400
+@@ -1,29 +1,74 @@
 -"""Pi live thinking transcript — temporary tree-style trace per topic.
 +"""Pi live thinking status — temporary live status bubble per topic.
  
@@ -55,17 +55,24 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +here, tool calls in tool_batch, final answers through the normal content
 +queue.
 +
-+The bubble is deliberately NOT a tree (dotfiles no-tree live status
-+revision): no ``├─``/``└─``/``▸`` connectors and no hanging indents —
-+Telegram mobile wraps by pixels in a proportional font, so connector
-+columns shattered on phone-width bubbles.  It renders:
++The bubble mirrors the Pi Telegram frontdoor daemon's goal-line
++rendering (``pi/bin/pi-telegram-daemon.py`` ``ThinkingTreeBuilder``):
 +
 +1. a header with a live elapsed timer (``🧠 Thinking… · 0:42``),
-+2. one bold current-goal line (the model's mid-turn narration), and
-+3. optionally the latest thinking summary as one plain line — omitted
-+   when it merely paraphrases the goal, so the same statement never
-+   shows twice,
-+4. a plain ``⏳ still thinking…`` footer.
++2. one bold goal line per goal — ``▸ **label**`` while the goal is
++   active, ``✓ **label**`` once a newer goal supersedes it.
++
++No ``├─``/``└─`` tree connectors and no prose thinking-summary lines:
++thinking blocks are tracked (a thinking-only turn derives the active
++goal's label from its first thinking block, like the frontdoor's
++``label_derived`` path) but never rendered as lines of their own — the
++``▸`` bullet is the only progress marker.  A thinking block whose first
++line paraphrases the same message's goal text is dropped in pi_format,
++so the screenshot case displays the concise goal once.
++
++Wrapped goal labels hang their continuation lines under the label text
++(a blank indent the width of the ``▸ ``/``✓ `` prefix), so wrapped lines
++stay visually subordinate to the bullet without any tree connector.
  
  Messages are marked by the Pi formatter via ``AgentMessage.phase``:
  
@@ -94,14 +101,14 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +- ``CCGRAM_PI_TRACE_IDLE_SECS`` — idle-timeout deletion (default 600 =
 +  10 minutes).
 +- ``CCGRAM_PI_TRACE_WRAP_CHARS`` — mobile wrap width (default 36).  Goal
-+  and step lines are word-wrapped to this many columns, no indentation.
-+  Telegram mobile lays text out in a proportional font and wraps by
-+  pixels; a phone bubble fits roughly 35–44 Latin characters, so 36
-+  keeps intentional breaks ahead of Telegram's own re-wrap.  0 disables
-+  intentional wrapping.
++  labels are word-wrapped to this many columns with a blank hanging
++  indent under the bullet.  Telegram mobile lays text out in a
++  proportional font and wraps by pixels; a phone bubble fits roughly
++  35–44 Latin characters, so 36 keeps intentional breaks ahead of
++  Telegram's own re-wrap.  0 disables intentional wrapping.
 +
-+State is in-memory per (user_id, thread_id): recent steps, the current
-+goal label, and the Telegram message id of the temporary status bubble.
++State is in-memory per (user_id, thread_id): the goal nodes (active +
++completed), and the Telegram message id of the temporary status bubble.
  """
  
  from __future__ import annotations
@@ -113,12 +120,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  import time
  from dataclasses import dataclass, field
  
-@@ -34,19 +72,31 @@
- from ...topic_state_registry import topic_state
- from .message_sender import edit_with_fallback, safe_send
- from .message_task import thread_key
-+from ccgram.providers.pi_format import is_goal_thinking_duplicate
- 
+@@ -38,110 +83,381 @@
  logger = structlog.get_logger()
  
  PI_LIVE_PHASE = "pi-live"
@@ -131,9 +133,10 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +# Status-bubble presentation knobs.
  MAX_STEP_CHARS = 120
 +MAX_GOAL_CHARS = 120
- 
--_TREE_HEADER = "\U0001f9e0 Thinking\u2026"
--_TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
++# Completed (✓) goal lines retained above the active one; older ones are
++# dropped (the bubble is a compact current-status view, not a scrollback).
++MAX_GOAL_LINES = 8
++
 +# Liveness knobs (dotfiles thinking-tree-live patch), env-configurable.
 +EDIT_MIN_SECS = float(os.getenv("CCGRAM_PI_TRACE_EDIT_SECS", "2.0"))
 +TICK_SECS = float(os.getenv("CCGRAM_PI_TRACE_TICK_SECS", "1.0"))
@@ -141,20 +144,42 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +WRAP_CHARS = int(os.getenv("CCGRAM_PI_TRACE_WRAP_CHARS", "36"))
 +
 +_STATUS_HEADER = "\U0001f9e0 Thinking\u2026"
-+_STATUS_SPINNER = "\u23f3 still thinking\u2026"
++_GOAL_ACTIVE_PREFIX = "\u25b8 "  # ▸ + space
++_GOAL_DONE_PREFIX = "\u2713 "  # ✓ + space
++# Blank indent for wrapped label continuations: same column width as the
++# bullet prefixes, so a wrapped label stays visually subordinate to its
++# bullet (matching the PR148 wrap mechanics — without any tree connector).
++_GOAL_CONT_INDENT = " " * len(_GOAL_ACTIVE_PREFIX)
 +
 +# Markdown metacharacters stripped from goal labels (mirrors the frontdoor
 +# daemon's _strip_markdown) so model markdown cannot leak literal markup or
 +# skew the bold entity offsets of the rendered goal line.
 +_MD_STRIP_RE = re.compile(r"(\*\*|__|~~|`)")
++
++
++@dataclass
++class _GoalNode:
++    """One goal line: a mid-turn narration, or derived from thinking.
+ 
+-_TREE_HEADER = "\U0001f9e0 Thinking\u2026"
+-_TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
++    ``derived`` marks a label taken from a thinking block's first line
++    (frontdoor ``label_derived``): it sticks until a text block in the
++    same turn replaces it, and only a text-derived goal starts a new
++    node (completing the previous one as ✓).
++    """
++
++    label: str
++    derived: bool = False
++    done: bool = False
  
  
  @dataclass
-@@ -54,94 +104,297 @@
+ class _LiveTrace:
      """Per-topic temporary thinking trace state."""
  
-     steps: list[str] = field(default_factory=list)
-+    goal: str | None = None
+-    steps: list[str] = field(default_factory=list)
++    goals: list[_GoalNode] = field(default_factory=list)
      message_id: int | None = None
      chat_id: int | None = None
 +    client: TelegramClient | None = None
@@ -185,10 +210,10 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +def _strip_markdown(text: str) -> str:
 +    """Remove markdown emphasis/code markers from a goal label."""
 +    return _MD_STRIP_RE.sub("", text)
++
  
 -    Overflow folds into a ``\u2026 (N earlier steps)`` node, matching the
 -    step-granularity live trace of the Pi TUI.
-+
 +def wrap_segments(prefix_width: int, text: str, width: int) -> list[str]:
 +    """Word-wrap ``text`` so ``prefix_width + segment`` fits ``width``.
 +
@@ -199,7 +224,15 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    <= 0 disables wrapping (single segment).  Width is counted in
 +    characters — Telegram wraps by pixels with a proportional font, so
 +    this is an intentional mobile-column approximation, not an exact fit.
-+    """
+     """
+-    lines = [_TREE_HEADER]
+-    shown = steps[-max_steps:] if max_steps > 0 else []
+-    hidden = len(steps) - len(shown)
+-    if hidden > 0:
+-        lines.append(f"\u251c\u2500 \u2026 ({hidden} earlier steps)")
+-    for step in shown:
+-        lines.append(f"\u251c\u2500 {step}")
+-    lines.append(_TREE_SPINNER)
 +    if width <= 0:
 +        return [text]
 +    avail = max(1, width - prefix_width)
@@ -224,44 +257,34 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +
 +
 +def render_thinking_status(
-+    steps: list[str],
-+    goal: str | None = None,
++    goals: list[_GoalNode],
 +    elapsed: float | None = None,
 +    wrap_chars: int = WRAP_CHARS,
 +) -> str:
-+    """Render the trace as a compact live status bubble (no tree).
++    """Render the trace as a frontdoor-style goal-line status bubble.
 +
-+    ``elapsed`` adds the liveness timer to the header (``· 0:42``); ``goal``
-+    renders as a bold line under the header.  Only the LATEST step shows,
-+    as one plain summary line — and only when it is not a paraphrase of
-+    the current goal, so the bubble never states the same progress twice.
-+    Goal and step lines are word-wrapped at ``wrap_chars`` with no
-+    connector prefix and no hanging indent (``wrap_chars`` <= 0 disables
++    Mirrors ``ThinkingTreeBuilder.render`` in the Pi Telegram frontdoor
++    daemon: header with the live elapsed timer, then one bold line per
++    goal — ``▸`` while the goal is active, ``✓`` once done.  No thinking
++    leaves, no tree connectors, no prose paragraphs.  Labels wrap at
++    ``wrap_chars`` with a blank hanging indent under the bullet so
++    continuations stay visually subordinate (``wrap_chars`` <= 0 disables
 +    intentional wrapping).
-     """
--    lines = [_TREE_HEADER]
--    shown = steps[-max_steps:] if max_steps > 0 else []
--    hidden = len(steps) - len(shown)
--    if hidden > 0:
--        lines.append(f"\u251c\u2500 \u2026 ({hidden} earlier steps)")
--    for step in shown:
--        lines.append(f"\u251c\u2500 {step}")
--    lines.append(_TREE_SPINNER)
++    """
 +    header = _STATUS_HEADER
 +    if elapsed is not None:
 +        header = f"{header} \u00b7 {format_elapsed(elapsed)}"
 +    lines = [header]
-+    if goal:
++    for node in goals:
++        bullet = _GOAL_DONE_PREFIX if node.done else _GOAL_ACTIVE_PREFIX
 +        # Bold each wrapped segment separately; the ``**`` markers are
 +        # converted to entities (not displayed), so width is counted on
-+        # the plain goal text.
-+        for seg in wrap_segments(0, goal, wrap_chars):
-+            lines.append(f"**{seg}**")
-+    step = steps[-1] if steps else ""
-+    if step and not (goal and is_goal_thinking_duplicate(goal, step)):
-+        for seg in wrap_segments(0, step, wrap_chars):
-+            lines.append(seg)
-+    lines.append(_STATUS_SPINNER)
++        # the plain label text.
++        for i, seg in enumerate(
++            wrap_segments(len(bullet), node.label, wrap_chars)
++        ):
++            prefix = bullet if i == 0 else _GOAL_CONT_INDENT
++            lines.append(f"{prefix}**{seg}**")
      return "\n".join(lines)
  
  
@@ -269,8 +292,19 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +def _render(trace: _LiveTrace, now: float) -> str:
 +    """Render a trace's current status text, including the live timer."""
 +    return render_thinking_status(
-+        trace.steps, goal=trace.goal, elapsed=now - trace.started_ts
++        trace.goals, elapsed=now - trace.started_ts
 +    )
++
++
++def _trim_goals(trace: _LiveTrace) -> None:
++    """Cap retained goal lines, dropping the oldest completed ones."""
++    while len(trace.goals) > MAX_GOAL_LINES:
++        for i, node in enumerate(trace.goals[:-1]):
++            if node.done:
++                del trace.goals[i]
++                break
++        else:
++            del trace.goals[0]
 +
 +
 +def _touch_trace(
@@ -443,12 +477,22 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    First block sends the bubble; later blocks edit it in place, rate-limited
 +    by EDIT_MIN_SECS (the final delete is never rate-limited).
 +    """
-+    step = normalize_step(step_text)
-+    if not step:
++    label = normalize_step(step_text)
++    if not label:
 +        return
 +
 +    _key, trace, now = _touch_trace(client, user_id, thread_id, chat_id)
-+    trace.steps.append(step)
++    node = trace.goals[-1] if trace.goals else None
++    if node is None or node.done:
++        # Thinking-only activity with no live goal: derive the active
++        # goal's label from this thinking block's first line (frontdoor
++        # ``label_derived`` path).  The label is sticky — later thinking
++        # blocks in the same goal never rewrite it, and thinking never
++        # renders as a line of its own.
++        trace.goals.append(
++            _GoalNode(label=_strip_markdown(label), derived=True)
++        )
++        _trim_goals(trace)
 +    _ensure_ticker()
 +    await _push_update(trace, thread_id, now)
 +
@@ -460,12 +504,15 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    chat_id: int,
 +    goal_text: str,
 +) -> None:
-+    """Fold mid-turn assistant text into the bubble as the bold goal line.
++    """Fold mid-turn assistant text into the bubble as the goal label.
 +
 +    The text block of a ``stopReason="toolUse"`` assistant message is the
-+    model narrating its current step; it updates the bubble's goal line
-+    (markdown-stripped, single-line) instead of becoming a separate
-+    notifying progress message.
++    model narrating its current step; it becomes the active ``▸`` goal
++    label (markdown-stripped, single-line) instead of a separate
++    notifying progress message.  A text block in the same turn as a
++    thinking-derived label REPLACES that label (frontdoor
++    ``label_derived``); a text block following a text-set goal completes
++    it (``✓``) and starts a new goal line.
 +    """
 +    goal = " ".join(_strip_markdown(goal_text or "").split())
 +    if not goal:
@@ -474,9 +521,22 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +        goal = goal[:MAX_GOAL_CHARS].rstrip() + "\u2026"
 +
 +    _key, trace, now = _touch_trace(client, user_id, thread_id, chat_id)
-+    if goal == trace.goal:
-+        return
-+    trace.goal = goal
++    node = trace.goals[-1] if trace.goals else None
++    if node is not None and not node.done and node.derived:
++        # The visible text block wins over the thinking-derived label in
++        # the same goal node.
++        if node.label == goal:
++            node.derived = False
++            return
++        node.label = goal
++        node.derived = False
++    else:
++        if node is not None and not node.done and node.label == goal:
++            return
++        if node is not None:
++            node.done = True
++        trace.goals.append(_GoalNode(label=goal))
++        _trim_goals(trace)
 +    _ensure_ticker()
 +    await _push_update(trace, thread_id, now)
 +
@@ -484,7 +544,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  async def clear_pi_thinking(
      client: TelegramClient,
      user_id: int,
-@@ -150,8 +403,8 @@
+@@ -150,8 +466,8 @@
      """Delete the topic's temporary trace bubble, if any.
  
      Called when the final assistant answer (or a terminal error notice) is
@@ -495,7 +555,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
      """
      key = (user_id, thread_key(thread_id))
      trace = _traces.pop(key, None)
-@@ -170,5 +423,9 @@
+@@ -170,5 +486,9 @@
  
  
  def clear_all_traces() -> None:

--- a/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
+++ b/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
@@ -1,6 +1,6 @@
 diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handlers/messaging_pipeline/message_routing.py
---- a/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-16 11:01:54.968490468 -0400
-+++ b/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-16 11:02:41.281276117 -0400
+--- a/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-16 12:23:28.799903842 -0400
++++ b/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-16 12:23:28.812342247 -0400
 @@ -28,8 +28,10 @@
  from .message_queue import enqueue_content_message, get_message_queue
  from .pi_live_transcript import (
@@ -31,14 +31,48 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handl
              stripped = (msg.text or "").strip()
              if len(stripped) < _MIN_THINKING_LENGTH:
 diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
---- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 11:01:54.968652031 -0400
-+++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 11:03:42.372474875 -0400
-@@ -13,17 +13,46 @@
+--- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 12:23:28.800045847 -0400
++++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 12:24:12.614650215 -0400
+@@ -1,29 +1,67 @@
+-"""Pi live thinking transcript — temporary tree-style trace per topic.
++"""Pi live thinking status — temporary live status bubble per topic.
+ 
+ Renderer-parity layer for the Pi provider (dotfiles ccgram-prototype patch).
+-Owns Pi thinking presentation so Pi sessions match the Pi TUI: while the
+-model works, ONE temporary message per topic shows the thinking trace as a
+-compact tree; when the final assistant answer is ready the trace is deleted
+-and only the answer remains.  Tool-call display stays with tool_batch
+-(ephemeral mode already collapses each run of tool calls into one edited
+-bubble and deletes it on flush), so a single pipeline owns the whole
+-Pi transcript flow: thinking here, tool calls in tool_batch, final answers
+-through the normal content queue.
++Owns Pi thinking presentation: while the model works, ONE temporary
++message per topic shows a compact live status bubble; when the final
++assistant answer is ready the bubble is deleted and only the answer
++remains.  Tool-call display stays with tool_batch (ephemeral mode already
++collapses each run of tool calls into one edited bubble and deletes it on
++flush), so a single pipeline owns the whole Pi transcript flow: thinking
++here, tool calls in tool_batch, final answers through the normal content
++queue.
++
++The bubble is deliberately NOT a tree (dotfiles no-tree live status
++revision): no ``├─``/``└─``/``▸`` connectors and no hanging indents —
++Telegram mobile wraps by pixels in a proportional font, so connector
++columns shattered on phone-width bubbles.  It renders:
++
++1. a header with a live elapsed timer (``🧠 Thinking… · 0:42``),
++2. one bold current-goal line (the model's mid-turn narration), and
++3. optionally the latest thinking summary as one plain line — omitted
++   when it merely paraphrases the goal, so the same statement never
++   shows twice,
++4. a plain ``⏳ still thinking…`` footer.
+ 
  Messages are marked by the Pi formatter via ``AgentMessage.phase``:
  
- - ``PI_LIVE_PHASE``  — a thinking block; folded into the temporary tree.
+-- ``PI_LIVE_PHASE``  — a thinking block; folded into the temporary tree.
++- ``PI_LIVE_PHASE``  — a thinking block; folded into the temporary bubble.
 +- ``PI_GOAL_PHASE``  — mid-turn assistant text (stopReason ``toolUse``);
-+  folded into the tree as the bold goal/top line instead of becoming a
++  folded into the bubble as the bold goal line instead of becoming a
 +  separate (notifying) progress message.
  - ``PI_FINAL_PHASE`` — assistant text with a terminal stopReason (anything
    but ``toolUse``); triggers deletion of the temporary trace before the
@@ -46,12 +80,11 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  
 -State is in-memory per (user_id, thread_id): rendered steps plus the
 -Telegram message id of the temporary trace bubble.
-+Liveness (dotfiles thinking-tree-live patch): the tree header carries a
-+live elapsed timer (``🧠 Thinking… · 0:42``) and a per-trace background
-+ticker re-renders the bubble at the edit cadence even when no new
-+completed JSONL message has arrived, so the trace always looks alive.
-+The same sweep deletes a stale bubble when no thinking/goal activity has
-+arrived for ``IDLE_SECS`` (a killed turn leaves no orphan).
++Liveness: a per-trace background ticker re-renders the bubble at the edit
++cadence even when no new completed JSONL message has arrived, so the
++timer always advances.  The same sweep deletes a stale bubble when no
++thinking/goal activity has arrived for ``IDLE_SECS`` (a killed turn
++leaves no orphan).
 +
 +Knobs (env, read at import):
 +
@@ -61,16 +94,14 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +- ``CCGRAM_PI_TRACE_IDLE_SECS`` — idle-timeout deletion (default 600 =
 +  10 minutes).
 +- ``CCGRAM_PI_TRACE_WRAP_CHARS`` — mobile wrap width (default 36).  Goal
-+  and step lines are word-wrapped to this many columns with a hanging
-+  indent under the node prefix, so the tree shape survives Telegram's
-+  phone-width line wrapping.  Telegram mobile lays text out in a
-+  proportional font and wraps by pixels; a phone bubble fits roughly
-+  35–44 Latin characters, so 36 keeps intentional breaks ahead of
-+  Telegram's own re-wrap (48 was wider than a phone bubble and shattered
-+  the tree on mobile).  0 disables intentional wrapping.
++  and step lines are word-wrapped to this many columns, no indentation.
++  Telegram mobile lays text out in a proportional font and wraps by
++  pixels; a phone bubble fits roughly 35–44 Latin characters, so 36
++  keeps intentional breaks ahead of Telegram's own re-wrap.  0 disables
++  intentional wrapping.
 +
-+State is in-memory per (user_id, thread_id): rendered steps, the current
-+goal label, and the Telegram message id of the temporary trace bubble.
++State is in-memory per (user_id, thread_id): recent steps, the current
++goal label, and the Telegram message id of the temporary status bubble.
  """
  
  from __future__ import annotations
@@ -82,34 +113,35 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  import time
  from dataclasses import dataclass, field
  
-@@ -38,15 +67,34 @@
+@@ -34,19 +72,31 @@
+ from ...topic_state_registry import topic_state
+ from .message_sender import edit_with_fallback, safe_send
+ from .message_task import thread_key
++from ccgram.providers.pi_format import is_goal_thinking_duplicate
+ 
  logger = structlog.get_logger()
  
  PI_LIVE_PHASE = "pi-live"
 +PI_GOAL_PHASE = "pi-live-goal"
  PI_FINAL_PHASE = "pi-final"
  
- # Tree presentation knobs (mirror the retired sidecar defaults).
- MAX_TREE_STEPS = 8
+-# Tree presentation knobs (mirror the retired sidecar defaults).
+-MAX_TREE_STEPS = 8
 -EDIT_MIN_SECS = 2.0
++# Status-bubble presentation knobs.
  MAX_STEP_CHARS = 120
 +MAX_GOAL_CHARS = 120
-+
+ 
+-_TREE_HEADER = "\U0001f9e0 Thinking\u2026"
+-_TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
 +# Liveness knobs (dotfiles thinking-tree-live patch), env-configurable.
 +EDIT_MIN_SECS = float(os.getenv("CCGRAM_PI_TRACE_EDIT_SECS", "2.0"))
 +TICK_SECS = float(os.getenv("CCGRAM_PI_TRACE_TICK_SECS", "1.0"))
 +IDLE_SECS = float(os.getenv("CCGRAM_PI_TRACE_IDLE_SECS", "600"))
 +WRAP_CHARS = int(os.getenv("CCGRAM_PI_TRACE_WRAP_CHARS", "36"))
- 
- _TREE_HEADER = "\U0001f9e0 Thinking\u2026"
- _TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
-+_GOAL_PREFIX = "\u25b8 "  # ▸ + space
-+_STEP_PREFIX = "\u251c\u2500 "  # ├─ + space
-+# Hanging indents for wrapped continuation lines: same column width as the
-+# node prefixes, so a wrapped line aligns under its node's text and the
-+# tree shape survives Telegram's phone-width wrapping.
-+_GOAL_INDENT = " " * len(_GOAL_PREFIX)
-+_STEP_INDENT = " " * len(_STEP_PREFIX)
++
++_STATUS_HEADER = "\U0001f9e0 Thinking\u2026"
++_STATUS_SPINNER = "\u23f3 still thinking\u2026"
 +
 +# Markdown metacharacters stripped from goal labels (mirrors the frontdoor
 +# daemon's _strip_markdown) so model markdown cannot leak literal markup or
@@ -118,7 +150,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  
  
  @dataclass
-@@ -54,14 +102,22 @@
+@@ -54,94 +104,297 @@
      """Per-topic temporary thinking trace state."""
  
      steps: list[str] = field(default_factory=list)
@@ -140,22 +172,29 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +
  
  def normalize_step(text: str, max_chars: int = MAX_STEP_CHARS) -> str:
-     """Reduce a thinking block to one compact tree node (first line)."""
-@@ -71,77 +127,277 @@
+-    """Reduce a thinking block to one compact tree node (first line)."""
++    """Reduce a thinking block to one compact summary line (first line)."""
+     first_line = (text or "").strip().splitlines()[0] if text and text.strip() else ""
+     if len(first_line) > max_chars:
+         first_line = first_line[:max_chars].rstrip() + "\u2026"
      return first_line
  
  
 -def render_thinking_tree(steps: list[str], max_steps: int = MAX_TREE_STEPS) -> str:
+-    """Render the trace as a compact tree, newest steps last.
 +def _strip_markdown(text: str) -> str:
 +    """Remove markdown emphasis/code markers from a goal label."""
 +    return _MD_STRIP_RE.sub("", text)
-+
+ 
+-    Overflow folds into a ``\u2026 (N earlier steps)`` node, matching the
+-    step-granularity live trace of the Pi TUI.
 +
 +def wrap_segments(prefix_width: int, text: str, width: int) -> list[str]:
 +    """Word-wrap ``text`` so ``prefix_width + segment`` fits ``width``.
 +
-+    Continuation segments share the first line's available width because
-+    the renderer hangs them under a same-width blank indent.  Breaks
++    The no-tree status bubble always passes ``prefix_width`` 0 (no
++    connector column to reserve); the parameter remains so a caller can
++    reserve a first-line inset if one is ever reintroduced.  Breaks
 +    prefer spaces; an unbreakable over-long word is hard-cut.  ``width``
 +    <= 0 disables wrapping (single segment).  Width is counted in
 +    characters — Telegram wraps by pixels with a proportional font, so
@@ -184,27 +223,31 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    return f"{total // 60}:{total % 60:02d}"
 +
 +
-+def render_thinking_tree(
++def render_thinking_status(
 +    steps: list[str],
 +    goal: str | None = None,
 +    elapsed: float | None = None,
-+    max_steps: int = MAX_TREE_STEPS,
 +    wrap_chars: int = WRAP_CHARS,
 +) -> str:
-     """Render the trace as a compact tree, newest steps last.
- 
--    Overflow folds into a ``\u2026 (N earlier steps)`` node, matching the
--    step-granularity live trace of the Pi TUI.
++    """Render the trace as a compact live status bubble (no tree).
++
 +    ``elapsed`` adds the liveness timer to the header (``· 0:42``); ``goal``
-+    renders as a bold top line under the header.  Overflow folds into a
-+    ``… (N earlier steps)`` node, matching the step-granularity live trace
-+    of the Pi TUI.  Goal and step lines are word-wrapped at ``wrap_chars``
-+    with a hanging indent under their node prefix, so the tree shape
-+    survives Telegram's phone-width wrapping (``wrap_chars`` <= 0 disables
++    renders as a bold line under the header.  Only the LATEST step shows,
++    as one plain summary line — and only when it is not a paraphrase of
++    the current goal, so the bubble never states the same progress twice.
++    Goal and step lines are word-wrapped at ``wrap_chars`` with no
++    connector prefix and no hanging indent (``wrap_chars`` <= 0 disables
 +    intentional wrapping).
      """
 -    lines = [_TREE_HEADER]
-+    header = _TREE_HEADER
+-    shown = steps[-max_steps:] if max_steps > 0 else []
+-    hidden = len(steps) - len(shown)
+-    if hidden > 0:
+-        lines.append(f"\u251c\u2500 \u2026 ({hidden} earlier steps)")
+-    for step in shown:
+-        lines.append(f"\u251c\u2500 {step}")
+-    lines.append(_TREE_SPINNER)
++    header = _STATUS_HEADER
 +    if elapsed is not None:
 +        header = f"{header} \u00b7 {format_elapsed(elapsed)}"
 +    lines = [header]
@@ -212,26 +255,20 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +        # Bold each wrapped segment separately; the ``**`` markers are
 +        # converted to entities (not displayed), so width is counted on
 +        # the plain goal text.
-+        for i, seg in enumerate(wrap_segments(len(_GOAL_PREFIX), goal, wrap_chars)):
-+            prefix = _GOAL_PREFIX if i == 0 else _GOAL_INDENT
-+            lines.append(f"{prefix}**{seg}**")
-     shown = steps[-max_steps:] if max_steps > 0 else []
-     hidden = len(steps) - len(shown)
-     if hidden > 0:
-         lines.append(f"\u251c\u2500 \u2026 ({hidden} earlier steps)")
-     for step in shown:
--        lines.append(f"\u251c\u2500 {step}")
-+        for i, seg in enumerate(wrap_segments(len(_STEP_PREFIX), step, wrap_chars)):
-+            prefix = _STEP_PREFIX if i == 0 else _STEP_INDENT
-+            lines.append(f"{prefix}{seg}")
-     lines.append(_TREE_SPINNER)
++        for seg in wrap_segments(0, goal, wrap_chars):
++            lines.append(f"**{seg}**")
++    step = steps[-1] if steps else ""
++    if step and not (goal and is_goal_thinking_duplicate(goal, step)):
++        for seg in wrap_segments(0, step, wrap_chars):
++            lines.append(seg)
++    lines.append(_STATUS_SPINNER)
      return "\n".join(lines)
  
  
 -async def handle_pi_thinking(
 +def _render(trace: _LiveTrace, now: float) -> str:
-+    """Render a trace's current tree text, including the live timer."""
-+    return render_thinking_tree(
++    """Render a trace's current status text, including the live timer."""
++    return render_thinking_status(
 +        trace.steps, goal=trace.goal, elapsed=now - trace.started_ts
 +    )
 +
@@ -401,7 +438,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    chat_id: int,
 +    step_text: str,
 +) -> None:
-+    """Fold one thinking block into the topic's temporary trace bubble.
++    """Fold one thinking block into the topic's temporary status bubble.
 +
 +    First block sends the bubble; later blocks edit it in place, rate-limited
 +    by EDIT_MIN_SECS (the final delete is never rate-limited).
@@ -423,10 +460,10 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    chat_id: int,
 +    goal_text: str,
 +) -> None:
-+    """Fold mid-turn assistant text into the tree as the bold goal line.
++    """Fold mid-turn assistant text into the bubble as the bold goal line.
 +
 +    The text block of a ``stopReason="toolUse"`` assistant message is the
-+    model narrating its current step; it updates the tree's top line
++    model narrating its current step; it updates the bubble's goal line
 +    (markdown-stripped, single-line) instead of becoming a separate
 +    notifying progress message.
 +    """
@@ -447,7 +484,18 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  async def clear_pi_thinking(
      client: TelegramClient,
      user_id: int,
-@@ -170,5 +426,9 @@
+@@ -150,8 +403,8 @@
+     """Delete the topic's temporary trace bubble, if any.
+ 
+     Called when the final assistant answer (or a terminal error notice) is
+-    about to be delivered, so the trace disappears exactly like Pi's
+-    tree-style live transcript.
++    about to be delivered, so the temporary status bubble disappears before
++    the answer lands.
+     """
+     key = (user_id, thread_key(thread_id))
+     trace = _traces.pop(key, None)
+@@ -170,5 +423,9 @@
  
  
  def clear_all_traces() -> None:
@@ -459,19 +507,25 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +        _tick_task.cancel()
 +    _tick_task = None
 diff -ruN a/ccgram/providers/pi_format.py b/ccgram/providers/pi_format.py
---- a/ccgram/providers/pi_format.py	2026-08-16 11:01:54.968744163 -0400
-+++ b/ccgram/providers/pi_format.py	2026-08-16 11:03:36.800471735 -0400
-@@ -22,11 +22,20 @@
+--- a/ccgram/providers/pi_format.py	2026-08-16 12:23:28.798744933 -0400
++++ b/ccgram/providers/pi_format.py	2026-08-16 12:24:52.846657139 -0400
+@@ -17,16 +17,25 @@
+ Renderer parity (dotfiles ccgram-prototype patch): ``thinking`` blocks are
+ no longer dropped.  They are emitted as ``content_type="thinking"`` messages
+ stamped ``phase="pi-live"`` so the messaging pipeline can fold them into one
+-temporary tree-style trace per topic (see
++temporary live status bubble per topic (see
+ ``handlers/messaging_pipeline/pi_live_transcript.py``).  Assistant text is
  stamped ``phase="pi-final"`` when the message carries a terminal stopReason
  (anything but ``toolUse``), which is the signal to delete that trace before
  the answer is delivered — matching Pi's own live-transcript behaviour.
 +Mid-turn assistant text (stopReason ``toolUse``) is stamped
-+``phase="pi-live-goal"`` so the pipeline folds it into the tree as the bold
-+goal/top line instead of a separate notifying progress message (dotfiles
-+thinking-tree-live patch).  When the same message also carries a thinking
-+block whose first line paraphrases that goal text, the thinking block is
-+dropped here — the goal already narrates the step, so rendering both makes
-+the mobile tree show the same statement twice, adjacently.
++``phase="pi-live-goal"`` so the pipeline folds it into the status bubble as
++the bold goal line instead of a separate notifying progress message
++(dotfiles thinking-tree-live patch).  When the same message also carries a
++thinking block whose first line paraphrases that goal text, the thinking
++block is dropped here — the goal already narrates the step, so rendering
++both would make the bubble state the same statement twice.
  """
  
  from __future__ import annotations
@@ -482,58 +536,75 @@ diff -ruN a/ccgram/providers/pi_format.py b/ccgram/providers/pi_format.py
  from typing import Any
  
  from ccgram.expandable_quote import format_expandable_quote
-@@ -195,6 +204,83 @@
+@@ -195,6 +204,100 @@
      )
  
  
-+# Same-message goal/thinking paraphrase dedupe thresholds (mobile tree
-+# fix).  A thinking first line is a near-duplicate of the goal when the
-+# normalized texts share an opening of at least this many words AND one
-+# common phrase of at least this many characters.  Requiring both keeps
-+# genuinely distinct thinking+text messages (different opening, or only a
-+# short incidental overlap) rendering as separate goal + step.
++# Same-message goal/thinking paraphrase dedupe thresholds (mobile status
++# bubble fix).  A thinking first line is a near-duplicate of the goal when
++# the normalized word streams share an opening of at least this many words
++# AND one common contiguous phrase of at least this many words.  Requiring
++# both keeps genuinely distinct thinking+text messages (different opening,
++# or only a short incidental overlap) rendering as separate goal + step.
++# Comparison is token-based: an earlier character-level SequenceMatcher
++# rule silently collapsed on long thinking lines (difflib autojunk marks
++# frequent characters as junk once the input grows, so the "longest common
++# substring" degraded to a few characters and real paraphrases slipped
++# through — the PR150 live-replay miss).
 +_DEDUPE_PREFIX_WORDS = 3
-+_DEDUPE_COMMON_CHARS = 20
++_DEDUPE_COMMON_WORDS = 4
 +_DEDUPE_NORM_RE = re.compile(r"[^a-z0-9]+")
 +
 +
-+def _normalize_dedupe(text: str) -> str:
-+    """Lowercase, alphanumeric-only, single-spaced text for comparison."""
-+    return " ".join(_DEDUPE_NORM_RE.sub(" ", text.lower()).split())
++def _dedupe_words(text: str) -> list[str]:
++    """Lowercase, alphanumeric-only word stream for comparison."""
++    return _DEDUPE_NORM_RE.sub(" ", text.lower()).split()
 +
 +
-+def _common_word_prefix(a: str, b: str) -> int:
-+    """Count the leading words two normalized strings share."""
++def _common_word_prefix(a: list[str], b: list[str]) -> int:
++    """Count the leading words two word streams share."""
 +    shared = 0
-+    for x, y in zip(a.split(), b.split()):
++    for x, y in zip(a, b):
 +        if x != y:
 +            break
 +        shared += 1
 +    return shared
 +
 +
-+def _is_goal_thinking_duplicate(goal: str, thinking: str) -> bool:
++def _common_word_run(a: list[str], b: list[str]) -> int:
++    """Length of the longest common contiguous word phrase.
++
++    Token-level ``find_longest_match`` is immune to the autojunk collapse
++    that broke the character-level rule (difflib only computes its
++    popular-element junk heuristic for sequences longer than 200 items,
++    and thinking first lines are far shorter than 200 words).
++    """
++    match = difflib.SequenceMatcher(None, a, b).find_longest_match(
++        0, len(a), 0, len(b)
++    )
++    return match.size
++
++
++def is_goal_thinking_duplicate(goal: str, thinking: str) -> bool:
 +    """True when a thinking block's first line paraphrases the goal text.
 +
 +    Some models emit a mid-turn visible text block that is a compressed
 +    paraphrase of their own thinking block in the same assistant message
 +    (e.g. goal ``Now let me check the vault's current state…`` beside
-+    thinking ``Now let me look at the vault's current state…``).  Folded
-+    into the tree, the pair renders as a bold goal line immediately
-+    followed by a near-identical ``├─`` step.  Only the thinking's first
-+    line is compared because that is all the tree step ever shows.
++    thinking ``Now let me look at the vault's current state…``).  Shown
++    together, the pair reads as the same statement twice.  Only the
++    thinking's first line is compared because that is all the status
++    bubble ever shows.  Public: the live-status renderer reuses this to
++    suppress a latest step that paraphrases the current goal.
 +    """
-+    g = _normalize_dedupe(goal)
++    g = _dedupe_words(goal)
 +    first_line = thinking.splitlines()[0] if thinking else ""
-+    t = _normalize_dedupe(first_line)
++    t = _dedupe_words(first_line)
 +    if not g or not t:
 +        return False
 +    if _common_word_prefix(g, t) < _DEDUPE_PREFIX_WORDS:
 +        return False
-+    match = difflib.SequenceMatcher(None, g, t).find_longest_match(
-+        0, len(g), 0, len(t)
-+    )
-+    return match.size >= _DEDUPE_COMMON_CHARS
++    return _common_word_run(g, t) >= _DEDUPE_COMMON_WORDS
 +
 +
 +def _drop_goal_thinking_duplicates(
@@ -544,7 +615,7 @@ diff -ruN a/ccgram/providers/pi_format.py b/ccgram/providers/pi_format.py
 +    Runs on one assistant message's parsed blocks (the only place both
 +    blocks are visible together), so thinking-only and text-only messages
 +    are unaffected, and a thinking block whose first line diverges from
-+    the goal is kept as its own tree step.
++    the goal is kept as its own status-bubble step.
 +    """
 +    goals = [
 +        m.text
@@ -558,7 +629,7 @@ diff -ruN a/ccgram/providers/pi_format.py b/ccgram/providers/pi_format.py
 +        for m in messages
 +        if not (
 +            m.content_type == "thinking"
-+            and any(_is_goal_thinking_duplicate(g, m.text) for g in goals)
++            and any(is_goal_thinking_duplicate(g, m.text) for g in goals)
 +        )
 +    ]
 +
@@ -566,31 +637,32 @@ diff -ruN a/ccgram/providers/pi_format.py b/ccgram/providers/pi_format.py
  def _parse_assistant_content(
      content: Any,
      pending: Pending,
-@@ -205,9 +291,14 @@
+@@ -205,9 +308,15 @@
  
      ``final`` marks the message as turn-terminal (stopReason != "toolUse");
      text messages then carry ``phase="pi-final"`` so the pipeline can retire
 -    the temporary thinking trace before delivering the answer.
 +    the temporary thinking trace before delivering the answer.  Mid-turn
-+    text carries ``phase="pi-live-goal"`` so it folds into the tree as the
-+    goal/top line (thinking-tree-live patch).  A mid-turn thinking block
-+    whose first line paraphrases the same message's goal text is dropped
-+    (``_drop_goal_thinking_duplicates``) so the tree does not render the
-+    same statement as both the bold goal line and an adjacent step.
++    text carries ``phase="pi-live-goal"`` so it folds into the status
++    bubble as the goal line (thinking-tree-live patch).  A mid-turn
++    thinking block whose first line paraphrases the same message's goal
++    text is dropped (``_drop_goal_thinking_duplicates``) so the bubble
++    does not state the same progress as both the bold goal line and an
++    adjacent step.
      """
 -    text_phase = "pi-final" if final else None
 +    text_phase = "pi-final" if final else "pi-live-goal"
      if isinstance(content, str):
          if content.strip():
              return [
-@@ -253,6 +344,11 @@
+@@ -253,6 +362,11 @@
                  )
          elif btype == "toolCall":
              messages.append(_tool_call_block_to_message(block, pending, timestamp))
 +    if not final:
-+        # Same-message goal/thinking paraphrase dedupe (mobile tree fix):
-+        # the goal already narrates this step, so a paraphrasing thinking
-+        # block must not also render as an adjacent ``├─`` step.
++        # Same-message goal/thinking paraphrase dedupe (mobile status
++        # bubble fix): the goal already narrates this step, so a
++        # paraphrasing thinking block must not also render as a step.
 +        messages = _drop_goal_thinking_duplicates(messages)
      return messages
  

--- a/ccgram-prototype/pi-renderer-patch.sh
+++ b/ccgram-prototype/pi-renderer-patch.sh
@@ -23,22 +23,22 @@
 #      nested-session primary preservation no longer pins reused Pi windows
 #      to the previous tenant's transcript.
 #   4. ccgram-4.5.2-pi-thinking-tree-live.patch
-#      No-tree live status bubble: live elapsed timer in the bubble header
-#      plus a background ticker that re-renders the bubble at the edit
-#      cadence even when no new JSONL message arrived;
-#      CCGRAM_PI_TRACE_EDIT_SECS / _TICK_SECS / _IDLE_SECS / _WRAP_CHARS
-#      env knobs; mid-turn assistant text (stopReason=toolUse) folds into
-#      the bubble as the bold goal line instead of a separate notifying
-#      message; goal/thinking paraphrase dedupe — parse-level in pi_format
-#      (a thinking block whose first line near-duplicates the same
-#      message's goal text is dropped; token-overlap rule, immune to the
-#      difflib autojunk collapse that let the real line-14 pair through
-#      the earlier character-level rule) plus render-level suppression of
-#      a latest step paraphrasing the current goal; no tree connectors or
-#      hanging indents (Telegram mobile wraps by pixels, which shattered
-#      the connector columns on phone-width bubbles); mobile-safe wrap
-#      default (36 columns); idle-timeout deletion of stale trace bubbles
-#      (default 10 min).
+#      Frontdoor-style live status bubble (mirrors pi-telegram-daemon's
+#      ThinkingTreeBuilder): live elapsed timer in the bubble header plus
+#      a background ticker that re-renders the bubble at the edit cadence
+#      even when no new JSONL message arrived; one bold goal line per
+#      goal — ▸ while active, ✓ once superseded; thinking blocks derive
+#      the active goal's label when no text label exists (sticky
+#      label_derived path) but never render as lines of their own — no
+#      ├─/└─ tree connectors, no prose paragraphs; CCGRAM_PI_TRACE_EDIT_SECS
+#      / _TICK_SECS / _IDLE_SECS / _WRAP_CHARS env knobs; mid-turn
+#      assistant text (stopReason=toolUse) folds into the bubble as the
+#      goal label instead of a separate notifying message; same-message
+#      goal/thinking paraphrase dedupe in pi_format (token-overlap rule,
+#      immune to the difflib autojunk collapse that let the real line-14
+#      pair through the earlier character-level rule); mobile-safe label
+#      wrap default (36 columns, blank hanging indent under the bullet);
+#      idle-timeout deletion of stale trace bubbles (default 10 min).
 #
 # Patch 2's context includes files added/edited by patch 1, so patch 2 only
 # applies on top of patch 1; patch 3 touches disjoint files and applies on

--- a/ccgram-prototype/pi-renderer-patch.sh
+++ b/ccgram-prototype/pi-renderer-patch.sh
@@ -6,7 +6,7 @@
 # topic transcript flow:
 #
 #   1. ccgram-4.5.2-pi-renderer-parity.patch
-#      Thinking (temporary tree-style trace), tool-call display (existing
+#      Thinking (temporary live trace bubble), tool-call display (existing
 #      ephemeral batch), final-answer delivery, phase stamping in pi_format.
 #   2. ccgram-4.5.2-low-noise-notifications.patch
 #      Final-answer-only notifications: the thinking trace bubble is silent
@@ -23,18 +23,22 @@
 #      nested-session primary preservation no longer pins reused Pi windows
 #      to the previous tenant's transcript.
 #   4. ccgram-4.5.2-pi-thinking-tree-live.patch
-#      Thinking-tree liveness: live elapsed timer in the trace header plus a
-#      background ticker that re-renders the bubble at the edit cadence even
-#      when no new JSONL message arrived; CCGRAM_PI_TRACE_EDIT_SECS /
-#      _TICK_SECS / _IDLE_SECS / _WRAP_CHARS env knobs; mid-turn assistant
-#      text (stopReason=toolUse) folds into the tree as the bold goal line
-#      instead of a separate notifying message, with same-message
-#      goal/thinking paraphrase dedupe in pi_format (a thinking block whose
-#      first line near-duplicates the goal text is dropped so the pair does
-#      not render as adjacent twins); mobile-safe wrap default (36 columns —
-#      48 was wider than a phone bubble's pixel capacity and shattered the
-#      tree on Telegram mobile); idle-timeout deletion of stale trace
-#      bubbles (default 10 min).
+#      No-tree live status bubble: live elapsed timer in the bubble header
+#      plus a background ticker that re-renders the bubble at the edit
+#      cadence even when no new JSONL message arrived;
+#      CCGRAM_PI_TRACE_EDIT_SECS / _TICK_SECS / _IDLE_SECS / _WRAP_CHARS
+#      env knobs; mid-turn assistant text (stopReason=toolUse) folds into
+#      the bubble as the bold goal line instead of a separate notifying
+#      message; goal/thinking paraphrase dedupe — parse-level in pi_format
+#      (a thinking block whose first line near-duplicates the same
+#      message's goal text is dropped; token-overlap rule, immune to the
+#      difflib autojunk collapse that let the real line-14 pair through
+#      the earlier character-level rule) plus render-level suppression of
+#      a latest step paraphrasing the current goal; no tree connectors or
+#      hanging indents (Telegram mobile wraps by pixels, which shattered
+#      the connector columns on phone-width bubbles); mobile-safe wrap
+#      default (36 columns); idle-timeout deletion of stale trace bubbles
+#      (default 10 min).
 #
 # Patch 2's context includes files added/edited by patch 1, so patch 2 only
 # applies on top of patch 1; patch 3 touches disjoint files and applies on

--- a/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
+++ b/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
@@ -24,17 +24,19 @@ Coverage:
      silent and notifying tasks never merge.
   4. Wiring: patched message_routing routes pi-live/pi-final phases and
      flags user echoes silent; the status bubble send honors quiet_progress.
-  5. No-tree live status bubble (patch layer 4): live elapsed timer in
-     the header; CCGRAM_PI_TRACE_EDIT_SECS/_TICK_SECS/_IDLE_SECS/_WRAP_CHARS
-     env knobs; mid-turn assistant text (stopReason toolUse) stamped
-     pi-live-goal and folded into the bubble as the bold goal line (no
-     separate message, no notification); same-message goal/thinking
-     paraphrase dedupe (token-overlap heuristic) plus render-level
-     suppression of a latest step that paraphrases the current goal, so
-     the bubble never states the same progress twice; no tree connectors
-     or hanging indents anywhere in the bubble; ticker timer refresh
-     without new steps; idle-timeout deletion of stale trace bubbles;
-     mobile-safe 36-column wrap.
+  5. Frontdoor-style goal-line status bubble (patch layer 4): live elapsed
+     timer in the header; one bold goal line per goal — `▸` active, `✓`
+     done — matching pi/bin/pi-telegram-daemon.py's ThinkingTreeBuilder
+     (thinking blocks can derive the active goal's label but never render
+     as lines of their own; no ├─/└─ tree connectors, no prose
+     paragraphs); CCGRAM_PI_TRACE_EDIT_SECS/_TICK_SECS/_IDLE_SECS/
+     _WRAP_CHARS env knobs; mid-turn assistant text (stopReason toolUse)
+     stamped pi-live-goal and folded into the bubble as the goal label
+     (no separate message, no notification); same-message goal/thinking
+     paraphrase dedupe (token-overlap heuristic), so the screenshot case
+     displays the concise goal once; ticker timer refresh without new
+     steps; idle-timeout deletion of stale trace bubbles; mobile-safe
+     36-column label wrap with a blank hanging indent under the bullet.
 """
 
 from __future__ import annotations
@@ -335,20 +337,25 @@ class PiRendererParityTest(unittest.TestCase):
 
     # ── 2. Live trace rendering + temporary-bubble state machine ─────────
 
-    def test_status_bubble_renders_latest_step_only(self):
-        # No tree, no overflow fold: the bubble shows the header, the
-        # LATEST step as one plain summary line, and the spinner.
-        steps = [f"step {i}" for i in range(1, 12)]
-        bubble = self.trace.render_thinking_status(steps)
+    def test_goal_lines_render_active_and_done_bullets(self):
+        # Frontdoor shape: header + one bold line per goal (▸ active, ✓
+        # done). No tree connectors, no prose lines, no spinner footer.
+        node = self.trace._GoalNode
+        bubble = self.trace.render_thinking_status(
+            [node("first goal", done=True), node("current goal")]
+        )
         lines = bubble.splitlines()
         self.assertEqual(lines[0], "🧠 Thinking…")
-        self.assertEqual(lines[1], "step 11")
-        self.assertNotIn("step 10", bubble)
-        self.assertNotIn("step 3\n", bubble)
-        self.assertEqual(lines[-1], "⏳ still thinking…")
-        # No tree connectors anywhere.
-        for connector in ("├─", "└─", "▸"):
+        self.assertEqual(lines[1], "✓ **first goal**")
+        self.assertEqual(lines[2], "▸ **current goal**")
+        self.assertEqual(len(lines), 3)
+        for connector in ("├─", "└─", "⏳"):
             self.assertNotIn(connector, bubble)
+        # A single active goal renders exactly one bullet line.
+        bubble = self.trace.render_thinking_status([node("only goal")])
+        self.assertEqual(
+            bubble.splitlines(), ["🧠 Thinking…", "▸ **only goal**"]
+        )
 
     def test_normalize_step_first_line_and_truncation(self):
         self.assertEqual(
@@ -370,24 +377,27 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(len(client.sent), 1)
         self.assertEqual(client.sent[0]["chat_id"], -100999)
         self.assertEqual(client.sent[0].get("message_thread_id"), 42)
-        self.assertIn("first step", client.sent[0]["text"])
+        # A thinking-only start derives the active goal's ▸ label.
+        self.assertIn("▸ first step", client.sent[0]["text"])
         self.assertNotIn("├─", client.sent[0]["text"])
         # Low-noise: the temporary trace is silent on first send — it is
         # edited in place and deleted on final, so it must never notify.
         self.assertIs(client.sent[0].get("disable_notification"), True)
 
-        # Rate limit: an immediate second step does not edit yet.
-        run(trace.handle_pi_thinking(client, 1, 42, -100999, "second step"))
+        # Rate limit: an immediate goal update does not edit yet.
+        run(trace.handle_pi_goal(client, 1, 42, -100999, "second step"))
         self.assertEqual(len(client.edited), 0)
 
-        # After the edit window, the same bubble is edited in place.
+        # After the edit window, the same bubble is edited in place.  A
+        # second text goal completes the first (✓) and takes over the ▸.
         key = (1, 42)
         trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
-        run(trace.handle_pi_thinking(client, 1, 42, -100999, "third step"))
+        run(trace.handle_pi_goal(client, 1, 42, -100999, "third step"))
         self.assertEqual(len(client.edited), 1)
         self.assertEqual(client.edited[0]["message_id"], 1001)
-        self.assertIn("third step", client.edited[0]["text"])
-        # Only the latest step shows: the earlier one is gone.
+        self.assertIn("✓ second step", client.edited[0]["text"])
+        self.assertIn("▸ third step", client.edited[0]["text"])
+        # The thinking-derived label was replaced, never ✓-retained.
         self.assertNotIn("first step", client.edited[0]["text"])
 
         # Final answer retires the bubble.
@@ -466,10 +476,11 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(self.trace.WRAP_CHARS, 36)
 
     def test_header_shows_live_elapsed_timer(self):
-        bubble = self.trace.render_thinking_status(["step"], elapsed=42.7)
+        node = self.trace._GoalNode
+        bubble = self.trace.render_thinking_status([node("step")], elapsed=42.7)
         self.assertEqual(bubble.splitlines()[0], "🧠 Thinking… · 0:42")
         # Without elapsed the header is unchanged (static render).
-        bare = self.trace.render_thinking_status(["step"])
+        bare = self.trace.render_thinking_status([node("step")])
         self.assertEqual(bare.splitlines()[0], "🧠 Thinking…")
         self.assertEqual(self.trace.format_elapsed(0), "0:00")
         self.assertEqual(self.trace.format_elapsed(65), "1:05")
@@ -481,14 +492,11 @@ class PiRendererParityTest(unittest.TestCase):
             "Fix parser race now",
         )
         bubble = self.trace.render_thinking_status(
-            ["step"], goal="Fix parser race now", elapsed=1
+            [self.trace._GoalNode("Fix parser race now")], elapsed=1
         )
-        self.assertIn("**Fix parser race now**", bubble)
-        # Goal sits directly under the header, above the step line, with
-        # no connector prefix.
+        self.assertIn("▸ **Fix parser race now**", bubble)
         lines = bubble.splitlines()
-        self.assertEqual(lines[1], "**Fix parser race now**")
-        self.assertEqual(lines[2], "step")
+        self.assertEqual(lines[1], "▸ **Fix parser race now**")
 
     def test_wrap_segments_word_wraps_and_hard_cuts(self):
         ws = self.trace.wrap_segments
@@ -504,48 +512,58 @@ class PiRendererParityTest(unittest.TestCase):
         # Width 0 disables wrapping.
         self.assertEqual(ws(3, "a " * 50, 0), ["a " * 50])
 
-    def test_long_step_wraps_plain_without_indent(self):
-        step = (
+    def test_long_label_wraps_subordinate_to_bullet(self):
+        label = (
             "Checking whether the transcript binding race fix holds for "
             "reused session directories across consecutive worker spawns"
         )
-        bubble = self.trace.render_thinking_status([step], wrap_chars=48)
-        step_lines = [
-            l
-            for l in bubble.splitlines()
-            if l not in ("🧠 Thinking…", "⏳ still thinking…")
-        ]
-        self.assertGreater(len(step_lines), 1)  # actually wrapped
-        for line in step_lines:
-            # No connector, no hanging indent: plain column-0 wrap.
-            self.assertLessEqual(len(line), 48, line)
-            self.assertEqual(line, line.lstrip(), line)
+        bubble = self.trace.render_thinking_status(
+            [self.trace._GoalNode(label)], wrap_chars=48
+        )
+        label_lines = bubble.splitlines()[1:]
+        self.assertGreater(len(label_lines), 1)  # actually wrapped
+        self.assertTrue(label_lines[0].startswith("▸ **"))
+        for cont in label_lines[1:]:
+            # Continuation hangs under the label text: visually
+            # subordinate to the bullet, with no tree connector.
+            self.assertTrue(cont.startswith("  **"), cont)
+            self.assertNotIn("▸", cont)
+        for line in label_lines:
+            # Displayed width excludes the non-rendering ** markers.
+            self.assertLessEqual(len(line) - 4, 48, line)
+        for connector in ("├─", "└─"):
+            self.assertNotIn(connector, bubble)
         # No text lost across the wrap.
-        self.assertEqual(" ".join(step_lines), step)
+        reassembled = " ".join(
+            l.removeprefix("▸ ").strip().strip("*") for l in label_lines
+        )
+        self.assertEqual(reassembled, label)
 
-    def test_long_goal_wraps_bold_segments_without_indent(self):
-        goal = (
+    def test_done_goal_wraps_with_check_bullet(self):
+        label = (
             "Refactoring the message routing pipeline so mid-turn assistant "
             "text folds into the status bubble instead of notifying"
         )
         bubble = self.trace.render_thinking_status(
-            ["step"], goal=goal, wrap_chars=48
+            [self.trace._GoalNode(label, done=True)], wrap_chars=48
         )
-        goal_lines = [l for l in bubble.splitlines() if "**" in l]
-        self.assertGreater(len(goal_lines), 1)
-        for line in goal_lines:
-            self.assertTrue(line.startswith("**"), line)
-            self.assertTrue(line.endswith("**"), line)
-            # Displayed width excludes the non-rendering ** markers.
-            self.assertLessEqual(len(line) - 4, 48, line)
-        reassembled = " ".join(l.strip("*") for l in goal_lines)
-        self.assertEqual(reassembled, goal)
+        label_lines = bubble.splitlines()[1:]
+        self.assertGreater(len(label_lines), 1)
+        self.assertTrue(label_lines[0].startswith("✓ **"))
+        for cont in label_lines[1:]:
+            self.assertTrue(cont.startswith("  **"), cont)
+            self.assertNotIn("✓", cont)
+        reassembled = " ".join(
+            l.removeprefix("✓ ").strip().strip("*") for l in label_lines
+        )
+        self.assertEqual(reassembled, label)
 
     def test_wrap_disabled_keeps_single_lines(self):
+        node = self.trace._GoalNode
         bubble = self.trace.render_thinking_status(
-            ["s " * 60], goal="g " * 60, wrap_chars=0
+            [node("g " * 60), node("s " * 60)], wrap_chars=0
         )
-        self.assertEqual(len(bubble.splitlines()), 4)  # header, goal, step, spinner
+        self.assertEqual(len(bubble.splitlines()), 3)  # header + 2 goal lines
 
     def test_mid_turn_text_folds_into_goal_line_no_new_message(self):
         trace = self.trace
@@ -557,7 +575,8 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(len(client.sent), 1)
 
         # Mid-turn assistant text (stopReason toolUse) edits the SAME
-        # bubble's goal line: no separate message, no notification.
+        # bubble's goal line: no separate message, no notification.  The
+        # text label replaces the thinking-derived one (same goal node).
         key = (1, 42)
         trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
         run(
@@ -569,10 +588,13 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(len(client.edited), 1)
         self.assertEqual(client.edited[0]["message_id"], 1001)
         # convert_to_entities strips the markdown into bold entities, so
-        # the plain text carries the stripped goal (word-wrapped at the
-        # 36-column mobile width)…
-        self.assertIn("I found the cause; patching it now.", client.edited[0]["text"])
-        self.assertNotIn("▸", client.edited[0]["text"])
+        # the plain text carries the ▸ bullet and the stripped goal
+        # (word-wrapped at the 36-column mobile width)…
+        self.assertIn("▸ I found the cause; patching it", client.edited[0]["text"])
+        self.assertIn("now.", client.edited[0]["text"])
+        # …and the derived label is gone (replaced, not ✓-retained).
+        self.assertNotIn("first step", client.edited[0]["text"])
+        self.assertNotIn("✓", client.edited[0]["text"])
         # …and the goal line is rendered bold via entities.
         entities = client.edited[0].get("entities") or []
         self.assertTrue(
@@ -591,8 +613,7 @@ class PiRendererParityTest(unittest.TestCase):
         client = _FakeClient()
         asyncio.run(trace.handle_pi_goal(client, 1, 42, -100999, "working on it"))
         self.assertEqual(len(client.sent), 1)
-        self.assertIn("working on it", client.sent[0]["text"])
-        self.assertNotIn("▸", client.sent[0]["text"])
+        self.assertIn("▸ working on it", client.sent[0]["text"])
         self.assertIs(client.sent[0].get("disable_notification"), True)
         trace.clear_all_traces()
 
@@ -769,22 +790,41 @@ class PiRendererParityTest(unittest.TestCase):
         # The line-19 follow-up is topically related but not a paraphrase.
         self.assertFalse(dup(self._LINE14_GOAL, self._LINE19_THINKING))
 
-    def test_render_suppresses_latest_step_paraphrasing_goal(self):
-        # Render-level belt-and-braces: even if a paraphrasing step made
-        # it into trace state (e.g. it arrived in an EARLIER message than
-        # the goal), the bubble never shows it beside its goal twin.
-        render = self.trace.render_thinking_status
-        bubble = render(
-            [self.trace.normalize_step(self._LINE14_THINKING)],
-            goal=self._LINE14_GOAL,
-            elapsed=14,
-        )
-        self.assertNotIn("look at the vault", bubble)
-        # A genuinely different latest step still shows.
-        bubble = render(
-            [self._LINE19_THINKING], goal=self._LINE14_GOAL, elapsed=14
-        )
-        self.assertIn("Now check the trip plan note", bubble)
+    def test_thinking_after_goal_never_renders_prose_line(self):
+        # A thinking block arriving while a text goal is active changes
+        # NOTHING visible: the label is not rewritten and the thinking
+        # never appears as a prose line below the bullet (this is what
+        # keeps the screenshot case showing the concise goal once even
+        # if a paraphrasing thinking block slipped past parse dedupe).
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_goal(client, 1, 42, -100999, self._LINE14_GOAL))
+        self.assertEqual(len(client.sent), 1)
+        trace._traces[(1, 42)].last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, self._LINE14_THINKING))
+        latest = client.edited[-1]["text"] if client.edited else client.sent[0]["text"]
+        self.assertIn("▸ Now let me check the vault's", latest)
+        self.assertNotIn("look at the vault", latest)
+        trace.clear_all_traces()
+
+    def test_derived_label_is_sticky_until_text_arrives(self):
+        # Frontdoor label_derived semantics: a thinking-only turn derives
+        # the active goal's label from its FIRST thinking block; later
+        # thinking blocks never rewrite it (tracked, not rendered).
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "Reading the prior reports first."))
+        self.assertIn("▸ Reading the prior reports first.", client.sent[0]["text"])
+        trace._traces[(1, 42)].last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "Now checking daemon health instead."))
+        latest = client.edited[-1]["text"] if client.edited else client.sent[0]["text"]
+        self.assertIn("▸ Reading the prior reports first.", latest)
+        self.assertNotIn("daemon health", latest)
+        trace.clear_all_traces()
 
     def test_paraphrase_pair_renders_once_in_bubble(self):
         # End-to-end golden for the original screenshot scenario: the
@@ -811,25 +851,24 @@ class PiRendererParityTest(unittest.TestCase):
                 run(trace.handle_pi_goal(client, 1, 42, -100999, msg.text))
         self.assertEqual(len(client.sent), 1)
         bubble = client.sent[0]["text"]
-        # The goal renders once, directly under the header, word-wrapped
-        # at the 36-column mobile width (convert_to_entities strips the
-        # ** markers into bold entities)…
-        self.assertIn("Now let me check the vault's", bubble)
-        # …and no step echoes the paraphrase.
+        # The goal renders once as a ▸ bullet under the header,
+        # word-wrapped at the 36-column mobile width
+        # (convert_to_entities strips the ** markers into bold entities)…
+        self.assertIn("▸ Now let me check the vault's", bubble)
+        self.assertTrue(bubble.splitlines()[1].startswith("▸ "))
+        # …and the thinking paraphrase appears nowhere: no prose line.
         self.assertNotIn("look at the vault", bubble)
-        # No tree connectors or hanging indents survive anywhere.
-        for connector in ("├─", "└─", "▸"):
+        # No tree connectors anywhere.
+        for connector in ("├─", "└─"):
             self.assertNotIn(connector, bubble)
-        for line in bubble.splitlines():
-            self.assertEqual(line, line.lstrip(), line)
         trace.clear_all_traces()
 
-    def test_smoke_turn_bubble_lifecycle_no_tree(self):
+    def test_smoke_turn_bubble_lifecycle_goal_lines(self):
         # Live-smoke scenario (firstmate ▸ fm-ccgram-live-smoke-test):
-        # a thinking-only message starts the bubble, a mid-turn text sets
-        # the goal line, a divergent thinking replaces the step, and the
-        # final answer deletes the bubble — one message throughout, no
-        # connectors, never notifying.
+        # a thinking-only message starts the bubble with a derived ▸
+        # label, a mid-turn text replaces it, a later text goal completes
+        # it (✓), and the final answer deletes the bubble — one message
+        # throughout, no connectors, never notifying.
         trace = self.trace
         trace.clear_all_traces()
         client = _FakeClient()
@@ -837,60 +876,55 @@ class PiRendererParityTest(unittest.TestCase):
 
         run(trace.handle_pi_thinking(client, 1, 42, -100999, "Reading the worker brief and prior reports."))
         self.assertEqual(len(client.sent), 1)
-        first = client.sent[0]["text"]
-        self.assertIn("Reading the worker brief", first)
+        self.assertIn("▸ Reading the worker brief", client.sent[0]["text"])
         self.assertIs(client.sent[0].get("disable_notification"), True)
 
         key = (1, 42)
         trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
         run(trace.handle_pi_goal(client, 1, 42, -100999, "Verifying the mirrored topic renders cleanly."))
         trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
-        run(trace.handle_pi_thinking(client, 1, 42, -100999, "Checking service logs for errors during the turn."))
+        run(trace.handle_pi_goal(client, 1, 42, -100999, "Wrapping up the smoke verification."))
         self.assertEqual(len(client.sent), 1)  # still one bubble
         self.assertEqual(len(client.edited), 2)
         latest = client.edited[-1]["text"]
-        self.assertIn("Verifying the mirrored topic", latest)
-        self.assertIn("Checking service logs", latest)
-        # Earlier step replaced; nothing tree-shaped anywhere.
+        self.assertIn("✓ Verifying the mirrored topic", latest)
+        self.assertIn("▸ Wrapping up the smoke", latest)
+        self.assertIn("verification.", latest)
+        # The thinking-derived label was replaced, never ✓-retained, and
+        # nothing tree-shaped or prose-like appears.
         self.assertNotIn("Reading the worker brief", latest)
-        for connector in ("├─", "└─", "▸"):
+        for connector in ("├─", "└─", "⏳"):
             self.assertNotIn(connector, latest)
 
         run(trace.clear_pi_thinking(client, 1, 42))
         self.assertEqual(client.deleted, [{"chat_id": -100999, "message_id": 1001}])
         trace.clear_all_traces()
 
-    def test_mobile_wrap_width_36_keeps_status_shape(self):
-        # The 2026-08-16 screenshot regression, restated for the no-tree
+    def test_mobile_wrap_width_36_keeps_bullet_shape(self):
+        # The 2026-08-16 screenshot regression, restated for the bullet
         # bubble: 36 columns keeps intentional breaks ahead of Telegram's
-        # own pixel wrap on typical phones, and with no connector column
-        # or hanging indent there is nothing for a re-wrap to shatter.
+        # own pixel wrap on typical phones, and the blank hanging indent
+        # keeps continuations visually subordinate to the ▸ bullet.
         bubble = self.trace.render_thinking_status(
-            [self._LINE19_THINKING], goal=self._LINE14_GOAL, elapsed=14,
+            [self.trace._GoalNode(self._LINE14_GOAL)], elapsed=14,
             wrap_chars=36,
         )
         lines = bubble.splitlines()
         self.assertEqual(lines[0], "🧠 Thinking… · 0:14")
+        self.assertEqual(len(lines), 1 + 3)  # header + 3 wrapped segments
+        self.assertTrue(lines[1].startswith("▸ **"))
         for line in lines[1:]:
             display = line.replace("**", "")  # ** renders as bold entities
             self.assertLessEqual(len(display), 36, line)
-            self.assertEqual(line, line.lstrip(), line)  # no indent
-        goal_lines = [l for l in lines if "**" in l]
-        self.assertGreater(len(goal_lines), 1)
-        for line in goal_lines:
-            self.assertTrue(line.startswith("**") and line.endswith("**"), line)
-        step_lines = [
-            l
-            for l in lines
-            if "**" not in l
-            and l not in ("🧠 Thinking… · 0:14", "⏳ still thinking…")
-        ]
-        self.assertGreater(len(step_lines), 1)
+        for cont in lines[2:]:
+            self.assertTrue(cont.startswith("  **"), cont)
+        for connector in ("├─", "└─"):
+            self.assertNotIn(connector, bubble)
         # No text lost across the wrap.
-        reassembled_goal = " ".join(l.strip("*") for l in goal_lines)
-        self.assertEqual(reassembled_goal, self._LINE14_GOAL)
-        self.assertEqual(" ".join(step_lines), self._LINE19_THINKING)
-        self.assertEqual(lines[-1], "⏳ still thinking…")
+        reassembled = " ".join(
+            l.removeprefix("▸ ").strip().strip("*") for l in lines[1:]
+        )
+        self.assertEqual(reassembled, self._LINE14_GOAL)
 
     def test_idle_cleanup_deletes_stale_bubble(self):
         trace = self.trace

--- a/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
+++ b/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
@@ -1,33 +1,40 @@
 """Offline fixture tests for the ccgram Pi renderer-parity patch.
 
-Runs against a THROWAWAY COPY of the installed ccgram package with the
-tracked patch stack applied (the live uv tool is never touched). Requires
-the ccgram uv tool's python (deps: telegram, structlog, dotenv) —
-validate.sh invokes this with `~/.local/share/uv/tools/ccgram/bin/python`.
+Runs against a THROWAWAY COPY of ccgram with the tracked patch stack
+applied (the live uv tool is never touched).  The copy is built from the
+PRISTINE 4.5.2 wheel in the uv cache when available (so the suite always
+exercises the tracked stack, even when the live install carries an older
+patch revision); otherwise it falls back to copying the installed package
+and applying whatever layers are missing.  Requires the ccgram uv tool's
+python (deps: telegram, structlog, dotenv) — validate.sh invokes this
+with `~/.local/share/uv/tools/ccgram/bin/python`.
 
 Coverage:
   1. pi_format: thinking blocks -> content_type "thinking", phase "pi-live";
      turn-terminal assistant text -> phase "pi-final"; mid-turn text
      (stopReason toolUse) and tool_use/tool_result stay phase-free so the
      existing ephemeral tool_batch keeps owning tool-call display.
-  2. pi_live_transcript: tree rendering (folding, first-line nodes) and the
-     temporary-bubble state machine (silent send -> rate-limited edit ->
-     delete) against a fake TelegramClient. No Bot API calls are made.
+  2. pi_live_transcript: status-bubble rendering (header timer, bold goal
+     line, latest-step summary line) and the temporary-bubble state
+     machine (silent send -> rate-limited edit -> delete) against a fake
+     TelegramClient. No Bot API calls are made.
   3. Low-noise notifications: the thinking trace is silent on first send;
      under CCGRAM_QUIET_PROGRESS user-echo content tasks are delivered with
      disable_notification=True while the final answer still notifies;
      silent and notifying tasks never merge.
   4. Wiring: patched message_routing routes pi-live/pi-final phases and
      flags user echoes silent; the status bubble send honors quiet_progress.
-  5. Thinking-tree liveness (patch layer 4): live elapsed timer in the
-     tree header; CCGRAM_PI_TRACE_EDIT_SECS/_TICK_SECS/_IDLE_SECS/_WRAP_CHARS
+  5. No-tree live status bubble (patch layer 4): live elapsed timer in
+     the header; CCGRAM_PI_TRACE_EDIT_SECS/_TICK_SECS/_IDLE_SECS/_WRAP_CHARS
      env knobs; mid-turn assistant text (stopReason toolUse) stamped
-     pi-live-goal and folded into the tree as the bold goal line (no
+     pi-live-goal and folded into the bubble as the bold goal line (no
      separate message, no notification); same-message goal/thinking
-     paraphrase dedupe (a thinking block whose first line near-duplicates
-     the goal text is dropped, so the pair renders once); ticker timer
-     refresh without new steps; idle-timeout deletion of stale trace
-     bubbles; mobile-safe 36-column wrap.
+     paraphrase dedupe (token-overlap heuristic) plus render-level
+     suppression of a latest step that paraphrases the current goal, so
+     the bubble never states the same progress twice; no tree connectors
+     or hanging indents anywhere in the bubble; ticker timer refresh
+     without new steps; idle-timeout deletion of stale trace bubbles;
+     mobile-safe 36-column wrap.
 """
 
 from __future__ import annotations
@@ -67,6 +74,9 @@ os.environ.setdefault("CCGRAM_PI_TRACE_TICK_SECS", "3600")
 os.environ.setdefault("CCGRAM_PI_TRACE_WRAP_CHARS", "36")
 
 
+EXPECTED_VERSION = "4.5.2"
+
+
 def _find_site_packages() -> Path:
     candidates = glob.glob(
         os.path.expanduser("~/.local/share/uv/tools/ccgram/lib/python*/site-packages")
@@ -77,8 +87,114 @@ def _find_site_packages() -> Path:
     raise unittest.SkipTest("ccgram uv tool not installed; cannot run patch tests")
 
 
+def _find_pristine_source() -> Path | None:
+    """Locate a pristine ccgram wheel unpack in the uv cache, if present.
+
+    Testing the tracked patch stack against the INSTALLED package breaks
+    down when the live install carries an older revision of a patch layer
+    (the new revision neither applies on top nor should be forced over
+    live code).  uv keeps the pristine wheel unpacked under
+    ``~/.cache/uv/archive-v0/*/``; a pristine 4.5.2 there lets the suite
+    apply the full tracked stack from scratch — hermetic, and never
+    touching the live install.
+    """
+    for dist_info in sorted(
+        glob.glob(
+            os.path.expanduser(
+                f"~/.cache/uv/archive-v0/*/ccgram-{EXPECTED_VERSION}.dist-info"
+            )
+        )
+    ):
+        root = Path(dist_info).parent
+        pkg = root / "ccgram"
+        fmt = pkg / "providers" / "pi_format.py"
+        if pkg.is_dir() and fmt.is_file():
+            # Purity check: a patched unpack would carry layer-1 markers.
+            if 'phase="pi-live"' not in fmt.read_text(encoding="utf-8"):
+                return root
+    return None
+
+
+def _renderer_parity_applied(root: Path) -> bool:
+    # Marker-based detection: `patch -R --dry-run` auto-detects unreversed
+    # patches and ignores -R, so it cannot tell applied from pristine.
+    new_file = root / "ccgram/handlers/messaging_pipeline/pi_live_transcript.py"
+    fmt = root / "ccgram/providers/pi_format.py"
+    return new_file.exists() and 'phase="pi-live"' in fmt.read_text(
+        encoding="utf-8"
+    )
+
+
+def _low_noise_applied(root: Path) -> bool:
+    cfg = (root / "ccgram/config.py").read_text(encoding="utf-8")
+    task = (root / "ccgram/handlers/messaging_pipeline/message_task.py").read_text(
+        encoding="utf-8"
+    )
+    return "CCGRAM_QUIET_PROGRESS" in cfg and "silent: bool = False" in task
+
+
+def _thinking_tree_live_applied(root: Path) -> bool:
+    # Revision markers: an installed tool carrying an OLDER layer-4
+    # revision (tree renderer, or goal folding without the same-message
+    # goal/thinking dedupe) fails this check, so the copy is NOT mistaken
+    # for the tracked stack and the suite skips with a clear reason
+    # instead of silently testing stale code.
+    live = root / "ccgram/handlers/messaging_pipeline/pi_live_transcript.py"
+    fmt = root / "ccgram/providers/pi_format.py"
+    return (
+        live.exists()
+        and "render_thinking_status" in live.read_text(encoding="utf-8")
+        and "pi-live-goal" in fmt.read_text(encoding="utf-8")
+        and "is_goal_thinking_duplicate" in fmt.read_text(encoding="utf-8")
+    )
+
+
+_MARKER_CHECKS = [
+    _renderer_parity_applied,
+    _low_noise_applied,
+    _thinking_tree_live_applied,
+]
+
+
+def _apply_patch_file(patch_file: Path, tmp: Path) -> None:
+    with open(patch_file, "rb") as fh:
+        subprocess.run(
+            ["patch", "-p1", "--batch", "-s", "-d", str(tmp)],
+            stdin=fh,
+            check=True,
+        )
+
+
+def _prepare_from_pristine(src: Path) -> Path:
+    """Apply the full tracked patch stack to a pristine wheel unpack copy.
+
+    A patch that fails against pristine 4.5.2 is a hard error here (not a
+    skip): this path proves the tracked stack applies cleanly from
+    scratch.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="ccgram-pristine-"))
+    shutil.copytree(
+        src / "ccgram",
+        tmp / "ccgram",
+        ignore=shutil.ignore_patterns("__pycache__"),
+    )
+    for patch_file, applied_check in zip(PATCH_FILES, _MARKER_CHECKS):
+        _apply_patch_file(patch_file, tmp)
+        if not applied_check(tmp):
+            raise RuntimeError(f"{patch_file.name} applied but markers missing")
+    return tmp
+
+
 def _prepare_patched_copy() -> Path:
-    """Copy the installed ccgram package to a temp dir and apply the patch."""
+    """Copy ccgram to a temp dir and apply the tracked patch stack.
+
+    Prefers a pristine wheel unpack from the uv cache (full stack applied
+    from scratch); falls back to the installed package with only the
+    missing layers applied.
+    """
+    pristine = _find_pristine_source()
+    if pristine is not None:
+        return _prepare_from_pristine(pristine)
     sp = _find_site_packages()
     tmp = Path(tempfile.mkdtemp(prefix="ccgram-patched-"))
     shutil.copytree(
@@ -87,44 +203,7 @@ def _prepare_patched_copy() -> Path:
         ignore=shutil.ignore_patterns("__pycache__"),
     )
 
-    def renderer_parity_applied(root: Path) -> bool:
-        # Marker-based detection: `patch -R --dry-run` auto-detects unreversed
-        # patches and ignores -R, so it cannot tell applied from pristine.
-        new_file = root / "ccgram/handlers/messaging_pipeline/pi_live_transcript.py"
-        fmt = root / "ccgram/providers/pi_format.py"
-        return new_file.exists() and 'phase="pi-live"' in fmt.read_text(
-            encoding="utf-8"
-        )
-
-    def low_noise_applied(root: Path) -> bool:
-        cfg = (root / "ccgram/config.py").read_text(encoding="utf-8")
-        task = (
-            root / "ccgram/handlers/messaging_pipeline/message_task.py"
-        ).read_text(encoding="utf-8")
-        return "CCGRAM_QUIET_PROGRESS" in cfg and "silent: bool = False" in task
-
-    def thinking_tree_live_applied(root: Path) -> bool:
-        # The dedupe helper doubles as the revision marker: an installed
-        # tool carrying an OLDER layer-4 revision (goal folding without
-        # same-message goal/thinking dedupe) fails this check, so the copy
-        # is NOT mistaken for the tracked stack and the suite skips with a
-        # clear reason instead of silently testing stale code.
-        live = root / "ccgram/handlers/messaging_pipeline/pi_live_transcript.py"
-        fmt = root / "ccgram/providers/pi_format.py"
-        return (
-            live.exists()
-            and "CCGRAM_PI_TRACE_EDIT_SECS" in live.read_text(encoding="utf-8")
-            and "pi-live-goal" in fmt.read_text(encoding="utf-8")
-            and "_drop_goal_thinking_duplicates" in fmt.read_text(encoding="utf-8")
-        )
-
-    marker_checks = [
-        renderer_parity_applied,
-        low_noise_applied,
-        thinking_tree_live_applied,
-    ]
-
-    for patch_file, applied_check in zip(PATCH_FILES, marker_checks):
+    for patch_file, applied_check in zip(PATCH_FILES, _MARKER_CHECKS):
         if applied_check(tmp):
             continue  # live tool already patched; the copy is too
         with open(patch_file, "rb") as fh:
@@ -140,12 +219,7 @@ def _prepare_patched_copy() -> Path:
                 "tool carries an older revision of this patch layer (apply "
                 "the updated patch stack to run these tests)"
             )
-        with open(patch_file, "rb") as fh:
-            subprocess.run(
-                ["patch", "-p1", "--batch", "-s", "-d", str(tmp)],
-                stdin=fh,
-                check=True,
-            )
+        _apply_patch_file(patch_file, tmp)
         if not applied_check(tmp):
             raise RuntimeError(f"{patch_file.name} applied but markers missing")
     return tmp
@@ -238,7 +312,7 @@ class PiRendererParityTest(unittest.TestCase):
 
     def test_mid_turn_text_is_stamped_pi_live_goal(self):
         # Layer 4: mid-turn assistant text (stopReason toolUse) folds into
-        # the thinking tree as the goal line instead of a separate message.
+        # the status bubble as the goal line instead of a separate message.
         msgs = self._parse_fixture()
         mid_turn = [
             m
@@ -261,15 +335,20 @@ class PiRendererParityTest(unittest.TestCase):
 
     # ── 2. Live trace rendering + temporary-bubble state machine ─────────
 
-    def test_tree_rendering_folds_overflow(self):
+    def test_status_bubble_renders_latest_step_only(self):
+        # No tree, no overflow fold: the bubble shows the header, the
+        # LATEST step as one plain summary line, and the spinner.
         steps = [f"step {i}" for i in range(1, 12)]
-        tree = self.trace.render_thinking_tree(steps, max_steps=8)
-        lines = tree.splitlines()
+        bubble = self.trace.render_thinking_status(steps)
+        lines = bubble.splitlines()
         self.assertEqual(lines[0], "🧠 Thinking…")
-        self.assertIn("… (3 earlier steps)", lines[1])
-        self.assertIn("step 11", tree)
-        self.assertNotIn("step 3\n", tree)
-        self.assertTrue(lines[-1].startswith("└─ ⏳ still thinking"))
+        self.assertEqual(lines[1], "step 11")
+        self.assertNotIn("step 10", bubble)
+        self.assertNotIn("step 3\n", bubble)
+        self.assertEqual(lines[-1], "⏳ still thinking…")
+        # No tree connectors anywhere.
+        for connector in ("├─", "└─", "▸"):
+            self.assertNotIn(connector, bubble)
 
     def test_normalize_step_first_line_and_truncation(self):
         self.assertEqual(
@@ -291,7 +370,8 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(len(client.sent), 1)
         self.assertEqual(client.sent[0]["chat_id"], -100999)
         self.assertEqual(client.sent[0].get("message_thread_id"), 42)
-        self.assertIn("├─ first step", client.sent[0]["text"])
+        self.assertIn("first step", client.sent[0]["text"])
+        self.assertNotIn("├─", client.sent[0]["text"])
         # Low-noise: the temporary trace is silent on first send — it is
         # edited in place and deleted on final, so it must never notify.
         self.assertIs(client.sent[0].get("disable_notification"), True)
@@ -306,7 +386,9 @@ class PiRendererParityTest(unittest.TestCase):
         run(trace.handle_pi_thinking(client, 1, 42, -100999, "third step"))
         self.assertEqual(len(client.edited), 1)
         self.assertEqual(client.edited[0]["message_id"], 1001)
-        self.assertIn("├─ third step", client.edited[0]["text"])
+        self.assertIn("third step", client.edited[0]["text"])
+        # Only the latest step shows: the earlier one is gone.
+        self.assertNotIn("first step", client.edited[0]["text"])
 
         # Final answer retires the bubble.
         run(trace.clear_pi_thinking(client, 1, 42))
@@ -372,7 +454,7 @@ class PiRendererParityTest(unittest.TestCase):
         other_silent = ct(window_id="w", parts=("c",), silent=True)
         self.assertTrue(self.message_queue._can_merge_tasks(silent, other_silent))
 
-    # ── 5. Thinking-tree liveness (patch layer 4) ────────────────────────
+    # ── 5. No-tree live status bubble (patch layer 4) ─────────────────
 
     def test_liveness_env_knobs(self):
         # CCGRAM_PI_TRACE_EDIT_SECS=1.0 / _TICK_SECS=3600 / _WRAP_CHARS=36
@@ -384,10 +466,10 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(self.trace.WRAP_CHARS, 36)
 
     def test_header_shows_live_elapsed_timer(self):
-        tree = self.trace.render_thinking_tree(["step"], elapsed=42.7)
-        self.assertEqual(tree.splitlines()[0], "🧠 Thinking… · 0:42")
+        bubble = self.trace.render_thinking_status(["step"], elapsed=42.7)
+        self.assertEqual(bubble.splitlines()[0], "🧠 Thinking… · 0:42")
         # Without elapsed the header is unchanged (static render).
-        bare = self.trace.render_thinking_tree(["step"])
+        bare = self.trace.render_thinking_status(["step"])
         self.assertEqual(bare.splitlines()[0], "🧠 Thinking…")
         self.assertEqual(self.trace.format_elapsed(0), "0:00")
         self.assertEqual(self.trace.format_elapsed(65), "1:05")
@@ -398,14 +480,15 @@ class PiRendererParityTest(unittest.TestCase):
             self.trace._strip_markdown("Fix **parser** `race` ~~now~~"),
             "Fix parser race now",
         )
-        tree = self.trace.render_thinking_tree(
+        bubble = self.trace.render_thinking_status(
             ["step"], goal="Fix parser race now", elapsed=1
         )
-        self.assertIn("▸ **Fix parser race now**", tree)
-        # Goal sits directly under the header, above the step nodes.
-        lines = tree.splitlines()
-        self.assertTrue(lines[1].startswith("▸ **"))
-        self.assertTrue(lines[2].startswith("├─"))
+        self.assertIn("**Fix parser race now**", bubble)
+        # Goal sits directly under the header, above the step line, with
+        # no connector prefix.
+        lines = bubble.splitlines()
+        self.assertEqual(lines[1], "**Fix parser race now**")
+        self.assertEqual(lines[2], "step")
 
     def test_wrap_segments_word_wraps_and_hard_cuts(self):
         ws = self.trace.wrap_segments
@@ -421,53 +504,48 @@ class PiRendererParityTest(unittest.TestCase):
         # Width 0 disables wrapping.
         self.assertEqual(ws(3, "a " * 50, 0), ["a " * 50])
 
-    def test_long_step_wraps_with_hanging_indent(self):
+    def test_long_step_wraps_plain_without_indent(self):
         step = (
             "Checking whether the transcript binding race fix holds for "
             "reused session directories across consecutive worker spawns"
         )
-        tree = self.trace.render_thinking_tree([step], wrap_chars=48)
-        step_lines = [l for l in tree.splitlines() if "Checking" in l or l.startswith("   ")]
+        bubble = self.trace.render_thinking_status([step], wrap_chars=48)
+        step_lines = [
+            l
+            for l in bubble.splitlines()
+            if l not in ("🧠 Thinking…", "⏳ still thinking…")
+        ]
         self.assertGreater(len(step_lines), 1)  # actually wrapped
-        self.assertTrue(step_lines[0].startswith("├─ "))
-        for cont in step_lines[1:]:
-            # Continuation aligns under the node's text column, so the
-            # tree shape survives Telegram's phone-width wrapping.
-            self.assertTrue(cont.startswith("   "), cont)
-            self.assertNotIn("├─", cont)
         for line in step_lines:
+            # No connector, no hanging indent: plain column-0 wrap.
             self.assertLessEqual(len(line), 48, line)
-        # No text lost: stripping prefixes/indent reassembles the step.
-        reassembled = " ".join(
-            l.removeprefix("├─ ").strip() for l in step_lines
-        )
-        self.assertEqual(reassembled, step)
+            self.assertEqual(line, line.lstrip(), line)
+        # No text lost across the wrap.
+        self.assertEqual(" ".join(step_lines), step)
 
-    def test_long_goal_wraps_bold_segments_with_hanging_indent(self):
+    def test_long_goal_wraps_bold_segments_without_indent(self):
         goal = (
             "Refactoring the message routing pipeline so mid-turn assistant "
-            "text folds into the thinking tree instead of notifying"
+            "text folds into the status bubble instead of notifying"
         )
-        tree = self.trace.render_thinking_tree(["step"], goal=goal, wrap_chars=48)
-        goal_lines = [l for l in tree.splitlines() if "**" in l]
+        bubble = self.trace.render_thinking_status(
+            ["step"], goal=goal, wrap_chars=48
+        )
+        goal_lines = [l for l in bubble.splitlines() if "**" in l]
         self.assertGreater(len(goal_lines), 1)
-        self.assertTrue(goal_lines[0].startswith("▸ **"))
-        for cont in goal_lines[1:]:
-            self.assertTrue(cont.startswith("  **"), cont)
-            self.assertNotIn("▸", cont)
         for line in goal_lines:
+            self.assertTrue(line.startswith("**"), line)
+            self.assertTrue(line.endswith("**"), line)
             # Displayed width excludes the non-rendering ** markers.
             self.assertLessEqual(len(line) - 4, 48, line)
-        reassembled = " ".join(
-            l.removeprefix("▸ ").strip().strip("*") for l in goal_lines
-        )
+        reassembled = " ".join(l.strip("*") for l in goal_lines)
         self.assertEqual(reassembled, goal)
 
     def test_wrap_disabled_keeps_single_lines(self):
-        tree = self.trace.render_thinking_tree(
+        bubble = self.trace.render_thinking_status(
             ["s " * 60], goal="g " * 60, wrap_chars=0
         )
-        self.assertEqual(len(tree.splitlines()), 4)  # header, goal, step, spinner
+        self.assertEqual(len(bubble.splitlines()), 4)  # header, goal, step, spinner
 
     def test_mid_turn_text_folds_into_goal_line_no_new_message(self):
         trace = self.trace
@@ -493,8 +571,8 @@ class PiRendererParityTest(unittest.TestCase):
         # convert_to_entities strips the markdown into bold entities, so
         # the plain text carries the stripped goal (word-wrapped at the
         # 36-column mobile width)…
-        self.assertIn("▸ I found the cause; patching it", client.edited[0]["text"])
-        self.assertIn("now.", client.edited[0]["text"])
+        self.assertIn("I found the cause; patching it now.", client.edited[0]["text"])
+        self.assertNotIn("▸", client.edited[0]["text"])
         # …and the goal line is rendered bold via entities.
         entities = client.edited[0].get("entities") or []
         self.assertTrue(
@@ -513,7 +591,8 @@ class PiRendererParityTest(unittest.TestCase):
         client = _FakeClient()
         asyncio.run(trace.handle_pi_goal(client, 1, 42, -100999, "working on it"))
         self.assertEqual(len(client.sent), 1)
-        self.assertIn("▸ working on it", client.sent[0]["text"])
+        self.assertIn("working on it", client.sent[0]["text"])
+        self.assertNotIn("▸", client.sent[0]["text"])
         self.assertIs(client.sent[0].get("disable_notification"), True)
         trace.clear_all_traces()
 
@@ -550,7 +629,7 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertEqual(len(client.edited), 0)
         trace.clear_all_traces()
 
-    # ── 6. Same-message goal/thinking dedupe + mobile wrap width ───────
+    # ── 6. Goal/thinking dedupe + no-tree mobile wrap ──────────────────
 
     # The captain's 2026-08-16 mobile screenshot (scout report
     # ccgram-tree-regression-scout): transcript line 14 of the
@@ -560,13 +639,23 @@ class PiRendererParityTest(unittest.TestCase):
         "since the prior scouts."
     )
     # …with this thinking block in the SAME assistant message — a
-    # paraphrase ("check" vs "look at"), which the tree rendered as
-    # adjacent goal + step twins.
+    # paraphrase ("check" vs "look at").  This is the EXACT thinking text
+    # from the transcript (one long line, 250 chars): the PR150
+    # character-level dedupe rule silently collapsed on it (difflib
+    # autojunk) and the post-PR150 live smoke/replay still rendered the
+    # pair twice, which is why the heuristic is now token-based.
     _LINE14_THINKING = (
         "Now let me look at the vault's current state to verify whether "
         "anything has changed since the prior scouts (auto-commits, weekly "
-        "backlog W33/W34). Today is Sun Aug 16, 2026 (W33).\nSecond line "
-        "of private reasoning the tree never shows."
+        "backlog W33/W34). Today is Sun Aug 16, 2026 (W33). Check recent "
+        "git activity in the vault, the weekly backlog, WIP items."
+    )
+    # The next thinking block in that transcript (line 19) — topically
+    # related but NOT a paraphrase of the goal; it must survive as the
+    # bubble's step line.
+    _LINE19_THINKING = (
+        "Now check the trip plan note for the current state (booked or "
+        "not), the reminder script state, daemon health, recruiting audit."
     )
 
     def _parse_assistant_blocks(self, blocks, stop_reason="toolUse"):
@@ -640,7 +729,7 @@ class PiRendererParityTest(unittest.TestCase):
             ["pi-live"],
         )
         # Final answers (stopReason != toolUse) are never deduped: the
-        # text is the delivered answer, not a tree goal line.
+        # text is the delivered answer, not a bubble goal line.
         final = self._parse_assistant_blocks(
             [
                 {"type": "thinking", "thinking": self._LINE14_THINKING},
@@ -656,8 +745,8 @@ class PiRendererParityTest(unittest.TestCase):
         )
 
     def test_dedupe_heuristic_boundaries(self):
-        dup = self.pi_format._is_goal_thinking_duplicate
-        # The line-14 paraphrase pair.
+        dup = self.pi_format.is_goal_thinking_duplicate
+        # The exact line-14 paraphrase pair (the PR150 live-replay miss).
         self.assertTrue(dup(self._LINE14_GOAL, self._LINE14_THINKING))
         # Exact prefix of a longer thinking line.
         self.assertTrue(
@@ -677,11 +766,31 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertFalse(
             dup("Now let me see.", "Now let me try a completely different angle.")
         )
+        # The line-19 follow-up is topically related but not a paraphrase.
+        self.assertFalse(dup(self._LINE14_GOAL, self._LINE19_THINKING))
 
-    def test_paraphrase_pair_renders_once_in_tree(self):
-        # End-to-end golden: line-14 blocks routed through the trace state
-        # machine render the statement once (bold goal), with no adjacent
-        # near-duplicate `├─` step.
+    def test_render_suppresses_latest_step_paraphrasing_goal(self):
+        # Render-level belt-and-braces: even if a paraphrasing step made
+        # it into trace state (e.g. it arrived in an EARLIER message than
+        # the goal), the bubble never shows it beside its goal twin.
+        render = self.trace.render_thinking_status
+        bubble = render(
+            [self.trace.normalize_step(self._LINE14_THINKING)],
+            goal=self._LINE14_GOAL,
+            elapsed=14,
+        )
+        self.assertNotIn("look at the vault", bubble)
+        # A genuinely different latest step still shows.
+        bubble = render(
+            [self._LINE19_THINKING], goal=self._LINE14_GOAL, elapsed=14
+        )
+        self.assertIn("Now check the trip plan note", bubble)
+
+    def test_paraphrase_pair_renders_once_in_bubble(self):
+        # End-to-end golden for the original screenshot scenario: the
+        # exact line-14 blocks routed through the trace state machine
+        # render the statement ONCE (bold goal line), with no duplicate
+        # step and no tree connectors anywhere in the bubble.
         trace = self.trace
         trace.clear_all_traces()
         client = _FakeClient()
@@ -702,59 +811,86 @@ class PiRendererParityTest(unittest.TestCase):
                 run(trace.handle_pi_goal(client, 1, 42, -100999, msg.text))
         self.assertEqual(len(client.sent), 1)
         bubble = client.sent[0]["text"]
-        # The goal renders once, directly under the header (convert_to_entities
-        # turns the ** markers into bold entities, and the line word-wraps
-        # at the 36-column mobile width)…
-        self.assertIn("▸ Now let me check the vault's", bubble)
-        self.assertTrue(bubble.splitlines()[1].startswith("▸ "))
-        # …and no `├─` step echoes the paraphrase.
-        step_lines = [l for l in bubble.splitlines() if l.startswith("├─")]
-        self.assertEqual(step_lines, [])
+        # The goal renders once, directly under the header, word-wrapped
+        # at the 36-column mobile width (convert_to_entities strips the
+        # ** markers into bold entities)…
+        self.assertIn("Now let me check the vault's", bubble)
+        # …and no step echoes the paraphrase.
         self.assertNotIn("look at the vault", bubble)
+        # No tree connectors or hanging indents survive anywhere.
+        for connector in ("├─", "└─", "▸"):
+            self.assertNotIn(connector, bubble)
+        for line in bubble.splitlines():
+            self.assertEqual(line, line.lstrip(), line)
         trace.clear_all_traces()
 
-    def test_mobile_wrap_width_36_keeps_tree_shape(self):
-        # The 2026-08-16 screenshot regression: at 48 columns every
-        # intentional line outlived a phone bubble's pixel capacity and
-        # Telegram's re-wrap shattered the tree. 36 stays ahead of the
-        # client-side wrap on typical phones.
-        goal = (
-            "Now let me check the vault's current state and recent "
-            "activity since the prior scouts."
+    def test_smoke_turn_bubble_lifecycle_no_tree(self):
+        # Live-smoke scenario (firstmate ▸ fm-ccgram-live-smoke-test):
+        # a thinking-only message starts the bubble, a mid-turn text sets
+        # the goal line, a divergent thinking replaces the step, and the
+        # final answer deletes the bubble — one message throughout, no
+        # connectors, never notifying.
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "Reading the worker brief and prior reports."))
+        self.assertEqual(len(client.sent), 1)
+        first = client.sent[0]["text"]
+        self.assertIn("Reading the worker brief", first)
+        self.assertIs(client.sent[0].get("disable_notification"), True)
+
+        key = (1, 42)
+        trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.handle_pi_goal(client, 1, 42, -100999, "Verifying the mirrored topic renders cleanly."))
+        trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "Checking service logs for errors during the turn."))
+        self.assertEqual(len(client.sent), 1)  # still one bubble
+        self.assertEqual(len(client.edited), 2)
+        latest = client.edited[-1]["text"]
+        self.assertIn("Verifying the mirrored topic", latest)
+        self.assertIn("Checking service logs", latest)
+        # Earlier step replaced; nothing tree-shaped anywhere.
+        self.assertNotIn("Reading the worker brief", latest)
+        for connector in ("├─", "└─", "▸"):
+            self.assertNotIn(connector, latest)
+
+        run(trace.clear_pi_thinking(client, 1, 42))
+        self.assertEqual(client.deleted, [{"chat_id": -100999, "message_id": 1001}])
+        trace.clear_all_traces()
+
+    def test_mobile_wrap_width_36_keeps_status_shape(self):
+        # The 2026-08-16 screenshot regression, restated for the no-tree
+        # bubble: 36 columns keeps intentional breaks ahead of Telegram's
+        # own pixel wrap on typical phones, and with no connector column
+        # or hanging indent there is nothing for a re-wrap to shatter.
+        bubble = self.trace.render_thinking_status(
+            [self._LINE19_THINKING], goal=self._LINE14_GOAL, elapsed=14,
+            wrap_chars=36,
         )
-        step = (
-            "Now check the trip plan note for the current state, the "
-            "reminder script state, and daemon health."
-        )
-        tree = self.trace.render_thinking_tree(
-            [step], goal=goal, elapsed=14, wrap_chars=36
-        )
-        lines = tree.splitlines()
+        lines = bubble.splitlines()
         self.assertEqual(lines[0], "🧠 Thinking… · 0:14")
         for line in lines[1:]:
             display = line.replace("**", "")  # ** renders as bold entities
             self.assertLessEqual(len(display), 36, line)
-        # Wrapped continuation lines keep the hanging indent, and the
-        # connector prefixes survive on the first segment of each node.
+            self.assertEqual(line, line.lstrip(), line)  # no indent
         goal_lines = [l for l in lines if "**" in l]
         self.assertGreater(len(goal_lines), 1)
-        self.assertTrue(goal_lines[0].startswith("▸ **"))
-        for cont in goal_lines[1:]:
-            self.assertTrue(cont.startswith("  **"), cont)
+        for line in goal_lines:
+            self.assertTrue(line.startswith("**") and line.endswith("**"), line)
         step_lines = [
-            l for l in lines if l.startswith("├─") or l.startswith("   ")
+            l
+            for l in lines
+            if "**" not in l
+            and l not in ("🧠 Thinking… · 0:14", "⏳ still thinking…")
         ]
         self.assertGreater(len(step_lines), 1)
-        self.assertTrue(step_lines[0].startswith("├─ "))
         # No text lost across the wrap.
-        reassembled_goal = " ".join(
-            l.removeprefix("▸ ").strip().strip("*") for l in goal_lines
-        )
-        self.assertEqual(reassembled_goal, goal)
-        reassembled_step = " ".join(
-            l.removeprefix("├─ ").strip() for l in step_lines
-        )
-        self.assertEqual(reassembled_step, step)
+        reassembled_goal = " ".join(l.strip("*") for l in goal_lines)
+        self.assertEqual(reassembled_goal, self._LINE14_GOAL)
+        self.assertEqual(" ".join(step_lines), self._LINE19_THINKING)
+        self.assertEqual(lines[-1], "⏳ still thinking…")
 
     def test_idle_cleanup_deletes_stale_bubble(self):
         trace = self.trace
@@ -787,8 +923,8 @@ class PiRendererParityTest(unittest.TestCase):
         self.assertIn('msg.phase == PI_LIVE_PHASE', src)
         self.assertIn('msg.phase == PI_FINAL_PHASE', src)
 
-    def test_routing_folds_mid_turn_text_into_tree(self):
-        # Layer 4: pi-live-goal text routes into the tree (and continues,
+    def test_routing_folds_mid_turn_text_into_bubble(self):
+        # Layer 4: pi-live-goal text routes into the bubble (and continues,
         # so it never becomes a separate progress message).
         src = (
             self.tmp / "ccgram/handlers/messaging_pipeline/message_routing.py"

--- a/ccgram-prototype/validate.sh
+++ b/ccgram-prototype/validate.sh
@@ -70,7 +70,7 @@ else
     fail=1
 fi
 
-echo "==> Pi patch stack (renderer parity + low-noise + transcript binding + no-tree live status): applies cleanly + offline fixture tests"
+echo "==> Pi patch stack (renderer parity + low-noise + transcript binding + frontdoor live status): applies cleanly + offline fixture tests"
 PATCH_SH="$PKG_DIR/pi-renderer-patch.sh"
 CCGRAM_PY="$HOME/.local/share/uv/tools/ccgram/bin/python"
 if [[ ! -x "$CCGRAM_PY" ]]; then

--- a/ccgram-prototype/validate.sh
+++ b/ccgram-prototype/validate.sh
@@ -70,7 +70,7 @@ else
     fail=1
 fi
 
-echo "==> Pi patch stack (renderer parity + low-noise + transcript binding + thinking-tree-live): applies cleanly + offline fixture tests"
+echo "==> Pi patch stack (renderer parity + low-noise + transcript binding + no-tree live status): applies cleanly + offline fixture tests"
 PATCH_SH="$PKG_DIR/pi-renderer-patch.sh"
 CCGRAM_PY="$HOME/.local/share/uv/tools/ccgram/bin/python"
 if [[ ! -x "$CCGRAM_PY" ]]; then


### PR DESCRIPTION
## What

Reworks ccgram's temporary Pi live bubble (patch layer 4) to **match the Pi Telegram frontdoor daemon's rendering** (`pi/bin/pi-telegram-daemon.py`, `ThinkingTreeBuilder.render`), per captain redirect: live timer plus `▸`/`✓` goal lines — not prose paragraphs, not a multi-line step/tree list.

Bubble shape:

```
🧠 Thinking… · 0:14
✓ **Now let me check the vault's**
  **current state and recent activity**
  **since the prior scouts.**
▸ **All prior findings remain**
  **unresolved. Let me read the**
  **completion-gate skill…**
```

Frontdoor semantics, mapped onto ccgram's JSONL message granularity:

- **One bold goal line per goal** — `▸ **label**` while active, `✓ **label**` once a newer text goal supersedes it. Up to 8 goal lines retained (oldest completed drop off).
- **Thinking blocks never render as lines of their own** — no `├─`/`└─` tree connectors, no prose thinking-summary paragraphs.
- **Thinking-derived labels** (frontdoor `label_derived` path): a thinking-only turn derives the active goal's label from its *first* thinking block (markdown-stripped); the label is sticky until a text block in the same turn replaces it. A text block following a text-set goal completes it (`✓`) and starts a new `▸` line.
- **Label wrap**: 36-column mobile width (PR150 knob kept) with a *blank hanging indent under the bullet* — continuation lines stay visually subordinate to the `▸`/`✓` marker, no tree connector to shatter on Telegram mobile's pixel wrap.
- **Kept unchanged**: live elapsed timer + background ticker, silent (low-noise) send/edits, delete-on-final-answer, idle-timeout bubble deletion, 1s edit cadence knob.

## Why (PR150 follow-up)

The post-PR150 live smoke worker mirrored topic `firstmate ▸ fm-ccgram-live-smoke-test` cleanly, but replaying the captain's original `fm-vault-next-work-scout` transcript line 14 through the installed PR150 code **still rendered the duplicate adjacent goal+step**. Root cause: PR150's dedupe compared normalized strings with `difflib.SequenceMatcher.find_longest_match` at the **character** level; on the real 250-char thinking line, difflib's autojunk heuristic marks frequent characters as junk and the "longest common substring" collapsed to 2 chars (`"d "`), so the paraphrase pair slipped through.

Fix: `pi_format.is_goal_thinking_duplicate` is now **token-based** — normalized word streams must share a 3+ word opening AND a 4+ word contiguous phrase ("the vault s current state" / "since the prior scouts"). Token sequences are far under difflib's 200-element autojunk threshold. Genuinely distinct pairs (different opening, or only a short shared opening) still keep both entries. With the frontdoor rendering, thinking no longer renders as its own line at all, so the screenshot case displays the concise goal exactly once.

## Tests

`ccgram-prototype/pi-renderer/test_pi_renderer_parity.py` — 37 tests, all green; `./validate.sh` passes (units, sidecar, hook shim, patch-stack check, fixture tests, transcript-binding tests, secret scan):

- **Exact line-14 transcript text** (250 chars, single line — the shortened synthetic had masked the autojunk collapse): paraphrasing thinking dropped at parse time; golden test routes the exact blocks through the trace state machine and asserts the bubble shows the goal once as a `▸` bullet, with zero `├─`/`└─` connectors and no "look at the vault" prose.
- **Frontdoor semantics**: `✓` completion when a newer text goal supersedes the active one; text-replaces-derived-label in the same node; sticky derived labels in thinking-only turns (`test_derived_label_is_sticky_until_text_arrives`); thinking-after-goal renders no prose line.
- **Live-smoke lifecycle** (`test_smoke_turn_bubble_lifecycle_goal_lines`): thinking-only start → derived `▸` → goal replace → goal completes (`✓`) → delete on final; one silent message throughout.
- **Bullet-safe 36-col wrap**: continuations hang under the label text, ≤36 displayed chars, no text loss, no connectors.
- Harness: the patched copy is built from the **pristine 4.5.2 wheel in the uv cache** when available, so the suite always exercises the tracked stack even when the live install carries an older layer-4 revision (fallback to installed-package copy unchanged).

## Deploy notes (for whoever merges — this worker did not touch live state)

- The live install still carries the **old** layer-4 revision; `pi-renderer-patch.sh status` markers match both revisions, so deploy should **roll back layer 4 with the pre-merge revision** (`git show HEAD~2:ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch | patch -p1 -R -d <site-packages>`) or restore from `~/.ccgram-prototype/renderer-patch-backup/4.5.2/`, then `pi-renderer-patch.sh apply` and restart `ccgram-prototype.service`.
- No env changes needed; `CCGRAM_PI_TRACE_WRAP_CHARS=36` stays.

Refs: scout `ccgram-tree-regression-scout` (line-14 screenshot diagnosis), `ccgram-live-smoke-test` (post-PR150 live smoke), frontdoor reference `pi/bin/pi-telegram-daemon.py`.