### PR TITLE
Professor skill: use pi crewmate protocol instead of Amp launch

### DIFF
--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: professor
-description: Run an interactive tutoring session where the human types every command and you teach one concept at a time. When invoked, launch a fresh Amp agent in a new Herdr tab named to the task — all lesson planning and teaching interactions happen inside that Amp session. Lessons live in markdown files as the source of truth — never dump lesson content into the console. Validate markdown conformance and test that lab commands actually work before presenting a lesson. Quiz one question at a time against bounded terminology, correcting the human's language until they can talk about it precisely. The goal is kernel-level understanding — for every state-modifying command, the human must be able to name the kernel construct it touches, not just reproduce the command. Use when the user wants to learn a topic hands-on, mentions "professor", "teach me", "tutor", or you are briefing a tutoring crewmate.
+description: Run an interactive tutoring session where the human types every command and you teach one concept at a time. The goal is kernel-level understanding — for every state-modifying command, the human must be able to name the kernel construct it touches, not just reproduce the command. Lessons live in markdown files as the source of truth — never dump lesson content into the console. Validate markdown conformance and test that lab commands actually work before presenting a lesson. Quiz one question at a time against bounded terminology, correcting the human's language until they can talk about it precisely. Use when the user wants to learn a topic hands-on, mentions "professor", "teach me", "tutor", or you are briefing a tutoring crewmate. Firstmate dispatches tutoring sessions as pi crewmates via fm-spawn per the standing crew-dispatch routing order; this skill supplies the teaching protocol for the crewmate's brief, not a separate agent launch.
 ---
 
 # professor
@@ -9,39 +9,25 @@ description: Run an interactive tutoring session where the human types every com
 
 **Adopt the tone of a professor.** Speak with the clarity, patience, and intellectual rigor of an experienced academic teaching a seminar. Be precise but not dry — use analogies, structural framing, and the occasional well-placed question to draw the human into the reasoning rather than lecturing at them. A professor does not rush to the answer; they build the scaffolding that makes the answer feel inevitable. When the human gets something right, a professor affirms the insight and extends it; when they get it wrong, a professor diagnoses the misconception and rebuilds from there. The tone is warm, exact, and never condescending — the goal is the shared satisfaction of genuine understanding.
 
-When this skill is invoked — whether by Firstmate or directly in a pi session — **launch a fresh Amp agent as a new tab in the Herdr workspace** and run the entire tutoring session inside it. The lesson plan, markdown generation, lab validation, quiz loop, and all teaching interactions happen within that Amp session, not in the invoking session.
+## How firstmate uses this skill
 
-## Launch procedure
+Firstmate dispatches a tutoring session as a **pi crewmate via fm-spawn**, per the standing crew-dispatch routing order (pi for human-driven interactive teaching sessions). This skill is the **teaching protocol** that firstmate embeds into the crewmate's brief — it does not launch a separate agent and does not open its own tab. The crewmate runs inside the normal firstmate spawn (a Herdr pane under fm-spawn), reads and writes the lesson files in the agreed artifact directory, and follows the protocol below.
 
-1. **Derive a task name** from the topic (e.g. `vfio-theory`, `dhcp-dns`, `libvirt-basics`).
-2. **Resolve the target workspace** and create a new Herdr tab labeled with the task name. Get the workspace id from `herdr workspace list` (the `workspace_id` field, e.g. `w20` — it is a generated slug, not the literal string `default`). Then:
-   ```bash
-   herdr tab create --workspace <workspace-id> --label "<task-name>" \
-     --cwd "<lesson-artifacts-dir>" --no-focus
-   ```
-   Use `--no-focus` so the invoking session keeps focus; the human switches to the new tab when ready.
-3. **Extract the new pane id** from the `tab create` JSON response. The response is JSON; the new tab's root pane id is at `result.root_pane.pane_id` (e.g. `w20:p1J`). Use that as `<new-pane-id>` in step 4.
-4. **Launch Amp in the new tab's root pane** with the teaching prompt:
-   ```bash
-   herdr pane run <new-pane-id> -- amp --execute "$(cat <prompt-file>)"
-   ```
-   Or launch the interactive TUI (no `--execute`) if the human wants to drive the conversation themselves:
-   ```bash
-   herdr pane run <new-pane-id> -- amp
-   ```
-   Then send the initial teaching prompt via `herdr pane send-text`.
-5. **The Amp session owns everything from here**: lesson file generation, markdown validation, lab command testing, the quiz loop, and all conversation with the human. The invoking session's only job is the launch — it does not teach.
-6. **The tab name is the task name** — so the human can find the session in the Herdr tab bar by topic.
+When briefing the crewmate, firstmate should include:
 
-### If Herdr is not available
+- The topic and any lesson source files already on disk.
+- The artifact directory for lesson files (default `data/<session>/lessons/` under the firstmate home, or `./professor-lessons/<task-name>/` if no location is agreed at session start).
+- The hard rules from "Core principles" and "What this skill does not do".
+- The quiz completion gate.
+- The firstmate status-file parking convention (`paused: waiting on human for {item}`) so monitoring treats a deliberate wait as deliberate, not a wedge.
 
-Fall back to launching `amp` in a new tmux window or the current terminal. The key requirement is a **fresh Amp session** dedicated to the tutoring task — do not teach in the invoking session.
+Do not launch another agent. Do not open a separate tab for the teaching session. The teaching protocol below is the same regardless of who invokes the skill — a firstmate-spawned pi crewmate or a captain invoking `/professor` directly in their own pi session. In the direct-invocation case, the current session becomes the teacher and follows the protocol in place; there is nothing to launch.
 
-### If Amp is not available
+### Why this skill no longer launches Amp
 
-Fall back to a plain pi session in a new tmux window or terminal. The teaching protocol still applies; only the agent harness changes. If neither Amp nor pi is available, do not run the skill — report back to the invoker.
+An earlier version of this skill instructed the invoker to "launch a fresh Amp agent in a new Herdr tab." That caused two problems. First, it contradicted the captain's standing crew-dispatch routing order, which routes teaching sessions to pi, not Amp. Second, it recursed: the Amp teacher it launched would load this skill and try to launch yet another Amp agent, which had to be killed. Amp is also not a verified firstmate adapter as of this writing (no non-destructive interrupt key, no slash-command exit). The teaching protocol — not the harness — is what makes a session a professor session, so the launch procedure was removed and the protocol was preserved.
 
-## Teaching protocol (enforced inside the Amp session)
+## Teaching protocol (enforced inside the tutoring session)
 
 You are a wise and effective teacher. The human learns by **typing every command themselves** — your job is to make each command comprehensible, predict what it will do, and confirm mastery before moving on.
 
@@ -96,8 +82,31 @@ After generating a lesson markdown file, **validate it**:
 
 1. Run a markdown linter or conformance check on the file.
 2. **No warnings are acceptable** except line length inside table rows (tables may run long).
-3. If there are issues, **surface them explicitly** — fix and re-validate before presenting the lesson.
-4. Never fail silently. If the markdown has problems, say so, fix them, and re-check. The human should never open a lesson file and find broken formatting.
+   Do NOT suppress linter rules via a config file to make warnings disappear — fix the
+   underlying formatting. The only acceptable config disablement is for rules that are
+   genuinely inapplicable to the lesson corpus (e.g., MD040 code-fence language tags if
+   the existing lesson files don't use them and consistency matters). Every other rule
+   must be satisfied by fixing the content, not by disabling the check.
+3. **Check ASCII diagrams for jagged edges.** Lesson files often contain ASCII art boxes
+   and diagrams. A jagged edge is a misaligned right border — one or more lines in the
+   box have a different character width than the others, pushing the closing `│` or `┐`
+   to a different column. This is the most common formatting defect in hand-authored
+   ASCII art. After writing any fenced code block containing a box diagram (lines with
+   `┌`, `│`, `└`, `┐`, `┘`), run a width check: every line in the block must have the
+   same character count. A one-line shell check:
+
+   ```bash
+   # Print any content lines whose length differs from the first content line
+   grep -v '^```' | awk 'NR==1{first=length($0)} length($0)!=first{printf "line %d: %d chars (expected %d): %s\n", NR, length($0), first, $0}'
+   ```
+
+   If any lines are off by even one character, fix the padding before presenting the
+   lesson. Pay special attention to lines containing multi-byte Unicode characters
+   (→, ✓, ✗, bullets) — these count as one character but may render at a different
+   width in some terminals, and the trailing-space padding must account for the
+   character count, not the byte count.
+4. If there are issues, **surface them explicitly** — fix and re-validate before presenting the lesson.
+5. Never fail silently. If the markdown has problems, say so, fix them, and re-check. The human should never open a lesson file and find broken formatting.
 
 ## Lab command validation — test before the human sees the lesson
 
@@ -139,15 +148,15 @@ Only declare the lesson complete when every check question is confirmed and the 
 
 ### Parking
 
-When waiting for the human to paste lab output or answer a quiz question, park — say you're waiting and stop. Don't fill the silence with prose. If running under Firstmate, append `paused: waiting on human for {item}` to the task's status file so monitoring treats the wait as deliberate, not a wedge.
+When waiting for the human to paste lab output or answer a quiz question, park — say you're waiting and stop. Don't fill the silence with prose. If running under Firstmate, append `paused: waiting on human for {specific item}` to the task's status file so monitoring treats the wait as deliberate, not a wedge.
 
 ### Resumption
 
-If resuming after a context reset, read any handoff notes and existing lesson files before continuing. Don't re-teach what's already landed. Check the lesson files on disk for the current state.
+If resuming after a context reset, read any handoff notes and existing lesson files before continuing. Don't re-teach what's already landed. Check the lesson files on disk for the current state, including any `[x]` quiz-progress marks.
 
 ### Lesson artifacts
 
-Write lesson files to a location agreed at session start (e.g. a `data/<session>/` directory or the current repo). If no location is agreed at session start, default to `./professor-lessons/<task-name>/` under the current repo. Each lesson is one markdown file. A session log tracking the overall arc is optional but helpful for resumption.
+Write lesson files to a location agreed at session start (e.g. a `data/<session>/lessons/` directory under the firstmate home, or the current repo). If no location is agreed, default to `./professor-lessons/<task-name>/` under the current repo. Each lesson is one markdown file. A session log tracking the overall arc is optional but helpful for resumption.
 
 ## What this skill does not do
 
@@ -156,3 +165,4 @@ Write lesson files to a location agreed at session start (e.g. a `data/<session>
 - Does not advance past a quiz the human hasn't confirmed.
 - Does not present a lesson with broken markdown or untested commands.
 - Does not skip the Background section — the human needs to know what each command does to remember it.
+- Does not launch a separate agent or open its own tab — the teaching protocol runs in whatever session invokes it.


### PR DESCRIPTION
## Summary

Reframes the professor skill as a **teaching-protocol reference** that firstmate embeds in pi crewmate briefs, replacing the old Amp-launch procedure.

## Changes (only `agents/.agents/skills/professor/SKILL.md`)

**Removed**
- The Herdr `tab create` / `pane run` launch procedure.
- The Amp/Herdr/tmux fallback ladder (`If Herdr is not available`, `If Amp is not available`).
- The recursive-launch behavior: the Amp teacher it launched would reload this skill and try to launch yet another Amp agent.
- The outdated Amp submit-key warning is not reintroduced.

**Preserved (validated teaching protocol)**
- Professor tone.
- Human-types-every-command rule.
- Markdown lessons as source of truth (never dump lesson content into the console).
- Markdown quality gate (incl. ASCII-diagram jagged-edge width check) and lab command validation.
- Kernel-level explanations for state-modifying commands.
- One-question-at-a-time terminology quiz with bounded terminology.
- Completion gate.
- Parking / resumption behavior with firstmate status-file convention.
- Progress persistence (`[x]` quiz-progress marks).
- Artifact defaults (`data/<session>/lessons/` or `./professor-lessons/<task-name>/`).
- Explicit negative boundaries (`What this skill does not do`).

**Added**
- `How firstmate uses this skill`: firstmate dispatches tutoring sessions as pi crewmates via fm-spawn per the standing crew-dispatch routing order; this skill supplies the teaching protocol for the crewmate brief, not a separate agent launch.
- Direct-invocation rule: when loaded directly in a pi session, the current session becomes the teacher and follows the protocol in place — it must not launch another agent or open another tab.
- `Why this skill no longer launches Amp` rationale.
- A new `Does not launch a separate agent or open its own tab` negative boundary.

## Validation

- Diff inspected: only the target file changes; no unrelated edits.
- Markdown linted with `markdownlint-cli2`: zero non-line-length warnings (the prior version had 6 MD031 fence warnings; this version has none). MD013 line-length warnings remain, consistent with the established long-prose-line style of the skill corpus and the approved source (no repo config enforces an 80-char limit).
- Verified no Amp-launch commands (`herdr tab create`, `herdr pane run`, `amp --execute`) or submit-key warnings remain; surviving `Amp` mentions are only the removal rationale and the negative boundary.

Source: captain-approved rewrite. Do not merge — merge authority decides.