### PR TITLE
herdr: restore pane_scrollbars after 0.8.0 upgrade

### DIFF
--- a/herdr/.config/herdr/config.toml
+++ b/herdr/.config/herdr/config.toml
@@ -33,10 +33,7 @@ split_vertical = "prefix+|"
 split_horizontal = "prefix+minus"
 
 [ui]
-# Zellij-style pane framing
-# pane_scrollbars is valid in herdr 0.8.0+ (release-notes #2167);
-# commented out on 0.7.5 to fix the unknown-key warning. Uncomment after upgrading.
-# pane_scrollbars = false
+pane_scrollbars = false
 
 mouse_capture = true
 pane_borders = true


### PR DESCRIPTION
Uncomment `ui.pane_scrollbars = false` and remove the 0.7.5 compatibility note now that herdr has been upgraded to 0.8.0 via live handoff.

## Verification
- `herdr --version`: **0.8.0**
- `herdr server reload-config`: **diagnostics: []** (zero unknown keys)
- `herdr config check`: **ok**