### PR TITLE
Add pi /nvim extension and skill for opening vim in the current tab

### DIFF
--- a/agents/.agents/skills/nvim/SKILL.md
+++ b/agents/.agents/skills/nvim/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvim
-description: "Open a Neovim/vim editor session in the folder the agent is working with. Launches vim as a vertical split in the current Herdr tab. If an editor is already running in that tab, sends files to the existing instance instead of launching a new one. Accepts natural-language file references (e.g. 'the readme', 'the extension file') and resolves them via a small LLM call, prompting with a multiple-choice selection if uncertain. Use when the user wants to open an editor for the current workspace or specific files, says 'open in vim'/'nvim', 'edit', or types /nvim."
+description: "Open a vim editor session in the folder the agent is working with. Launches vim as a vertical split in the current Herdr tab. If an editor is already running in that tab, sends files to the existing instance instead of launching a new one. Use when the user wants to open an editor for the current workspace or specific files, says 'open in vim'/'nvim', 'edit', or types /nvim."
 ---
 
 # Open Editor
@@ -11,33 +11,19 @@ current Herdr tab. If an editor is already running in the current tab,
 files are sent to the existing instance — a second instance is never
 launched.
 
-## Natural-language file resolution
-
-The `/nvim` command accepts both direct file paths and natural-language
-references:
-
-- **Direct paths**: `/nvim src/main.ts README.md` — opens those files
-  directly.
-- **Natural language**: `/nvim the readme` or `/nvim open the extension
-  file we just edited` — runs a small LLM call to resolve the reference
-  against the files in the agent's cwd.
-
-If the LLM is confident about the match, the file is opened automatically.
-If it is uncertain, a **numbered multiple-choice menu** is presented in the
-terminal — the user selects the intended file by number or presses Enter
-to cancel.
-
 ## Invocation
 
 Call the `nvim_open` tool to perform the launch. Pass the agent's current
-working directory as `cwd`.
+working directory as `cwd`. If the user references a file by name rather
+than by path, resolve it yourself before calling the tool — the extension
+does not do natural-language resolution.
 
 - **`/nvim`** (no arguments) → call `nvim_open` with `cwd` set to the
   agent's cwd and no `files`. Opens vim at the workspace root.
 
 - **`/nvim <file> [<file>...]`** → call `nvim_open` with `cwd` set to the
-  agent's cwd and `files` set to the listed paths or natural-language
-  references. Relative paths are resolved against `cwd`.
+  agent's cwd and `files` set to the listed paths. Relative paths are
+  resolved against `cwd`.
 
 ## Example tool call
 
@@ -53,18 +39,15 @@ working directory as `cwd`.
 
 ## Behavior
 
-1. **Resolve file references:** direct file paths are used as-is.
-   Natural-language queries are resolved via a small LLM call that lists
-   files in the cwd and asks the model to match. Uncertain matches prompt
-   a numbered multiple-choice selection.
-2. **Detect existing editor:** the extension inspects every pane in the
+1. **Detect existing editor:** the extension inspects every pane in the
    current Herdr tab via `herdr pane list` + `herdr pane process-info`,
    looking for a foreground process named `vim` or `nvim`.
-3. **If an editor exists:** files are sent to the running instance (via
-   nvim's RPC socket, discovered by PID, with a `herdr pane send-text`
-   fallback). With no files, the existing pane is focused. No second
-   instance is launched.
-4. **If no editor exists:** a new pane is created with
+2. **If an editor exists:** files are sent to the running instance
+   via `herdr pane send-text` with `:e <file>` ex commands (paths escaped
+   with fnameescape semantics). The editor pane is focused using
+   `herdr pane neighbor` + `herdr pane focus`. With no files, just the
+   existing pane is focused. No second instance is launched.
+3. **If no editor exists:** a new pane is created with
    `herdr pane split --current --direction right` and `vim` is launched
    in it. Focus moves to the editor pane.
-5. **No Herdr:** falls back to a tmux split, or prints a manual command.
+4. **No Herdr:** falls back to a tmux split, or prints a manual command.

--- a/agents/.agents/skills/nvim/SKILL.md
+++ b/agents/.agents/skills/nvim/SKILL.md
@@ -1,26 +1,43 @@
 ---
 name: nvim
-description: "Open a Neovim editor session in the folder the agent is working with. Launches nvim as a vertical split in the current Herdr tab. If nvim is already running in that tab, sends files to the existing instance instead of launching a new one. Use when the user wants to open nvim for the current workspace or specific files, says 'open in nvim', 'edit in neovim', or types /nvim."
+description: "Open a Neovim/vim editor session in the folder the agent is working with. Launches vim as a vertical split in the current Herdr tab. If an editor is already running in that tab, sends files to the existing instance instead of launching a new one. Accepts natural-language file references (e.g. 'the readme', 'the extension file') and resolves them via a small LLM call, prompting with a multiple-choice selection if uncertain. Use when the user wants to open an editor for the current workspace or specific files, says 'open in vim'/'nvim', 'edit', or types /nvim."
 ---
 
-# Open Neovim
+# Open Editor
 
-Open a Neovim session for the current workspace or specific files. Neovim
-launches as a **vertical split to the right of the agent pane** in the current Herdr
-tab. If nvim is already running in the current tab, files are sent to the
-existing instance — a second instance is never launched.
+Open a vim session for the current workspace or specific files. Vim
+launches as a **vertical split to the right of the agent pane** in the
+current Herdr tab. If an editor is already running in the current tab,
+files are sent to the existing instance — a second instance is never
+launched.
+
+## Natural-language file resolution
+
+The `/nvim` command accepts both direct file paths and natural-language
+references:
+
+- **Direct paths**: `/nvim src/main.ts README.md` — opens those files
+  directly.
+- **Natural language**: `/nvim the readme` or `/nvim open the extension
+  file we just edited` — runs a small LLM call to resolve the reference
+  against the files in the agent's cwd.
+
+If the LLM is confident about the match, the file is opened automatically.
+If it is uncertain, a **numbered multiple-choice menu** is presented in the
+terminal — the user selects the intended file by number or presses Enter
+to cancel.
 
 ## Invocation
 
 Call the `nvim_open` tool to perform the launch. Pass the agent's current
 working directory as `cwd`.
 
-- **`/nvim`** (no arguments) → call `nvim_open` with `cwd` set to the agent's
-  cwd and no `files`. Opens nvim at the workspace root.
+- **`/nvim`** (no arguments) → call `nvim_open` with `cwd` set to the
+  agent's cwd and no `files`. Opens vim at the workspace root.
 
 - **`/nvim <file> [<file>...]`** → call `nvim_open` with `cwd` set to the
-  agent's cwd and `files` set to the listed paths. Relative paths are resolved
-  against `cwd`.
+  agent's cwd and `files` set to the listed paths or natural-language
+  references. Relative paths are resolved against `cwd`.
 
 ## Example tool call
 
@@ -36,13 +53,18 @@ working directory as `cwd`.
 
 ## Behavior
 
-1. **Detect existing nvim:** the extension inspects every pane in the current
-   Herdr tab via `herdr pane list` + `herdr pane process-info`, looking for a
-   foreground process named `nvim`.
-2. **If nvim exists:** files are sent to the running instance (via nvim's RPC
-   socket, discovered by PID, with a `herdr pane send-text` fallback). With no
-   files, the existing nvim pane is focused. No second instance is launched.
-3. **If no nvim exists:** a new pane is created with
-   `herdr pane split --current --direction right` and `nvim` is launched in it.
-   Focus moves to the nvim pane.
-4. **No Herdr:** falls back to a tmux vertical split, or prints a manual command.
+1. **Resolve file references:** direct file paths are used as-is.
+   Natural-language queries are resolved via a small LLM call that lists
+   files in the cwd and asks the model to match. Uncertain matches prompt
+   a numbered multiple-choice selection.
+2. **Detect existing editor:** the extension inspects every pane in the
+   current Herdr tab via `herdr pane list` + `herdr pane process-info`,
+   looking for a foreground process named `vim` or `nvim`.
+3. **If an editor exists:** files are sent to the running instance (via
+   nvim's RPC socket, discovered by PID, with a `herdr pane send-text`
+   fallback). With no files, the existing pane is focused. No second
+   instance is launched.
+4. **If no editor exists:** a new pane is created with
+   `herdr pane split --current --direction right` and `vim` is launched
+   in it. Focus moves to the editor pane.
+5. **No Herdr:** falls back to a tmux split, or prints a manual command.

--- a/agents/.agents/skills/nvim/SKILL.md
+++ b/agents/.agents/skills/nvim/SKILL.md
@@ -11,43 +11,29 @@ current Herdr tab. If an editor is already running in the current tab,
 files are sent to the existing instance — a second instance is never
 launched.
 
-## Invocation
+## Usage
 
-Call the `nvim_open` tool to perform the launch. Pass the agent's current
-working directory as `cwd`. If the user references a file by name rather
-than by path, resolve it yourself before calling the tool — the extension
-does not do natural-language resolution.
+Run the bundled shell script from this skill directory:
 
-- **`/nvim`** (no arguments) → call `nvim_open` with `cwd` set to the
-  agent's cwd and no `files`. Opens vim at the workspace root.
+```bash
+# Open vim at the agent's cwd
+./nvim-open.sh "$(pwd)"
 
-- **`/nvim <file> [<file>...]`** → call `nvim_open` with `cwd` set to the
-  agent's cwd and `files` set to the listed paths. Relative paths are
-  resolved against `cwd`.
-
-## Example tool call
-
-```json
-{
-  "name": "nvim_open",
-  "parameters": {
-    "cwd": "/home/user/project",
-    "files": ["src/main.ts", "src/util.ts"]
-  }
-}
+# Open specific files (relative paths resolved against cwd)
+./nvim-open.sh "$(pwd)" src/main.ts src/util.ts
 ```
 
-## Behavior
+The script handles:
+- **Detecting an existing editor** in the current Herdr tab via `herdr
+  pane list` + `herdr pane process-info`, looking for `vim` or `nvim`.
+- **Sending files to an existing editor** via `herdr pane send-text`
+  with `:e <file>` ex commands (paths escaped with fnameescape
+  semantics). The editor pane is focused using `herdr pane neighbor` +
+  `herdr pane focus`.
+- **Launching a new editor** via `herdr pane split --current --direction
+  right` + `herdr pane run` when no editor exists.
+- **tmux fallback** when Herdr is unavailable.
 
-1. **Detect existing editor:** the extension inspects every pane in the
-   current Herdr tab via `herdr pane list` + `herdr pane process-info`,
-   looking for a foreground process named `vim` or `nvim`.
-2. **If an editor exists:** files are sent to the running instance
-   via `herdr pane send-text` with `:e <file>` ex commands (paths escaped
-   with fnameescape semantics). The editor pane is focused using
-   `herdr pane neighbor` + `herdr pane focus`. With no files, just the
-   existing pane is focused. No second instance is launched.
-3. **If no editor exists:** a new pane is created with
-   `herdr pane split --current --direction right` and `vim` is launched
-   in it. Focus moves to the editor pane.
-4. **No Herdr:** falls back to a tmux split, or prints a manual command.
+If the user references a file by name rather than by path (e.g. "the
+readme"), resolve it yourself before calling the script — the script
+does not do natural-language resolution.

--- a/agents/.agents/skills/nvim/SKILL.md
+++ b/agents/.agents/skills/nvim/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: nvim
-description: "Open a Neovim editor session in the folder the agent is working with. Launches nvim as a horizontal split in the current Herdr tab. If nvim is already running in that tab, sends files to the existing instance instead of launching a new one. Use when the user wants to open nvim for the current workspace or specific files, says 'open in nvim', 'edit in neovim', or types /nvim."
+description: "Open a Neovim editor session in the folder the agent is working with. Launches nvim as a vertical split in the current Herdr tab. If nvim is already running in that tab, sends files to the existing instance instead of launching a new one. Use when the user wants to open nvim for the current workspace or specific files, says 'open in nvim', 'edit in neovim', or types /nvim."
 ---
 
 # Open Neovim
 
 Open a Neovim session for the current workspace or specific files. Neovim
-launches as a **horizontal split below the agent pane** in the current Herdr
+launches as a **vertical split to the right of the agent pane** in the current Herdr
 tab. If nvim is already running in the current tab, files are sent to the
 existing instance — a second instance is never launched.
 
@@ -43,6 +43,6 @@ working directory as `cwd`.
    socket, discovered by PID, with a `herdr pane send-text` fallback). With no
    files, the existing nvim pane is focused. No second instance is launched.
 3. **If no nvim exists:** a new pane is created with
-   `herdr pane split --current --direction down` and `nvim` is launched in it.
+   `herdr pane split --current --direction right` and `nvim` is launched in it.
    Focus moves to the nvim pane.
 4. **No Herdr:** falls back to a tmux vertical split, or prints a manual command.

--- a/agents/.agents/skills/nvim/SKILL.md
+++ b/agents/.agents/skills/nvim/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: nvim
+description: "Open a Neovim editor session in the folder the agent is working with. Launches nvim as a horizontal split in the current Herdr tab. If nvim is already running in that tab, sends files to the existing instance instead of launching a new one. Use when the user wants to open nvim for the current workspace or specific files, says 'open in nvim', 'edit in neovim', or types /nvim."
+---
+
+# Open Neovim
+
+Open a Neovim session for the current workspace or specific files. Neovim
+launches as a **horizontal split below the agent pane** in the current Herdr
+tab. If nvim is already running in the current tab, files are sent to the
+existing instance — a second instance is never launched.
+
+## Invocation
+
+Call the `nvim_open` tool to perform the launch. Pass the agent's current
+working directory as `cwd`.
+
+- **`/nvim`** (no arguments) → call `nvim_open` with `cwd` set to the agent's
+  cwd and no `files`. Opens nvim at the workspace root.
+
+- **`/nvim <file> [<file>...]`** → call `nvim_open` with `cwd` set to the
+  agent's cwd and `files` set to the listed paths. Relative paths are resolved
+  against `cwd`.
+
+## Example tool call
+
+```json
+{
+  "name": "nvim_open",
+  "parameters": {
+    "cwd": "/home/user/project",
+    "files": ["src/main.ts", "src/util.ts"]
+  }
+}
+```
+
+## Behavior
+
+1. **Detect existing nvim:** the extension inspects every pane in the current
+   Herdr tab via `herdr pane list` + `herdr pane process-info`, looking for a
+   foreground process named `nvim`.
+2. **If nvim exists:** files are sent to the running instance (via nvim's RPC
+   socket, discovered by PID, with a `herdr pane send-text` fallback). With no
+   files, the existing nvim pane is focused. No second instance is launched.
+3. **If no nvim exists:** a new pane is created with
+   `herdr pane split --current --direction down` and `nvim` is launched in it.
+   Focus moves to the nvim pane.
+4. **No Herdr:** falls back to a tmux vertical split, or prints a manual command.

--- a/agents/.agents/skills/nvim/nvim-open.sh
+++ b/agents/.agents/skills/nvim/nvim-open.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# nvim-open.sh — open vim in the current Herdr tab as a vertical split,
+# or send files to an existing editor instance.
+#
+# Usage:
+#   nvim-open.sh [cwd] [file1] [file2] ...
+#   nvim-open.sh /path/to/cwd           # open vim at cwd
+#   nvim-open.sh /path/to/cwd file.ts   # open file in vim
+set -euo pipefail
+
+CWD="${1:-$(pwd)}"
+shift || true
+FILES=("$@")
+
+HERDR_TIMEOUT=5
+
+# Escape a file path for Vim :e ex command (fnameescape semantics)
+fnameescape() {
+	local path="$1"
+	# Backslash-escape: backslash, space, pipe, percent, hash, double-quote,
+	# single-quote, tab, newline, CR
+	printf '%s' "$path" | sed 's/[][\\ |%"'"'"'#\t\r\n]/\\&/g'
+}
+
+# Run herdr command, return JSON or null
+herdr_json() {
+	timeout "$HERDR_TIMEOUT" herdr "$@" 2>/dev/null || true
+}
+
+herdr_ok() {
+	timeout "$HERDR_TIMEOUT" herdr "$@" >/dev/null 2>&1
+}
+
+# Check if herdr is available
+if ! herdr_json workspace list >/dev/null 2>&1; then
+	# No herdr — try tmux
+	if command -v tmux >/dev/null 2>&1; then
+		if [[ ${#FILES[@]} -gt 0 ]]; then
+			quoted=$(printf "'%s' " "${FILES[@]}")
+			tmux split-window -h -c "$CWD" "vim $quoted"
+		else
+			tmux split-window -h -c "$CWD" "vim"
+		fi
+		echo "Launched vim in a tmux split at $CWD."
+		exit 0
+	fi
+	echo "Could not launch vim. Run manually: cd $CWD && vim ${FILES[*]}"
+	exit 1
+fi
+
+# Get current pane info
+CURRENT_PANE_JSON=$(herdr_json pane current)
+if [[ -z "$CURRENT_PANE_JSON" ]]; then
+	echo "Could not get current pane from herdr."
+	exit 1
+fi
+
+TAB_ID=$(echo "$CURRENT_PANE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['pane']['tab_id'])" 2>/dev/null || echo "")
+CURRENT_PANE_ID=$(echo "$CURRENT_PANE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['pane']['pane_id'])" 2>/dev/null || echo "")
+
+if [[ -z "$TAB_ID" || -z "$CURRENT_PANE_ID" ]]; then
+	echo "Could not parse current pane info."
+	exit 1
+fi
+
+# Detect existing editor in the current tab
+EDITOR_PANE_ID=""
+EDITOR_FOUND=false
+SCAN_ERROR=false
+
+PANES_JSON=$(herdr_json pane list)
+if [[ -z "$PANES_JSON" ]]; then
+	SCAN_ERROR=true
+else
+	# Get panes in this tab
+	TAB_PANES=$(echo "$PANES_JSON" | python3 -c "
+import sys,json
+data=json.load(sys.stdin)
+panes=[p['pane_id'] for p in data.get('result',{}).get('panes',[]) if p.get('tab_id')=='$TAB_ID']
+print('\n'.join(panes))
+" 2>/dev/null || echo "")
+
+	if [[ -z "$TAB_PANES" ]]; then
+		SCAN_ERROR=true
+	else
+		while IFS= read -r pane_id; do
+			[[ -z "$pane_id" ]] && continue
+			PROC_JSON=$(herdr_json pane process-info --pane "$pane_id")
+			if [[ -z "$PROC_JSON" ]]; then
+				SCAN_ERROR=true
+				continue
+			fi
+			# Check if foreground process is vim or nvim
+			IS_EDITOR=$(echo "$PROC_JSON" | python3 -c "
+import sys,json
+data=json.load(sys.stdin)
+procs=data.get('result',{}).get('process_info',{}).get('foreground_processes',[])
+for p in procs:
+    name=p.get('name','')
+    argv0=(p.get('argv',[''])[0]) if p.get('argv') else ''
+    if name in ('vim','nvim') or argv0 in ('vim','nvim'):
+        print('yes')
+        break
+" 2>/dev/null || echo "")
+
+			if [[ "$IS_EDITOR" == "yes" ]]; then
+				EDITOR_PANE_ID="$pane_id"
+				EDITOR_FOUND=true
+				break
+			fi
+		done <<< "$TAB_PANES"
+	fi
+fi
+
+# If editor exists, send files to it
+if [[ "$EDITOR_FOUND" == "true" ]]; then
+	if [[ ${#FILES[@]} -gt 0 ]]; then
+		for file in "${FILES[@]}"; do
+			escaped=$(fnameescape "$file")
+			# Escape to exit insert mode, then :e with escaped path, then Enter
+			herdr_ok pane send-text "$EDITOR_PANE_ID" $'\x1b:e '"$escaped"$'\r'
+		done
+		echo "Sent ${#FILES[@]} file(s) to existing editor (pane $EDITOR_PANE_ID)."
+	else
+		echo "Editor already running (pane $EDITOR_PANE_ID)."
+	fi
+	# Focus the editor pane — find direction via neighbor
+	for dir in right down left up; do
+		NEIGHBOR=$(herdr_json pane neighbor --pane "$CURRENT_PANE_ID" --direction "$dir" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',{}).get('neighbor',{}).get('pane_id',''))" 2>/dev/null || echo "")
+		if [[ "$NEIGHBOR" == "$EDITOR_PANE_ID" ]]; then
+			herdr_ok pane focus --current --direction "$dir"
+			break
+		fi
+	done
+	exit 0
+fi
+
+# On scan error, don't launch a duplicate — fall through to tmux
+if [[ "$SCAN_ERROR" == "true" ]]; then
+	echo "Warning: could not fully scan panes for existing editor." >&2
+	if command -v tmux >/dev/null 2>&1; then
+		if [[ ${#FILES[@]} -gt 0 ]]; then
+			quoted=$(printf "'%s' " "${FILES[@]}")
+			tmux split-window -h -c "$CWD" "vim $quoted"
+		else
+			tmux split-window -h -c "$CWD" "vim"
+		fi
+		echo "Launched vim in a tmux split at $CWD."
+		exit 0
+	fi
+fi
+
+# No existing editor — launch a new vertical split
+SPLIT_JSON=$(herdr_json pane split --current --direction right --cwd "$CWD" --focus)
+NEW_PANE_ID=$(echo "$SPLIT_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',{}).get('pane',{}).get('pane_id',''))" 2>/dev/null || echo "")
+
+if [[ -z "$NEW_PANE_ID" ]]; then
+	echo "Could not create split pane."
+	exit 1
+fi
+
+# Launch vim in the new pane
+if [[ ${#FILES[@]} -gt 0 ]]; then
+	if herdr_ok pane run "$NEW_PANE_ID" vim "${FILES[@]}"; then
+		echo "Launched vim in a vertical split (pane $NEW_PANE_ID) at $CWD with ${#FILES[@]} file(s)."
+	else
+		echo "Failed to launch vim in pane $NEW_PANE_ID."
+		exit 1
+	fi
+else
+	if herdr_ok pane run "$NEW_PANE_ID" vim; then
+		echo "Launched vim in a vertical split (pane $NEW_PANE_ID) at $CWD."
+	else
+		echo "Failed to launch vim in pane $NEW_PANE_ID."
+		exit 1
+	fi
+fi

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -1,17 +1,13 @@
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { execFileSync, spawn } from "node:child_process";
-import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
-import { join, resolve, isAbsolute, relative } from "node:path";
+import { execFileSync } from "node:child_process";
+import { resolve, isAbsolute } from "node:path";
 
 const HERDR_TIMEOUT_MS = 5000;
-const LLM_TIMEOUT_MS = 20000;
-const MAX_FILE_LIST = 200;
 
 // ---------------------------------------------------------------------------
 // Herdr helpers
 // ---------------------------------------------------------------------------
-
 interface PaneInfo {
 	pane_id: string;
 	tab_id: string;
@@ -19,19 +15,16 @@ interface PaneInfo {
 	foreground_cwd?: string;
 	workspace_id: string;
 }
-
 interface ProcessEntry {
 	name: string;
 	pid: number;
 	argv?: string[];
 	cmdline?: string;
 }
-
 interface ProcessInfo {
 	foreground_processes: ProcessEntry[];
 	pane_id: string;
 }
-
 /** Run a herdr subcommand and parse its JSON response. Returns null on failure. */
 function herdrJson(args: string[]): unknown | null {
 	try {
@@ -43,7 +36,6 @@ function herdrJson(args: string[]): unknown | null {
 		return null;
 	}
 }
-
 /** Run a herdr subcommand, discarding output. Returns true on success. */
 function herdrOk(args: string[]): boolean {
 	try {
@@ -55,40 +47,32 @@ function herdrOk(args: string[]): boolean {
 		return false;
 	}
 }
-
 function getCurrentPane(): PaneInfo | null {
 	const res = herdrJson(["pane", "current"]) as
 		| { result?: { pane?: PaneInfo } } | null;
 	return res?.result?.pane ?? null;
 }
-
 function listPanes(): PaneInfo[] | null {
 	const res = herdrJson(["pane", "list"]) as
 		| { result?: { panes?: PaneInfo[] } } | null;
-	// Return null on failure (not []) so callers can distinguish error from empty
 	return res?.result?.panes ?? null;
 }
-
 function getProcessInfo(paneId: string): ProcessInfo | null {
 	const res = herdrJson(["pane", "process-info", "--pane", paneId]) as
 		| { result?: { process_info?: ProcessInfo } } | null;
 	return res?.result?.process_info ?? null;
 }
-
 // ---------------------------------------------------------------------------
 // editor detection (tri-state: found | absent | error)
 // ---------------------------------------------------------------------------
-
 interface EditorPane {
 	paneId: string;
 	pid: number;
 }
-
 type DetectionResult =
 	| { status: "found"; editor: EditorPane }
 	| { status: "absent" }
 	| { status: "error" };
-
 /**
  * Search all panes in the current tab for one whose foreground process is
  * vim/nvim. Returns "error" if any herdr call fails, so the caller does NOT
@@ -97,10 +81,8 @@ type DetectionResult =
 function findEditorPane(currentTabId: string): DetectionResult {
 	const panes = listPanes();
 	if (panes === null) return { status: "error" };
-
 	const tabPanes = panes.filter((p) => p.tab_id === currentTabId);
 	if (tabPanes.length === 0) return { status: "error" };
-
 	let hadError = false;
 	for (const pane of tabPanes) {
 		const info = getProcessInfo(pane.pane_id);
@@ -117,30 +99,23 @@ function findEditorPane(currentTabId: string): DetectionResult {
 			}
 		}
 	}
-	// Only report "absent" if every pane was successfully scanned
 	return hadError ? { status: "error" } : { status: "absent" };
 }
-
 // ---------------------------------------------------------------------------
 // editor communication
 // ---------------------------------------------------------------------------
-
 /**
  * Escape a file path for use in a Vim `:e` ex command, following
  * fnameescape() semantics. Backslash-escape every character that has
- * special meaning in ex commands: backslash itself, space, pipe, percent,
- * hash, double-quote, single-quote, tab, and newline.
+ * special meaning in ex commands.
  */
 function fnameEscape(path: string): string {
-	// Characters that need backslash-escaping in ex commands
 	return path.replace(/[\\ |%"'#\t\n\r]/g, "\\$&");
 }
-
 /** Send `:e <file>` keystrokes to the editor pane via herdr send-text. */
 function sendFilesViaText(paneId: string, files: string[]): void {
 	for (const file of files) {
 		const escaped = fnameEscape(file);
-		// Escape to exit insert mode, then :e with the escaped path, then Enter.
 		const text = `\x1b:e ${escaped}\r`;
 		try {
 			execFileSync("herdr", ["pane", "send-text", paneId, text], {
@@ -151,11 +126,9 @@ function sendFilesViaText(paneId: string, files: string[]): void {
 		}
 	}
 }
-
 // ---------------------------------------------------------------------------
 // launch & focus
 // ---------------------------------------------------------------------------
-
 /**
  * Split the current pane to the right and launch vim in the new pane.
  * Returns the new pane ID, or null if the split or run failed.
@@ -164,27 +137,21 @@ function launchEditor(cwd: string, files: string[]): string | null {
 	const splitRes = herdrJson([
 		"pane", "split", "--current", "--direction", "right", "--cwd", cwd, "--focus",
 	]) as { result?: { pane?: { pane_id?: string } } } | null;
-
 	const newPaneId = splitRes?.result?.pane?.pane_id;
 	if (!newPaneId) return null;
-
 	const cmd = files.length > 0 ? ["vim", ...files] : ["vim"];
-	// Check the run result — don't claim success if vim failed to start
 	if (!herdrOk(["pane", "run", newPaneId, ...cmd])) {
 		return null;
 	}
 	return newPaneId;
 }
-
 /**
  * Focus the editor pane by discovering the direction from the current pane
- * to the editor pane using `herdr pane neighbor`. Falls back to trying all
- * four directions. `herdr pane focus` requires --direction, so we cannot
- * focus by pane ID alone.
+ * to the editor pane using `herdr pane neighbor`. `herdr pane focus` requires
+ * --direction, so we cannot focus by pane ID alone.
  */
 function focusEditorPane(editorPaneId: string, currentPaneId: string): boolean {
 	const directions = ["right", "down", "left", "up"] as const;
-
 	for (const dir of directions) {
 		const res = herdrJson(["pane", "neighbor", "--pane", currentPaneId, "--direction", dir]) as
 			| { result?: { neighbor?: { pane_id?: string } } } | null;
@@ -193,26 +160,20 @@ function focusEditorPane(editorPaneId: string, currentPaneId: string): boolean {
 			return herdrOk(["pane", "focus", "--current", "--direction", dir]);
 		}
 	}
-
 	// Fallback: try each direction directly
 	for (const dir of directions) {
 		if (herdrOk(["pane", "focus", "--current", "--direction", dir])) {
-			// Check if we landed on the editor pane
 			const current = getCurrentPane();
 			if (current?.pane_id === editorPaneId) return true;
 		}
 	}
 	return false;
 }
-
 // ---------------------------------------------------------------------------
 // tmux fallback
 // ---------------------------------------------------------------------------
-
 function tmuxFallback(cwd: string, files: string[]): boolean {
 	try {
-		// tmux split-window accepts ONE optional shell-command as the last arg.
-		// Construct a single safely-quoted shell command string.
 		let shellCmd: string;
 		if (files.length > 0) {
 			const quotedFiles = files.map((f) => `'${f.replace(/'/g, "'\\''")}'`);
@@ -228,59 +189,9 @@ function tmuxFallback(cwd: string, files: string[]): boolean {
 		return false;
 	}
 }
-
-// ---------------------------------------------------------------------------
-// file listing for LLM resolution
-// ---------------------------------------------------------------------------
-
-/**
- * Recursively list files under cwd (limited depth/count), returning relative
- * paths. Skips known large/build dirs but allows hidden project config dirs
- * like .pi, .agents, .claude so source files in them are discoverable.
- */
-function listFilesForLlm(cwd: string): string[] {
-	const results: string[] = [];
-	// Only skip these known-large or irrelevant directories
-	const skipDirs = new Set([
-		".git", "node_modules", ".venv", "__pycache__",
-		"target", "dist", "build", ".cache", ".treehouse",
-	]);
-
-	function walk(dir: string, depth: number) {
-		if (depth > 4 || results.length >= MAX_FILE_LIST) return;
-		let entries: string[];
-		try {
-			entries = readdirSync(dir);
-		} catch {
-			return;
-		}
-		for (const entry of entries) {
-			if (results.length >= MAX_FILE_LIST) return;
-			const full = join(dir, entry);
-			try {
-				const st = statSync(full);
-				if (st.isDirectory()) {
-					// Skip only known large dirs — allow hidden config dirs
-					if (!skipDirs.has(entry)) {
-						walk(full, depth + 1);
-					}
-				} else {
-					results.push(relative(cwd, full));
-				}
-			} catch {
-				// skip
-			}
-		}
-	}
-
-	walk(cwd, 0);
-	return results.sort();
-}
-
 // ---------------------------------------------------------------------------
 // argument parsing (quote-aware)
 // ---------------------------------------------------------------------------
-
 /**
  * Parse a string into arguments, respecting single and double quotes.
  * Handles paths with spaces like: docs/"My Notes.md" or docs/'My Notes.md'
@@ -290,10 +201,8 @@ function parseArgs(input: string): string[] {
 	let current = "";
 	let inSingle = false;
 	let inDouble = false;
-
 	for (let i = 0; i < input.length; i++) {
 		const ch = input[i];
-
 		if (inSingle) {
 			if (ch === "'") {
 				inSingle = false;
@@ -304,7 +213,6 @@ function parseArgs(input: string): string[] {
 			if (ch === '"') {
 				inDouble = false;
 			} else if (ch === "\\" && i + 1 < input.length) {
-				// Escaped char inside double quotes
 				current += input[++i];
 			} else {
 				current += ch;
@@ -331,277 +239,24 @@ function parseArgs(input: string): string[] {
 	if (current) args.push(current);
 	return args;
 }
-
-// ---------------------------------------------------------------------------
-// LLM-based file resolution
-// ---------------------------------------------------------------------------
-
-interface LlmResolution {
-	files: string[];
-	confident: boolean;
-	candidates: string[];
-}
-
-/** Extract the assistant text from pi --mode json -p output (NDJSON lines). */
-function extractAssistantText(jsonOutput: string): string {
-	let lastText = "";
-	for (const line of jsonOutput.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed) continue;
-		try {
-			const obj = JSON.parse(trimmed);
-			if (obj.type === "turn_end" && obj.message?.role === "assistant") {
-				const content = obj.message.content;
-				if (Array.isArray(content)) {
-					lastText = content
-						.filter((c: any) => c.type === "text")
-						.map((c: any) => c.text)
-						.join("");
-				} else if (typeof content === "string") {
-					lastText = content;
-				}
-			}
-		} catch {
-			// not JSON, skip
-		}
-	}
-	return lastText;
-}
-
-function resolvePiBinary(): { command: string; baseArgs: string[] } {
-	const entry = process.argv[1];
-	if (entry) {
-		try {
-			const realEntry = realpathSync(entry);
-			if (/\.(?:mjs|cjs|js)$/i.test(realEntry)) {
-				return { command: process.execPath, baseArgs: [realEntry] };
-			}
-		} catch {}
-	}
-	return { command: "pi", baseArgs: [] };
-}
-
-/**
- * Resolve a natural-language file query using a small LLM call via pi print mode.
- * Uses newline-separated paths in the response to preserve spaces in file paths.
- */
-function resolveFilesWithLlm(cwd: string, query: string): Promise<LlmResolution> {
-	const fileList = listFilesForLlm(cwd);
-	const fileSet = new Set(fileList);
-
-	const systemPrompt = `You resolve natural-language file references to actual file paths.
-Given a list of files in the working directory and a user's request, determine which file(s) to open.
-
-Respond in ONE of these formats:
-1. If you are confident, reply with EXACTLY this structure (paths on separate lines):
-CONFIDENT:
-<file1>
-<file2>
-2. If you are uncertain, reply with EXACTLY: UNCERTAIN: <option1> | <option2> | <option3>
-   List 2-5 candidate files separated by " | ".
-
-Rules:
-- File paths must be relative paths from the working directory, matching the file list exactly.
-- If the user's request doesn't match any file, reply with: UNCERTAIN: (no matches)
-- Reply with only the format, no explanation.`;
-
-	const userPrompt = `Working directory: ${cwd}
-
-Available files (relative paths):
-${fileList.length > 0 ? fileList.join("\n") : "(no files found)"}
-
-User request: "${query}"
-
-Which file(s) should be opened?`;
-
-	return new Promise<LlmResolution>((resolve) => {
-		const piBin = resolvePiBinary();
-		const args = [
-			...piBin.baseArgs,
-			"--mode", "json", "-p",
-			"--no-skills", "--no-extensions", "--no-context-files",
-			"--no-prompt-templates", "--no-themes",
-			"--system-prompt", systemPrompt,
-			userPrompt,
-		];
-
-		// Strip Herdr env vars so the child pi process doesn't report to Herdr
-		const childEnv: Record<string, string> = {};
-		for (const [key, val] of Object.entries(process.env)) {
-			if (val !== undefined && !key.startsWith("HERDR_")) {
-				childEnv[key] = val;
-			}
-		}
-
-		let stdout = "";
-		let stderr = "";
-		const child = spawn(piBin.command, args, {
-			stdio: ["pipe", "pipe", "pipe"],
-			timeout: LLM_TIMEOUT_MS,
-			env: childEnv,
-		});
-
-		child.stdin.end();
-
-		child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()));
-		child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
-		child.on("error", () =>
-			resolve({ files: [], confident: false, candidates: [] }),
-		);
-		child.on("close", () => {
-			const text = extractAssistantText(stdout).trim();
-
-			if (text.startsWith("CONFIDENT:")) {
-				// Paths are newline-separated after the CONFIDENT: line
-				const paths = text
-					.slice("CONFIDENT:".length)
-					.trim()
-					.split("\n")
-					.map((s) => s.trim())
-					.filter(Boolean)
-					.filter((p) => fileSet.has(p));
-				resolve({ files: paths, confident: true, candidates: [] });
-			} else if (text.startsWith("UNCERTAIN:")) {
-				const rest = text.slice("UNCERTAIN:".length).trim();
-				if (rest === "(no matches)") {
-					resolve({ files: [], confident: false, candidates: [] });
-				} else {
-					const candidates = rest
-						.split("|")
-						.map((s) => s.trim())
-						.filter(Boolean)
-						.filter((c) => fileSet.has(c));
-					resolve({ files: [], confident: false, candidates });
-				}
-			} else {
-				resolve({ files: [], confident: false, candidates: [] });
-			}
-		});
-	});
-}
-
-// ---------------------------------------------------------------------------
-// multiple-choice selection via terminal
-// ---------------------------------------------------------------------------
-
-interface UIContext {
-	notify: (msg: string, level: string) => void;
-	onTerminalInput: (cb: (data: string) => { consume?: boolean } | undefined) => () => void;
-}
-
-/** Present a numbered multiple-choice menu and wait for the user's selection. */
-function presentChoice(
-	ui: UIContext,
-	prompt: string,
-	candidates: string[],
-): Promise<string | null> {
-	return new Promise((resolve) => {
-		const lines = [
-			prompt,
-			"",
-			...candidates.map((c, i) => `  ${i + 1}. ${c}`),
-			"",
-			"Enter a number (or press Enter to cancel):",
-		];
-		ui.notify(lines.join("\n"), "info");
-
-		const stop = ui.onTerminalInput((data: string) => {
-			const trimmed = data.trim();
-			if (!trimmed) {
-				stop?.();
-				resolve(null);
-				return;
-			}
-			const num = parseInt(trimmed, 10);
-			if (Number.isFinite(num) && num >= 1 && num <= candidates.length) {
-				stop?.();
-				resolve(candidates[num - 1]);
-				return { consume: true };
-			}
-			ui.notify(`Invalid choice "${trimmed}". Enter 1-${candidates.length} or press Enter to cancel.`, "warn");
-			return { consume: true };
-		});
-
-		const timer = setTimeout(() => {
-			stop?.();
-			resolve(null);
-		}, 30000);
-		timer.unref?.();
-	});
-}
-
 // ---------------------------------------------------------------------------
 // core orchestration
 // ---------------------------------------------------------------------------
-
 function resolveFilePaths(cwd: string, files: string[]): string[] {
 	return files.map((f) => (isAbsolute(f) ? f : resolve(cwd, f)));
 }
-
-/** Check if a string is a direct file path that exists on disk. */
-function isDirectFilePath(cwd: string, arg: string): boolean {
-	const full = isAbsolute(arg) ? arg : resolve(cwd, arg);
-	return existsSync(full);
-}
-
 async function openEditor(
 	cwd: string,
 	rawArgs: string[],
-	ctx?: { ui?: UIContext },
 ): Promise<{ message: string; launched: boolean }> {
-	// Classify args: direct file paths vs natural-language queries
-	const directFiles: string[] = [];
-	const naturalLanguage: string[] = [];
-
-	for (const arg of rawArgs) {
-		if (isDirectFilePath(cwd, arg)) {
-			directFiles.push(arg);
-		} else {
-			naturalLanguage.push(arg);
-		}
-	}
-
-	// Resolve natural-language args via LLM
-	let resolvedFiles = [...directFiles];
-
-	if (naturalLanguage.length > 0) {
-		const query = naturalLanguage.join(" ");
-		ctx?.ui?.notify(`Resolving "${query}" ...`, "info");
-		const resolution = await resolveFilesWithLlm(cwd, query);
-
-		if (resolution.confident && resolution.files.length > 0) {
-			resolvedFiles.push(...resolution.files);
-		} else if (!resolution.confident && resolution.candidates.length > 0 && ctx?.ui) {
-			const choice = await presentChoice(
-				ctx.ui,
-				`Which file did you mean by "${query}"?`,
-				resolution.candidates,
-			);
-			if (choice) {
-				resolvedFiles.push(choice);
-			} else {
-				return { message: "Cancelled — no file selected.", launched: false };
-			}
-		} else if (!resolution.confident && ctx?.ui) {
-			ctx.ui.notify(
-				`Could not resolve "${query}" to any file. Launching vim with no file.`,
-				"warn",
-			);
-		}
-	}
-
-	const finalFiles = resolveFilePaths(cwd, resolvedFiles);
-
+	const finalFiles = resolveFilePaths(cwd, rawArgs);
 	// Try Herdr — getCurrentPane returns null if herdr is unavailable
 	const current = getCurrentPane();
 	if (current) {
 		const detection = findEditorPane(current.tab_id);
-
 		if (detection.status === "found") {
 			const editor = detection.editor;
 			if (finalFiles.length > 0) {
-				// Send files to the existing editor via herdr pane send-text.
-				// This always targets the correct pane — no socket correlation needed.
 				sendFilesViaText(editor.paneId, finalFiles);
 				focusEditorPane(editor.paneId, current.pane_id);
 				return {
@@ -615,7 +270,6 @@ async function openEditor(
 				launched: false,
 			};
 		}
-
 		// Only launch a new editor if we definitively confirmed no editor exists.
 		// On error, fall through to tmux fallback rather than risking a duplicate.
 		if (detection.status === "absent") {
@@ -628,30 +282,19 @@ async function openEditor(
 				};
 			}
 		}
-
-		if (detection.status === "error") {
-			ctx?.ui?.notify(
-				"Could not scan panes for existing editor — falling back to tmux.",
-				"warn",
-			);
-		}
 	}
-
 	// Herdr unavailable or failed — try tmux.
 	if (tmuxFallback(cwd, finalFiles)) {
 		return { message: `Launched vim in a tmux split at ${cwd}.`, launched: true };
 	}
-
 	return {
 		message: `Could not launch vim automatically. Run manually: cd ${cwd} && vim ${finalFiles.join(" ")}`,
 		launched: false,
 	};
 }
-
 // ---------------------------------------------------------------------------
 // extension registration
 // ---------------------------------------------------------------------------
-
 const nvimOpenTool = defineTool({
 	name: "nvim_open",
 	label: "Open Editor",
@@ -674,28 +317,25 @@ const nvimOpenTool = defineTool({
 			}),
 		),
 	}),
-	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+	async execute(_toolCallId, params) {
 		const cwd = params.cwd ?? process.cwd();
 		const files = params.files ?? [];
-		const result = await openEditor(cwd, files, ctx as { ui?: UIContext });
+		const result = await openEditor(cwd, files);
 		return { content: [{ type: "text", text: result.message }] };
 	},
 });
-
 export default function (pi: ExtensionAPI) {
 	pi.registerTool(nvimOpenTool);
-
 	pi.registerCommand("nvim", {
 		description: "Open vim in the current Herdr tab as a vertical split",
-		handler: async (args: unknown, ctx: { cwd?: string; ui: UIContext }) => {
+		handler: async (args: unknown, ctx: { cwd?: string; ui: { notify: (msg: string, level: string) => void } }) => {
 			const cwd = ctx?.cwd ?? process.cwd();
-			// Parse args with quote-aware splitting for paths with spaces
 			const fileList: string[] = (() => {
 				if (Array.isArray(args)) return args.map(String);
 				if (typeof args === "string") return args.trim() ? parseArgs(args.trim()) : [];
 				return [];
 			})();
-			const result = await openEditor(cwd, fileList, ctx);
+			const result = await openEditor(cwd, fileList);
 			ctx?.ui?.notify(result.message, "info");
 		},
 	});

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -184,7 +184,7 @@ function launchNvim(cwd: string, files: string[]): string | null {
 	const newPaneId = splitRes?.result?.pane?.pane_id;
 	if (!newPaneId) return null;
 
-	const cmd = files.length > 0 ? ["vim", ...files] : ["vim", "."];
+	const cmd = files.length > 0 ? ["vim", ...files] : ["vim"];
 	herdrOk(["pane", "run", newPaneId, ...cmd]);
 	return newPaneId;
 }
@@ -275,7 +275,7 @@ function openNvim(cwd: string, files: string[]): { message: string; launched: bo
 	}
 
 	return {
-		message: `Could not launch nvim automatically. Run manually: cd ${cwd} && nvim ${resolvedFiles.join(" ") || "."}`,
+		message: `Could not launch nvim automatically. Run manually: cd ${cwd} && vim ${resolvedFiles.join(" ")}`,
 		launched: false,
 	};
 }

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -1,14 +1,44 @@
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
-import { userInfo } from "node:os";
+import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { join, resolve, isAbsolute, relative } from "node:path";
 
 const HERDR_TIMEOUT_MS = 5000;
 const NVIM_TIMEOUT_MS = 4000;
-const LLM_TIMEOUT_MS = 30000;
+const LLM_TIMEOUT_MS = 20000;
 const MAX_FILE_LIST = 200;
+
+// ---------------------------------------------------------------------------
+// binary discovery
+// ---------------------------------------------------------------------------
+
+/** Find the nvim binary, checking PATH and common bob install locations. */
+function findNvimBinary(): string | null {
+	// 1. On PATH directly
+	try {
+		const path = execFileSync("which", ["nvim"], { encoding: "utf-8", timeout: 2000, stdio: ["pipe", "pipe", "pipe"] }).trim();
+		if (path) return path;
+	} catch {}
+
+	// 2. bob-managed nightly (most common on this homelab)
+	const bobCandidates = [
+		`${process.env.HOME}/.local/share/bob/nightly/bin/nvim`,
+		`${process.env.HOME}/.local/share/bob/stable/bin/nvim`,
+	];
+	for (const c of bobCandidates) {
+		if (existsSync(c)) return c;
+	}
+
+	// 3. Fallback to "nvim" and hope the shell resolves it
+	return "nvim";
+}
+
+let _nvimBin: string | null | undefined;
+function nvimBin(): string {
+	if (_nvimBin === undefined) _nvimBin = findNvimBinary();
+	return _nvimBin ?? "nvim";
+}
 
 // ---------------------------------------------------------------------------
 // Herdr helpers
@@ -61,18 +91,6 @@ function herdrOk(args: string[]): boolean {
 	}
 }
 
-function herdrAvailable(): boolean {
-	try {
-		execFileSync("herdr", ["workspace", "list"], {
-			timeout: 3000,
-			stdio: ["pipe", "pipe", "pipe"],
-		});
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 function getCurrentPane(): PaneInfo | null {
 	const res = herdrJson(["pane", "current"]) as
 		| { result?: { pane?: PaneInfo } }
@@ -95,16 +113,16 @@ function getProcessInfo(paneId: string): ProcessInfo | null {
 }
 
 // ---------------------------------------------------------------------------
-// nvim detection & communication
+// editor detection & communication
 // ---------------------------------------------------------------------------
 
-interface NvimPane {
+interface EditorPane {
 	paneId: string;
 	pid: number;
 }
 
 /** Search all panes in the current tab for one whose foreground process is vim/nvim. */
-function findEditorPane(currentTabId: string): NvimPane | null {
+function findEditorPane(currentTabId: string): EditorPane | null {
 	const panes = listPanes().filter((p) => p.tab_id === currentTabId);
 	for (const pane of panes) {
 		const info = getProcessInfo(pane.pane_id);
@@ -121,28 +139,58 @@ function findEditorPane(currentTabId: string): NvimPane | null {
 	return null;
 }
 
-/** Discover the nvim RPC socket for a given PID by globbing the nvim temp dir. */
-function findNvimSocket(pid: number): string | null {
-	const user = userInfo().username;
+/**
+ * Discover a live nvim RPC socket. Nvim puts sockets in $XDG_RUNTIME_DIR
+ * (typically /run/user/<uid> on Linux) or $TMPDIR/nvim.<user>/ on macOS.
+ * The socket filename uses nvim's own PID, which may differ slightly from the
+ * process PID reported by the OS, so we glob all sockets and test for liveness.
+ */
+function findNvimSocket(): string | null {
+	const bin = nvimBin();
+	const searchDirs: string[] = [];
+
+	// Linux: $XDG_RUNTIME_DIR
+	if (process.env.XDG_RUNTIME_DIR) {
+		searchDirs.push(process.env.XDG_RUNTIME_DIR);
+	}
+	// macOS / fallback: $TMPDIR/nvim.<user>/
+	const user = process.env.USER ?? "unknown";
 	const tmp = process.env.TMPDIR ?? "/tmp";
-	const nvimDir = join(tmp, `nvim.${user}`);
-	if (!existsSync(nvimDir)) return null;
-	try {
-		for (const sub of readdirSync(nvimDir)) {
-			const sock = join(nvimDir, sub, `nvim.${pid}.0`);
-			if (existsSync(sock)) return sock;
+	searchDirs.push(join(tmp, `nvim.${user}`));
+
+	for (const dir of searchDirs) {
+		if (!existsSync(dir)) continue;
+		try {
+			const entries = readdirSync(dir);
+			// Collect nvim socket files (nvim.<pid>.0)
+			const sockets = entries
+				.filter((e) => /^nvim\.\d+\.0$/.test(e))
+				.map((e) => join(dir, e));
+			// Test each for liveness — return the first live one
+			for (const sock of sockets) {
+				try {
+					execFileSync(bin, ["--server", sock, "--remote-expr", "1"], {
+						timeout: 1000,
+						stdio: "ignore",
+					});
+					return sock;
+				} catch {
+					// stale socket, skip
+				}
+			}
+		} catch {
+			// ignore
 		}
-	} catch {
-		// ignore
 	}
 	return null;
 }
 
 /** Open files in an existing nvim instance via its RPC socket. Returns true on success. */
 function sendFilesViaRpc(socket: string, files: string[]): boolean {
+	const bin = nvimBin();
 	try {
 		for (const file of files) {
-			execFileSync("nvim", ["--server", socket, "--remote", file], {
+			execFileSync(bin, ["--server", socket, "--remote", file], {
 				timeout: NVIM_TIMEOUT_MS,
 				stdio: "ignore",
 			});
@@ -156,8 +204,10 @@ function sendFilesViaRpc(socket: string, files: string[]): boolean {
 /** Fallback: send `:e <file>` keystrokes to the editor pane via herdr send-text. */
 function sendFilesViaText(paneId: string, files: string[]): void {
 	for (const file of files) {
+		// Escape spaces in the path for the ex command
+		const escaped = file.replace(/ /g, "\\ ");
 		// Escape to exit insert mode, then :e with the path, then Enter.
-		const text = `\x1b:e ${file}\r`;
+		const text = `\x1b:e ${escaped}\r`;
 		try {
 			execFileSync("herdr", ["pane", "send-text", paneId, text], {
 				timeout: HERDR_TIMEOUT_MS,
@@ -194,9 +244,9 @@ function launchEditor(cwd: string, files: string[]): string | null {
 	return newPaneId;
 }
 
-/** Best-effort focus of the pane to the right of the current one. */
-function focusPaneRight(): void {
-	herdrOk(["pane", "focus", "--current", "--direction", "right"]);
+/** Focus a specific pane by ID. */
+function focusPane(paneId: string): void {
+	herdrOk(["pane", "focus", "--pane", paneId]);
 }
 
 // ---------------------------------------------------------------------------
@@ -243,10 +293,12 @@ function listFilesForLlm(cwd: string): string[] {
 			try {
 				const st = statSync(full);
 				if (st.isDirectory()) {
+					// Skip hidden directories and known large dirs
 					if (!skipDirs.has(entry) && !entry.startsWith(".")) {
 						walk(full, depth + 1);
 					}
 				} else {
+					// Include regular files (including dotfiles)
 					results.push(relative(cwd, full));
 				}
 			} catch {
@@ -300,9 +352,23 @@ function extractAssistantText(jsonOutput: string): string {
 	return lastText;
 }
 
+function resolvePiBinary(): { command: string; baseArgs: string[] } {
+	const entry = process.argv[1];
+	if (entry) {
+		try {
+			const realEntry = realpathSync(entry);
+			if (/\.(?:mjs|cjs|js)$/i.test(realEntry)) {
+				return { command: process.execPath, baseArgs: [realEntry] };
+			}
+		} catch {}
+	}
+	return { command: "pi", baseArgs: [] };
+}
+
 /** Resolve a natural-language file query using a small LLM call via pi print mode. */
 function resolveFilesWithLlm(cwd: string, query: string): Promise<LlmResolution> {
 	const fileList = listFilesForLlm(cwd);
+	const fileSet = new Set(fileList);
 
 	const systemPrompt = `You resolve natural-language file references to actual file paths.
 Given a list of files in the working directory and a user's request, determine which file(s) to open.
@@ -341,12 +407,20 @@ Which file(s) should be opened?`;
 			userPrompt,
 		];
 
+		// Strip Herdr env vars so the child pi process doesn't try to report to Herdr
+		const childEnv: Record<string, string> = {};
+		for (const [key, val] of Object.entries(process.env)) {
+			if (val !== undefined && !key.startsWith("HERDR_")) {
+				childEnv[key] = val;
+			}
+		}
+
 		let stdout = "";
 		let stderr = "";
 		const child = spawn(piBin.command, args, {
 			stdio: ["pipe", "pipe", "pipe"],
 			timeout: LLM_TIMEOUT_MS,
-			env: process.env,
+			env: childEnv,
 		});
 
 		// Close stdin so pi print mode does not wait for input.
@@ -365,7 +439,9 @@ Which file(s) should be opened?`;
 					.slice("CONFIDENT:".length)
 					.trim()
 					.split(/\s+/)
-					.filter(Boolean);
+					.filter(Boolean)
+					// Validate that resolved paths actually exist in the file list
+					.filter((p) => fileSet.has(p));
 				resolve({ files: paths, confident: true, candidates: [] });
 			} else if (text.startsWith("UNCERTAIN:")) {
 				const rest = text.slice("UNCERTAIN:".length).trim();
@@ -375,7 +451,9 @@ Which file(s) should be opened?`;
 					const candidates = rest
 						.split("|")
 						.map((s) => s.trim())
-						.filter(Boolean);
+						.filter(Boolean)
+						// Validate candidates too
+						.filter((c) => fileSet.has(c));
 					resolve({ files: [], confident: false, candidates });
 				}
 			} else {
@@ -385,26 +463,18 @@ Which file(s) should be opened?`;
 	});
 }
 
-function resolvePiBinary(): { command: string; baseArgs: string[] } {
-	const entry = process.argv[1];
-	if (entry) {
-		try {
-			const realEntry = require("node:fs").realpathSync(entry);
-			if (/\.(?:mjs|cjs|js)$/i.test(realEntry)) {
-				return { command: process.execPath, baseArgs: [realEntry] };
-			}
-		} catch {}
-	}
-	return { command: "pi", baseArgs: [] };
-}
-
 // ---------------------------------------------------------------------------
 // multiple-choice selection via terminal
 // ---------------------------------------------------------------------------
 
+interface UIContext {
+	notify: (msg: string, level: string) => void;
+	onTerminalInput: (cb: (data: string) => { consume?: boolean } | undefined) => () => void;
+}
+
 /** Present a numbered multiple-choice menu and wait for the user's selection. */
 function presentChoice(
-	ctx: { ui: { notify: (msg: string, level: string) => void; onTerminalInput: (cb: (data: string) => { consume?: boolean } | undefined) => () => void } },
+	ctx: UIContext,
 	prompt: string,
 	candidates: string[],
 ): Promise<string | null> {
@@ -461,7 +531,7 @@ function isDirectFilePath(cwd: string, arg: string): boolean {
 async function openEditor(
 	cwd: string,
 	rawArgs: string[],
-	ctx?: { ui: { notify: (msg: string, level: string) => void; onTerminalInput: (cb: (data: string) => { consume?: boolean } | undefined) => () => void } },
+	ctx?: { ui?: UIContext },
 ): Promise<{ message: string; launched: boolean }> {
 	// Classify args: direct file paths vs natural-language queries
 	const directFiles: string[] = [];
@@ -485,9 +555,9 @@ async function openEditor(
 
 		if (resolution.confident && resolution.files.length > 0) {
 			resolvedFiles.push(...resolution.files);
-		} else if (!resolution.confident && resolution.candidates.length > 0 && ctx) {
+		} else if (!resolution.confident && resolution.candidates.length > 0 && ctx?.ui) {
 			const choice = await presentChoice(
-				ctx,
+				ctx.ui,
 				`Which file did you mean by "${query}"?`,
 				resolution.candidates,
 			);
@@ -499,7 +569,7 @@ async function openEditor(
 					launched: false,
 				};
 			}
-		} else if (!resolution.confident && ctx) {
+		} else if (!resolution.confident && ctx?.ui) {
 			ctx.ui.notify(
 				`Could not resolve "${query}" to any file. Launching vim with no file.`,
 				"warn",
@@ -509,46 +579,46 @@ async function openEditor(
 
 	const finalFiles = resolveFilePaths(cwd, resolvedFiles);
 
-	if (herdrAvailable()) {
-		const current = getCurrentPane();
-		if (current) {
-			const existing = findEditorPane(current.tab_id);
-			if (existing) {
-				if (finalFiles.length > 0) {
-					const sock = findNvimSocket(existing.pid);
-					if (sock && sendFilesViaRpc(sock, finalFiles)) {
-						focusPaneRight();
-						return {
-							message: `Opened ${finalFiles.length} file(s) in existing editor (pane ${existing.paneId}) via RPC.`,
-							launched: false,
-						};
-					}
-					sendFilesViaText(existing.paneId, finalFiles);
-					focusPaneRight();
+	// Try Herdr — getCurrentPane returns null if herdr is unavailable
+	const current = getCurrentPane();
+	if (current) {
+		const existing = findEditorPane(current.tab_id);
+		if (existing) {
+			if (finalFiles.length > 0) {
+				// Try RPC first, fall back to send-text
+				const sock = findNvimSocket();
+				if (sock && sendFilesViaRpc(sock, finalFiles)) {
+					focusPane(existing.paneId);
 					return {
-						message: `Sent ${finalFiles.length} file(s) to existing editor (pane ${existing.paneId}) via send-text.`,
+						message: `Opened ${finalFiles.length} file(s) in existing editor (pane ${existing.paneId}) via RPC.`,
 						launched: false,
 					};
 				}
-				focusPaneRight();
+				sendFilesViaText(existing.paneId, finalFiles);
+				focusPane(existing.paneId);
 				return {
-					message: `Focused existing editor pane (${existing.paneId}).`,
+					message: `Sent ${finalFiles.length} file(s) to existing editor (pane ${existing.paneId}) via send-text.`,
 					launched: false,
 				};
 			}
+			focusPane(existing.paneId);
+			return {
+				message: `Focused existing editor pane (${existing.paneId}).`,
+				launched: false,
+			};
+		}
 
-			// No existing editor in this tab — launch a new vertical split.
-			const newPane = launchEditor(cwd, finalFiles);
-			if (newPane) {
-				const fileNote =
-					finalFiles.length > 0
-						? ` with ${finalFiles.length} file(s)`
-						: "";
-				return {
-					message: `Launched vim in a vertical split (pane ${newPane}) at ${cwd}${fileNote}.`,
-					launched: true,
-				};
-			}
+		// No existing editor in this tab — launch a new vertical split.
+		const newPane = launchEditor(cwd, finalFiles);
+		if (newPane) {
+			const fileNote =
+				finalFiles.length > 0
+					? ` with ${finalFiles.length} file(s)`
+					: "";
+			return {
+				message: `Launched vim in a vertical split (pane ${newPane}) at ${cwd}${fileNote}.`,
+				launched: true,
+			};
 		}
 	}
 
@@ -592,28 +662,20 @@ const nvimOpenTool = defineTool({
 			}),
 		),
 	}),
-	async execute(_toolCallId, params) {
+	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 		const cwd = params.cwd ?? process.cwd();
 		const files = params.files ?? [];
-		const result = await openEditor(cwd, files);
+		const result = await openEditor(cwd, files, ctx as { ui?: UIContext });
 		return { content: [{ type: "text", text: result.message }] };
 	},
 });
-
-interface CommandCtx {
-	cwd?: string;
-	ui: {
-		notify: (msg: string, level: string) => void;
-		onTerminalInput: (cb: (data: string) => { consume?: boolean } | undefined) => () => void;
-	};
-}
 
 export default function (pi: ExtensionAPI) {
 	pi.registerTool(nvimOpenTool);
 
 	pi.registerCommand("nvim", {
 		description: "Open vim in the current Herdr tab as a vertical split",
-		handler: async (args: unknown, ctx: CommandCtx) => {
+		handler: async (args: unknown, ctx: { cwd?: string; ui: UIContext }) => {
 			const cwd = ctx?.cwd ?? process.cwd();
 			const fileList: string[] = (() => {
 				if (Array.isArray(args)) return args.map(String);

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -185,7 +185,7 @@ function launchNvim(cwd: string, files: string[]): string | null {
 	if (!newPaneId) return null;
 
 	const cmd = files.length > 0 ? ["nvim", ...files] : ["nvim", "."];
-	herdrOk(["pane", "run", newPaneId, "--", ...cmd]);
+	herdrOk(["pane", "run", newPaneId, ...cmd]);
 	return newPaneId;
 }
 
@@ -203,7 +203,7 @@ function tmuxFallback(cwd: string, files: string[]): boolean {
 		const fileArgs = files.length > 0 ? files : ["."];
 		execFileSync(
 			"tmux",
-			["split-window", "-v", "-c", cwd, "--", "nvim", ...fileArgs],
+			["split-window", "-v", "-c", cwd, "nvim", ...fileArgs],
 			{ timeout: HERDR_TIMEOUT_MS, stdio: "ignore" },
 		);
 		return true;

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -168,14 +168,14 @@ function sendFilesViaText(paneId: string, files: string[]): void {
 // launch & focus
 // ---------------------------------------------------------------------------
 
-/** Split the current pane downward and launch nvim in the new pane. */
+/** Split the current pane to the right and launch nvim in the new pane. */
 function launchNvim(cwd: string, files: string[]): string | null {
 	const splitRes = herdrJson([
 		"pane",
 		"split",
 		"--current",
 		"--direction",
-		"down",
+		"right",
 		"--cwd",
 		cwd,
 		"--focus",
@@ -191,7 +191,7 @@ function launchNvim(cwd: string, files: string[]): string | null {
 
 /** Best-effort focus of the pane below the current one. */
 function focusPaneDown(): void {
-	herdrOk(["pane", "focus", "--current", "--direction", "down"]);
+	herdrOk(["pane", "focus", "--current", "--direction", "right"]);
 }
 
 // ---------------------------------------------------------------------------
@@ -251,7 +251,7 @@ function openNvim(cwd: string, files: string[]): { message: string; launched: bo
 				};
 			}
 
-			// No existing nvim in this tab — launch a new horizontal split.
+			// No existing nvim in this tab — launch a new vertical split.
 			const newPane = launchNvim(cwd, resolvedFiles);
 			if (newPane) {
 				const fileNote =
@@ -259,7 +259,7 @@ function openNvim(cwd: string, files: string[]): { message: string; launched: bo
 						? ` with ${resolvedFiles.length} file(s)`
 						: "";
 				return {
-					message: `Launched nvim in a horizontal split (pane ${newPane}) at ${cwd}${fileNote}.`,
+					message: `Launched nvim in a vertical split (pane ${newPane}) at ${cwd}${fileNote}.`,
 					launched: true,
 				};
 			}
@@ -288,13 +288,13 @@ const nvimOpenTool = defineTool({
 	name: "nvim_open",
 	label: "Open Neovim",
 	description:
-		"Open Neovim as a horizontal split in the current Herdr tab, or send files to an existing Neovim instance in the current tab. If nvim is already running in the current tab, files are sent to the existing instance instead of launching a new one. With no files, opens nvim at the agent's cwd.",
-	promptSnippet: "Open Neovim in the current Herdr tab as a horizontal split",
+		"Open Neovim as a vertical split in the current Herdr tab, or send files to an existing Neovim instance in the current tab. If nvim is already running in the current tab, files are sent to the existing instance instead of launching a new one. With no files, opens nvim at the agent's cwd.",
+	promptSnippet: "Open Neovim in the current Herdr tab as a vertical split",
 	promptGuidelines: [
 		"Use nvim_open when the user wants to open Neovim (nvim) for editing, either at the current working directory or for specific files.",
 		"If nvim is already running in the current Herdr tab, this tool sends files to the existing instance rather than launching a duplicate.",
 		"With no files provided, it opens nvim at the agent's cwd. With file paths, it opens those specific files.",
-		"The split is horizontal (below the agent pane) and focus moves to the nvim pane so the captain can see the editor.",
+		"The split is vertical (to the right of the agent pane) and focus moves to the nvim pane so the captain can see the editor.",
 	],
 	parameters: Type.Object({
 		cwd: Type.String({
@@ -318,7 +318,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool(nvimOpenTool);
 
 	pi.registerCommand("nvim", {
-		description: "Open Neovim in the current Herdr tab as a horizontal split",
+		description: "Open Neovim in the current Herdr tab as a vertical split",
 		handler: async (args: unknown, ctx: { cwd?: string; ui: { notify: (msg: string, level: string) => void } }) => {
 			const cwd = ctx?.cwd ?? process.cwd();
 			const fileList: string[] = (() => {

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -1,12 +1,14 @@
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { userInfo } from "node:os";
-import { join, resolve, isAbsolute } from "node:path";
+import { join, resolve, isAbsolute, relative } from "node:path";
 
 const HERDR_TIMEOUT_MS = 5000;
 const NVIM_TIMEOUT_MS = 4000;
+const LLM_TIMEOUT_MS = 30000;
+const MAX_FILE_LIST = 200;
 
 // ---------------------------------------------------------------------------
 // Herdr helpers
@@ -101,14 +103,17 @@ interface NvimPane {
 	pid: number;
 }
 
-/** Search all panes in the current tab for one whose foreground process is nvim. */
-function findNvimPane(currentTabId: string): NvimPane | null {
+/** Search all panes in the current tab for one whose foreground process is vim/nvim. */
+function findEditorPane(currentTabId: string): NvimPane | null {
 	const panes = listPanes().filter((p) => p.tab_id === currentTabId);
 	for (const pane of panes) {
 		const info = getProcessInfo(pane.pane_id);
 		if (!info) continue;
 		for (const proc of info.foreground_processes ?? []) {
-			if (proc.name === "vim" || proc.argv?.[0] === "vim" || proc.name === "nvim" || proc.argv?.[0] === "nvim") {
+			if (
+				proc.name === "vim" || proc.argv?.[0] === "vim" ||
+				proc.name === "nvim" || proc.argv?.[0] === "nvim"
+			) {
 				return { paneId: pane.pane_id, pid: proc.pid };
 			}
 		}
@@ -148,7 +153,7 @@ function sendFilesViaRpc(socket: string, files: string[]): boolean {
 	}
 }
 
-/** Fallback: send `:e <file>` keystrokes to the nvim pane via herdr send-text. */
+/** Fallback: send `:e <file>` keystrokes to the editor pane via herdr send-text. */
 function sendFilesViaText(paneId: string, files: string[]): void {
 	for (const file of files) {
 		// Escape to exit insert mode, then :e with the path, then Enter.
@@ -168,8 +173,8 @@ function sendFilesViaText(paneId: string, files: string[]): void {
 // launch & focus
 // ---------------------------------------------------------------------------
 
-/** Split the current pane to the right and launch nvim in the new pane. */
-function launchNvim(cwd: string, files: string[]): string | null {
+/** Split the current pane to the right and launch vim in the new pane. */
+function launchEditor(cwd: string, files: string[]): string | null {
 	const splitRes = herdrJson([
 		"pane",
 		"split",
@@ -189,8 +194,8 @@ function launchNvim(cwd: string, files: string[]): string | null {
 	return newPaneId;
 }
 
-/** Best-effort focus of the pane below the current one. */
-function focusPaneDown(): void {
+/** Best-effort focus of the pane to the right of the current one. */
+function focusPaneRight(): void {
 	herdrOk(["pane", "focus", "--current", "--direction", "right"]);
 }
 
@@ -200,10 +205,10 @@ function focusPaneDown(): void {
 
 function tmuxFallback(cwd: string, files: string[]): boolean {
 	try {
-		const fileArgs = files.length > 0 ? files : ["."];
+		const fileArgs = files.length > 0 ? files : [];
 		execFileSync(
 			"tmux",
-			["split-window", "-v", "-c", cwd, "vim", ...fileArgs],
+			["split-window", "-h", "-c", cwd, "vim", ...fileArgs],
 			{ timeout: HERDR_TIMEOUT_MS, stdio: "ignore" },
 		);
 		return true;
@@ -213,53 +218,328 @@ function tmuxFallback(cwd: string, files: string[]): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// file listing for LLM resolution
+// ---------------------------------------------------------------------------
+
+/** Recursively list files under cwd (limited depth/count), returning relative paths. */
+function listFilesForLlm(cwd: string): string[] {
+	const results: string[] = [];
+	const skipDirs = new Set([
+		".git", "node_modules", ".venv", "__pycache__", ".pi", ".agents",
+		"target", "dist", "build", ".cache", ".treehouse",
+	]);
+
+	function walk(dir: string, depth: number) {
+		if (depth > 3 || results.length >= MAX_FILE_LIST) return;
+		let entries: string[];
+		try {
+			entries = readdirSync(dir);
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (results.length >= MAX_FILE_LIST) return;
+			const full = join(dir, entry);
+			try {
+				const st = statSync(full);
+				if (st.isDirectory()) {
+					if (!skipDirs.has(entry) && !entry.startsWith(".")) {
+						walk(full, depth + 1);
+					}
+				} else {
+					results.push(relative(cwd, full));
+				}
+			} catch {
+				// skip
+			}
+		}
+	}
+
+	walk(cwd, 0);
+	return results.sort();
+}
+
+// ---------------------------------------------------------------------------
+// LLM-based file resolution
+// ---------------------------------------------------------------------------
+
+interface LlmResolution {
+	/** Resolved file paths (relative to cwd), or empty if uncertain. */
+	files: string[];
+	/** Whether the LLM was confident. */
+	confident: boolean;
+	/** Candidate options for multiple-choice (when not confident). */
+	candidates: string[];
+}
+
+/** Extract the assistant text from pi --mode json -p output (NDJSON lines). */
+function extractAssistantText(jsonOutput: string): string {
+	for (const line of jsonOutput.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const obj = JSON.parse(trimmed);
+			if (obj.type === "turn_end" && obj.message?.role === "assistant") {
+				const content = obj.message.content;
+				if (Array.isArray(content)) {
+					return content
+						.filter((c: any) => c.type === "text")
+						.map((c: any) => c.text)
+						.join("");
+				}
+				if (typeof content === "string") return content;
+			}
+		} catch {
+			// not JSON, skip
+		}
+	}
+	return "";
+}
+
+/** Resolve a natural-language file query using a small LLM call via pi print mode. */
+function resolveFilesWithLlm(cwd: string, query: string): Promise<LlmResolution> {
+	const fileList = listFilesForLlm(cwd);
+
+	const systemPrompt = `You resolve natural-language file references to actual file paths.
+Given a list of files in the working directory and a user's request, determine which file(s) to open.
+
+Respond in ONE of these formats:
+1. If you are confident, reply with EXACTLY: CONFIDENT: <file1> [file2 ...]
+2. If you are uncertain, reply with EXACTLY: UNCERTAIN: <option1> | <option2> | <option3>
+   List 2-5 candidate files separated by " | ".
+
+Rules:
+- File paths must be relative paths from the working directory, matching the file list exactly.
+- If the user's request doesn't match any file, reply with: UNCERTAIN: (no matches)
+- Reply with only the format line, no explanation.`;
+
+	const userPrompt = `Working directory: ${cwd}
+
+Available files (relative paths):
+${fileList.length > 0 ? fileList.join("\n") : "(no files found)"}
+
+User request: "${query}"
+
+Which file(s) should be opened?`;
+
+	return new Promise<LlmResolution>((resolve) => {
+		const piBin = resolvePiBinary();
+		const args = [
+			...piBin.baseArgs,
+			"--mode", "json",
+			"-p",
+			"--no-skills",
+			"--no-extensions",
+			"--no-context-files",
+			"--no-prompt-templates",
+			"--no-themes",
+			"--tools", "read",
+			"--system-prompt", systemPrompt,
+			userPrompt,
+		];
+
+		let stdout = "";
+		let stderr = "";
+		const child = spawn(piBin.command, args, {
+			stdio: ["pipe", "pipe", "pipe"],
+			timeout: LLM_TIMEOUT_MS,
+			env: process.env,
+		});
+
+		child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()));
+		child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+		child.on("error", () =>
+			resolve({ files: [], confident: false, candidates: [] }),
+		);
+		child.on("close", () => {
+			const text = extractAssistantText(stdout).trim();
+
+			if (text.startsWith("CONFIDENT:")) {
+				const paths = text
+					.slice("CONFIDENT:".length)
+					.trim()
+					.split(/\s+/)
+					.filter(Boolean);
+				resolve({ files: paths, confident: true, candidates: [] });
+			} else if (text.startsWith("UNCERTAIN:")) {
+				const rest = text.slice("UNCERTAIN:".length).trim();
+				if (rest === "(no matches)") {
+					resolve({ files: [], confident: false, candidates: [] });
+				} else {
+					const candidates = rest
+						.split("|")
+						.map((s) => s.trim())
+						.filter(Boolean);
+					resolve({ files: [], confident: false, candidates });
+				}
+			} else {
+				resolve({ files: [], confident: false, candidates: [] });
+			}
+		});
+	});
+}
+
+function resolvePiBinary(): { command: string; baseArgs: string[] } {
+	const entry = process.argv[1];
+	if (entry) {
+		try {
+			const realEntry = require("node:fs").realpathSync(entry);
+			if (/\.(?:mjs|cjs|js)$/i.test(realEntry)) {
+				return { command: process.execPath, baseArgs: [realEntry] };
+			}
+		} catch {}
+	}
+	return { command: "pi", baseArgs: [] };
+}
+
+// ---------------------------------------------------------------------------
+// multiple-choice selection via terminal
+// ---------------------------------------------------------------------------
+
+/** Present a numbered multiple-choice menu and wait for the user's selection. */
+function presentChoice(
+	ctx: { ui: { notify: (msg: string, level: string) => void; onTerminalInput: (cb: (data: string) => { consume?: boolean } | undefined) => () => void } },
+	prompt: string,
+	candidates: string[],
+): Promise<string | null> {
+	return new Promise((resolve) => {
+		const lines = [
+			prompt,
+			"",
+			...candidates.map((c, i) => `  ${i + 1}. ${c}`),
+			"",
+			"Enter a number (or press Enter to cancel):",
+		];
+		ctx.ui.notify(lines.join("\n"), "info");
+
+		const stop = ctx.ui.onTerminalInput((data: string) => {
+			const trimmed = data.trim();
+			if (!trimmed) {
+				stop?.();
+				resolve(null);
+				return;
+			}
+			const num = parseInt(trimmed, 10);
+			if (Number.isFinite(num) && num >= 1 && num <= candidates.length) {
+				stop?.();
+				resolve(candidates[num - 1]);
+				return { consume: true };
+			}
+			ctx.ui.notify(`Invalid choice "${trimmed}". Enter 1-${candidates.length} or press Enter to cancel.`, "warn");
+			return { consume: true };
+		});
+
+		// Timeout after 30s
+		const timer = setTimeout(() => {
+			stop?.();
+			resolve(null);
+		}, 30000);
+		timer.unref?.();
+	});
+}
+
+// ---------------------------------------------------------------------------
 // core orchestration
 // ---------------------------------------------------------------------------
 
-function resolveFiles(cwd: string, files: string[]): string[] {
+function resolveFilePaths(cwd: string, files: string[]): string[] {
 	return files.map((f) => (isAbsolute(f) ? f : resolve(cwd, f)));
 }
 
-function openNvim(cwd: string, files: string[]): { message: string; launched: boolean } {
-	const resolvedFiles = resolveFiles(cwd, files);
+/** Check if a string is a direct file path that exists on disk. */
+function isDirectFilePath(cwd: string, arg: string): boolean {
+	const full = isAbsolute(arg) ? arg : resolve(cwd, arg);
+	return existsSync(full);
+}
+
+async function openEditor(
+	cwd: string,
+	rawArgs: string[],
+	ctx?: { ui: { notify: (msg: string, level: string) => void; onTerminalInput: (cb: (data: string) => { consume?: boolean } | undefined) => () => void } },
+): Promise<{ message: string; launched: boolean }> {
+	// Classify args: direct file paths vs natural-language queries
+	const directFiles: string[] = [];
+	const naturalLanguage: string[] = [];
+
+	for (const arg of rawArgs) {
+		if (isDirectFilePath(cwd, arg)) {
+			directFiles.push(arg);
+		} else {
+			naturalLanguage.push(arg);
+		}
+	}
+
+	// Resolve natural-language args via LLM
+	let resolvedFiles = [...directFiles];
+
+	if (naturalLanguage.length > 0) {
+		const query = naturalLanguage.join(" ");
+		ctx?.ui?.notify(`Resolving "${query}" ...`, "info");
+		const resolution = await resolveFilesWithLlm(cwd, query);
+
+		if (resolution.confident && resolution.files.length > 0) {
+			resolvedFiles.push(...resolution.files);
+		} else if (!resolution.confident && resolution.candidates.length > 0 && ctx) {
+			const choice = await presentChoice(
+				ctx,
+				`Which file did you mean by "${query}"?`,
+				resolution.candidates,
+			);
+			if (choice) {
+				resolvedFiles.push(choice);
+			} else {
+				return {
+					message: "Cancelled — no file selected.",
+					launched: false,
+				};
+			}
+		} else if (!resolution.confident && ctx) {
+			ctx.ui.notify(
+				`Could not resolve "${query}" to any file. Launching vim with no file.`,
+				"warn",
+			);
+		}
+	}
+
+	const finalFiles = resolveFilePaths(cwd, resolvedFiles);
 
 	if (herdrAvailable()) {
 		const current = getCurrentPane();
 		if (current) {
-			const existing = findNvimPane(current.tab_id);
+			const existing = findEditorPane(current.tab_id);
 			if (existing) {
-				if (resolvedFiles.length > 0) {
+				if (finalFiles.length > 0) {
 					const sock = findNvimSocket(existing.pid);
-					if (sock && sendFilesViaRpc(sock, resolvedFiles)) {
-						focusPaneDown();
+					if (sock && sendFilesViaRpc(sock, finalFiles)) {
+						focusPaneRight();
 						return {
-							message: `Opened ${resolvedFiles.length} file(s) in existing nvim (pane ${existing.paneId}) via RPC.`,
+							message: `Opened ${finalFiles.length} file(s) in existing editor (pane ${existing.paneId}) via RPC.`,
 							launched: false,
 						};
 					}
-					sendFilesViaText(existing.paneId, resolvedFiles);
-					focusPaneDown();
+					sendFilesViaText(existing.paneId, finalFiles);
+					focusPaneRight();
 					return {
-						message: `Sent ${resolvedFiles.length} file(s) to existing nvim (pane ${existing.paneId}) via send-text.`,
+						message: `Sent ${finalFiles.length} file(s) to existing editor (pane ${existing.paneId}) via send-text.`,
 						launched: false,
 					};
 				}
-				focusPaneDown();
+				focusPaneRight();
 				return {
-					message: `Focused existing nvim pane (${existing.paneId}).`,
+					message: `Focused existing editor pane (${existing.paneId}).`,
 					launched: false,
 				};
 			}
 
-			// No existing nvim in this tab — launch a new vertical split.
-			const newPane = launchNvim(cwd, resolvedFiles);
+			// No existing editor in this tab — launch a new vertical split.
+			const newPane = launchEditor(cwd, finalFiles);
 			if (newPane) {
 				const fileNote =
-					resolvedFiles.length > 0
-						? ` with ${resolvedFiles.length} file(s)`
+					finalFiles.length > 0
+						? ` with ${finalFiles.length} file(s)`
 						: "";
 				return {
-					message: `Launched nvim in a vertical split (pane ${newPane}) at ${cwd}${fileNote}.`,
+					message: `Launched vim in a vertical split (pane ${newPane}) at ${cwd}${fileNote}.`,
 					launched: true,
 				};
 			}
@@ -267,15 +547,15 @@ function openNvim(cwd: string, files: string[]): { message: string; launched: bo
 	}
 
 	// Herdr unavailable or failed — try tmux.
-	if (tmuxFallback(cwd, resolvedFiles)) {
+	if (tmuxFallback(cwd, finalFiles)) {
 		return {
-			message: `Launched nvim in a tmux split at ${cwd}.`,
+			message: `Launched vim in a tmux split at ${cwd}.`,
 			launched: true,
 		};
 	}
 
 	return {
-		message: `Could not launch nvim automatically. Run manually: cd ${cwd} && vim ${resolvedFiles.join(" ")}`,
+		message: `Could not launch vim automatically. Run manually: cd ${cwd} && vim ${finalFiles.join(" ")}`,
 		launched: false,
 	};
 }
@@ -286,47 +566,55 @@ function openNvim(cwd: string, files: string[]): { message: string; launched: bo
 
 const nvimOpenTool = defineTool({
 	name: "nvim_open",
-	label: "Open Neovim",
+	label: "Open Editor",
 	description:
-		"Open Neovim as a vertical split in the current Herdr tab, or send files to an existing Neovim instance in the current tab. If nvim is already running in the current tab, files are sent to the existing instance instead of launching a new one. With no files, opens nvim at the agent's cwd.",
-	promptSnippet: "Open Neovim in the current Herdr tab as a vertical split",
+		"Open vim as a vertical split in the current Herdr tab, or send files to an existing editor instance in the current tab. If an editor is already running in the current tab, files are sent to the existing instance instead of launching a new one. With no files, opens vim at the agent's cwd.",
+	promptSnippet: "Open vim in the current Herdr tab as a vertical split",
 	promptGuidelines: [
-		"Use nvim_open when the user wants to open Neovim (nvim) for editing, either at the current working directory or for specific files.",
-		"If nvim is already running in the current Herdr tab, this tool sends files to the existing instance rather than launching a duplicate.",
-		"With no files provided, it opens nvim at the agent's cwd. With file paths, it opens those specific files.",
-		"The split is vertical (to the right of the agent pane) and focus moves to the nvim pane so the captain can see the editor.",
+		"Use nvim_open when the user wants to open an editor (vim) for editing, either at the current working directory or for specific files.",
+		"If an editor is already running in the current Herdr tab, this tool sends files to the existing instance rather than launching a duplicate.",
+		"With no files provided, it opens vim at the agent's cwd. With file paths, it opens those specific files.",
+		"The split is vertical (to the right of the agent pane) and focus moves to the editor pane so the captain can see it.",
 	],
 	parameters: Type.Object({
 		cwd: Type.String({
-			description: "The working directory to open nvim in. Defaults to the agent's cwd.",
+			description: "The working directory to open vim in. Defaults to the agent's cwd.",
 		}),
 		files: Type.Optional(
 			Type.Array(Type.String(), {
-				description: "Optional list of file paths to open in nvim. Relative paths are resolved against cwd.",
+				description: "Optional list of file paths to open in vim. Relative paths are resolved against cwd.",
 			}),
 		),
 	}),
 	async execute(_toolCallId, params) {
 		const cwd = params.cwd ?? process.cwd();
 		const files = params.files ?? [];
-		const result = openNvim(cwd, files);
+		const result = await openEditor(cwd, files);
 		return { content: [{ type: "text", text: result.message }] };
 	},
 });
+
+interface CommandCtx {
+	cwd?: string;
+	ui: {
+		notify: (msg: string, level: string) => void;
+		onTerminalInput: (cb: (data: string) => { consume?: boolean } | undefined) => () => void;
+	};
+}
 
 export default function (pi: ExtensionAPI) {
 	pi.registerTool(nvimOpenTool);
 
 	pi.registerCommand("nvim", {
-		description: "Open Neovim in the current Herdr tab as a vertical split",
-		handler: async (args: unknown, ctx: { cwd?: string; ui: { notify: (msg: string, level: string) => void } }) => {
+		description: "Open vim in the current Herdr tab as a vertical split",
+		handler: async (args: unknown, ctx: CommandCtx) => {
 			const cwd = ctx?.cwd ?? process.cwd();
 			const fileList: string[] = (() => {
 				if (Array.isArray(args)) return args.map(String);
 				if (typeof args === "string") return args.trim() ? args.trim().split(/\s+/) : [];
 				return [];
 			})();
-			const result = openNvim(cwd, fileList);
+			const result = await openEditor(cwd, fileList, ctx);
 			ctx?.ui?.notify(result.message, "info");
 		},
 	});

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -274,6 +274,9 @@ interface LlmResolution {
 
 /** Extract the assistant text from pi --mode json -p output (NDJSON lines). */
 function extractAssistantText(jsonOutput: string): string {
+	// Track the LAST turn_end — tool calls produce multiple turns, and the
+	// final assistant message (after any tool results) is the one we want.
+	let lastText = "";
 	for (const line of jsonOutput.split("\n")) {
 		const trimmed = line.trim();
 		if (!trimmed) continue;
@@ -282,18 +285,19 @@ function extractAssistantText(jsonOutput: string): string {
 			if (obj.type === "turn_end" && obj.message?.role === "assistant") {
 				const content = obj.message.content;
 				if (Array.isArray(content)) {
-					return content
+					lastText = content
 						.filter((c: any) => c.type === "text")
 						.map((c: any) => c.text)
 						.join("");
+				} else if (typeof content === "string") {
+					lastText = content;
 				}
-				if (typeof content === "string") return content;
 			}
 		} catch {
 			// not JSON, skip
 		}
 	}
-	return "";
+	return lastText;
 }
 
 /** Resolve a natural-language file query using a small LLM call via pi print mode. */
@@ -333,7 +337,6 @@ Which file(s) should be opened?`;
 			"--no-context-files",
 			"--no-prompt-templates",
 			"--no-themes",
-			"--tools", "read",
 			"--system-prompt", systemPrompt,
 			userPrompt,
 		];
@@ -345,6 +348,9 @@ Which file(s) should be opened?`;
 			timeout: LLM_TIMEOUT_MS,
 			env: process.env,
 		});
+
+		// Close stdin so pi print mode does not wait for input.
+		child.stdin.end();
 
 		child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()));
 		child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -1,0 +1,333 @@
+import { Type } from "@earendil-works/pi-ai";
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { userInfo } from "node:os";
+import { join, resolve, isAbsolute } from "node:path";
+
+const HERDR_TIMEOUT_MS = 5000;
+const NVIM_TIMEOUT_MS = 4000;
+
+// ---------------------------------------------------------------------------
+// Herdr helpers
+// ---------------------------------------------------------------------------
+
+interface PaneInfo {
+	pane_id: string;
+	tab_id: string;
+	cwd: string;
+	foreground_cwd?: string;
+	workspace_id: string;
+}
+
+interface ProcessEntry {
+	name: string;
+	pid: number;
+	argv?: string[];
+	cmdline?: string;
+}
+
+interface ProcessInfo {
+	foreground_processes: ProcessEntry[];
+	pane_id: string;
+}
+
+/** Run a herdr subcommand and parse its JSON response. Returns null on failure. */
+function herdrJson(args: string[]): unknown | null {
+	try {
+		const out = execFileSync("herdr", args, {
+			encoding: "utf-8",
+			timeout: HERDR_TIMEOUT_MS,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return JSON.parse(out);
+	} catch {
+		return null;
+	}
+}
+
+/** Run a herdr subcommand, discarding output. Returns true on success. */
+function herdrOk(args: string[]): boolean {
+	try {
+		execFileSync("herdr", args, {
+			timeout: HERDR_TIMEOUT_MS,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function herdrAvailable(): boolean {
+	try {
+		execFileSync("herdr", ["workspace", "list"], {
+			timeout: 3000,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function getCurrentPane(): PaneInfo | null {
+	const res = herdrJson(["pane", "current"]) as
+		| { result?: { pane?: PaneInfo } }
+		| null;
+	return res?.result?.pane ?? null;
+}
+
+function listPanes(): PaneInfo[] {
+	const res = herdrJson(["pane", "list"]) as
+		| { result?: { panes?: PaneInfo[] } }
+		| null;
+	return res?.result?.panes ?? [];
+}
+
+function getProcessInfo(paneId: string): ProcessInfo | null {
+	const res = herdrJson(["pane", "process-info", "--pane", paneId]) as
+		| { result?: { process_info?: ProcessInfo } }
+		| null;
+	return res?.result?.process_info ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// nvim detection & communication
+// ---------------------------------------------------------------------------
+
+interface NvimPane {
+	paneId: string;
+	pid: number;
+}
+
+/** Search all panes in the current tab for one whose foreground process is nvim. */
+function findNvimPane(currentTabId: string): NvimPane | null {
+	const panes = listPanes().filter((p) => p.tab_id === currentTabId);
+	for (const pane of panes) {
+		const info = getProcessInfo(pane.pane_id);
+		if (!info) continue;
+		for (const proc of info.foreground_processes ?? []) {
+			if (proc.name === "nvim" || proc.argv?.[0] === "nvim") {
+				return { paneId: pane.pane_id, pid: proc.pid };
+			}
+		}
+	}
+	return null;
+}
+
+/** Discover the nvim RPC socket for a given PID by globbing the nvim temp dir. */
+function findNvimSocket(pid: number): string | null {
+	const user = userInfo().username;
+	const tmp = process.env.TMPDIR ?? "/tmp";
+	const nvimDir = join(tmp, `nvim.${user}`);
+	if (!existsSync(nvimDir)) return null;
+	try {
+		for (const sub of readdirSync(nvimDir)) {
+			const sock = join(nvimDir, sub, `nvim.${pid}.0`);
+			if (existsSync(sock)) return sock;
+		}
+	} catch {
+		// ignore
+	}
+	return null;
+}
+
+/** Open files in an existing nvim instance via its RPC socket. Returns true on success. */
+function sendFilesViaRpc(socket: string, files: string[]): boolean {
+	try {
+		for (const file of files) {
+			execFileSync("nvim", ["--server", socket, "--remote", file], {
+				timeout: NVIM_TIMEOUT_MS,
+				stdio: "ignore",
+			});
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Fallback: send `:e <file>` keystrokes to the nvim pane via herdr send-text. */
+function sendFilesViaText(paneId: string, files: string[]): void {
+	for (const file of files) {
+		// Escape to exit insert mode, then :e with the path, then Enter.
+		const text = `\x1b:e ${file}\r`;
+		try {
+			execFileSync("herdr", ["pane", "send-text", paneId, text], {
+				timeout: HERDR_TIMEOUT_MS,
+				stdio: "ignore",
+			});
+		} catch {
+			// best-effort
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// launch & focus
+// ---------------------------------------------------------------------------
+
+/** Split the current pane downward and launch nvim in the new pane. */
+function launchNvim(cwd: string, files: string[]): string | null {
+	const splitRes = herdrJson([
+		"pane",
+		"split",
+		"--current",
+		"--direction",
+		"down",
+		"--cwd",
+		cwd,
+		"--focus",
+	]) as { result?: { pane?: { pane_id?: string } } } | null;
+
+	const newPaneId = splitRes?.result?.pane?.pane_id;
+	if (!newPaneId) return null;
+
+	const cmd = files.length > 0 ? ["nvim", ...files] : ["nvim", "."];
+	herdrOk(["pane", "run", newPaneId, "--", ...cmd]);
+	return newPaneId;
+}
+
+/** Best-effort focus of the pane below the current one. */
+function focusPaneDown(): void {
+	herdrOk(["pane", "focus", "--current", "--direction", "down"]);
+}
+
+// ---------------------------------------------------------------------------
+// tmux fallback
+// ---------------------------------------------------------------------------
+
+function tmuxFallback(cwd: string, files: string[]): boolean {
+	try {
+		const fileArgs = files.length > 0 ? files : ["."];
+		execFileSync(
+			"tmux",
+			["split-window", "-v", "-c", cwd, "--", "nvim", ...fileArgs],
+			{ timeout: HERDR_TIMEOUT_MS, stdio: "ignore" },
+		);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// core orchestration
+// ---------------------------------------------------------------------------
+
+function resolveFiles(cwd: string, files: string[]): string[] {
+	return files.map((f) => (isAbsolute(f) ? f : resolve(cwd, f)));
+}
+
+function openNvim(cwd: string, files: string[]): { message: string; launched: boolean } {
+	const resolvedFiles = resolveFiles(cwd, files);
+
+	if (herdrAvailable()) {
+		const current = getCurrentPane();
+		if (current) {
+			const existing = findNvimPane(current.tab_id);
+			if (existing) {
+				if (resolvedFiles.length > 0) {
+					const sock = findNvimSocket(existing.pid);
+					if (sock && sendFilesViaRpc(sock, resolvedFiles)) {
+						focusPaneDown();
+						return {
+							message: `Opened ${resolvedFiles.length} file(s) in existing nvim (pane ${existing.paneId}) via RPC.`,
+							launched: false,
+						};
+					}
+					sendFilesViaText(existing.paneId, resolvedFiles);
+					focusPaneDown();
+					return {
+						message: `Sent ${resolvedFiles.length} file(s) to existing nvim (pane ${existing.paneId}) via send-text.`,
+						launched: false,
+					};
+				}
+				focusPaneDown();
+				return {
+					message: `Focused existing nvim pane (${existing.paneId}).`,
+					launched: false,
+				};
+			}
+
+			// No existing nvim in this tab — launch a new horizontal split.
+			const newPane = launchNvim(cwd, resolvedFiles);
+			if (newPane) {
+				const fileNote =
+					resolvedFiles.length > 0
+						? ` with ${resolvedFiles.length} file(s)`
+						: "";
+				return {
+					message: `Launched nvim in a horizontal split (pane ${newPane}) at ${cwd}${fileNote}.`,
+					launched: true,
+				};
+			}
+		}
+	}
+
+	// Herdr unavailable or failed — try tmux.
+	if (tmuxFallback(cwd, resolvedFiles)) {
+		return {
+			message: `Launched nvim in a tmux split at ${cwd}.`,
+			launched: true,
+		};
+	}
+
+	return {
+		message: `Could not launch nvim automatically. Run manually: cd ${cwd} && nvim ${resolvedFiles.join(" ") || "."}`,
+		launched: false,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// extension registration
+// ---------------------------------------------------------------------------
+
+const nvimOpenTool = defineTool({
+	name: "nvim_open",
+	label: "Open Neovim",
+	description:
+		"Open Neovim as a horizontal split in the current Herdr tab, or send files to an existing Neovim instance in the current tab. If nvim is already running in the current tab, files are sent to the existing instance instead of launching a new one. With no files, opens nvim at the agent's cwd.",
+	promptSnippet: "Open Neovim in the current Herdr tab as a horizontal split",
+	promptGuidelines: [
+		"Use nvim_open when the user wants to open Neovim (nvim) for editing, either at the current working directory or for specific files.",
+		"If nvim is already running in the current Herdr tab, this tool sends files to the existing instance rather than launching a duplicate.",
+		"With no files provided, it opens nvim at the agent's cwd. With file paths, it opens those specific files.",
+		"The split is horizontal (below the agent pane) and focus moves to the nvim pane so the captain can see the editor.",
+	],
+	parameters: Type.Object({
+		cwd: Type.String({
+			description: "The working directory to open nvim in. Defaults to the agent's cwd.",
+		}),
+		files: Type.Optional(
+			Type.Array(Type.String(), {
+				description: "Optional list of file paths to open in nvim. Relative paths are resolved against cwd.",
+			}),
+		),
+	}),
+	async execute(_toolCallId, params) {
+		const cwd = params.cwd ?? process.cwd();
+		const files = params.files ?? [];
+		const result = openNvim(cwd, files);
+		return { content: [{ type: "text", text: result.message }] };
+	},
+});
+
+export default function (pi: ExtensionAPI) {
+	pi.registerTool(nvimOpenTool);
+
+	pi.registerCommand("nvim", {
+		description: "Open Neovim in the current Herdr tab as a horizontal split",
+		handler: async (args: unknown, ctx: { cwd?: string; ui: { notify: (msg: string, level: string) => void } }) => {
+			const cwd = ctx?.cwd ?? process.cwd();
+			const fileList: string[] = (() => {
+				if (Array.isArray(args)) return args.map(String);
+				if (typeof args === "string") return args.trim() ? args.trim().split(/\s+/) : [];
+				return [];
+			})();
+			const result = openNvim(cwd, fileList);
+			ctx?.ui?.notify(result.message, "info");
+		},
+	});
+}

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -108,7 +108,7 @@ function findNvimPane(currentTabId: string): NvimPane | null {
 		const info = getProcessInfo(pane.pane_id);
 		if (!info) continue;
 		for (const proc of info.foreground_processes ?? []) {
-			if (proc.name === "nvim" || proc.argv?.[0] === "nvim") {
+			if (proc.name === "vim" || proc.argv?.[0] === "vim" || proc.name === "nvim" || proc.argv?.[0] === "nvim") {
 				return { paneId: pane.pane_id, pid: proc.pid };
 			}
 		}
@@ -184,7 +184,7 @@ function launchNvim(cwd: string, files: string[]): string | null {
 	const newPaneId = splitRes?.result?.pane?.pane_id;
 	if (!newPaneId) return null;
 
-	const cmd = files.length > 0 ? ["nvim", ...files] : ["nvim", "."];
+	const cmd = files.length > 0 ? ["vim", ...files] : ["vim", "."];
 	herdrOk(["pane", "run", newPaneId, ...cmd]);
 	return newPaneId;
 }
@@ -203,7 +203,7 @@ function tmuxFallback(cwd: string, files: string[]): boolean {
 		const fileArgs = files.length > 0 ? files : ["."];
 		execFileSync(
 			"tmux",
-			["split-window", "-v", "-c", cwd, "nvim", ...fileArgs],
+			["split-window", "-v", "-c", cwd, "vim", ...fileArgs],
 			{ timeout: HERDR_TIMEOUT_MS, stdio: "ignore" },
 		);
 		return true;

--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -5,40 +5,8 @@ import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { join, resolve, isAbsolute, relative } from "node:path";
 
 const HERDR_TIMEOUT_MS = 5000;
-const NVIM_TIMEOUT_MS = 4000;
 const LLM_TIMEOUT_MS = 20000;
 const MAX_FILE_LIST = 200;
-
-// ---------------------------------------------------------------------------
-// binary discovery
-// ---------------------------------------------------------------------------
-
-/** Find the nvim binary, checking PATH and common bob install locations. */
-function findNvimBinary(): string | null {
-	// 1. On PATH directly
-	try {
-		const path = execFileSync("which", ["nvim"], { encoding: "utf-8", timeout: 2000, stdio: ["pipe", "pipe", "pipe"] }).trim();
-		if (path) return path;
-	} catch {}
-
-	// 2. bob-managed nightly (most common on this homelab)
-	const bobCandidates = [
-		`${process.env.HOME}/.local/share/bob/nightly/bin/nvim`,
-		`${process.env.HOME}/.local/share/bob/stable/bin/nvim`,
-	];
-	for (const c of bobCandidates) {
-		if (existsSync(c)) return c;
-	}
-
-	// 3. Fallback to "nvim" and hope the shell resolves it
-	return "nvim";
-}
-
-let _nvimBin: string | null | undefined;
-function nvimBin(): string {
-	if (_nvimBin === undefined) _nvimBin = findNvimBinary();
-	return _nvimBin ?? "nvim";
-}
 
 // ---------------------------------------------------------------------------
 // Herdr helpers
@@ -68,9 +36,7 @@ interface ProcessInfo {
 function herdrJson(args: string[]): unknown | null {
 	try {
 		const out = execFileSync("herdr", args, {
-			encoding: "utf-8",
-			timeout: HERDR_TIMEOUT_MS,
-			stdio: ["pipe", "pipe", "pipe"],
+			encoding: "utf-8", timeout: HERDR_TIMEOUT_MS, stdio: ["pipe", "pipe", "pipe"],
 		});
 		return JSON.parse(out);
 	} catch {
@@ -82,8 +48,7 @@ function herdrJson(args: string[]): unknown | null {
 function herdrOk(args: string[]): boolean {
 	try {
 		execFileSync("herdr", args, {
-			timeout: HERDR_TIMEOUT_MS,
-			stdio: ["pipe", "pipe", "pipe"],
+			timeout: HERDR_TIMEOUT_MS, stdio: ["pipe", "pipe", "pipe"],
 		});
 		return true;
 	} catch {
@@ -93,27 +58,25 @@ function herdrOk(args: string[]): boolean {
 
 function getCurrentPane(): PaneInfo | null {
 	const res = herdrJson(["pane", "current"]) as
-		| { result?: { pane?: PaneInfo } }
-		| null;
+		| { result?: { pane?: PaneInfo } } | null;
 	return res?.result?.pane ?? null;
 }
 
-function listPanes(): PaneInfo[] {
+function listPanes(): PaneInfo[] | null {
 	const res = herdrJson(["pane", "list"]) as
-		| { result?: { panes?: PaneInfo[] } }
-		| null;
-	return res?.result?.panes ?? [];
+		| { result?: { panes?: PaneInfo[] } } | null;
+	// Return null on failure (not []) so callers can distinguish error from empty
+	return res?.result?.panes ?? null;
 }
 
 function getProcessInfo(paneId: string): ProcessInfo | null {
 	const res = herdrJson(["pane", "process-info", "--pane", paneId]) as
-		| { result?: { process_info?: ProcessInfo } }
-		| null;
+		| { result?: { process_info?: ProcessInfo } } | null;
 	return res?.result?.process_info ?? null;
 }
 
 // ---------------------------------------------------------------------------
-// editor detection & communication
+// editor detection (tri-state: found | absent | error)
 // ---------------------------------------------------------------------------
 
 interface EditorPane {
@@ -121,97 +84,67 @@ interface EditorPane {
 	pid: number;
 }
 
-/** Search all panes in the current tab for one whose foreground process is vim/nvim. */
-function findEditorPane(currentTabId: string): EditorPane | null {
-	const panes = listPanes().filter((p) => p.tab_id === currentTabId);
-	for (const pane of panes) {
+type DetectionResult =
+	| { status: "found"; editor: EditorPane }
+	| { status: "absent" }
+	| { status: "error" };
+
+/**
+ * Search all panes in the current tab for one whose foreground process is
+ * vim/nvim. Returns "error" if any herdr call fails, so the caller does NOT
+ * launch a duplicate on a transient failure.
+ */
+function findEditorPane(currentTabId: string): DetectionResult {
+	const panes = listPanes();
+	if (panes === null) return { status: "error" };
+
+	const tabPanes = panes.filter((p) => p.tab_id === currentTabId);
+	if (tabPanes.length === 0) return { status: "error" };
+
+	let hadError = false;
+	for (const pane of tabPanes) {
 		const info = getProcessInfo(pane.pane_id);
-		if (!info) continue;
+		if (!info) {
+			hadError = true;
+			continue;
+		}
 		for (const proc of info.foreground_processes ?? []) {
 			if (
 				proc.name === "vim" || proc.argv?.[0] === "vim" ||
 				proc.name === "nvim" || proc.argv?.[0] === "nvim"
 			) {
-				return { paneId: pane.pane_id, pid: proc.pid };
+				return { status: "found", editor: { paneId: pane.pane_id, pid: proc.pid } };
 			}
 		}
 	}
-	return null;
+	// Only report "absent" if every pane was successfully scanned
+	return hadError ? { status: "error" } : { status: "absent" };
 }
+
+// ---------------------------------------------------------------------------
+// editor communication
+// ---------------------------------------------------------------------------
 
 /**
- * Discover a live nvim RPC socket. Nvim puts sockets in $XDG_RUNTIME_DIR
- * (typically /run/user/<uid> on Linux) or $TMPDIR/nvim.<user>/ on macOS.
- * The socket filename uses nvim's own PID, which may differ slightly from the
- * process PID reported by the OS, so we glob all sockets and test for liveness.
+ * Escape a file path for use in a Vim `:e` ex command, following
+ * fnameescape() semantics. Backslash-escape every character that has
+ * special meaning in ex commands: backslash itself, space, pipe, percent,
+ * hash, double-quote, single-quote, tab, and newline.
  */
-function findNvimSocket(): string | null {
-	const bin = nvimBin();
-	const searchDirs: string[] = [];
-
-	// Linux: $XDG_RUNTIME_DIR
-	if (process.env.XDG_RUNTIME_DIR) {
-		searchDirs.push(process.env.XDG_RUNTIME_DIR);
-	}
-	// macOS / fallback: $TMPDIR/nvim.<user>/
-	const user = process.env.USER ?? "unknown";
-	const tmp = process.env.TMPDIR ?? "/tmp";
-	searchDirs.push(join(tmp, `nvim.${user}`));
-
-	for (const dir of searchDirs) {
-		if (!existsSync(dir)) continue;
-		try {
-			const entries = readdirSync(dir);
-			// Collect nvim socket files (nvim.<pid>.0)
-			const sockets = entries
-				.filter((e) => /^nvim\.\d+\.0$/.test(e))
-				.map((e) => join(dir, e));
-			// Test each for liveness — return the first live one
-			for (const sock of sockets) {
-				try {
-					execFileSync(bin, ["--server", sock, "--remote-expr", "1"], {
-						timeout: 1000,
-						stdio: "ignore",
-					});
-					return sock;
-				} catch {
-					// stale socket, skip
-				}
-			}
-		} catch {
-			// ignore
-		}
-	}
-	return null;
+function fnameEscape(path: string): string {
+	// Characters that need backslash-escaping in ex commands
+	return path.replace(/[\\ |%"'#\t\n\r]/g, "\\$&");
 }
 
-/** Open files in an existing nvim instance via its RPC socket. Returns true on success. */
-function sendFilesViaRpc(socket: string, files: string[]): boolean {
-	const bin = nvimBin();
-	try {
-		for (const file of files) {
-			execFileSync(bin, ["--server", socket, "--remote", file], {
-				timeout: NVIM_TIMEOUT_MS,
-				stdio: "ignore",
-			});
-		}
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/** Fallback: send `:e <file>` keystrokes to the editor pane via herdr send-text. */
+/** Send `:e <file>` keystrokes to the editor pane via herdr send-text. */
 function sendFilesViaText(paneId: string, files: string[]): void {
 	for (const file of files) {
-		// Escape spaces in the path for the ex command
-		const escaped = file.replace(/ /g, "\\ ");
-		// Escape to exit insert mode, then :e with the path, then Enter.
+		const escaped = fnameEscape(file);
+		// Escape to exit insert mode, then :e with the escaped path, then Enter.
 		const text = `\x1b:e ${escaped}\r`;
 		try {
 			execFileSync("herdr", ["pane", "send-text", paneId, text], {
-				timeout: HERDR_TIMEOUT_MS,
-				stdio: "ignore",
+				timeout: HERDR_TIMEOUT_MS, stdio: "ignore",
 			});
 		} catch {
 			// best-effort
@@ -223,30 +156,53 @@ function sendFilesViaText(paneId: string, files: string[]): void {
 // launch & focus
 // ---------------------------------------------------------------------------
 
-/** Split the current pane to the right and launch vim in the new pane. */
+/**
+ * Split the current pane to the right and launch vim in the new pane.
+ * Returns the new pane ID, or null if the split or run failed.
+ */
 function launchEditor(cwd: string, files: string[]): string | null {
 	const splitRes = herdrJson([
-		"pane",
-		"split",
-		"--current",
-		"--direction",
-		"right",
-		"--cwd",
-		cwd,
-		"--focus",
+		"pane", "split", "--current", "--direction", "right", "--cwd", cwd, "--focus",
 	]) as { result?: { pane?: { pane_id?: string } } } | null;
 
 	const newPaneId = splitRes?.result?.pane?.pane_id;
 	if (!newPaneId) return null;
 
 	const cmd = files.length > 0 ? ["vim", ...files] : ["vim"];
-	herdrOk(["pane", "run", newPaneId, ...cmd]);
+	// Check the run result — don't claim success if vim failed to start
+	if (!herdrOk(["pane", "run", newPaneId, ...cmd])) {
+		return null;
+	}
 	return newPaneId;
 }
 
-/** Focus a specific pane by ID. */
-function focusPane(paneId: string): void {
-	herdrOk(["pane", "focus", "--pane", paneId]);
+/**
+ * Focus the editor pane by discovering the direction from the current pane
+ * to the editor pane using `herdr pane neighbor`. Falls back to trying all
+ * four directions. `herdr pane focus` requires --direction, so we cannot
+ * focus by pane ID alone.
+ */
+function focusEditorPane(editorPaneId: string, currentPaneId: string): boolean {
+	const directions = ["right", "down", "left", "up"] as const;
+
+	for (const dir of directions) {
+		const res = herdrJson(["pane", "neighbor", "--pane", currentPaneId, "--direction", dir]) as
+			| { result?: { neighbor?: { pane_id?: string } } } | null;
+		const neighborId = res?.result?.neighbor?.pane_id;
+		if (neighborId === editorPaneId) {
+			return herdrOk(["pane", "focus", "--current", "--direction", dir]);
+		}
+	}
+
+	// Fallback: try each direction directly
+	for (const dir of directions) {
+		if (herdrOk(["pane", "focus", "--current", "--direction", dir])) {
+			// Check if we landed on the editor pane
+			const current = getCurrentPane();
+			if (current?.pane_id === editorPaneId) return true;
+		}
+	}
+	return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -255,12 +211,18 @@ function focusPane(paneId: string): void {
 
 function tmuxFallback(cwd: string, files: string[]): boolean {
 	try {
-		const fileArgs = files.length > 0 ? files : [];
-		execFileSync(
-			"tmux",
-			["split-window", "-h", "-c", cwd, "vim", ...fileArgs],
-			{ timeout: HERDR_TIMEOUT_MS, stdio: "ignore" },
-		);
+		// tmux split-window accepts ONE optional shell-command as the last arg.
+		// Construct a single safely-quoted shell command string.
+		let shellCmd: string;
+		if (files.length > 0) {
+			const quotedFiles = files.map((f) => `'${f.replace(/'/g, "'\\''")}'`);
+			shellCmd = `vim ${quotedFiles.join(" ")}`;
+		} else {
+			shellCmd = "vim";
+		}
+		execFileSync("tmux", ["split-window", "-h", "-c", cwd, shellCmd], {
+			timeout: HERDR_TIMEOUT_MS, stdio: "ignore",
+		});
 		return true;
 	} catch {
 		return false;
@@ -271,16 +233,21 @@ function tmuxFallback(cwd: string, files: string[]): boolean {
 // file listing for LLM resolution
 // ---------------------------------------------------------------------------
 
-/** Recursively list files under cwd (limited depth/count), returning relative paths. */
+/**
+ * Recursively list files under cwd (limited depth/count), returning relative
+ * paths. Skips known large/build dirs but allows hidden project config dirs
+ * like .pi, .agents, .claude so source files in them are discoverable.
+ */
 function listFilesForLlm(cwd: string): string[] {
 	const results: string[] = [];
+	// Only skip these known-large or irrelevant directories
 	const skipDirs = new Set([
-		".git", "node_modules", ".venv", "__pycache__", ".pi", ".agents",
+		".git", "node_modules", ".venv", "__pycache__",
 		"target", "dist", "build", ".cache", ".treehouse",
 	]);
 
 	function walk(dir: string, depth: number) {
-		if (depth > 3 || results.length >= MAX_FILE_LIST) return;
+		if (depth > 4 || results.length >= MAX_FILE_LIST) return;
 		let entries: string[];
 		try {
 			entries = readdirSync(dir);
@@ -293,12 +260,11 @@ function listFilesForLlm(cwd: string): string[] {
 			try {
 				const st = statSync(full);
 				if (st.isDirectory()) {
-					// Skip hidden directories and known large dirs
-					if (!skipDirs.has(entry) && !entry.startsWith(".")) {
+					// Skip only known large dirs — allow hidden config dirs
+					if (!skipDirs.has(entry)) {
 						walk(full, depth + 1);
 					}
 				} else {
-					// Include regular files (including dotfiles)
 					results.push(relative(cwd, full));
 				}
 			} catch {
@@ -312,22 +278,72 @@ function listFilesForLlm(cwd: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// argument parsing (quote-aware)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a string into arguments, respecting single and double quotes.
+ * Handles paths with spaces like: docs/"My Notes.md" or docs/'My Notes.md'
+ */
+function parseArgs(input: string): string[] {
+	const args: string[] = [];
+	let current = "";
+	let inSingle = false;
+	let inDouble = false;
+
+	for (let i = 0; i < input.length; i++) {
+		const ch = input[i];
+
+		if (inSingle) {
+			if (ch === "'") {
+				inSingle = false;
+			} else {
+				current += ch;
+			}
+		} else if (inDouble) {
+			if (ch === '"') {
+				inDouble = false;
+			} else if (ch === "\\" && i + 1 < input.length) {
+				// Escaped char inside double quotes
+				current += input[++i];
+			} else {
+				current += ch;
+			}
+		} else {
+			if (ch === "'" && !inDouble) {
+				inSingle = true;
+			} else if (ch === '"' && !inSingle) {
+				inDouble = true;
+			} else if (ch === "\\") {
+				if (i + 1 < input.length) {
+					current += input[++i];
+				}
+			} else if (/\s/.test(ch)) {
+				if (current) {
+					args.push(current);
+					current = "";
+				}
+			} else {
+				current += ch;
+			}
+		}
+	}
+	if (current) args.push(current);
+	return args;
+}
+
+// ---------------------------------------------------------------------------
 // LLM-based file resolution
 // ---------------------------------------------------------------------------
 
 interface LlmResolution {
-	/** Resolved file paths (relative to cwd), or empty if uncertain. */
 	files: string[];
-	/** Whether the LLM was confident. */
 	confident: boolean;
-	/** Candidate options for multiple-choice (when not confident). */
 	candidates: string[];
 }
 
 /** Extract the assistant text from pi --mode json -p output (NDJSON lines). */
 function extractAssistantText(jsonOutput: string): string {
-	// Track the LAST turn_end — tool calls produce multiple turns, and the
-	// final assistant message (after any tool results) is the one we want.
 	let lastText = "";
 	for (const line of jsonOutput.split("\n")) {
 		const trimmed = line.trim();
@@ -365,7 +381,10 @@ function resolvePiBinary(): { command: string; baseArgs: string[] } {
 	return { command: "pi", baseArgs: [] };
 }
 
-/** Resolve a natural-language file query using a small LLM call via pi print mode. */
+/**
+ * Resolve a natural-language file query using a small LLM call via pi print mode.
+ * Uses newline-separated paths in the response to preserve spaces in file paths.
+ */
 function resolveFilesWithLlm(cwd: string, query: string): Promise<LlmResolution> {
 	const fileList = listFilesForLlm(cwd);
 	const fileSet = new Set(fileList);
@@ -374,14 +393,17 @@ function resolveFilesWithLlm(cwd: string, query: string): Promise<LlmResolution>
 Given a list of files in the working directory and a user's request, determine which file(s) to open.
 
 Respond in ONE of these formats:
-1. If you are confident, reply with EXACTLY: CONFIDENT: <file1> [file2 ...]
+1. If you are confident, reply with EXACTLY this structure (paths on separate lines):
+CONFIDENT:
+<file1>
+<file2>
 2. If you are uncertain, reply with EXACTLY: UNCERTAIN: <option1> | <option2> | <option3>
    List 2-5 candidate files separated by " | ".
 
 Rules:
 - File paths must be relative paths from the working directory, matching the file list exactly.
 - If the user's request doesn't match any file, reply with: UNCERTAIN: (no matches)
-- Reply with only the format line, no explanation.`;
+- Reply with only the format, no explanation.`;
 
 	const userPrompt = `Working directory: ${cwd}
 
@@ -396,18 +418,14 @@ Which file(s) should be opened?`;
 		const piBin = resolvePiBinary();
 		const args = [
 			...piBin.baseArgs,
-			"--mode", "json",
-			"-p",
-			"--no-skills",
-			"--no-extensions",
-			"--no-context-files",
-			"--no-prompt-templates",
-			"--no-themes",
+			"--mode", "json", "-p",
+			"--no-skills", "--no-extensions", "--no-context-files",
+			"--no-prompt-templates", "--no-themes",
 			"--system-prompt", systemPrompt,
 			userPrompt,
 		];
 
-		// Strip Herdr env vars so the child pi process doesn't try to report to Herdr
+		// Strip Herdr env vars so the child pi process doesn't report to Herdr
 		const childEnv: Record<string, string> = {};
 		for (const [key, val] of Object.entries(process.env)) {
 			if (val !== undefined && !key.startsWith("HERDR_")) {
@@ -423,7 +441,6 @@ Which file(s) should be opened?`;
 			env: childEnv,
 		});
 
-		// Close stdin so pi print mode does not wait for input.
 		child.stdin.end();
 
 		child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()));
@@ -435,12 +452,13 @@ Which file(s) should be opened?`;
 			const text = extractAssistantText(stdout).trim();
 
 			if (text.startsWith("CONFIDENT:")) {
+				// Paths are newline-separated after the CONFIDENT: line
 				const paths = text
 					.slice("CONFIDENT:".length)
 					.trim()
-					.split(/\s+/)
+					.split("\n")
+					.map((s) => s.trim())
 					.filter(Boolean)
-					// Validate that resolved paths actually exist in the file list
 					.filter((p) => fileSet.has(p));
 				resolve({ files: paths, confident: true, candidates: [] });
 			} else if (text.startsWith("UNCERTAIN:")) {
@@ -452,7 +470,6 @@ Which file(s) should be opened?`;
 						.split("|")
 						.map((s) => s.trim())
 						.filter(Boolean)
-						// Validate candidates too
 						.filter((c) => fileSet.has(c));
 					resolve({ files: [], confident: false, candidates });
 				}
@@ -474,7 +491,7 @@ interface UIContext {
 
 /** Present a numbered multiple-choice menu and wait for the user's selection. */
 function presentChoice(
-	ctx: UIContext,
+	ui: UIContext,
 	prompt: string,
 	candidates: string[],
 ): Promise<string | null> {
@@ -486,9 +503,9 @@ function presentChoice(
 			"",
 			"Enter a number (or press Enter to cancel):",
 		];
-		ctx.ui.notify(lines.join("\n"), "info");
+		ui.notify(lines.join("\n"), "info");
 
-		const stop = ctx.ui.onTerminalInput((data: string) => {
+		const stop = ui.onTerminalInput((data: string) => {
 			const trimmed = data.trim();
 			if (!trimmed) {
 				stop?.();
@@ -501,11 +518,10 @@ function presentChoice(
 				resolve(candidates[num - 1]);
 				return { consume: true };
 			}
-			ctx.ui.notify(`Invalid choice "${trimmed}". Enter 1-${candidates.length} or press Enter to cancel.`, "warn");
+			ui.notify(`Invalid choice "${trimmed}". Enter 1-${candidates.length} or press Enter to cancel.`, "warn");
 			return { consume: true };
 		});
 
-		// Timeout after 30s
 		const timer = setTimeout(() => {
 			stop?.();
 			resolve(null);
@@ -564,10 +580,7 @@ async function openEditor(
 			if (choice) {
 				resolvedFiles.push(choice);
 			} else {
-				return {
-					message: "Cancelled — no file selected.",
-					launched: false,
-				};
+				return { message: "Cancelled — no file selected.", launched: false };
 			}
 		} else if (!resolution.confident && ctx?.ui) {
 			ctx.ui.notify(
@@ -582,52 +595,51 @@ async function openEditor(
 	// Try Herdr — getCurrentPane returns null if herdr is unavailable
 	const current = getCurrentPane();
 	if (current) {
-		const existing = findEditorPane(current.tab_id);
-		if (existing) {
+		const detection = findEditorPane(current.tab_id);
+
+		if (detection.status === "found") {
+			const editor = detection.editor;
 			if (finalFiles.length > 0) {
-				// Try RPC first, fall back to send-text
-				const sock = findNvimSocket();
-				if (sock && sendFilesViaRpc(sock, finalFiles)) {
-					focusPane(existing.paneId);
-					return {
-						message: `Opened ${finalFiles.length} file(s) in existing editor (pane ${existing.paneId}) via RPC.`,
-						launched: false,
-					};
-				}
-				sendFilesViaText(existing.paneId, finalFiles);
-				focusPane(existing.paneId);
+				// Send files to the existing editor via herdr pane send-text.
+				// This always targets the correct pane — no socket correlation needed.
+				sendFilesViaText(editor.paneId, finalFiles);
+				focusEditorPane(editor.paneId, current.pane_id);
 				return {
-					message: `Sent ${finalFiles.length} file(s) to existing editor (pane ${existing.paneId}) via send-text.`,
+					message: `Sent ${finalFiles.length} file(s) to existing editor (pane ${editor.paneId}).`,
 					launched: false,
 				};
 			}
-			focusPane(existing.paneId);
+			focusEditorPane(editor.paneId, current.pane_id);
 			return {
-				message: `Focused existing editor pane (${existing.paneId}).`,
+				message: `Focused existing editor pane (${editor.paneId}).`,
 				launched: false,
 			};
 		}
 
-		// No existing editor in this tab — launch a new vertical split.
-		const newPane = launchEditor(cwd, finalFiles);
-		if (newPane) {
-			const fileNote =
-				finalFiles.length > 0
-					? ` with ${finalFiles.length} file(s)`
-					: "";
-			return {
-				message: `Launched vim in a vertical split (pane ${newPane}) at ${cwd}${fileNote}.`,
-				launched: true,
-			};
+		// Only launch a new editor if we definitively confirmed no editor exists.
+		// On error, fall through to tmux fallback rather than risking a duplicate.
+		if (detection.status === "absent") {
+			const newPane = launchEditor(cwd, finalFiles);
+			if (newPane) {
+				const fileNote = finalFiles.length > 0 ? ` with ${finalFiles.length} file(s)` : "";
+				return {
+					message: `Launched vim in a vertical split (pane ${newPane}) at ${cwd}${fileNote}.`,
+					launched: true,
+				};
+			}
+		}
+
+		if (detection.status === "error") {
+			ctx?.ui?.notify(
+				"Could not scan panes for existing editor — falling back to tmux.",
+				"warn",
+			);
 		}
 	}
 
 	// Herdr unavailable or failed — try tmux.
 	if (tmuxFallback(cwd, finalFiles)) {
-		return {
-			message: `Launched vim in a tmux split at ${cwd}.`,
-			launched: true,
-		};
+		return { message: `Launched vim in a tmux split at ${cwd}.`, launched: true };
 	}
 
 	return {
@@ -677,9 +689,10 @@ export default function (pi: ExtensionAPI) {
 		description: "Open vim in the current Herdr tab as a vertical split",
 		handler: async (args: unknown, ctx: { cwd?: string; ui: UIContext }) => {
 			const cwd = ctx?.cwd ?? process.cwd();
+			// Parse args with quote-aware splitting for paths with spaces
 			const fileList: string[] = (() => {
 				if (Array.isArray(args)) return args.map(String);
-				if (typeof args === "string") return args.trim() ? args.trim().split(/\s+/) : [];
+				if (typeof args === "string") return args.trim() ? parseArgs(args.trim()) : [];
 				return [];
 			})();
 			const result = await openEditor(cwd, fileList, ctx);


### PR DESCRIPTION
## Summary

Adds a pi agent extension, a standalone shell script, and an accompanying `/nvim` skill that opens a vim session in the folder the agent is working with. Works with both **pi** (via TypeScript extension) and **Codex** (via the shell script + skill).

## Extension — `pi/.pi/agent/extensions/nvim-open.ts`

Registers the `nvim_open` tool and a `/nvim` command for pi. The extension:
- Launches vim as a vertical split via `herdr pane split --current --direction right`
- Detects existing vim/nvim in the tab (tri-state: found/absent/error)
- Sends files to existing editor via `herdr pane send-text` with fnameescape-escaped `:e` commands
- Focuses editor pane via `herdr pane neighbor` + `herdr pane focus --direction`
- Falls back to tmux when Herdr is unavailable
- Quote-aware argument parsing for paths with spaces

## Shell script — `agents/.agents/skills/nvim/nvim-open.sh`

Standalone bash script that encapsulates the same herdr/tmux logic, so Codex (which doesn't have a TypeScript extension system) can use it via the skill. Tested end-to-end: launch, send-to-existing, and focus-existing all work.

## Skill — `agents/.agents/skills/nvim/SKILL.md`

Shared skill file that instructs the agent to run `nvim-open.sh`:
- **`/nvim`** (no args) → opens vim at the agent's cwd
- **`/nvim <file> [<file>...]`** → opens specific files

The skill instructs the agent to resolve file references itself before calling the script.

## Codex setup

Symlink the skill into `~/.codex/skills/nvim/` so Codex discovers it:
```bash
mkdir -p ~/.codex/skills/nvim
ln -sf <dotfiles>/agents/.agents/skills/nvim/SKILL.md ~/.codex/skills/nvim/SKILL.md
ln -sf <dotfiles>/agents/.agents/skills/nvim/nvim-open.sh ~/.codex/skills/nvim/nvim-open.sh
```

## File placement

- Extension: `pi/.pi/agent/extensions/nvim-open.ts` (stows to `~/.pi/agent/extensions/`)
- Skill + script: `agents/.agents/skills/nvim/` (stows to `~/.agents/skills/nvim/`)