### PR TITLE
nvim: override <leader>at to send buffer to Herdr agent pane

### DIFF
--- a/nvim/.config/nvim/lua/plugins/herdr-agent.lua
+++ b/nvim/.config/nvim/lua/plugins/herdr-agent.lua
@@ -1,0 +1,23 @@
+-- `<leader>at`: send this buffer (or the visual selection) to the agent pane in
+-- the same Herdr tab. Logic lives in ./herdr/agent_send.lua.
+-- This overrides sidekick.nvim's "Send This" binding (see plugins/sidekick.lua).
+return {
+  "folke/snacks.nvim",
+  keys = {
+    {
+      "<leader>at",
+      function()
+        require("plugins.herdr.agent_send").send({ visual = false })
+      end,
+      desc = "Send buffer to Herdr agent pane",
+    },
+    {
+      "<leader>at",
+      function()
+        require("plugins.herdr.agent_send").send({ visual = true })
+      end,
+      mode = "x",
+      desc = "Send selection to Herdr agent pane",
+    },
+  },
+}

--- a/nvim/.config/nvim/lua/plugins/herdr/agent_send.lua
+++ b/nvim/.config/nvim/lua/plugins/herdr/agent_send.lua
@@ -1,0 +1,170 @@
+-- Send the current buffer (or visual selection) to the agent pane that lives in
+-- the same Herdr tab as this Neovim pane.
+--
+-- Pane discovery contract (herdr 0.8.0):
+--   * current pane: `$HERDR_PANE_ID`, falling back to `herdr pane current`
+--   * candidates:   `herdr pane list` -> result.panes, filtered to the same tab_id
+--   * delivery:     `herdr pane send-text <pane_id> <text>` + `herdr pane send-keys <pane_id> Enter`
+--
+-- Only panes in the SAME tab with a positive agent lifecycle status are ever
+-- targeted, so this never crosses tabs and never types into a bare shell.
+local herdr = require("plugins.sidekick.herdr")
+
+local M = {}
+
+-- `herdr pane report-agent` states that mean "an agent owns this pane".
+-- "unknown" (bare shell / firstmate primary before it reports) is excluded.
+M.agent_statuses = {
+  working = true,
+  busy = true,
+  idle = true,
+  done = true,
+  waiting = true,
+}
+
+-- Guard against pasting a giant buffer into an agent prompt.
+M.max_bytes = 64 * 1024
+
+local function notify(message, level)
+  vim.notify(message, level or vim.log.levels.WARN)
+end
+
+---@return string|nil
+function M.current_pane_id()
+  local env = os.getenv("HERDR_PANE_ID")
+  if env and env ~= "" then
+    return env
+  end
+  local result = herdr.call({ "pane", "current" }, true)
+  local pane = result and result.pane
+  return pane and pane.pane_id or nil
+end
+
+---@param pane table
+---@return boolean
+function M.is_agent_pane(pane)
+  return type(pane) == "table" and M.agent_statuses[pane.agent_status] == true
+end
+
+---Pick the agent pane that shares a tab with `current_pane_id`.
+---@param panes table[]
+---@param current_pane_id string
+---@return table|nil pane
+function M.find_agent_pane(panes, current_pane_id)
+  local tab_id
+  for _, pane in ipairs(panes or {}) do
+    if pane.pane_id == current_pane_id then
+      tab_id = pane.tab_id
+      break
+    end
+  end
+  if not tab_id then
+    return nil
+  end
+  local fallback
+  for _, pane in ipairs(panes) do
+    if pane.pane_id ~= current_pane_id and pane.tab_id == tab_id and M.is_agent_pane(pane) then
+      -- Prefer a pane that also advertises an agent kind (codex/pi/...).
+      if pane.agent then
+        return pane
+      end
+      fallback = fallback or pane
+    end
+  end
+  return fallback
+end
+
+---@return table|nil pane
+---@return string|nil error
+function M.resolve_target()
+  local current = M.current_pane_id()
+  if not current then
+    return nil, "Not running inside a Herdr pane"
+  end
+  local panes = herdr.list_panes()
+  if not panes or #panes == 0 then
+    return nil, "No agent pane found in this tab"
+  end
+  local pane = M.find_agent_pane(panes, current)
+  if not pane then
+    return nil, "No agent pane found in this tab"
+  end
+  return pane, nil
+end
+
+---@param bufnr integer
+---@return integer start_line 1-indexed inclusive
+---@return integer end_line 1-indexed inclusive
+local function visual_range(bufnr)
+  local mode = vim.fn.mode()
+  local first, last
+  if mode == "v" or mode == "V" or mode == "\22" then
+    first = vim.fn.getpos("v")[2]
+    last = vim.fn.getpos(".")[2]
+  else
+    first = vim.fn.getpos("'<")[2]
+    last = vim.fn.getpos("'>")[2]
+  end
+  if first == 0 or last == 0 then
+    return 1, vim.api.nvim_buf_line_count(bufnr)
+  end
+  if first > last then
+    first, last = last, first
+  end
+  return first, last
+end
+
+---@param bufnr integer
+---@param visual boolean
+---@return string text
+---@return string label
+function M.build_payload(bufnr, visual)
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  local label = name ~= "" and vim.fn.fnamemodify(name, ":~:.") or "[No Name]"
+  local first, last
+  if visual then
+    first, last = visual_range(bufnr)
+  else
+    first, last = 1, vim.api.nvim_buf_line_count(bufnr)
+  end
+  local lines = vim.api.nvim_buf_get_lines(bufnr, first - 1, last, false)
+  local body = table.concat(lines, "\n")
+  local truncated = false
+  if #body > M.max_bytes then
+    body = body:sub(1, M.max_bytes)
+    truncated = true
+  end
+  local header = visual and string.format("From neovim buffer %s (lines %d-%d):", label, first, last)
+    or string.format("From neovim buffer %s:", label)
+  local text = header .. "\n" .. body
+  if truncated then
+    text = text .. string.format("\n[truncated: only the first %d bytes were sent]", M.max_bytes)
+  end
+  return text, label
+end
+
+---@param opts? { visual?: boolean, bufnr?: integer }
+---@return boolean sent
+function M.send(opts)
+  opts = opts or {}
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local pane, err = M.resolve_target()
+  if not pane then
+    notify(err or "No agent pane found in this tab")
+    return false
+  end
+  local text, label = M.build_payload(bufnr, opts.visual == true)
+  if herdr.call({ "pane", "send-text", pane.pane_id, text }) == nil then
+    return false
+  end
+  if not herdr.send_key(pane.pane_id, "Enter") then
+    return false
+  end
+  notify(
+    string.format("Sent %s to %s (%s)", label, pane.agent or "agent", pane.pane_id),
+    vim.log.levels.INFO
+  )
+  return true
+end
+
+return M

--- a/nvim/.config/nvim/lua/plugins/sidekick.lua
+++ b/nvim/.config/nvim/lua/plugins/sidekick.lua
@@ -149,14 +149,9 @@ return {
       end,
       desc = "Ask: yank answer on current line",
     },
-    {
-      "<leader>at",
-      function()
-        require("sidekick.cli").send({ msg = "{this}" })
-      end,
-      mode = { "n", "x" },
-      desc = "Send This",
-    },
+    -- <leader>at is intentionally NOT bound here: it is overridden in
+    -- plugins/herdr-agent.lua to send the buffer/selection to the agent pane in
+    -- the same Herdr tab instead of sidekick's floating CLI terminal.
     {
       "<leader>av",
       function()

--- a/nvim/.config/nvim/tests/herdr_agent_send_spec.lua
+++ b/nvim/.config/nvim/tests/herdr_agent_send_spec.lua
@@ -1,0 +1,64 @@
+local config_root = vim.fn.getcwd()
+package.path = config_root .. "/lua/?.lua;" .. config_root .. "/lua/?/init.lua;" .. package.path
+
+local agent_send = require("plugins.herdr.agent_send")
+
+local function assert_eq(actual, expected, msg)
+  if actual ~= expected then
+    error(string.format("%s\nexpected: %s\nactual:   %s", msg, vim.inspect(expected), vim.inspect(actual)), 2)
+  end
+end
+
+local panes = {
+  { pane_id = "w37:p2", tab_id = "w37:t2", agent_status = "unknown" }, -- this nvim pane
+  { pane_id = "w37:p3", tab_id = "w37:t2", agent_status = "idle", agent = "pi" },
+  { pane_id = "w37:p4", tab_id = "w37:t2", agent_status = "unknown" }, -- bare shell
+  { pane_id = "w20:p1", tab_id = "w20:t1", agent_status = "working", agent = "pi" }, -- other tab
+}
+
+assert_eq(agent_send.find_agent_pane(panes, "w37:p2").pane_id, "w37:p3", "picks the agent pane in the same tab")
+assert_eq(agent_send.find_agent_pane(panes, "w20:p1"), nil, "never targets a pane in another tab")
+assert_eq(agent_send.find_agent_pane(panes, "w99:p9"), nil, "unknown current pane resolves to no target")
+assert_eq(
+  agent_send.find_agent_pane({
+    { pane_id = "a", tab_id = "t", agent_status = "unknown" },
+    { pane_id = "b", tab_id = "t", agent_status = "unknown" },
+  }, "a"),
+  nil,
+  "bare shells are not agent panes"
+)
+assert_eq(
+  agent_send.find_agent_pane({
+    { pane_id = "a", tab_id = "t", agent_status = "unknown" },
+    { pane_id = "b", tab_id = "t", agent_status = "done" },
+    { pane_id = "c", tab_id = "t", agent_status = "busy", agent = "codex" },
+  }, "a").pane_id,
+  "c",
+  "prefers a pane that advertises an agent kind"
+)
+
+local tmp = vim.fn.tempname()
+vim.fn.mkdir(tmp, "p")
+local file = tmp .. "/sample.lua"
+vim.fn.writefile({ "line one", "line two", "line three" }, file)
+vim.cmd("edit " .. vim.fn.fnameescape(file))
+local bufnr = vim.api.nvim_get_current_buf()
+
+local text = agent_send.build_payload(bufnr, false)
+assert_eq(text:match("^From neovim buffer [^\n]*sample%.lua:") ~= nil, true, "buffer payload carries a context line")
+assert_eq(text:find("line one\nline two\nline three", 1, true) ~= nil, true, "buffer payload carries all lines")
+
+vim.api.nvim_buf_set_mark(bufnr, "<", 2, 0, {})
+vim.api.nvim_buf_set_mark(bufnr, ">", 3, 0, {})
+local selection = agent_send.build_payload(bufnr, true)
+assert_eq(selection:match("%(lines 2%-3%):") ~= nil, true, "selection payload notes the line range")
+assert_eq(selection:find("line two\nline three", 1, true) ~= nil, true, "selection payload carries selected lines")
+assert_eq(selection:find("line one", 1, true), nil, "selection payload excludes unselected lines")
+
+local saved_max = agent_send.max_bytes
+agent_send.max_bytes = 10
+local truncated = agent_send.build_payload(bufnr, false)
+assert_eq(truncated:find("[truncated", 1, true) ~= nil, true, "large payloads are truncated with a note")
+agent_send.max_bytes = saved_max
+
+print("herdr_agent_send_spec: ok")


### PR DESCRIPTION
## Summary

Overrides the `<leader>at` binding so that, instead of sidekick.nvim's "Send This" (which targets sidekick's floating CLI terminal), it sends the current buffer (normal mode) or the visual selection (visual mode) to the **agent pane in the same Herdr tab** as this Neovim pane.

## Behavior

- **Normal mode** `<leader>at`: sends the whole buffer.
- **Visual mode** `<leader>at`: sends the selected line range.
- **Pane discovery**: `herdr pane list` → filter to panes sharing the current pane's `tab_id`.
- **Safety**: only panes with a **positive agent lifecycle status** (`working`, `busy`, `idle`, `done`, `waiting`) are targeted. Bare shells and the firstmate primary (which report `unknown`) are never targeted, and delivery never crosses tabs. The current pane itself is excluded.
- **Delivery**: `herdr pane send-text <pane_id> <text>` followed by `herdr pane send-keys <pane_id> Enter`.
- **No agent pane**: `vim.notify` warning, nothing sent.
- **Size guard**: payloads over 64 KiB are truncated with a note.

## Files

- `nvim/.config/nvim/lua/plugins/herdr-agent.lua` (new) — Lazy keys spec carrying the two `<leader>at` bindings (normal + visual).
- `nvim/.config/nvim/lua/plugins/herdr/agent_send.lua` (new) — Send logic: pane resolution, payload building, delivery.
- `nvim/.config/nvim/tests/herdr_agent_send_spec.lua` (new) — Covers tab filtering, agent-kind preference, bare-shell exclusion, payload shaping, and truncation. Passes under `nvim --headless --noplugin -u NONE -c "luafile tests/herdr_agent_send_spec.lua" -c "qa!"`.
- `nvim/.config/nvim/lua/plugins/sidekick.lua` (modified) — Removed the old `<leader>at` "Send This" binding; replaced with a pointer comment to the new spec.

## Test

```
cd nvim/.config/nvim
nvim --headless --noplugin -u NONE -c "luafile tests/herdr_agent_send_spec.lua" -c "qa!"
# => herdr_agent_send_spec: ok
```
