### PR TITLE
pi: set markdown.codeBlockIndent empty for clean copy/paste

### DIFF
--- a/pi/.pi/agent/settings.json
+++ b/pi/.pi/agent/settings.json
@@ -15,5 +15,8 @@
   "defaultModel": "gpt-5.6-sol",
   "defaultThinkingLevel": "high",
   "theme": "gruvbox-material",
-  "transport": "websocket-cached"
+  "transport": "websocket-cached",
+  "markdown": {
+    "codeBlockIndent": ""
+  }
 }


### PR DESCRIPTION
## What

Set `markdown.codeBlockIndent` to an empty string in `pi/.pi/agent/settings.json` so terminal-selected fenced code blocks paste without the renderer's default 2-space leading indent.

## Why

Pi renders assistant Markdown through `@earendil-works/pi-tui`'s `Markdown` component, which prefixes every code-block content line with `theme.codeBlockIndent` (default `"  "`). Terminal-selecting a code block (mouse/tmux copy) therefore pastes with two leading spaces on every line.

Setting it to `""` makes code content render flush with the fence borders at column zero.

## What this does not change

- **`/copy` and `Ctrl+X`** — already copy raw Markdown source (clean); unaffected.
- **Syntax highlighting / fence colors** — unaffected; the prefix wraps the highlighted text.
- **List-nested code blocks** — still indented by list depth (`"    ".repeat(depth)`), which is structurally required by CommonMark. Mitigation: keep copyable code at the top level, not nested in lists.

## Validation

- JSON well-formed; setting reads back as `""`.
- Direct render against the installed `@earendil-works/pi-tui` `Markdown` component confirmed top-level code lines go to column zero with `codeBlockIndent: ""` (the default `"  "` adds two spaces).
- `/copy` path (`session.getLastAssistantText()`) returns raw source regardless of this setting.

## Investigation report

Full scout report with evidence, file:line references, and tradeoffs:
`data/pi-code-block-format-scout/report.md`
