### PR TITLE
homelab: seat-independent hidraw access for Steam controllers (fix DS4 not registering)

### DIFF
--- a/ops/homelab-steam-controller/71-steam-controller-hidraw.rules
+++ b/ops/homelab-steam-controller/71-steam-controller-hidraw.rules
@@ -1,0 +1,26 @@
+# Seat-independent hidraw access for Sony game controllers on the homelab.
+#
+# Stock /usr/lib/udev/rules.d/60-steam-input.rules grants these hidraw nodes
+# access only via TAG+="uaccess" (base mode stays 0600 root:root). The uaccess
+# builtin depends on a logind round-trip from the udev worker; when logind is
+# slow (e.g. udevd flooded by another device's event storm) or when the GDM
+# greeter owns the seat, no ACL lands and Steam's SDL gets EACCES opening the
+# hidraw node. SDL then permanently disables the hidapi driver for that
+# controller ("driver = NONE (DISABLED)") until Steam restarts, and the
+# controller never registers in Steam.
+#
+# GROUP=input is applied locally by udevd in the same rule pass that creates
+# the node and emits the uevent -- no logind dependency -- so hotplug works
+# regardless of seat state or logind health. Requires the gaming user in
+# group "input" (see apply.sh).
+#
+# KERNELS matches the parent HID device name (<bus>:<vid>:<pid>.<n>):
+#   0003 = USB HID, 0005 = Bluetooth HID, 054C = Sony Interactive Entertainment.
+# ATTRS{idVendor} is NOT used: for Bluetooth the sysfs parent chain ends at the
+# BT adapter's USB vendor, so vendor-based rules silently never match BT gamepads.
+#
+# Covers DS3 (0268), DS4 (05c4/09cc), DualSense (0ce6), DualSense Edge (0df2)
+# and any future 054c controller, over both USB and Bluetooth.
+
+ACTION=="add|change", SUBSYSTEM=="hidraw", KERNELS=="0003:054C:*", GROUP="input", MODE="0660", TAG+="uaccess"
+ACTION=="add|change", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:*", GROUP="input", MODE="0660", TAG+="uaccess"

--- a/ops/homelab-steam-controller/README.md
+++ b/ops/homelab-steam-controller/README.md
@@ -1,0 +1,120 @@
+# Homelab Steam controller recognition fix
+
+Fix for DualShock 4 controllers not registering as controllers in Steam on the
+`homelab` host (Ubuntu 24.04, GNOME/Wayland, gdm-autologin, Steam native deb).
+
+## Observed symptom
+
+- Steam (Settings -> Controller) showed **no controller**, or at most one
+  degraded "PS4 Controller" with no identity, while one or two DualShock 4 v2
+  pads (`054c:09cc`, BT MACs `a4:ae:11:d0:25:f9` and `dc:af:68:fb:71:eb`) were
+  connected.
+- The kernel saw the pads fine the whole time: `hid-playstation` registered
+  them, `/dev/input/eventN` + `jsN` + `/dev/hidrawN` existed, BlueZ showed
+  `Connected: yes`, `Paired: yes`, `Trusted: yes`.
+
+## Root cause
+
+Separated into trigger, mechanism, masking condition, and visible symptom:
+
+1. **Trigger (environmental, pre-existing):** since boot, the distro's
+   `/usr/lib/udev/rules.d/71-nvidia.rules` fires failing
+   `/sbin/modprobe nvidia*` calls in a tight loop (12,732 failures in the
+   first 28 minutes after boot, still ongoing at diagnosis time; GPU is in
+   vfio/nvidia flux from the RTX 3060 / `pi-stt` migration). `systemd-udevd`
+   burns ~46% CPU continuously, `udevadm settle` never returns ("Timed out
+   for waiting the udev queue being empty"), and GDM session workers time out
+   waiting on the udev queue at login.
+2. **Mechanism:** when a DS4 (re)connects over Bluetooth, devtmpfs creates
+   `/dev/hidrawN` as `0600 root:root`. Access for `054c` hidraw nodes comes
+   only from `TAG+="uaccess"` (stock `60-steam-input.rules`); the uaccess
+   builtin needs a logind round-trip from the udev worker. Under the storm --
+   and also whenever the GDM greeter owns the seat (this box idles at the
+   login screen) -- that step fails or lags: the node stays `0600` (verified:
+   node born 14:10:53 still `crw------- root root` minutes later, while its
+   udev DB entry already carried `TAGS=:seat:uaccess:`). Steam's SDL opens
+   the hidraw node at device-appearance time, gets `EACCES`, and **permanently
+   registers the pad as `driver = NONE (DISABLED)`** for the process lifetime
+   (`~/.local/share/Steam/logs/console_log.txt`:
+   `HIDAPI_SetupDeviceDriver() couldn't open /dev/hidrawN: Permission denied`).
+3. **Masking condition:** much later, SDL's generic evdev fallback can surface
+   the pad, but with no serial -> Steam synthesizes `54c-9cc-395442b`, identical
+   for both DS4s, so the two pads dedupe into ONE visible entry, with a degraded
+   mapping (no touchpad) and broken per-controller config persistence.
+4. **Visible symptom:** controller missing in Steam's controller UI and in
+   games, despite being connected and functional at every OS layer.
+
+Intermittency explained: on a quiet host (e.g. 2026-08-16 23:40-23:41) the same
+hotplugs won the race and logged
+`Added HIDAPI device ... driver = SDL_JOYSTICK_HIDAPI_PS4 (ENABLED)` with real
+serials -- the proven path this fix restores deterministically.
+
+## Layers checked
+
+| Layer | Result |
+| --- | --- |
+| Physical / BT link | Both pads Connected/Paired/Trusted via onboard BT (Foxconn 0489:e0e2); links flap occasionally (see Follow-ups) |
+| USB identity (`lsusb`) | n/a (Bluetooth HID), BT adapter healthy |
+| Kernel input (`/proc/bus/input/devices`, journal) | `hid-playstation` registers both pads every time; evdev `js0/js1` present |
+| `/dev/input` + hidraw perms | evdev `root:input 0660`; hidraw nodes intermittently left `0600 root:root` (the bug) |
+| udev rules | Stock `60-steam-input.rules` present; grants access only via `uaccess` tag |
+| Seat/session | Greeter owns seat while box idles; uaccess ACL follows active session -- but EACCES also reproduced during a confirmed-active session |
+| Steam runtime/SDL | SDL 3.4.0, udev hidapi discovery; hotplug monitor alive (removals logged within 1s) |
+| Steam Input settings | PlayStation hidapi path ENABLED at startup; per-controller configsets exist for the real serials |
+
+## Counterfactual test and disconfirming evidence
+
+- Test: with the GNOME session confirmed active, `bluetoothctl disconnect` /
+  reconnect DS4 `a4:ae:11:d0:25:f9` (the pad not in use; the in-game pad was
+  untouched and MK11 unaffected).
+- Disconnect half: SDL removed the device within ~1s (monitor healthy).
+- Reconnect half (after a physical PS-button press -- host-side reconnect is
+  impossible once the DS4 powers off; BlueZ reports `Host is down (112)`):
+  SDL **still** got `Permission denied` at 14:10:53 and re-registered the pad
+  as `driver = NONE (DISABLED)`.
+- This **disconfirmed** the initial "greeter owns the seat" theory as the sole
+  cause and exposed the load-dependent uaccess/logind failure (the udev storm
+  above). It also confirmed the group-based fix shape: GROUP/MODE are applied
+  locally by udevd in the same rule pass that emits the uevent (rule processing
+  demonstrably runs even under the storm -- DB entries/TAGS land); only the
+  logind round-trip fails.
+
+## Fix
+
+`71-steam-controller-hidraw.rules` sets `GROUP="input", MODE="0660"` on Sony
+controller hidraw nodes (`KERNELS=="0003:054C:*"` USB and `0005:054C:*"` BT;
+vendor-attr matching silently never matches Bluetooth pads), keeping
+`TAG+="uaccess"` for multi-seat correctness. `avirus` is added to group
+`input`. Trade-off accepted by the captain: group `input` can read all
+`/dev/input/event*` (incl. keyboards) on this single-user appliance box.
+
+## Apply (on homelab)
+
+```sh
+sudo ~/dotfiles/ops/homelab-steam-controller/apply.sh
+```
+
+Then re-login (or reboot) so group membership reaches the running Steam, and
+reconnect the pad (PS button) or restart Steam.
+
+Expected verification after apply:
+
+```
+console_log.txt: Added HIDAPI device 'Wireless Controller' VID 0x054c, PID 0x09cc, bluetooth 1, serial a4:ae:11:d0:25:f9, driver = SDL_JOYSTICK_HIDAPI_PS4 (ENABLED)
+controller.txt:  Local Device Found / type: 054c 09cc / !! Steam controller device opened for index N
+```
+
+and no `Permission denied` lines.
+
+## Follow-ups (not fixed here)
+
+- **udev storm:** `71-nvidia.rules` failing-`modprobe` loop (~46% CPU udevd,
+  queue never settles) is a side effect of the RTX 3060 / `pi-stt` GPU
+  migration owned by another worker. Controller hotplug becomes reliable once
+  udevd is calm; this fix removes the remaining race margin. Do not "fix" the
+  nvidia rule from this lane.
+- **BT link flapping:** pads drop with `hid_read failure` on DS4 idle power-off
+  (overnight: benign) and occasionally in rapid drop/reconnect bursts
+  (2026-08-16 23:39-23:41: worth a `btmon` look another day). With deterministic
+  hotplug recovery, a flap is a seconds-long blip instead of a permanently
+  invisible controller.

--- a/ops/homelab-steam-controller/apply.sh
+++ b/ops/homelab-steam-controller/apply.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Install the seat-independent Steam controller hidraw rule on the homelab.
+#
+# Usage (on homelab):
+#   sudo ~/dotfiles/ops/homelab-steam-controller/apply.sh
+#
+# Afterwards: log the GNOME session out and back in (or reboot) so group
+# "input" reaches already-running processes such as Steam, then reconnect the
+# controller (PS button) or restart Steam. See README.md for why.
+set -euo pipefail
+
+readonly RULE_SRC="$(cd "$(dirname "$0")" && pwd -P)/71-steam-controller-hidraw.rules"
+readonly RULE_DST="/etc/udev/rules.d/71-steam-controller-hidraw.rules"
+readonly GAMING_USER="avirus"
+
+install -m 0644 -o root -g root "$RULE_SRC" "$RULE_DST"
+usermod -aG input "$GAMING_USER"
+udevadm control --reload
+# Apply the rule to already-connected controller hidraw nodes.
+udevadm trigger --subsystem-match=hidraw --action=change
+
+echo "Installed $RULE_DST"
+echo "Added $GAMING_USER to group input (effective for new logins)."
+echo "Next: re-login (or reboot), then reconnect the controller or restart Steam."


### PR DESCRIPTION
## Observed symptom

Steam on the homelab showed **no controller** (or at most one degraded, serial-less "PS4 Controller") in Settings → Controller and in games, while two DualShock 4 v2 pads (\`054c:09cc\`) were connected via Bluetooth and fully visible to the kernel (evdev \`js0/js1\` + hidraw nodes present, BlueZ Connected/Paired/Trusted).

## Root cause

Trigger → mechanism → masking → symptom (full evidence in \`ops/homelab-steam-controller/README.md\`):

1. **Trigger:** since boot, the distro's \`71-nvidia.rules\` fires failing \`modprobe nvidia*\` calls in a tight loop (12,732 failures in the first 28 min; GPU in vfio/nvidia flux from the RTX 3060/pi-stt migration, owned by another lane). \`systemd-udevd\` spins at ~46% CPU; the event queue never settles.
2. **Mechanism:** on BT (re)connect, devtmpfs creates \`/dev/hidrawN\` as \`0600 root:root\`. The only access grant for \`054c\` hidraw is \`TAG+="uaccess"\` (stock \`60-steam-input.rules\`) — a logind round-trip from the udev worker. Under the storm (and whenever the GDM greeter owns the seat), it fails/lags: node stays \`0600\` even though its udev DB entry gets \`TAGS=:seat:uaccess:\`. Steam's SDL opens the node at device-appearance time → \`EACCES\` → **permanently** registers the pad as \`driver = NONE (DISABLED)\` for the process lifetime.
3. **Masking:** the evdev fallback later surfaces at most ONE pad with synthetic serial \`54c-9cc-395442b\` — both DS4s dedupe into one degraded entry (no touchpad, broken per-controller config).
4. **Symptom:** controller missing in Steam despite working at every OS layer.

## Layers checked

BT link, USB/BT identity, kernel input/hid exposure, /dev/input + hidraw perms, udev rules, seat/session access, Steam runtime/SDL behavior, Steam Input settings — table in the README. Proven path for comparison: same host, 2026-08-16 23:40–23:41, hotplug registered via \`SDL_JOYSTICK_HIDAPI_PS4 (ENABLED)\` with real serials on a quiet udev.

## Counterfactual test + disconfirming evidence

With the GNOME session confirmed active: \`bluetoothctl disconnect\` → SDL removed the pad within ~1s (monitor healthy). Reconnect (physical PS press — host-side reconnect impossible once a DS4 powers off; \`Host is down (112)\`) → SDL **still** got \`Permission denied\` at 14:10:53 and re-registered \`driver = NONE (DISABLED)\`. This disconfirmed the "greeter owns the seat" theory as the sole cause and exposed the load-dependent uaccess/logind failure — while also proving GROUP/MODE (applied locally by udevd in the same pass that emits the uevent) bypass the failing step entirely.

## Fix

- \`ops/homelab-steam-controller/71-steam-controller-hidraw.rules\`: \`GROUP="input", MODE="0660"\` on Sony controller hidraw nodes, matched by parent HID device name (\`KERNELS=="0003:054C:*"\` USB, \`"0005:054C:*"\` BT) — vendor-attr matching silently never matches Bluetooth pads. \`TAG+="uaccess"\` kept.
- \`ops/homelab-steam-controller/apply.sh\`: installs the rule, \`usermod -aG input avirus\`, reloads udev, triggers hidraw reprocessing.
- Captain accepted the trade-off: group \`input\` can read all \`/dev/input/event*\` on this single-user appliance box.

## Verification evidence

- Failure side captured live: \`console_log.txt\` EACCES + \`driver = NONE (DISABLED)\` at 13:24:03 / 13:38:40 / 13:41:36 / 14:10:53; \`controller.txt\` degraded evdev registration with synthetic serial at 13:48:04; hidraw node born 14:10:53 still \`0600 root:root\` minutes later while its DB entry carried \`TAGS=:seat:uaccess:\`.
- Success evidence pending host apply (needs sudo): expected \`driver = SDL_JOYSTICK_HIDAPI_PS4 (ENABLED)\` + \`Local Device Found\` with real serial, no EACCES — steps in README.

## Out of scope / follow-ups

- The \`71-nvidia.rules\` modprobe-failure udev storm itself (RTX 3060/pi-stt migration lane) — noted, not touched; hotplug becomes reliable once udevd is calm and this rule removes the remaining race margin.
- Occasional BT link flaps (DS4 idle power-off = benign; one rapid drop/reconnect burst on 08-16 23:39–23:41 worth a future \`btmon\` look).
- Host apply + re-login + pad reconnect needs sudo/physical actions on homelab.