### PR TITLE
pi: add /decisions extension for the captain's decision queue

### DIFF
--- a/pi/.pi/agent/extensions/decision-queue/collect.ts
+++ b/pi/.pi/agent/extensions/decision-queue/collect.ts
@@ -1,0 +1,286 @@
+/**
+ * decision-queue collector — pure data reads for the captain's decision queue.
+ *
+ * Two sources on the firstmate host (FM_HOME):
+ *   1. state/*.status logs — open keyed needs-decision/blocked records.
+ *      The fold below is a TypeScript port of the authoritative rule in
+ *      firstmate bin/fm-classify-lib.sh (status_open_decisions /
+ *      _fm_decision_fold_line): a needs-decision/blocked line OPENS a keyed
+ *      decision; only an explicit resolved/captain-held line with the same key
+ *      CLOSES it. Key grammar: optional "[key=<slug>]" before the first colon,
+ *      or equivalently at note head; slug charset [A-Za-z0-9._-]+; no token
+ *      means key "default". Reserved "pending-reply-*" keys only transition
+ *      when the note speaks that namespace's vocabulary.
+ *   2. data/backlog.md — unchecked items tagged "(kind: captain)", i.e. tasks
+ *      whose WORK is the captain's decision. Selection is deliberately on
+ *      "kind", not "hold-kind" (captain's call 2026-08-18): a ship/scout task
+ *      merely parked behind him carries "(hold-kind: captain)" too, and those
+ *      linger in the backlog after his order already settled them — they showed
+ *      up here as decisions he had de facto closed. "kind: captain" is the
+ *      task's own identity, so it cannot go stale that way.
+ *      Independently, any HELD backlog slug parks the matching lane's open
+ *      decisions (rendered dim), e.g. a lane held by captain order.
+ *
+ * No pi imports here on purpose: this module is loadable standalone (jiti)
+ * for testing against live firstmate data.
+ */
+
+import { readFileSync, readdirSync, lstatSync } from "node:fs";
+import { join } from "node:path";
+
+export interface DecisionItem {
+	source: "lane" | "backlog";
+	/** task id (status log basename) or backlog slug */
+	lane: string;
+	/** decision key; "default" when unkeyed; backlog items use the slug */
+	key: string;
+	verb: "needs-decision" | "blocked" | "captain-hold";
+	note: string;
+	file?: string;
+	line?: number;
+	/** true when the owning lane/task is itself held in the backlog */
+	parked: boolean;
+}
+
+const OPEN_VERBS = new Set(["needs-decision", "blocked"]);
+const CLOSE_VERBS = new Set(["resolved", "captain-held"]);
+const RESERVED_PREFIXES = ["pending-reply-"];
+const SLUG = /^[A-Za-z0-9._-]+$/;
+
+/** leading verb word: text before the first colon, minus any [tag] run */
+export function statusLineVerb(line: string): string {
+	const ci = line.indexOf(":");
+	let v = ci === -1 ? line : line.slice(0, ci);
+	const bi = v.indexOf("[");
+	if (bi !== -1) v = v.slice(0, bi);
+	return v.trim();
+}
+
+/**
+ * Extract { key, note } from one status line, or null when a stated key slug
+ * is malformed (the folds skip such lines rather than rewriting to "default").
+ */
+export function parseKeyNote(line: string): { key: string; note: string } | null {
+	const ci = line.indexOf(":");
+	const beforeColon = ci === -1 ? line : line.slice(0, ci);
+	const beforeM = beforeColon.match(/\[key=([^\]]+)\]/);
+	let key: string | null = null;
+	let fromNoteHead = false;
+	if (beforeM) {
+		key = beforeM[1]!;
+	} else if (ci !== -1) {
+		const rest = line.slice(ci + 1).trim();
+		const hm = rest.match(/^\[key=([^\]]+)\]/);
+		if (hm) {
+			key = hm[1]!;
+			fromNoteHead = true;
+		}
+	}
+	if (key === null) key = "default";
+	if (!SLUG.test(key)) return null;
+	let note = ci === -1 ? line.trim() : line.slice(ci + 1).trim();
+	if (fromNoteHead) note = note.replace(/^\[key=[^\]]+\]\s*/, "");
+	return { key, note };
+}
+
+/** reserved namespaces only open/close when the note speaks their vocabulary */
+function transitionAllowed(key: string, note: string): boolean {
+	for (const p of RESERVED_PREFIXES) {
+		if (key.startsWith(p)) return note.startsWith(p) && note.includes(":");
+	}
+	return true;
+}
+
+export interface OpenRecord {
+	key: string;
+	verb: string;
+	note: string;
+	/** 1-based line number where the currently-open record was opened */
+	line: number;
+}
+
+/**
+ * Fold one status log's text into still-open decisions.
+ * Most-recently-opened-last, matching status_open_decisions.
+ */
+export function foldStatusText(text: string): OpenRecord[] {
+	let open: OpenRecord[] = [];
+	text.split("\n").forEach((line, i) => {
+		if (!line.replace(/\s/g, "")) return;
+		const verb = statusLineVerb(line);
+		const kn = parseKeyNote(line);
+		if (!kn || !transitionAllowed(kn.key, kn.note)) return;
+		if (OPEN_VERBS.has(verb)) {
+			open = open.filter((r) => r.key !== kn.key);
+			open.push({ key: kn.key, verb, note: kn.note, line: i + 1 });
+		} else if (CLOSE_VERBS.has(verb)) {
+			open = open.filter((r) => r.key !== kn.key);
+		}
+	});
+	return open;
+}
+
+export interface BacklogHold {
+	slug: string;
+	title: string;
+	hold: string;
+	line: number;
+}
+
+/**
+ * Split one backlog line's trailing "(name: value)" tag run.
+ *
+ * Values are free prose: they carry " - ", colons, and balanced parentheses
+ * ("Branch preserved (unlanded)"). Two shapes exist in live data — "(kind:
+ * captain)" and "(since 2026-08-15)" — so a value cannot be delimited by the
+ * next "(name: " opener either: "since" has no colon and would be swallowed
+ * into "kind". Groups are therefore split by paren DEPTH, which is exactly the
+ * structure the backlog writes, and each top-level group is then read as
+ * "name: value" or "name value".
+ * Returns the tag map plus the index where the tag run begins (title cutoff).
+ */
+export function parseTags(line: string): { tags: Map<string, string>; tagStart: number } {
+	const tags = new Map<string, string>();
+	let tagStart = line.length;
+	let depth = 0;
+	let open = -1;
+	for (let i = 0; i < line.length; i++) {
+		const ch = line[i];
+		if (ch === "(") {
+			if (depth === 0) open = i;
+			depth++;
+			continue;
+		}
+		if (ch !== ")" || depth === 0) continue;
+		depth--;
+		if (depth !== 0 || open === -1) continue;
+		const group = line.slice(open + 1, i);
+		const m = group.match(/^([A-Za-z][A-Za-z-]*):?\s+([\s\S]*)$/);
+		if (m) {
+			if (!tags.has(m[1]!)) tags.set(m[1]!, m[2]!.trim());
+			if (open < tagStart) tagStart = open;
+		}
+		open = -1;
+	}
+	return { tags, tagStart };
+}
+
+export function parseBacklog(text: string): {
+	captainHolds: BacklogHold[];
+	parkedSlugs: Set<string>;
+} {
+	const captainHolds: BacklogHold[] = [];
+	const parkedSlugs = new Set<string>();
+	text.split("\n").forEach((raw, i) => {
+		const m = raw.match(/^- \[ \] (\S+) - (.*)$/);
+		if (!m) return;
+		const slug = m[1]!;
+		const { tags, tagStart } = parseTags(raw);
+		const hold = tags.get("hold") ?? "";
+		// Any held task parks its lane's decisions, whatever the task's kind.
+		if (hold) parkedSlugs.add(slug);
+		// The queue itself lists only tasks that ARE a captain decision.
+		if (tags.get("kind") !== "captain") return;
+		const title = raw.slice(raw.indexOf(" - ") + 3, tagStart).trim();
+		captainHolds.push({ slug, title, hold, line: i + 1 });
+	});
+	return { captainHolds, parkedSlugs };
+}
+
+/** Fresh full read of both sources. Cheap: a few small text files. */
+export function collectDecisions(fmHome: string): DecisionItem[] {
+	const items: DecisionItem[] = [];
+	const stateDir = join(fmHome, "state");
+	const backlogPath = join(fmHome, "data", "backlog.md");
+
+	let parkedSlugs = new Set<string>();
+	let captainHolds: BacklogHold[] = [];
+	try {
+		const parsed = parseBacklog(readFileSync(backlogPath, "utf8"));
+		parkedSlugs = parsed.parkedSlugs;
+		captainHolds = parsed.captainHolds;
+	} catch {
+		/* backlog unreadable — lane scan still works */
+	}
+
+	let files: string[] = [];
+	try {
+		files = readdirSync(stateDir)
+			.filter((f) => f.endsWith(".status"))
+			.sort();
+	} catch {
+		/* state dir unreadable */
+	}
+	for (const f of files) {
+		const full = join(stateDir, f);
+		try {
+			if (lstatSync(full).isSymbolicLink()) continue; // mirrors the lib's [ -L ] rejection
+		} catch {
+			continue;
+		}
+		const task = f.slice(0, -".status".length);
+		let text: string;
+		try {
+			text = readFileSync(full, "utf8");
+		} catch {
+			continue;
+		}
+		for (const rec of foldStatusText(text)) {
+			items.push({
+				source: "lane",
+				lane: task,
+				key: rec.key,
+				verb: rec.verb as "needs-decision" | "blocked",
+				note: rec.note,
+				file: full,
+				line: rec.line,
+				parked: parkedSlugs.has(task),
+			});
+		}
+	}
+	for (const h of captainHolds) {
+		items.push({
+			source: "backlog",
+			lane: h.slug,
+			key: h.slug,
+			verb: "captain-hold",
+			note: h.hold ? `${h.title} — hold: ${h.hold}` : h.title,
+			file: backlogPath,
+			line: h.line,
+			parked: false,
+		});
+	}
+	return items;
+}
+
+/**
+ * Canonical closing line for a keyed lane decision.
+ *
+ * The key token MUST sit in the documented before-colon position (or, as an
+ * accepted equivalent, at the very head of the note). A token further inside
+ * the note is prose: fm-classify-lib.sh states that a summary merely MENTIONING
+ * "[key=x]" can neither open nor close that decision. So a trailing
+ * "resolved: <choice> [key=x]" silently closes "default" and leaves the real
+ * decision open forever — it keeps resurfacing in /decisions after the captain
+ * already answered it. This helper is the one place that shape is written, and
+ * it matches what fm-send.sh --resolve-key appends ("resolved [key=<k>]: ...").
+ */
+export function resolvedLine(key: string, note = ""): string {
+	const head = key === "default" ? "resolved:" : `resolved [key=${key}]:`;
+	return note ? `${head} ${note}` : `${head} `;
+}
+
+/** Where the captain acts on this item, in one line. */
+export function answerHint(it: DecisionItem): string {
+	if (it.source === "lane") {
+		const keyPart = it.key === "default" ? "" : ` --resolve-key ${it.key}`;
+		return `fm-send.sh ${it.lane}${keyPart} <answer>   ·   or append: ${resolvedLine(it.key, "<how>")}`;
+	}
+	return `captain's call — resolve hold "${it.lane}" via firstmate bin/fm-decision-hold.sh resolve`;
+}
+
+/** Prefill for the pi editor when the captain picks an item. */
+export function editorTemplate(it: DecisionItem): string {
+	if (it.source === "lane") return resolvedLine(it.key);
+	return `decision on ${it.lane}: `;
+}

--- a/pi/.pi/agent/extensions/decision-queue/index.ts
+++ b/pi/.pi/agent/extensions/decision-queue/index.ts
@@ -1,0 +1,345 @@
+/**
+ * decision-queue — /decisions interactive 2-column view of the captain's
+ * open decision queue across firstmate-supervised work.
+ *
+ * Prototype (branch proto/pi-decision-queue, scout task pi-decision-queue-scout).
+ * Requirements gathered live from the captain 2026-08-17:
+ *   Q1 both sources (lane status decisions + captain-held backlog)
+ *   Q2 firstmate primary pi (prototype loads wherever symlinked)
+ *   Q3 slash command first, widget later
+ *   Q4 fresh read on every invocation (collectDecisions re-reads files)
+ *   Q5 interactive 2-column list with active element (approved ANSI mock)
+ *   + captain styling order: "stylize it and make it have more colors"
+ *     (v2: full gruvbox frame, per-verb colors, pink/purple accents)
+ *
+ * Also carries the documented reload-runtime plumbing (pi docs
+ * extensions.md → ctx.reload) so the agent can hot-reload extensions
+ * after edits via the reload_runtime tool.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { matchesKey, Key, visibleWidth, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+	collectDecisions,
+	answerHint,
+	editorTemplate,
+	type DecisionItem,
+} from "./collect.js";
+
+const FM_HOME = process.env.FM_HOME ?? "/home/avirus/projects/firstmate";
+const MAX_VISIBLE = 10;
+
+type Theme = {
+	fg: (color: string, s: string) => string;
+	bg: (color: string, s: string) => string;
+	bold: (s: string) => string;
+	italic: (s: string) => string;
+};
+
+function padVisible(s: string, w: number): string {
+	const gap = w - visibleWidth(s);
+	return gap > 0 ? s + " ".repeat(gap) : s;
+}
+
+function wrapText(text: string, w: number): string[] {
+	const words = text.split(/\s+/).filter(Boolean);
+	const lines: string[] = [];
+	let cur = "";
+	for (const word of words) {
+		if (cur && cur.length + 1 + word.length > w) {
+			lines.push(cur);
+			cur = word;
+		} else {
+			cur = cur ? `${cur} ${word}` : word;
+		}
+	}
+	if (cur) lines.push(cur);
+	return lines.length ? lines : [""];
+}
+
+/** verb → glyph + theme color (gruvbox-material: yellow / red / blue) */
+function verbStyle(t: Theme, verb: DecisionItem["verb"]): { glyph: string; colored: string } {
+	if (verb === "needs-decision") return { glyph: "?", colored: t.fg("warning", "?") };
+	if (verb === "blocked") return { glyph: "!", colored: t.fg("error", "!") };
+	return { glyph: "*", colored: t.fg("borderAccent", "*") };
+}
+
+function shortLabel(it: DecisionItem): string {
+	if (it.source === "lane") return it.key === "default" ? "(unkeyed)" : it.key;
+	// Backlog decision slugs are "<originating-task>-decision-<what>"; the tail is
+	// the distinguishing part and the shared prefix just eats the column. The full
+	// slug stays visible in the detail pane.
+	return it.lane.replace(/^.*-decision-/, "");
+}
+
+class DecisionQueueView {
+	private items: DecisionItem[];
+	private selected = 0;
+	private cachedWidth = 0;
+	private cachedLines: string[] | null = null;
+
+	constructor(
+		private tui: { requestRender: () => void },
+		private theme: Theme,
+		private onDone: (item: DecisionItem | null) => void,
+		private recollect: () => DecisionItem[],
+	) {
+		this.items = recollect();
+	}
+
+	private move(delta: number): void {
+		const next = this.selected + delta;
+		if (next < 0 || next >= this.items.length) return;
+		this.selected = next;
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, Key.up) || data === "k") this.move(-1);
+		else if (matchesKey(data, Key.down) || data === "j") this.move(1);
+		else if (matchesKey(data, Key.escape) || data === "q") return this.onDone(null);
+		else if (matchesKey(data, Key.enter)) {
+			return this.onDone(this.items[this.selected] ?? null);
+		} else if (data === "r") {
+			this.items = this.recollect();
+			if (this.selected >= this.items.length) {
+				this.selected = Math.max(0, this.items.length - 1);
+			}
+		} else return;
+		this.invalidate();
+		this.tui.requestRender();
+	}
+
+	/** left queue cell; selected row = per-segment selectedBg so inner colors survive */
+	private leftCell(it: DecisionItem, isSelected: boolean, leftW: number): string {
+		const t = this.theme;
+		const { glyph, colored } = verbStyle(t, it.verb);
+		const lane = (it.source === "lane" ? it.lane.slice(0, 8) : "backlog").padEnd(8);
+		const label = truncateToWidth(shortLabel(it), leftW - 13, "");
+
+		if (isSelected) {
+			const seg = (s: string) => t.bg("selectedBg", s);
+			const row =
+				seg(t.fg("accent", t.bold(">"))) +
+				seg(" ") +
+				seg(colored) +
+				seg(" ") +
+				seg(t.fg("muted", lane)) +
+				seg(" ") +
+				seg(t.bold(label));
+			const pad = leftW - (1 + 1 + 1 + 1 + 8 + 1 + visibleWidth(label));
+			return row + seg(" ".repeat(Math.max(0, pad)));
+		}
+		if (it.parked) {
+			const plain = truncateToWidth(`  ${glyph} ${lane} ${label}`, leftW, "");
+			return t.fg("dim", padVisible(plain, leftW));
+		}
+		const row = `  ${colored} ${t.fg("muted", lane)} ${t.fg("text", label)}`;
+		return padVisible(row, leftW);
+	}
+
+	private detail(it: DecisionItem | undefined, rightW: number): string[] {
+		const t = this.theme;
+		if (!it) return [t.fg("dim", "queue is clear")];
+		const pink = (s: string) => t.fg("customMessageLabel", s);
+		const out: string[] = [];
+		const push = (s: string) => out.push(padVisible(truncateToWidth(s, rightW), rightW));
+		const label = (k: string, v: string) => push(" " + pink(k.padEnd(7)) + v);
+		const { colored } = verbStyle(t, it.verb);
+		label("lane", t.fg("text", it.lane));
+		label(
+			"kind",
+			it.source === "lane"
+				? `${colored} ${it.verb} ${t.fg("dim", "·")} ${t.fg("syntaxNumber", `key=${it.key}`)}`
+				: `${colored} captain decision ${t.fg("dim", "·")} ${t.fg("dim", "backlog")}`,
+		);
+		if (it.file) {
+			const rel = it.file.replace(/^\/home\/[^/]+\/projects\//, "~/");
+			label("src", t.fg("mdLink", `${rel}${it.line ? `:${it.line}` : ""}`));
+		}
+		if (it.parked) push(t.fg("dim", t.italic(" (lane parked — backlog hold on this task)")));
+		push("");
+		for (const wl of wrapText(it.note, rightW - 2)) push(t.fg("text", ` ${wl}`));
+		push("");
+		push(" " + t.fg("success", t.bold("answer ")) + t.fg("borderAccent", answerHint(it)));
+		return out;
+	}
+
+	render(width: number): string[] {
+		if (this.cachedLines && this.cachedWidth === width) return this.cachedLines;
+		const t = this.theme;
+		const dim = (s: string) => t.fg("dim", s);
+		const frame = (s: string) => t.fg("borderMuted", s);
+		const W = Math.max(width, 60);
+		const leftW = Math.min(48, Math.max(30, Math.floor(W * 0.4)));
+		const rightW = W - leftW - 3;
+
+		const lines: string[] = [];
+
+		// header
+		const live = this.items.filter((i) => !i.parked).length;
+		const parkedN = this.items.length - live;
+		const header =
+			" " +
+			t.fg("accent", t.bold("captain's decision queue")) +
+			"  " +
+			t.fg("warning", t.bold(`${this.items.length} open`)) +
+			dim(` (${live} live · ${parkedN} parked)`) +
+			dim("  ·  state/*.status + backlog.md");
+		lines.push(padVisible(truncateToWidth(header, W), W));
+
+		// top border with section titles
+		const active = this.items[this.selected];
+		const qTitle = "─ " + t.fg("accent", "queue") + " ";
+		const qFill = leftW - visibleWidth(qTitle);
+		const dLabel = active ? shortLabel(active) : "-";
+		const dTitle =
+			"─ " +
+			t.fg("customMessageLabel", "detail") +
+			dim(`: ${truncateToWidth(dLabel, Math.max(0, rightW - 11), "")}`) +
+			" ";
+		const dFill = rightW - visibleWidth(dTitle);
+		lines.push(
+			frame("╭") +
+				qTitle +
+				frame("─".repeat(Math.max(0, qFill))) +
+				frame("┬") +
+				dTitle +
+				frame("─".repeat(Math.max(0, dFill))) +
+				frame("╮"),
+		);
+
+		// body
+		let start = 0;
+		if (this.items.length > MAX_VISIBLE) {
+			start = Math.min(
+				Math.max(0, this.selected - Math.floor(MAX_VISIBLE / 2)),
+				this.items.length - MAX_VISIBLE,
+			);
+		}
+		const window = this.items.slice(start, start + MAX_VISIBLE);
+		const leftCells: string[] = [];
+		if (start > 0) leftCells.push(dim(padVisible(`  ↑ +${start}`, leftW)));
+		window.forEach((it, i) => leftCells.push(this.leftCell(it, start + i === this.selected, leftW)));
+		const below = this.items.length - start - window.length;
+		if (below > 0) leftCells.push(dim(padVisible(`  ↓ +${below}`, leftW)));
+
+		const right = this.detail(active, rightW);
+		const rows = Math.max(leftCells.length, right.length);
+		for (let r = 0; r < rows; r++) {
+			const l = r < leftCells.length ? leftCells[r]! : " ".repeat(leftW);
+			const rr = r < right.length ? right[r]! : " ".repeat(rightW);
+			lines.push(frame("│") + l + frame("│") + rr + frame("│"));
+		}
+
+		// bottom border
+		lines.push(frame("╰" + "─".repeat(leftW) + "┴" + "─".repeat(rightW) + "╯"));
+
+		// footer: keys + position. Both footer lines must be clamped to W like the
+		// header is — an unclamped footer wraps and tears the frame open on narrow
+		// terminals (it overflowed by 13 columns at width 60). Narrow widths get
+		// compact labels first, so the clamp trims padding rather than meaning.
+		const narrow = W < 84;
+		const key = (k: string, what: string) => t.fg("accent", k) + dim(` ${what}`);
+		const keyBar = [
+			key("j/k", narrow ? "nav" : "navigate"),
+			key("enter", narrow ? "answer" : "answer template"),
+			key("r", "refresh"),
+			key("q", "close"),
+		].join(dim(" · "));
+		lines.push(
+			truncateToWidth(
+				" " +
+					keyBar +
+					"  " +
+					t.fg("customMessageLabel", t.bold(`${this.selected + 1}/${this.items.length}`)),
+				W,
+				"",
+			),
+		);
+		const gap = narrow ? " " : "  ";
+		const legend =
+			" " +
+			t.fg("warning", "?") +
+			dim((narrow ? " decision" : " needs-decision") + gap) +
+			t.fg("error", "!") +
+			dim(" blocked" + gap) +
+			t.fg("borderAccent", "*") +
+			dim(narrow ? " captain" : " captain decision");
+		lines.push(
+			truncateToWidth(narrow ? legend : legend + dim(t.italic("  · dim row = lane parked")), W, ""),
+		);
+
+		this.cachedLines = lines;
+		this.cachedWidth = width;
+		return lines;
+	}
+
+	invalidate(): void {
+		this.cachedWidth = 0;
+		this.cachedLines = null;
+	}
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerCommand("decisions", {
+		description: "Captain's decision queue — open items waiting on his answer (firstmate)",
+		handler: async (_args, ctx) => {
+			if (ctx.mode !== "tui") {
+				ctx.ui.notify("decisions: interactive TUI only", "warning");
+				return;
+			}
+			const recollect = () => collectDecisions(FM_HOME);
+			if (recollect().length === 0) {
+				ctx.ui.notify("decision queue is clear — nothing waiting on the captain", "info");
+				return;
+			}
+			const picked = await ctx.ui.custom<DecisionItem | null>((tui, theme, _kb, done) => {
+				const view = new DecisionQueueView(
+					tui,
+					theme as unknown as Theme,
+					(item) => done(item),
+					recollect,
+				);
+				return {
+					render: (w: number) => view.render(w),
+					invalidate: () => view.invalidate(),
+					handleInput: (data: string) => {
+						view.handleInput(data);
+						tui.requestRender();
+					},
+				};
+			});
+			if (picked) {
+				ctx.ui.setEditorText(editorTemplate(picked));
+				ctx.ui.notify(answerHint(picked), "info");
+			}
+		},
+	});
+
+	// Documented reload plumbing (pi docs → ExtensionCommandContext.reload):
+	// /reload-runtime runs the same flow as /reload; the reload_runtime tool
+	// lets the agent queue that command after editing extension sources.
+	pi.registerCommand("reload-runtime", {
+		description: "Reload extensions, skills, prompts, themes, and context files",
+		handler: async (_args, ctx) => {
+			await ctx.reload();
+			return;
+		},
+	});
+
+	pi.registerTool({
+		name: "reload_runtime",
+		label: "Reload Runtime",
+		description:
+			"Reload pi extensions, skills, prompts, themes, and context files. Use after editing extension source files so the running session picks up the changes.",
+		parameters: Type.Object({}),
+		async execute() {
+			pi.sendUserMessage("/reload-runtime", { deliverAs: "followUp" });
+			return {
+				content: [{ type: "text", text: "Queued /reload-runtime as a follow-up command." }],
+				details: {},
+			};
+		},
+	});
+}

--- a/scripts/verify-pi-decision-queue
+++ b/scripts/verify-pi-decision-queue
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Verify the pi decision-queue extension's collector against synthetic fixtures,
+# and against firstmate's authoritative status fold when firstmate is present.
+#
+# The collector (pi/.pi/agent/extensions/decision-queue/collect.ts) is a
+# TypeScript port of the open-decisions fold in firstmate's
+# bin/fm-classify-lib.sh. A port can silently drift from its original, so the
+# parity block below runs BOTH folds over the same fixture status files and
+# diffs them. Fixtures are used rather than live state/ because the real queue
+# churns between runs (observed twice in one hour during development).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ext_dir="$repo_root/pi/.pi/agent/extensions/decision-queue"
+collect_ts="$ext_dir/collect.ts"
+index_ts="$ext_dir/index.ts"
+for f in "$collect_ts" "$index_ts"; do
+  [ -f "$f" ] || { echo "missing $f" >&2; exit 1; }
+done
+
+pi_bin="$(command -v pi || true)"
+[ -n "$pi_bin" ] || { echo "SKIP: pi is not installed; nothing to load collect.ts with" >&2; exit 0; }
+pi_root="$(dirname "$(dirname "$(readlink -f "$pi_bin")")")"
+jiti_main="$pi_root/node_modules/jiti"
+[ -d "$jiti_main" ] || { echo "SKIP: jiti not found under $pi_root" >&2; exit 0; }
+
+verify_dir="$(mktemp -d "${TMPDIR:-/tmp}/pi-decision-queue-verify.XXXXXX")"
+trap 'rm -rf "$verify_dir"' EXIT
+fm_home="$verify_dir/fm"
+mkdir -p "$fm_home/state" "$fm_home/data"
+
+# --- fixtures ---------------------------------------------------------------
+# Every documented shape of the key grammar, plus the traps that bit us.
+cat >"$fm_home/state/alpha.status" <<'EOF'
+working: started
+needs-decision [key=api-shape]: pick a shape
+resolved [key=api-shape]: went with b
+needs-decision [key=still-open]: this one stays open
+done: shipped anyway
+EOF
+
+cat >"$fm_home/state/beta.status" <<'EOF'
+needs-decision: [key=note-head] key stated at the note head
+resolved: [key=note-head] closed from the note-head position
+blocked [key=trailing]: this closing line puts the key in PROSE
+resolved: fixed it [key=trailing]
+EOF
+
+cat >"$fm_home/state/gamma.status" <<'EOF'
+needs-decision: unkeyed, so key=default
+working: a later unrelated line must NOT close it
+EOF
+
+cat >"$fm_home/state/delta.status" <<'EOF'
+needs-decision [key=bad key!]: malformed slug, line is skipped entirely
+needs-decision [key=held]: closed by a captain-held transfer
+captain-held [key=held]: transferred to the backlog
+needs-decision [key=pending-reply-99]: reserved namespace, wrong vocabulary
+EOF
+
+# Filename == task id, and "parked" is keyed on the task id matching a held
+# backlog slug, so this file must be named for the held slug below.
+cat >"$fm_home/state/parked-lane.status" <<'EOF'
+needs-decision [key=on-hold]: owning task is on hold in the backlog
+EOF
+
+ln -s alpha.status "$fm_home/state/symlinked.status"
+
+cat >"$fm_home/data/backlog.md" <<'EOF'
+# Backlog
+- [ ] real-decision - A genuine captain call (repo: vault) (kind: captain) (since 2026-08-15) (hold: Needs his word; see report (section 4) - then book.) (hold-kind: captain)
+- [ ] held-ship-task - Ship task parked behind him (repo: firstmate) (kind: ship) (since 2026-08-16) (hold: Closed by captain order - already settled.) (hold-kind: captain)
+- [ ] parked-lane - Lane whose task is on hold (repo: dotfiles) (kind: ship) (since 2026-08-17) (hold: waiting on hardware) (hold-kind: captain)
+- [x] already-done - A settled captain call (repo: vault) (kind: captain) (since 2026-08-10) (hold: whatever) (hold-kind: captain)
+- [ ] plain-scout - No hold at all (repo: vault) (kind: scout) (since 2026-08-18)
+EOF
+
+# --- collector assertions ---------------------------------------------------
+cat >"$verify_dir/check.cjs" <<'EOF'
+const jiti = require(process.env.JITI_MAIN)(__filename, { interopDefault: true });
+const c = jiti(process.env.COLLECT_TS);
+const fmHome = process.env.FM_HOME;
+
+let failed = 0;
+const ok = (name, cond, detail) => {
+  console.log(`  ${cond ? "ok  " : "FAIL"}  ${name}${cond || !detail ? "" : `  -> ${detail}`}`);
+  if (!cond) failed++;
+};
+
+const items = c.collectDecisions(fmHome);
+const lanes = items.filter((i) => i.source === "lane");
+const backlog = items.filter((i) => i.source === "backlog");
+const laneKey = (lane, key) => lanes.find((i) => i.lane === lane && i.key === key);
+
+console.log("collector:");
+ok("resolved keyed decision does not resurface", !laneKey("alpha", "api-shape"));
+ok("still-open keyed decision is listed", !!laneKey("alpha", "still-open"));
+ok("later done: does not close an open decision", !!laneKey("alpha", "still-open"));
+ok("note-head close position works", !laneKey("beta", "note-head"));
+ok("trailing [key=] in prose does NOT close", !!laneKey("beta", "trailing"));
+ok("unkeyed decision uses key=default", !!laneKey("gamma", "default"));
+ok("malformed slug line is skipped", !lanes.some((i) => i.lane === "delta" && i.key.includes(" ")));
+ok("captain-held closes the decision", !laneKey("delta", "held"));
+ok("reserved key needs its own vocabulary", !laneKey("delta", "pending-reply-99"));
+ok("symlinked status file is rejected", !lanes.some((i) => i.lane === "symlinked"));
+
+console.log("backlog selection (kind, not hold-kind):");
+ok("kind: captain item is listed", backlog.some((i) => i.lane === "real-decision"));
+ok("held kind: ship task is NOT listed", !backlog.some((i) => i.lane === "held-ship-task"));
+ok("checked-off captain item is NOT listed", !backlog.some((i) => i.lane === "already-done"));
+ok("unheld non-captain task is NOT listed", !backlog.some((i) => i.lane === "plain-scout"));
+ok("a held task still parks its lane's decisions", laneKey("parked-lane", "on-hold")?.parked === true);
+ok("an unheld lane is not parked", laneKey("gamma", "default")?.parked === false);
+
+console.log("tag parsing:");
+const line = require("node:fs")
+  .readFileSync(`${fmHome}/data/backlog.md`, "utf8")
+  .split("\n")
+  .find((l) => l.includes("real-decision"));
+const { tags } = c.parseTags(line);
+ok("colon-form tag", tags.get("kind") === "captain", tags.get("kind"));
+ok("space-form tag does not swallow its neighbour", tags.get("since") === "2026-08-15", tags.get("since"));
+ok("hold prose keeps inner parens", (tags.get("hold") || "").includes("(section 4)"), tags.get("hold"));
+ok("hold prose is not truncated at hold-kind", (tags.get("hold") || "").endsWith("then book."), tags.get("hold"));
+const item = backlog.find((i) => i.lane === "real-decision");
+ok("title stops before the tag run", item.note.startsWith("A genuine captain call"), item.note);
+
+console.log("answer guidance round-trip:");
+// What the extension prefills MUST close the very item it was generated from,
+// or the captain answers a decision and it keeps coming back.
+for (const key of ["api-shape", "default"]) {
+  const it = { source: "lane", lane: "demo", key, verb: "needs-decision", note: "n", parked: false };
+  const opened = key === "default" ? "needs-decision: n" : `needs-decision [key=${key}]: n`;
+  const log = `${opened}\n${c.editorTemplate(it)}chose b\n`;
+  ok(`editorTemplate closes key=${key}`, c.foldStatusText(log).length === 0);
+}
+// Byte-parity with what fm-send.sh --resolve-key appends.
+ok("fm-send closing line is recognised", c.foldStatusText("needs-decision [key=k]: n\nresolved [key=k]: answered: y\n").length === 0);
+const hint = c.answerHint({ source: "lane", lane: "demo", key: "k3", verb: "needs-decision", note: "n", parked: false });
+ok("hint teaches the before-colon position", /resolved \[key=k3\]:/.test(hint), hint);
+ok("hint offers the sanctioned fm-send path", /--resolve-key k3/.test(hint), hint);
+
+// Emit the lane fold for the shell-parity diff.
+require("node:fs").writeFileSync(
+  process.env.TS_FOLD_OUT,
+  lanes
+    .map((i) => `${i.lane}\t${i.key}\t${i.verb}\t${i.note}`)
+    .sort()
+    .join("\n") + "\n",
+);
+
+process.exit(failed ? 1 : 0);
+EOF
+
+JITI_MAIN="$jiti_main" COLLECT_TS="$collect_ts" FM_HOME="$fm_home" \
+  TS_FOLD_OUT="$verify_dir/ts-fold.txt" node "$verify_dir/check.cjs"
+
+# --- render contract -------------------------------------------------------
+# The TUI draws a fixed-width 2-column frame, so any line wider than the
+# terminal wraps and corrupts the whole box. index.ts imports typebox and
+# pi-tui, which resolve only inside pi's own module scope, hence NODE_PATH.
+cat >"$verify_dir/render.cjs" <<'EOF'
+const jiti = require(process.env.JITI_MAIN)(__filename, { interopDefault: true });
+const { visibleWidth } = require("@earendil-works/pi-tui");
+const mod = jiti(process.env.INDEX_TS);
+
+let failed = 0;
+const ok = (name, cond, detail) => {
+  console.log(`  ${cond ? "ok  " : "FAIL"}  ${name}${cond || !detail ? "" : `  -> ${detail}`}`);
+  if (!cond) failed++;
+};
+
+const commands = new Map();
+const tools = [];
+mod.default({
+  registerCommand: (n, s) => commands.set(n, s),
+  registerTool: (t) => tools.push(t.name),
+  sendUserMessage: () => {},
+});
+
+console.log("registration:");
+ok("/decisions registered", commands.has("decisions"));
+ok("/reload-runtime registered", commands.has("reload-runtime"));
+ok("reload_runtime tool registered", tools.includes("reload_runtime"));
+
+// Minimal theme: identity styling, so visibleWidth measures real content.
+const theme = { fg: (_c, s) => s, bg: (_c, s) => s, bold: (s) => s, italic: (s) => s };
+let component = null;
+const ctx = {
+  mode: "tui",
+  ui: {
+    notify: () => {},
+    setEditorText: () => {},
+    custom: async (factory) => {
+      component = factory({ requestRender: () => {} }, theme, {}, () => {});
+      return null;
+    },
+  },
+};
+
+console.log("render contract:");
+(async () => {
+  await commands.get("decisions").handler("", ctx);
+  if (!component) {
+    ok("component built (queue non-empty for fixture FM_HOME)", false);
+    process.exit(1);
+  }
+  for (const width of [60, 80, 100, 120, 200]) {
+    component.invalidate();
+    const lines = component.render(width);
+    const over = lines.filter((l) => visibleWidth(l) > width);
+    ok(`width ${width}: no line exceeds the terminal`, over.length === 0,
+      over.length ? `${over.length} line(s), widest ${Math.max(...over.map(visibleWidth))}` : "");
+  }
+  // Navigation must not crash or escape the list bounds.
+  component.invalidate();
+  const before = component.render(100).join("\n");
+  for (const k of ["j", "j", "k", "\u001b[B", "\u001b[A", "r"]) component.handleInput(k);
+  const after = component.render(100);
+  ok("navigation + refresh keep rendering", after.length > 0 && typeof before === "string");
+  ok("still within width after navigation", after.every((l) => visibleWidth(l) <= 100));
+  process.exit(failed ? 1 : 0);
+})();
+EOF
+
+JITI_MAIN="$jiti_main" INDEX_TS="$index_ts" FM_HOME="$fm_home" \
+  NODE_PATH="$pi_root/node_modules" node "$verify_dir/render.cjs"
+
+# --- parity against firstmate's authoritative fold --------------------------
+fm_lib="${FIRSTMATE_HOME:-$HOME/projects/firstmate}/bin/fm-classify-lib.sh"
+if [ ! -r "$fm_lib" ]; then
+  echo "parity: SKIP (firstmate not on this host: $fm_lib)"
+  echo "verify-pi-decision-queue: OK (collector assertions only)"
+  exit 0
+fi
+
+# scan_open_decisions prints "<task>\t<key>\t<verb>\t<note>" for the directory.
+# shellcheck disable=SC1090
+( set +u; source "$fm_lib"; scan_open_decisions "$fm_home/state" ) \
+  | sed '/^$/d' | LC_ALL=C sort >"$verify_dir/sh-fold.txt"
+LC_ALL=C sort "$verify_dir/ts-fold.txt" | sed '/^$/d' >"$verify_dir/ts-fold.sorted"
+
+if diff -u "$verify_dir/sh-fold.txt" "$verify_dir/ts-fold.sorted" >"$verify_dir/parity.diff"; then
+  echo "parity: ok  TypeScript fold matches fm-classify-lib.sh on $(wc -l <"$verify_dir/sh-fold.txt" | tr -d ' ') open record(s)"
+else
+  echo "parity: FAIL  the port drifted from firstmate's authoritative fold:" >&2
+  cat "$verify_dir/parity.diff" >&2
+  exit 1
+fi
+
+echo "verify-pi-decision-queue: OK"


### PR DESCRIPTION
Adds a pi `/decisions` slash command that lists the open decisions waiting on the captain: unchecked `kind: captain` backlog tasks plus open keyed `needs-decision`/`blocked` records in firstmate's `state/*.status` logs, in an interactive 2-column TUI.

Recovered and continued from the `fm/pi-decision-queue-ext` prototype whose worktree died. `collect.ts` is a TypeScript port of the authoritative open-decisions fold in firstmate's `bin/fm-classify-lib.sh`, with no pi imports so it stays loadable standalone for verification.

## Two bugs fixed, both of which re-showed already-answered work

**The answer hint taught a closing line that cannot close anything.** It emitted `resolved: <choice> [key=x]` with the key trailing. `fm-classify-lib.sh` is explicit that a key token that deep in the note is prose — "a summary merely MENTIONING `[key=x]` cannot open or close that decision" — so the line closed the `default` bucket and left the real keyed decision open forever. Demonstrated:

| closing form | result |
| --- | --- |
| `resolved [key=api]: ...` | CLOSED |
| `resolved: [key=api] ...` | CLOSED |
| `resolved: ... [key=api]` | **STILL OPEN** |

Closing lines now come from one `resolvedLine()` helper emitting the documented before-colon form, byte-matching what `fm-send.sh --resolve-key` appends, and the hint leads with `fm-send` rather than hand-editing a status log.

**Backlog selection keyed on `hold-kind: captain`,** which also matches ship/scout tasks merely parked behind the captain. Those linger in the backlog after his order already settled them, so a closed task rendered as an open decision. Selection is now on the task's own `kind: captain` (captain's call). On live data this drops exactly one item — a `kind: ship` task whose hold text reads "Closed by captain order 2026-08-17" — and keeps all 18 real decisions.

Backlog tags are now parsed by paren depth instead of string anchors. Values are free prose with balanced parens, and the two live shapes (`kind: captain`, `since 2026-08-15`) mean neither the first `)` nor the next `(name: ` opener delimits a value correctly — the latter silently swallowed `since` into `kind`.

## Verification

`scripts/verify-pi-decision-queue` (repo `scripts/verify-pi-*` convention), 33 assertions, all green. It covers the key grammar in both documented positions, malformed slugs, `captain-held` transfers, the `pending-reply-*` reserved namespace, symlink rejection, backlog selection, tag parsing, and the round-trip property that **what the extension prefills must close the item it was generated from**.

It also diffs the port against `fm-classify-lib.sh`'s own fold over the same fixture files when firstmate is present, so drift between the two gets caught rather than assumed absent. Fixtures rather than live `state/` because the real queue churns between runs — it moved twice while I was working on this.

The render contract is pinned at widths 60/80/100/120/200. That caught the footer lines overflowing by 13 columns at width 60 and tearing the frame open; the earlier prototype only checked 80 and 100.

Skips cleanly on hosts without pi or without firstmate, so it is safe on macOS/devbox where `pi/` is also stowed.