### PR TITLE
ccgram-prototype: self-healing live status ticker (timer + goal updates)

### DIFF
--- a/ccgram-prototype/README.md
+++ b/ccgram-prototype/README.md
@@ -40,7 +40,7 @@ already publish agent sessions that ccgram discovers with zero code changes.
 | `patches/ccgram-4.5.2-pi-renderer-parity.patch` | Tracked unified diff, layer 1: patches the installed ccgram 4.5.2 Pi renderer (thinking + tool-call + final-answer flow). Not deployed by stow. |
 | `patches/ccgram-4.5.2-low-noise-notifications.patch` | Tracked unified diff, layer 2 (applies on top of layer 1): final-answer-only notifications (silent thinking trace, quiet-progress mode). Not deployed by stow. |
 | `patches/ccgram-4.5.2-pi-transcript-binding.patch` | Tracked unified diff, layer 3 (disjoint files): fixes the SessionStart transcript-binding race for reused session directories (exact-match-only binding, deferred pending resolution, offset reset on path change). Not deployed by stow. |
-| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): frontdoor-style live status bubble — live elapsed timer + ticker, one bold goal line per goal (`▸` active / `✓` done, matching the Pi Telegram frontdoor daemon; thinking blocks derive labels but never render as lines), `CCGRAM_PI_TRACE_*` cadence/idle/wrap knobs, same-message goal/thinking paraphrase dedupe, idle-timeout bubble deletion. Not deployed by stow. |
+| `patches/ccgram-4.5.2-pi-thinking-tree-live.patch` | Tracked unified diff, layer 4 (edits layer-1 files): frontdoor-style live status bubble — live elapsed timer + ticker, one bold goal line per goal (`▸` active / `✓` done, matching the Pi Telegram frontdoor daemon; thinking blocks derive labels but never render as lines), `CCGRAM_PI_TRACE_*` cadence/idle/wrap knobs, same-message goal/thinking paraphrase dedupe, idle-timeout bubble deletion, self-healing ticker (RetryAfter backoff + resend of a vanished bubble, so the timer never freezes mid-tool-call). Not deployed by stow. |
 | `.local/bin/ccgram-pi-hook` | Pi hook shim: waits (self-bounded) for the session's OWN transcript file at SessionStart, injects the exact `transcript_path`, delegates to `ccgram hook --provider pi`. Deployed by stow. |
 | `.pi/agent/extensions/hooks.json` | cc-thingz hook-runner wiring (SessionStart/Stop/SessionEnd → shim, async; SessionStart timeout raised to 20s to cover slow transcript creation). Deployed by stow. |
 | `pi-renderer-patch.sh` | Idempotent `status`/`check`/`apply`/`rollback` for the whole patch stack, with file-level backups. Not deployed by stow. |
@@ -283,6 +283,18 @@ tenant's transcript.
 touch any ccgram version other than 4.5.2 (set `CCGRAM_PATCH_FORCE=1` to
 override after regenerating the patch) and refuses to patch a dirty tree.
 
+Updating an existing patch layer: never hand-edit the `.patch` file.
+Build two scratch trees from the pristine 4.5.2 wheel in the uv cache —
+base = the layers below the one being changed, head = base + the current
+layer — edit the head tree's files, then regenerate with
+`diff -ruN --label a/<rel> --label b/<rel> base/<rel> head/<rel>` per
+touched file (one `diff -ruN a/... b/...` header line each, matching the
+tracked format) and verify the new patch applied to the base tree
+reproduces the edited head exactly. A layer revision never applies on
+top of its older revision on the live install: reverse the old revision
+first (`git show <old-rev>:ccgram-prototype/patches/<layer>.patch |
+patch -R -p1 -d "$SP"`), then `pi-renderer-patch.sh apply`.
+
 Offline tests (no Telegram, no live state):
 
 ```sh
@@ -397,7 +409,13 @@ completed ones drop off.
 - **Live elapsed timer.** The bubble header is `🧠 Thinking… · 0:42` and a
   per-trace background ticker re-renders the bubble at the edit cadence even
   when no new completed JSONL message has arrived, so the bubble always
-  looks alive. The ticker stops when no traces remain; edits never notify.
+  looks alive. The ticker is self-healing: a failing tick is logged and the
+  loop keeps running (one escaped exception never freezes the timer for the
+  rest of a long tool call), a Telegram `RetryAfter` becomes a per-trace
+  backoff instead of killing the sweep, and a bubble whose edits keep
+  failing is resent fresh from the ticker — the live timer never waits for
+  the next transcript event to reappear. The ticker stops when no traces
+  remain; edits (and resends) never notify.
 - **1s edit cadence knob.** `CCGRAM_PI_TRACE_EDIT_SECS` (default `2.0`)
   controls the minimum gap between trace edits; the prototype env sets
   `1.0`, matching the frontdoor's coalescing interval.

--- a/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
+++ b/ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch
@@ -1,6 +1,6 @@
 diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handlers/messaging_pipeline/message_routing.py
---- a/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-16 12:23:28.799903842 -0400
-+++ b/ccgram/handlers/messaging_pipeline/message_routing.py	2026-08-16 12:23:28.812342247 -0400
+--- a/ccgram/handlers/messaging_pipeline/message_routing.py
++++ b/ccgram/handlers/messaging_pipeline/message_routing.py
 @@ -28,8 +28,10 @@
  from .message_queue import enqueue_content_message, get_message_queue
  from .pi_live_transcript import (
@@ -31,9 +31,9 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/message_routing.py b/ccgram/handl
              stripped = (msg.text or "").strip()
              if len(stripped) < _MIN_THINKING_LENGTH:
 diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
---- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 12:23:28.800045847 -0400
-+++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py	2026-08-16 12:39:33.157817656 -0400
-@@ -1,29 +1,74 @@
+--- a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
++++ b/ccgram/handlers/messaging_pipeline/pi_live_transcript.py
+@@ -1,34 +1,84 @@
 -"""Pi live thinking transcript — temporary tree-style trace per topic.
 +"""Pi live thinking status — temporary live status bubble per topic.
  
@@ -89,9 +89,14 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 -Telegram message id of the temporary trace bubble.
 +Liveness: a per-trace background ticker re-renders the bubble at the edit
 +cadence even when no new completed JSONL message has arrived, so the
-+timer always advances.  The same sweep deletes a stale bubble when no
-+thinking/goal activity has arrived for ``IDLE_SECS`` (a killed turn
-+leaves no orphan).
++timer always advances.  The ticker is self-healing: a failing tick is
++logged and the loop keeps running (one escaped exception must never
++freeze the timer for the rest of a long tool call), a Telegram
++``RetryAfter`` sets a per-trace backoff instead of killing the sweep,
++and a bubble whose edits keep failing is resent fresh from the ticker —
++the live timer never waits for the next transcript event to reappear.
++The same sweep deletes a stale bubble when no thinking/goal activity
++has arrived for ``IDLE_SECS`` (a killed turn leaves no orphan).
 +
 +Knobs (env, read at import):
 +
@@ -120,7 +125,13 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
  import time
  from dataclasses import dataclass, field
  
-@@ -38,110 +83,381 @@
+ import structlog
+-from telegram.error import TelegramError
++from telegram.error import RetryAfter, TelegramError
+ 
+ from ...telegram_client import TelegramClient
+ from ...topic_state_registry import topic_state
+@@ -38,108 +88,445 @@
  logger = structlog.get_logger()
  
  PI_LIVE_PHASE = "pi-live"
@@ -160,15 +171,15 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +@dataclass
 +class _GoalNode:
 +    """One goal line: a mid-turn narration, or derived from thinking.
- 
--_TREE_HEADER = "\U0001f9e0 Thinking\u2026"
--_TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
++
 +    ``derived`` marks a label taken from a thinking block's first line
 +    (frontdoor ``label_derived``): it sticks until a text block in the
 +    same turn replaces it, and only a text-derived goal starts a new
 +    node (completing the previous one as ✓).
 +    """
-+
+ 
+-_TREE_HEADER = "\U0001f9e0 Thinking\u2026"
+-_TREE_SPINNER = "\u2514\u2500 \u23f3 still thinking\u2026"
 +    label: str
 +    derived: bool = False
 +    done: bool = False
@@ -183,10 +194,17 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
      message_id: int | None = None
      chat_id: int | None = None
 +    client: TelegramClient | None = None
++    thread_id: int | None = None
 +    started_ts: float = 0.0
      last_edit_ts: float = 0.0
 +    last_activity_ts: float = 0.0
 +    last_rendered: str = ""
++    # Telegram flood-control backoff (RetryAfter): skip edits until this
++    # monotonic timestamp; the timer catches up on the first tick after.
++    backoff_until: float = 0.0
++    # Consecutive tick-edit failures; two in a row means the bubble is
++    # gone (one may be a transient network error) and it is resent fresh.
++    edit_failures: int = 0
  
  
  # Active traces: (user_id, thread_id_or_0) -> _LiveTrace
@@ -334,20 +352,52 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    trace.last_activity_ts = now
 +    trace.client = client
      trace.chat_id = chat_id
++    trace.thread_id = thread_id
 +    return key, trace, now
  
 -    text = render_thinking_tree(trace.steps)
  
-+async def _push_update(
-+    trace: _LiveTrace, thread_id: int | None, now: float
-+) -> None:
++def _retry_after_secs(exc: RetryAfter) -> float:
++    """Telegram's requested flood-control wait, as a float (>= 1s)."""
++    return max(1.0, float(getattr(exc, "retry_after", 1.0) or 1.0))
++
++
++async def _send_bubble(trace: _LiveTrace, now: float) -> bool:
++    """Send (or resend) the trace bubble silently; True when sent.
++
++    Used on first content and by the ticker's self-healing resend.  The
++    bubble is ephemeral by design — edited in place, deleted when the
++    final answer lands — so the (re)send must never notify.
++    """
++    if trace.client is None or trace.chat_id is None:
++        return False
++    text = _render(trace, now)
++    sent = await safe_send(
++        trace.client,
++        trace.chat_id,
++        text,
++        message_thread_id=trace.thread_id,
++        disable_notification=True,
++    )
++    if sent is None:
++        return False
++    trace.message_id = sent.message_id
++    trace.last_edit_ts = now
++    trace.last_rendered = text
++    trace.edit_failures = 0
++    return True
++
++
++async def _push_update(trace: _LiveTrace, now: float) -> None:
 +    """Send the trace bubble on first content, else edit it in place.
 +
 +    First send is silent (dotfiles low-noise patch): the trace is ephemeral
 +    by design — edited in place, deleted when the final answer lands — so it
 +    must never notify.  Edits are rate-limited by EDIT_MIN_SECS and skipped
 +    when the rendered text is unchanged (the final delete is never
-+    rate-limited).
++    rate-limited).  A Telegram RetryAfter sets a per-trace backoff instead
++    of propagating — the ticker renders the latest state once the backoff
++    elapses, so a throttled update is delayed, never lost.
 +    """
 +    text = _render(trace, now)
      if trace.message_id is None:
@@ -355,40 +405,49 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 -        # ephemeral by design — edited in place, deleted when the final
 -        # answer lands — so it must never notify. Edits and deletes do not
 -        # notify either; only the final answer (normal path) may notify.
-         sent = await safe_send(
+-        sent = await safe_send(
 -            client,
 -            chat_id,
-+            trace.client,
-+            trace.chat_id,
-             text,
-             message_thread_id=thread_id,
-             disable_notification=True,
-         )
-         if sent is not None:
-             trace.message_id = sent.message_id
+-            text,
+-            message_thread_id=thread_id,
+-            disable_notification=True,
+-        )
+-        if sent is not None:
+-            trace.message_id = sent.message_id
 -            trace.last_edit_ts = time.monotonic()
-+            trace.last_edit_ts = now
-+            trace.last_rendered = text
++        await _send_bubble(trace, now)
          return
  
 -    now = time.monotonic()
 +    if text == trace.last_rendered:
 +        return
++    if now < trace.backoff_until:
++        return
      if now - trace.last_edit_ts < EDIT_MIN_SECS:
          return
-     edited = await edit_with_fallback(
+-    edited = await edit_with_fallback(
 -        client, chat_id, trace.message_id, text
-+        trace.client, trace.chat_id, trace.message_id, text
-     )
+-    )
++    try:
++        edited = await edit_with_fallback(
++            trace.client, trace.chat_id, trace.message_id, text
++        )
++    except RetryAfter as exc:
++        trace.backoff_until = now + _retry_after_secs(exc)
++        return
      if edited:
          trace.last_edit_ts = now
 +        trace.last_rendered = text
++        trace.edit_failures = 0
      else:
-         # Bubble vanished (topic cleaned, message deleted); resend fresh.
+-        # Bubble vanished (topic cleaned, message deleted); resend fresh.
++        # Bubble vanished (topic cleaned, message deleted); resend fresh
++        # right away so the new content stays visible.
          trace.message_id = None
-         trace.last_edit_ts = 0.0
- 
- 
+-        trace.last_edit_ts = 0.0
++        await _send_bubble(trace, now)
++
++
 +def _ensure_ticker() -> None:
 +    """Start the liveness ticker if it is not running (needs a live loop)."""
 +    global _tick_task
@@ -401,14 +460,21 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +
 +
 +async def _ticker() -> None:
-+    """Refresh live traces (timer) and sweep idle ones until none remain."""
++    """Refresh live traces (timer) and sweep idle ones until none remain.
++
++    A failing tick is logged and the loop CONTINUES: a single escaped
++    exception must never kill the ticker — ``_ensure_ticker`` only runs
++    on new transcript activity, so a dead ticker freezes the live timer
++    for the rest of a long tool call (the PR151 visible-smoke failure).
++    """
 +    global _tick_task
 +    try:
 +        while _traces:
 +            await asyncio.sleep(TICK_SECS)
-+            await tick_once()
-+    except Exception:
-+        logger.exception("Pi thinking trace ticker crashed")
++            try:
++                await tick_once()
++            except Exception:
++                logger.exception("Pi thinking trace tick failed")
 +    finally:
 +        _tick_task = None
 +
@@ -422,6 +488,10 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +    - Timer refresh: a live trace whose edit throttle has elapsed is
 +      re-rendered (the header timer advances even when no new JSONL
 +      message arrived).  Edits never notify.
++    - Self-healing: a trace whose bubble vanished is resent from here,
++      and a Telegram RetryAfter becomes a per-trace backoff — neither
++      aborts the sweep, so the timer keeps ticking through long tool
++      calls with no transcript activity.
 +    """
 +    now = time.monotonic() if now is None else now
 +    for key, trace in list(_traces.items()):
@@ -442,27 +512,45 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +                thread_id=key[1],
 +            )
 +            continue
-+        if (
-+            trace.client is None
-+            or trace.message_id is None
-+            or trace.chat_id is None
-+        ):
++        if trace.client is None or trace.chat_id is None:
++            continue
++        if now < trace.backoff_until:
++            # Telegram flood-control backoff; the timer catches up on the
++            # first tick after it elapses.
++            continue
++        if trace.message_id is None:
++            # The bubble vanished (or a previous send/edit failed): resend
++            # it from the ticker so the live timer never waits for the
++            # next transcript event to reappear.
++            await _send_bubble(trace, now)
 +            continue
 +        if now - trace.last_edit_ts < EDIT_MIN_SECS:
 +            continue
 +        text = _render(trace, now)
 +        if text == trace.last_rendered:
 +            continue
-+        edited = await edit_with_fallback(
-+            trace.client, trace.chat_id, trace.message_id, text
-+        )
++        try:
++            edited = await edit_with_fallback(
++                trace.client, trace.chat_id, trace.message_id, text
++            )
++        except RetryAfter as exc:
++            # Flood control: honor Telegram's backoff and keep ticking.
++            trace.backoff_until = now + _retry_after_secs(exc)
++            continue
 +        if edited:
 +            trace.last_edit_ts = now
 +            trace.last_rendered = text
++            trace.edit_failures = 0
 +        else:
-+            # Bubble vanished; the next activity resends it fresh.
-+            trace.message_id = None
-+            trace.last_edit_ts = 0.0
++            # Both edit attempts failed.  One failure may be transient
++            # (network); two in a row means the bubble is gone — resend
++            # it fresh so the timer keeps ticking through long tool calls
++            # instead of freezing until the next transcript event.
++            trace.edit_failures += 1
++            if trace.edit_failures >= 2:
++                trace.edit_failures = 0
++                trace.message_id = None
++                await _send_bubble(trace, now)
 +
 +
 +async def handle_pi_thinking(
@@ -494,7 +582,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +        )
 +        _trim_goals(trace)
 +    _ensure_ticker()
-+    await _push_update(trace, thread_id, now)
++    await _push_update(trace, now)
 +
 +
 +async def handle_pi_goal(
@@ -538,13 +626,11 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +        trace.goals.append(_GoalNode(label=goal))
 +        _trim_goals(trace)
 +    _ensure_ticker()
-+    await _push_update(trace, thread_id, now)
-+
-+
++    await _push_update(trace, now)
+ 
+ 
  async def clear_pi_thinking(
-     client: TelegramClient,
-     user_id: int,
-@@ -150,8 +466,8 @@
+@@ -150,8 +537,8 @@
      """Delete the topic's temporary trace bubble, if any.
  
      Called when the final assistant answer (or a terminal error notice) is
@@ -555,7 +641,7 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
      """
      key = (user_id, thread_key(thread_id))
      trace = _traces.pop(key, None)
-@@ -170,5 +486,9 @@
+@@ -170,5 +557,9 @@
  
  
  def clear_all_traces() -> None:
@@ -567,8 +653,8 @@ diff -ruN a/ccgram/handlers/messaging_pipeline/pi_live_transcript.py b/ccgram/ha
 +        _tick_task.cancel()
 +    _tick_task = None
 diff -ruN a/ccgram/providers/pi_format.py b/ccgram/providers/pi_format.py
---- a/ccgram/providers/pi_format.py	2026-08-16 12:23:28.798744933 -0400
-+++ b/ccgram/providers/pi_format.py	2026-08-16 12:24:52.846657139 -0400
+--- a/ccgram/providers/pi_format.py
++++ b/ccgram/providers/pi_format.py
 @@ -17,16 +17,25 @@
  Renderer parity (dotfiles ccgram-prototype patch): ``thinking`` blocks are
  no longer dropped.  They are emitted as ``content_type="thinking"`` messages

--- a/ccgram-prototype/pi-renderer-patch.sh
+++ b/ccgram-prototype/pi-renderer-patch.sh
@@ -38,7 +38,11 @@
 #      immune to the difflib autojunk collapse that let the real line-14
 #      pair through the earlier character-level rule); mobile-safe label
 #      wrap default (36 columns, blank hanging indent under the bullet);
-#      idle-timeout deletion of stale trace bubbles (default 10 min).
+#      idle-timeout deletion of stale trace bubbles (default 10 min);
+#      self-healing ticker — a failed tick is logged and the loop
+#      continues, Telegram RetryAfter becomes a per-trace backoff, and a
+#      bubble whose edits keep failing is resent fresh from the ticker
+#      (the timer never freezes waiting for the next transcript event).
 #
 # Patch 2's context includes files added/edited by patch 1, so patch 2 only
 # applies on top of patch 1; patch 3 touches disjoint files and applies on

--- a/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
+++ b/ccgram-prototype/pi-renderer/test_pi_renderer_parity.py
@@ -36,7 +36,14 @@ Coverage:
      paraphrase dedupe (token-overlap heuristic), so the screenshot case
      displays the concise goal once; ticker timer refresh without new
      steps; idle-timeout deletion of stale trace bubbles; mobile-safe
-     36-column label wrap with a blank hanging indent under the bullet.
+     36-column label wrap with a blank hanging indent under the bullet;
+     ticker resilience (PR151 visible-smoke regression): RetryAfter on a
+     timer/goal edit becomes a per-trace backoff (throttled updates are
+     delayed, never lost), a vanished bubble is resent fresh after two
+     consecutive failed tick edits (one failure never resends — no
+     duplicate bubbles on transient errors), and the real _ticker loop
+     survives an exploded tick while editing with zero transcript
+     updates.
 """
 
 from __future__ import annotations
@@ -233,13 +240,21 @@ class _FakeMessage:
 
 
 class _FakeClient:
-    """Records the Bot API calls pi_live_transcript would make."""
+    """Records the Bot API calls pi_live_transcript would make.
+
+    Failure injection for the ticker-resilience tests: ``edit_error``
+    (an exception instance or a callable returning one/None per call) is
+    raised from edit_message_text, simulating Telegram flood control
+    (RetryAfter) or a vanished bubble (BadRequest) without any Bot API
+    calls.
+    """
 
     def __init__(self) -> None:
         self.sent: list[dict] = []
         self.edited: list[dict] = []
         self.deleted: list[dict] = []
         self._next_id = 1000
+        self.edit_error = None
 
     async def send_message(self, chat_id, text, **kwargs):
         self._next_id += 1
@@ -247,6 +262,9 @@ class _FakeClient:
         return _FakeMessage(self._next_id)
 
     async def edit_message_text(self, chat_id, message_id, text, **kwargs):
+        err = self.edit_error() if callable(self.edit_error) else self.edit_error
+        if err is not None:
+            raise err
         self.edited.append(
             {"chat_id": chat_id, "message_id": message_id, "text": text, **kwargs}
         )
@@ -648,6 +666,244 @@ class PiRendererParityTest(unittest.TestCase):
         tr.started_ts -= 65
         run(trace.tick_once())
         self.assertEqual(len(client.edited), 0)
+        trace.clear_all_traces()
+
+    # ── 5b. Ticker resilience (PR151 visible-smoke regression) ─────────
+    # The captain's smoke: a long `sleep 90` tool call with no transcript
+    # activity — the bubble's timer must keep editing on the ticker's own
+    # cadence, and no single edit failure may freeze it for the rest of
+    # the tool call.
+
+    def test_tick_survives_retry_after_and_honors_backoff(self):
+        from telegram.error import RetryAfter
+
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "first step"))
+        key = (1, 42)
+        tr = trace._traces[key]
+
+        # Telegram flood control on the timer edit: RetryAfter must NOT
+        # propagate out of tick_once (it killed the ticker before the
+        # fix); it becomes a per-trace backoff instead.
+        client.edit_error = RetryAfter(30)
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        tr.started_ts -= 65
+        run(trace.tick_once())  # must not raise
+        self.assertEqual(len(client.edited), 0)
+        self.assertGreater(tr.backoff_until, 0.0)
+
+        # Ticks during the backoff are skipped (no hammering)…
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.tick_once())
+        self.assertEqual(len(client.edited), 0)
+
+        # …and the timer catches up on the first tick after the backoff
+        # elapses — the trace and ticker state survive intact.
+        client.edit_error = None
+        tr.backoff_until = 0.0
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.tick_once())
+        self.assertEqual(len(client.edited), 1)
+        self.assertIn("🧠 Thinking… · 1:05", client.edited[0]["text"])
+        trace.clear_all_traces()
+
+    def test_push_update_retry_after_delays_but_never_loses_goal(self):
+        from telegram.error import RetryAfter
+
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "first step"))
+        tr = trace._traces[(1, 42)]
+
+        # A goal update whose edit hits flood control is NOT lost: the
+        # RetryAfter sets a backoff and the ticker renders the latest
+        # state once it elapses.
+        client.edit_error = RetryAfter(30)
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.handle_pi_goal(client, 1, 42, -100999, "the real goal"))
+        self.assertEqual(len(client.edited), 0)  # edit attempt flooded
+        self.assertGreater(tr.backoff_until, 0.0)
+
+        client.edit_error = None
+        tr.backoff_until = 0.0
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.tick_once())
+        self.assertEqual(len(client.edited), 1)
+        self.assertIn("▸ the real goal", client.edited[0]["text"])
+        trace.clear_all_traces()
+
+    def test_tick_resends_bubble_after_repeated_edit_failure(self):
+        from telegram.error import BadRequest
+
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "first step"))
+        self.assertEqual(len(client.sent), 1)
+        tr = trace._traces[(1, 42)]
+
+        # The bubble vanished (topic cleaned / message deleted): both the
+        # entity edit and the plain retry fail with "not found".
+        client.edit_error = BadRequest("Bad Request: message to edit not found")
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        tr.started_ts -= 65
+        run(trace.tick_once())
+        # One failure may be transient: no resend yet, but the failure is
+        # counted and the trace survives.
+        self.assertEqual(len(client.sent), 1)
+        self.assertEqual(tr.edit_failures, 1)
+        self.assertIsNotNone(tr.message_id)
+
+        # The second consecutive failed tick resends the bubble fresh —
+        # silently, in the same topic — so the live timer keeps ticking
+        # through a long tool call instead of freezing until the next
+        # transcript event.
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.tick_once())
+        self.assertEqual(len(client.sent), 2)
+        self.assertIs(client.sent[1].get("disable_notification"), True)
+        self.assertEqual(client.sent[1].get("message_thread_id"), 42)
+        self.assertEqual(tr.message_id, 1002)
+        self.assertEqual(tr.edit_failures, 0)
+        self.assertIn("🧠 Thinking… · 1:05", client.sent[1]["text"])
+
+        # …and later ticks edit the RESENT bubble.
+        client.edit_error = None
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        tr.started_ts -= 1  # advance the timer so the text changes
+        run(trace.tick_once())
+        self.assertEqual(len(client.edited), 1)
+        self.assertEqual(client.edited[0]["message_id"], 1002)
+        self.assertIn("🧠 Thinking… · 1:06", client.edited[0]["text"])
+        trace.clear_all_traces()
+
+    def test_tick_single_edit_failure_does_not_resend_or_freeze(self):
+        from telegram.error import BadRequest
+
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "first step"))
+        tr = trace._traces[(1, 42)]
+
+        # One transient failure (network blip): no duplicate resend, and
+        # the next healthy tick edits the SAME bubble — no freeze.
+        errors = iter([BadRequest("Timed out"), None])
+        client.edit_error = lambda: next(errors, None)
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        tr.started_ts -= 65
+        run(trace.tick_once())
+        self.assertEqual(len(client.sent), 1)  # no duplicate bubble
+        tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.tick_once())
+        self.assertEqual(len(client.edited), 1)
+        self.assertEqual(client.edited[0]["message_id"], 1001)
+        self.assertIn("🧠 Thinking… · 1:05", client.edited[0]["text"])
+        trace.clear_all_traces()
+
+    def test_ticker_loop_survives_tick_error_and_ticks_without_content(self):
+        # The smoke scenario end-to-end against the REAL _ticker task
+        # (not direct tick_once calls): with no new transcript content
+        # the background ticker edits the bubble at its own cadence, and
+        # one exploded tick does not kill the loop.
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        real_tick_once = trace.tick_once
+        state = {"calls": 0}
+
+        async def flaky_tick_once(now=None):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise RuntimeError("boom")
+            await real_tick_once(now)
+
+        async def main():
+            saved_tick = trace.TICK_SECS
+            trace.TICK_SECS = 0.05
+            trace.tick_once = flaky_tick_once
+            try:
+                await trace.handle_pi_thinking(
+                    client, 1, 42, -100999, "first step"
+                )
+                self.assertIsNotNone(trace._tick_task)
+                # ~8 ticks, no new content; first tick explodes.
+                for _ in range(8):
+                    tr = trace._traces.get((1, 42))
+                    if tr is not None:
+                        tr.started_ts -= 1.0  # keep the timer advancing
+                        tr.last_edit_ts -= 1.0  # stay outside the throttle
+                    await asyncio.sleep(0.06)
+            finally:
+                trace.tick_once = real_tick_once
+                trace.TICK_SECS = saved_tick
+                trace.clear_all_traces()
+            await asyncio.sleep(0.05)  # let the cancelled ticker settle
+
+        asyncio.run(main())
+        # The exploded tick was logged and the loop CONTINUED: timer
+        # edits accumulated with zero transcript updates.
+        self.assertGreaterEqual(state["calls"], 3)
+        self.assertGreaterEqual(len(client.edited), 2)
+        self.assertIn("🧠 Thinking… ·", client.edited[-1]["text"])
+
+    def test_goal_sequence_updates_through_long_tool_call(self):
+        # The captain's enumerated frontdoor flow on the JSONL state
+        # machine: thinking-only derives ▸; a mid-turn text for the same
+        # step REPLACES the derived label (visible promptly via the
+        # ticker even when throttled at arrival); a genuinely new goal
+        # completes the prior one (✓) and takes the ▸; then a long
+        # no-content window (the sleep-90 tool call) keeps the timer
+        # editing with the active goal still visible.
+        trace = self.trace
+        trace.clear_all_traces()
+        client = _FakeClient()
+        run = asyncio.run
+        key = (1, 42)
+
+        run(trace.handle_pi_thinking(client, 1, 42, -100999, "Checking the worktree state first."))
+        self.assertEqual(len(client.sent), 1)
+        self.assertIn("▸ Checking the worktree state first.", client.sent[0]["text"])
+
+        # Mid-turn text for the same step arrives while the edit
+        # throttle is hot: no immediate edit, but the ticker makes the
+        # replacement visible promptly (derived label REPLACED, no ✓).
+        run(trace.handle_pi_goal(client, 1, 42, -100999, "Running the 90-second smoke wait."))
+        self.assertEqual(len(client.edited), 0)  # throttled at arrival
+        trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.tick_once())
+        self.assertEqual(len(client.edited), 1)
+        self.assertIn("▸ Running the 90-second smoke wait.", client.edited[0]["text"])
+        self.assertNotIn("✓", client.edited[0]["text"])
+        self.assertNotIn("Checking the worktree", client.edited[0]["text"])
+
+        # A genuinely new goal completes the prior one.
+        trace._traces[key].last_edit_ts -= trace.EDIT_MIN_SECS + 1
+        run(trace.handle_pi_goal(client, 1, 42, -100999, "Writing the smoke report."))
+        self.assertIn("✓ Running the 90-second smoke wait.", client.edited[-1]["text"])
+        self.assertIn("▸ Writing the smoke report.", client.edited[-1]["text"])
+
+        # Long tool call, no transcript updates: timer-only ticks keep
+        # editing the same bubble and the active goal stays visible.
+        for elapsed in (61.4, 62.4, 63.4):
+            tr = trace._traces[key]
+            tr.last_edit_ts -= trace.EDIT_MIN_SECS + 1
+            tr.started_ts = trace.time.monotonic() - elapsed
+            run(trace.tick_once())
+        texts = [e["text"] for e in client.edited[-3:]]
+        self.assertIn("· 1:01", texts[0])
+        self.assertIn("· 1:02", texts[1])
+        self.assertIn("· 1:03", texts[2])
+        for t in texts:
+            self.assertIn("▸ Writing the smoke report.", t)
+            self.assertEqual(e_msg := client.edited[-1]["message_id"], 1001)
         trace.clear_all_traces()
 
     # ── 6. Goal/thinking dedupe + no-tree mobile wrap ──────────────────


### PR DESCRIPTION
## What

Fixes the deployed PR151 live status bubble so it behaves like the Pi Telegram frontdoor in both dimensions the captain flagged during the visible smoke (`firstmate ▸ fm-ccgram-pr151-visible-smoke`):

1. **The elapsed timer visibly ticks on its own cadence** while a bubble is live — including through a long tool call (`sleep 90`) with zero transcript updates.
2. **Goal-line updates become visible promptly** — a mid-turn text block replaces the derived `▸` label, a genuinely new goal completes the prior one (`✓`) and takes the `▸`, even when the update arrived while the edit throttle or a flood-control backoff was hot.

## Root cause

The layer-4 ticker had **no self-healing**. Offline, the mechanics worked (and the existing tests drove `tick_once()` directly, so they never exercised the failure); live, any of these froze the bubble until the next transcript event — which, during a 90-second tool call, is exactly the captain's symptom:

- **One escaped tick exception killed the ticker for the rest of the quiet window.** `_ticker` wrapped the whole loop in a single `try/except`, and `_ensure_ticker` only re-runs on new thinking/goal activity. `edit_with_fallback` deliberately re-raises `RetryAfter`, so one flood-control response (a real risk at the prototype's 1s edit cadence) ended all timer edits until content arrived.
- **A failed tick edit orphaned the visible bubble.** `edited=False` nulled `message_id`, after which `tick_once` skipped the trace (`continue`) and the resend only happened on the *next transcript event* — silently (no log line).
- **`_push_update` let `RetryAfter` propagate**, losing the content update it was carrying — which is also why throttled **goal** updates never became visible once the ticker was gone: the render is state-driven, so a skipped edit is only safe if the ticker is alive to re-render.

I verified the deployed install is byte-identical to the tracked patch stack, replayed the actual smoke JSONL (`2026-08-16T16-56-45-928Z_01a00b81….jsonl`) through the patched parser + trace state machine offline (timer ticks `0:00 → 1:30+` across the sleep-90 window, goal updates render correctly), and confirmed no ticker crash was logged by the live service — consistent with the silent orphan/freeze paths above.

## Fix (patch layer 4, `pi_live_transcript.py` only)

- `_ticker`: per-tick exception isolation — a failed tick is logged and the loop **continues** while traces remain.
- `tick_once`: `RetryAfter` becomes a per-trace `backoff_until` (flood control honored, timer catches up after); a trace with no `message_id` is **resent from the ticker**; two consecutive failed tick edits resend the bubble fresh (one failure never resends — a transient blip cannot duplicate bubbles).
- `_push_update`: `RetryAfter` sets the backoff instead of propagating (throttled goal/timer updates are delayed, never lost); a vanished bubble is resent immediately so new content stays visible.
- `_LiveTrace` carries `thread_id` (silent resends land in the right topic), `backoff_until`, and `edit_failures`.

Goal state machine is unchanged (derived-label stickiness, text-replaces-derived, new-text-completes-prior all already match the frontdoor mapping); what was broken was those updates reaching Telegram when the ticker was dead or the edit was throttled/flooded.

## Tests (would have caught the smoke failure)

Six new tests in `ccgram-prototype/pi-renderer/test_pi_renderer_parity.py`:

- `RetryAfter` on a tick edit: does not propagate, backoff honored (no hammering), timer catches up after.
- `RetryAfter` on a goal-update edit: update delayed, never lost — the ticker renders the new `▸` label after the backoff.
- Repeated edit failure (bubble vanished): first failure counted (no resend), second failure resends silently into the same topic, later ticks edit the resent bubble.
- Single transient failure: no duplicate resend, next healthy tick edits the same bubble.
- **The real `_ticker` task** (not direct `tick_once` calls) survives an exploded tick and keeps editing with zero transcript updates.
- The captain's enumerated sequence: thinking-only derived `▸` → throttled text-goal replacement visible via ticker → new goal completes prior (`✓`/`▸`) → timer-only ticks `1:01/1:02/1:03` through a long tool call with the active goal visible.

`43 tests OK`; `ccgram-prototype/validate.sh` green.

## Deploy after merge

Layer 4 is a new revision of an already-applied patch; it will **not** apply over the old revision on the live install. From the primary checkout after merge:

```sh
SP=~/.local/share/uv/tools/ccgram/lib/python3.14/site-packages
# 1. Reverse the OLD layer 4 (the new patch only reverse-applies to code it created):
git show HEAD~1:ccgram-prototype/patches/ccgram-4.5.2-pi-thinking-tree-live.patch | patch -R -p1 -d "$SP"
# 2. Apply the updated stack (layer 4 is the only missing one; backs up first):
ccgram-prototype/pi-renderer-patch.sh apply
# 3. Restart the service:
systemctl --user restart ccgram-prototype.service
# 4. Verify: ccgram-prototype/pi-renderer-patch.sh status  → layer 4 applied
```

No env/config changes needed (`CCGRAM_PI_TRACE_EDIT_SECS=1.0`, `_TICK_SECS=1.0`, `_WRAP_CHARS=36` stay as-is). Then re-run the visible smoke: the bubble should tick `M:SS` every ~1s through the `sleep 90` and the goal line should flip promptly when mid-turn text arrives.

No live services were touched from this worker; no merge performed.
