### PR TITLE
nvim: disable wrap and line numbers for markdown

### DIFF
--- a/nvim/.config/nvim/lua/plugins/markdown.lua
+++ b/nvim/.config/nvim/lua/plugins/markdown.lua
@@ -64,6 +64,11 @@ return {
         pattern = "markdown",
         callback = function()
           vim.cmd("PencilSoft")
+          -- Disable wrap and line numbering for markdown buffers.
+          -- Set after PencilSoft so soft-wrap does not re-enable `wrap`.
+          vim.wo.wrap = false
+          vim.wo.number = false
+          vim.wo.relativenumber = false
           vim.opt_local.formatexpr = "v:lua.require'conform'.formatexpr()"
           require("helpers.markdown_links").setup()
         end,


### PR DESCRIPTION
Add `vim.wo.wrap = false`, `vim.wo.number = false`, and `vim.wo.relativenumber = false` to the existing markdown `FileType` autocmd (the `markdown_editing` augroup in `lua/plugins/markdown.lua`).

These are set immediately after `PencilSoft` so that vim-pencil's soft-wrap mode does not re-enable `wrap` after we disable it. No other changes.