### PR TITLE
herdr: fix unknown config key ui.pane_scrollbars

### DIFF
--- a/herdr/.config/herdr/config.toml
+++ b/herdr/.config/herdr/config.toml
@@ -34,7 +34,9 @@ split_horizontal = "prefix+minus"
 
 [ui]
 # Zellij-style pane framing
-pane_scrollbars = false
+# pane_scrollbars is valid in herdr 0.8.0+ (release-notes #2167);
+# commented out on 0.7.5 to fix the unknown-key warning. Uncomment after upgrading.
+# pane_scrollbars = false
 
 mouse_capture = true
 pane_borders = true


### PR DESCRIPTION
## Summary

`herdr config check` and `herdr server reload-config` both report:

```
unknown config key ui.pane_scrollbars; ignoring key
```

for `herdr/.config/herdr/config.toml`.

## Root cause

The installed herdr is **0.7.5**. `herdr --default-config` has **no** scrollbar key under `[ui]` on this version.

`~/.config/herdr/release-notes.json` advertises the upcoming **0.8.0**, which **adds** `ui.pane_scrollbars = false` (#2167 — *"hide terminal pane scrollbars and reclaim their reserved column"*).

So the key was written against 0.8.0 but is unknown on the currently-installed 0.7.5. The feature was **not removed** from herdr — it is pending in 0.8.0.

## Fix

There is no valid equivalent key on 0.7.5. Since the feature is coming in 0.8.0 (not removed), the original intent from ceb5e8f ("hide pane scrollbars") is **preserved** by commenting the line out with a note to uncomment after upgrading to 0.8.0+. This eliminates the unknown-key warning on the installed version without losing the intent.

## Verification

Pointed `XDG_CONFIG_HOME` at a copy of the fixed config and ran `herdr config check`:

```
config: ok        (exit 0, zero warnings)
```

(The live `~/.config/herdr/config.toml` is a symlink to the primary checkout, which this worktree cannot modify; the live check will report `config: ok` once this PR merges and updates the primary checkout.)

No herdr server was restarted.
