### PR TITLE
fix(nvim): prevent tilde artifacts in terminal pastes

### DIFF
--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -563,7 +563,8 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - The system clipboard is the default unnamed clipboard.
 - SSH clipboard copy works through OSC52.
 - SSH paste avoids remote terminal paste timeouts by using local Neovim registers.
-- Terminal-buffer paste uses bracketed-paste wrapping so pasted newlines are not interpreted as keystrokes by nested terminal programs.
+- Terminal-buffer paste honors nested bracketed-paste mode: opted-in programs receive markers so pasted newlines remain
+  paste text; other programs receive raw text without control-sequence artifacts.
 
 ### Statusline, tabline, dashboard, and GUI
 

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -50,55 +50,85 @@ end
 -- to raw mode (disabling echo), so the markers are never echoed and no
 -- tildes appear.
 --
--- We track bracketed-paste mode by wrapping vim.fn.termopen with an on_stdout
--- callback that scans the program's raw output for \27[?2004h / \27[?2004l.
--- Snacks.terminal (and any other caller) goes through vim.fn.termopen, so the
--- tracking covers every :term buffer.
+-- We track bracketed-paste mode by wrapping terminal job callbacks and scanning
+-- the program's raw output for \27[?2004h / \27[?2004l.
+local BP_ENABLE = "\27[?2004h"
+local BP_DISABLE = "\27[?2004l"
 local term_bp_mode = {} -- chan → boolean (inner program has BP enabled)
 local paste_buf = {}
 local default_paste = vim.paste
 
 do
   local original_termopen = vim.fn.termopen
-  if original_termopen then
-    vim.fn.termopen = function(cmd, opts)
-      opts = opts or {}
-      local user_on_stdout = opts.on_stdout
-      opts.on_stdout = function(job_id, data, event)
-        if type(data) == "table" then
-          for _, chunk in ipairs(data) do
-            -- plain=true: literal substring search, not a Lua pattern.
-            if chunk:find("\27[?2004h", 1, true) then
-              term_bp_mode[job_id] = true
-            end
-            if chunk:find("\27[?2004l", 1, true) then
-              term_bp_mode[job_id] = false
-            end
+  local original_jobstart = vim.fn.jobstart
+
+  local function tracked_opts(opts)
+    opts = vim.tbl_extend("force", {}, opts or {})
+    local user_on_stdout = opts.on_stdout
+    local tail = ""
+    opts.on_stdout = function(job_id, data, event)
+      if type(data) == "table" then
+        local output = tail .. table.concat(data, "\n")
+        local offset = 1
+        while true do
+          local enabled_at = output:find(BP_ENABLE, offset, true)
+          local disabled_at = output:find(BP_DISABLE, offset, true)
+          if enabled_at and (not disabled_at or enabled_at < disabled_at) then
+            term_bp_mode[job_id] = true
+            offset = enabled_at + #BP_ENABLE
+          elseif disabled_at then
+            term_bp_mode[job_id] = false
+            offset = disabled_at + #BP_DISABLE
+          else
+            break
           end
         end
-        if user_on_stdout then
-          user_on_stdout(job_id, data, event)
+
+        tail = ""
+        for length = math.min(#output, #BP_ENABLE - 1), 1, -1 do
+          local suffix = output:sub(-length)
+          if BP_ENABLE:sub(1, length) == suffix or BP_DISABLE:sub(1, length) == suffix then
+            tail = suffix
+            break
+          end
         end
       end
-      local chan = original_termopen(cmd, opts)
-      if chan and chan ~= 0 then
-        term_bp_mode[chan] = false
+      if user_on_stdout then
+        user_on_stdout(job_id, data, event)
       end
-      return chan
     end
+    return opts
+  end
+
+  local function tracked_start(start, cmd, opts)
+    local chan = start(cmd, tracked_opts(opts))
+    if chan and chan ~= 0 then
+      term_bp_mode[chan] = false
+    end
+    return chan
+  end
+
+  if original_termopen then
+    vim.fn.termopen = function(cmd, opts)
+      return tracked_start(original_termopen, cmd, opts)
+    end
+  end
+
+  vim.fn.jobstart = function(cmd, opts)
+    if type(opts) == "table" and opts.term == true then
+      return tracked_start(original_jobstart, cmd, opts)
+    end
+    return original_jobstart(cmd, opts)
   end
 end
 
 vim.paste = function(lines, phase)
   if vim.bo.buftype == "terminal" and vim.b.terminal_job_id then
     local chan = vim.b.terminal_job_id
-    local use_markers = term_bp_mode[chan] == true
-    if use_markers then
-      local START, END = "\27[200~", "\27[201~"
-      if phase == -1 then
-        vim.api.nvim_chan_send(chan, START .. table.concat(lines, "\n") .. END)
-        return true
-      end
+    local content
+    if phase == -1 then
+      content = table.concat(lines, "\n")
+    else
       if phase == 1 then
         paste_buf = vim.deepcopy(lines)
       elseif #paste_buf > 0 and #lines > 0 then
@@ -112,35 +142,18 @@ vim.paste = function(lines, phase)
         vim.list_extend(paste_buf, lines)
       end
       if phase == 3 then
-        vim.api.nvim_chan_send(chan, START .. table.concat(paste_buf, "\n") .. END)
+        content = table.concat(paste_buf, "\n")
         paste_buf = {}
       end
-      return true
-    else
-      -- Inner program has not enabled bracketed paste: send raw content.
-      -- No markers means no ESC bytes, so echoctl cannot mangle them into
-      -- visible tildes.  The \n → `j` problem does not apply because programs
-      -- that interpret \n as a motion (vim) always enable bracketed paste.
-      if phase == -1 then
-        vim.api.nvim_chan_send(chan, table.concat(lines, "\n"))
-        return true
-      end
-      if phase == 1 then
-        paste_buf = vim.deepcopy(lines)
-      elseif #paste_buf > 0 and #lines > 0 then
-        paste_buf[#paste_buf] = paste_buf[#paste_buf] .. lines[1]
-        for i = 2, #lines do
-          table.insert(paste_buf, lines[i])
-        end
-      else
-        vim.list_extend(paste_buf, lines)
-      end
-      if phase == 3 then
-        vim.api.nvim_chan_send(chan, table.concat(paste_buf, "\n"))
-        paste_buf = {}
-      end
-      return true
     end
+
+    if content then
+      if term_bp_mode[chan] == true then
+        content = "\27[200~" .. content .. "\27[201~"
+      end
+      vim.api.nvim_chan_send(chan, content)
+    end
+    return true
   end
   return default_paste(lines, phase)
 end

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -122,6 +122,16 @@ do
   end
 end
 
+vim.api.nvim_create_autocmd("TermOpen", {
+  callback = function(args)
+    local chan = vim.b[args.buf].terminal_job_id
+    if chan then
+      -- Vimscript :terminal bypasses tracked callbacks, so its BP mode cannot be tracked and paste stays raw.
+      term_bp_mode[chan] = false
+    end
+  end,
+})
+
 vim.paste = function(lines, phase)
   if vim.bo.buftype == "terminal" and vim.b.terminal_job_id then
     local chan = vim.b.terminal_job_id

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -32,40 +32,115 @@ if vim.env.SSH_TTY then
   }
 end
 
--- Re-wrap pastes into :term buffers with bracketed-paste markers, so nested
--- terminal programs (tmux + interactive apps inside :term) see a paste, not raw
--- keystrokes (\n = Ctrl-J = vim normal-mode `j`). Buffers chunked phases
--- (which happen over SSH when bytes arrive split across reads) into a single
--- write — splitting the bracketed-paste sequence across two writes lets some
--- inner programs can bail out before the end marker
--- arrives and fall back to interpreting the content as keystrokes.
+-- Send pastes into :term buffers to the inner program's PTY.  Neovim's
+-- default vim.paste uses nvim_put() for terminal buffers, which does forward
+-- text to the PTY but does NOT wrap it in bracketed-paste markers.  Without
+-- markers, nested programs in normal mode (e.g. vim) interpret pasted \n as
+-- Ctrl-J = `j` motion.  Wrapping with \27[200~…\27[201~ tells such programs to
+-- treat the content as a paste.
+--
+-- However, only wrap when the inner program has actually ENABLED bracketed-
+-- paste mode (sent \27[?2004h).  When the inner program has not opted in (e.g.
+-- cat, a REPL, a shell running a foreground process), the markers are
+-- meaningless and cause visible tilde artifacts: the :term PTY has echo +
+-- echoctl enabled by default, so the kernel echoes the ESC byte as literal
+-- "^[" (caret notation), preventing libvterm from recognising the CSI
+-- sequence.  The "~" in \27[200~ / \27[201~ then appears as a literal tilde.
+-- Programs that enable bracketed paste (vim, zsh ZLE, pi-agent) set the PTY
+-- to raw mode (disabling echo), so the markers are never echoed and no
+-- tildes appear.
+--
+-- We track bracketed-paste mode by wrapping vim.fn.termopen with an on_stdout
+-- callback that scans the program's raw output for \27[?2004h / \27[?2004l.
+-- Snacks.terminal (and any other caller) goes through vim.fn.termopen, so the
+-- tracking covers every :term buffer.
+local term_bp_mode = {} -- chan → boolean (inner program has BP enabled)
 local paste_buf = {}
 local default_paste = vim.paste
+
+do
+  local original_termopen = vim.fn.termopen
+  if original_termopen then
+    vim.fn.termopen = function(cmd, opts)
+      opts = opts or {}
+      local user_on_stdout = opts.on_stdout
+      opts.on_stdout = function(job_id, data, event)
+        if type(data) == "table" then
+          for _, chunk in ipairs(data) do
+            -- plain=true: literal substring search, not a Lua pattern.
+            if chunk:find("\27[?2004h", 1, true) then
+              term_bp_mode[job_id] = true
+            end
+            if chunk:find("\27[?2004l", 1, true) then
+              term_bp_mode[job_id] = false
+            end
+          end
+        end
+        if user_on_stdout then
+          user_on_stdout(job_id, data, event)
+        end
+      end
+      local chan = original_termopen(cmd, opts)
+      if chan and chan ~= 0 then
+        term_bp_mode[chan] = false
+      end
+      return chan
+    end
+  end
+end
+
 vim.paste = function(lines, phase)
   if vim.bo.buftype == "terminal" and vim.b.terminal_job_id then
     local chan = vim.b.terminal_job_id
-    local START, END = "\27[200~", "\27[201~"
-    if phase == -1 then
-      vim.api.nvim_chan_send(chan, START .. table.concat(lines, "\n") .. END)
+    local use_markers = term_bp_mode[chan] == true
+    if use_markers then
+      local START, END = "\27[200~", "\27[201~"
+      if phase == -1 then
+        vim.api.nvim_chan_send(chan, START .. table.concat(lines, "\n") .. END)
+        return true
+      end
+      if phase == 1 then
+        paste_buf = vim.deepcopy(lines)
+      elseif #paste_buf > 0 and #lines > 0 then
+        -- Continuation: last line of buf concatenates with first line of new
+        -- chunk (nvim splits at byte boundaries, so a line can span phases).
+        paste_buf[#paste_buf] = paste_buf[#paste_buf] .. lines[1]
+        for i = 2, #lines do
+          table.insert(paste_buf, lines[i])
+        end
+      else
+        vim.list_extend(paste_buf, lines)
+      end
+      if phase == 3 then
+        vim.api.nvim_chan_send(chan, START .. table.concat(paste_buf, "\n") .. END)
+        paste_buf = {}
+      end
+      return true
+    else
+      -- Inner program has not enabled bracketed paste: send raw content.
+      -- No markers means no ESC bytes, so echoctl cannot mangle them into
+      -- visible tildes.  The \n → `j` problem does not apply because programs
+      -- that interpret \n as a motion (vim) always enable bracketed paste.
+      if phase == -1 then
+        vim.api.nvim_chan_send(chan, table.concat(lines, "\n"))
+        return true
+      end
+      if phase == 1 then
+        paste_buf = vim.deepcopy(lines)
+      elseif #paste_buf > 0 and #lines > 0 then
+        paste_buf[#paste_buf] = paste_buf[#paste_buf] .. lines[1]
+        for i = 2, #lines do
+          table.insert(paste_buf, lines[i])
+        end
+      else
+        vim.list_extend(paste_buf, lines)
+      end
+      if phase == 3 then
+        vim.api.nvim_chan_send(chan, table.concat(paste_buf, "\n"))
+        paste_buf = {}
+      end
       return true
     end
-    if phase == 1 then
-      paste_buf = vim.deepcopy(lines)
-    elseif #paste_buf > 0 and #lines > 0 then
-      -- Continuation: last line of buf concatenates with first line of new
-      -- chunk (nvim splits at byte boundaries, so a line can span phases).
-      paste_buf[#paste_buf] = paste_buf[#paste_buf] .. lines[1]
-      for i = 2, #lines do
-        table.insert(paste_buf, lines[i])
-      end
-    else
-      vim.list_extend(paste_buf, lines)
-    end
-    if phase == 3 then
-      vim.api.nvim_chan_send(chan, START .. table.concat(paste_buf, "\n") .. END)
-      paste_buf = {}
-    end
-    return true
   end
   return default_paste(lines, phase)
 end

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -93,8 +93,10 @@ do
           end
         end
       end
-      if user_on_stdout then
+      if type(user_on_stdout) == "function" then
         user_on_stdout(job_id, data, event)
+      elseif user_on_stdout then
+        vim.fn.call(user_on_stdout, { job_id, data, event }, opts)
       end
     end
     return opts

--- a/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
+++ b/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
@@ -1,0 +1,138 @@
+--- Tests for the vim.paste override that prevents tilde artifacts when pasting
+--- into :term buffers. See lua/config/options.lua.
+---
+--- Root cause: the old override always wrapped :term pastes with bracketed-paste
+--- markers (\27[200~ … \27[201~).  The :term PTY has echo + echoctl enabled by
+--- default, so the kernel echoes the ESC byte as literal "^[" (caret notation),
+--- preventing libvterm from recognising the CSI sequence.  The "~" in the markers
+--- then appears as a literal tilde.
+---
+--- Fix: only wrap with markers when the inner program has enabled bracketed
+--- paste mode (sent \27[?2004h).  Track the mode via an on_stdout callback
+--- injected through a vim.fn.termopen wrapper.
+
+-- Tests are run from the nvim config root (nvim/.config/nvim/).
+local config_root = vim.fn.getcwd()
+package.path = config_root .. "/lua/?.lua;" .. config_root .. "/lua/?/init.lua;" .. package.path
+
+-- Load options.lua (defines the vim.paste override and termopen wrapper)
+dofile(config_root .. "/lua/config/options.lua")
+
+local function make_term(cmd)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+  local chan = vim.fn.termopen(cmd, { bufnr = buf })
+  vim.cmd("startinsert")
+  vim.wait(500)
+  return buf, chan
+end
+
+local function close_term(buf, chan)
+  vim.api.nvim_chan_send(chan, "\4") -- Ctrl-D: EOF for cat
+  vim.wait(300)
+  pcall(vim.fn.chanclose, chan)
+  vim.wait(300)
+  pcall(vim.cmd, "bdelete! " .. buf)
+end
+
+local function buf_has_tilde(buf)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  for _, line in ipairs(lines) do
+    if line:find("~", 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
+local tests = {}
+
+--- Pasting into a :term running cat (no bracketed paste) must not produce
+--- visible tilde characters from bracketed-paste markers.
+function tests.test_no_tildes_when_bp_disabled()
+  local buf, chan = make_term("cat")
+  vim.paste({ "echo hello", "ls -la" }, -1)
+  vim.wait(300)
+  local has_tilde = buf_has_tilde(buf)
+  close_term(buf, chan)
+  assert(not has_tilde, "expected no tildes in :term buffer with cat")
+  print("PASS: no tildes when bracketed paste is not enabled")
+end
+
+--- When the inner program HAS enabled bracketed paste mode, the markers must
+--- still be sent so programs like vim handle the paste correctly.
+function tests.test_markers_sent_when_bp_enabled()
+  local tmp = vim.fn.tempname()
+  local buf, chan = make_term(string.format(
+    "bash -c 'printf \"\\x1b[?2004h\"; cat > %s'",
+    vim.fn.shellescape(tmp)
+  ))
+  vim.wait(800) -- wait for BP enable to be detected via on_stdout
+  vim.paste({ "echo hello" }, -1)
+  vim.wait(300)
+  close_term(buf, chan)
+
+  local f = io.open(tmp, "rb")
+  assert(f, "output file not created")
+  local content = f:read("*a")
+  f:close()
+  vim.fn.delete(tmp)
+
+  assert(content:find("\27[200~", 1, true), "start marker missing in paste output")
+  assert(content:find("\27[201~", 1, true), "end marker missing in paste output")
+  assert(content:find("echo hello", 1, true), "paste content missing")
+  print("PASS: bracketed-paste markers sent when inner program enables BP")
+end
+
+--- Pasting into a regular (non-terminal) buffer should use the default handler.
+function tests.test_regular_buffer_uses_default_paste()
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+  vim.bo[buf].buftype = ""
+  vim.paste({ "hello world" }, -1)
+  local line = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1]
+  assert(line == "hello world", "regular buffer paste failed: got " .. tostring(line))
+  vim.cmd("bdelete! " .. buf)
+  print("PASS: regular buffer paste uses default handler")
+end
+
+--- Multi-phase paste (simulates SSH chunked delivery) must reassemble content
+--- correctly without tildes when BP is not enabled.
+function tests.test_multiphase_no_tildes_when_bp_disabled()
+  local tmp = vim.fn.tempname()
+  local buf, chan = make_term(string.format("cat > %s", vim.fn.shellescape(tmp)))
+  vim.paste({ "ech" }, 1)
+  vim.wait(100)
+  vim.paste({ "o hello" }, 2)
+  vim.wait(100)
+  vim.paste({ "" }, 3)
+  vim.wait(300)
+  close_term(buf, chan)
+
+  local f = io.open(tmp, "r")
+  assert(f, "output file not created")
+  local content = f:read("*a")
+  f:close()
+  vim.fn.delete(tmp)
+
+  assert(content:find("echo hello", 1, true), "multi-phase paste content mismatch: " .. vim.inspect(content))
+  assert(not content:find("~", 1, true), "tildes found in multi-phase paste output")
+  print("PASS: multi-phase paste reassembles correctly without tildes")
+end
+
+-- Run all tests
+local failures = 0
+for name, fn in pairs(tests) do
+  local ok, err = pcall(fn)
+  if not ok then
+    print("FAIL: " .. name .. " — " .. tostring(err))
+    failures = failures + 1
+  end
+end
+
+if failures > 0 then
+  print(string.format("\n%d test(s) failed", failures))
+  vim.cmd("cquit 1")
+else
+  print(string.format("\nAll %d tests passed", #vim.tbl_keys(tests)))
+end

--- a/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
+++ b/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
@@ -68,7 +68,9 @@ function tests.test_markers_sent_when_bp_enabled()
     vim.fn.shellescape(tmp)
   ))
   vim.wait(800) -- wait for BP enable to be detected via on_stdout
-  vim.paste({ "echo hello" }, -1)
+  vim.paste({ "echo " }, 1)
+  vim.paste({ "hello" }, 2)
+  vim.paste({ "" }, 3)
   vim.wait(300)
   close_term(buf, chan)
 
@@ -82,6 +84,35 @@ function tests.test_markers_sent_when_bp_enabled()
   assert(content:find("\27[201~", 1, true), "end marker missing in paste output")
   assert(content:find("echo hello", 1, true), "paste content missing")
   print("PASS: bracketed-paste markers sent when inner program enables BP")
+end
+
+function tests.test_jobstart_tracks_ordered_split_bp_output()
+  local tmp = vim.fn.tempname()
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+  local chan = vim.fn.jobstart({
+    "bash",
+    "-c",
+    string.format(
+      "printf '\\033[?2004h\\033[?2004l\\033[?20'; sleep 0.2; printf '04h'; cat > %s",
+      vim.fn.shellescape(tmp)
+    ),
+  }, { term = true })
+  vim.cmd("startinsert")
+  vim.wait(800)
+  vim.paste({ "echo hello" }, -1)
+  vim.wait(300)
+  close_term(buf, chan)
+
+  local f = io.open(tmp, "rb")
+  assert(f, "output file not created")
+  local content = f:read("*a")
+  f:close()
+  vim.fn.delete(tmp)
+
+  assert(content:find("\27[200~", 1, true), "start marker missing after split enable sequence")
+  assert(content:find("\27[201~", 1, true), "end marker missing after split enable sequence")
+  print("PASS: jobstart tracks ordered split bracketed-paste output")
 end
 
 --- Pasting into a regular (non-terminal) buffer should use the default handler.

--- a/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
+++ b/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
@@ -1,21 +1,10 @@
---- Tests for the vim.paste override that prevents tilde artifacts when pasting
---- into :term buffers. See lua/config/options.lua.
----
---- Root cause: the old override always wrapped :term pastes with bracketed-paste
---- markers (\27[200~ … \27[201~).  The :term PTY has echo + echoctl enabled by
---- default, so the kernel echoes the ESC byte as literal "^[" (caret notation),
---- preventing libvterm from recognising the CSI sequence.  The "~" in the markers
---- then appears as a literal tilde.
----
---- Fix: only wrap with markers when the inner program has enabled bracketed
---- paste mode (sent \27[?2004h).  Track the mode via an on_stdout callback
---- injected through a vim.fn.termopen wrapper.
+--- Regression coverage for terminal paste behavior. See lua/config/options.lua.
 
 -- Tests are run from the nvim config root (nvim/.config/nvim/).
 local config_root = vim.fn.getcwd()
 package.path = config_root .. "/lua/?.lua;" .. config_root .. "/lua/?/init.lua;" .. package.path
 
--- Load options.lua (defines the vim.paste override and termopen wrapper)
+-- Load options.lua (defines the vim.paste override and terminal-job wrappers)
 dofile(config_root .. "/lua/config/options.lua")
 
 local function make_term(cmd)
@@ -68,8 +57,7 @@ function tests.test_no_tildes_when_bp_disabled()
   print("PASS: no tildes when bracketed paste is not enabled")
 end
 
---- When the inner program HAS enabled bracketed paste mode, the markers must
---- still be sent so programs like vim handle the paste correctly.
+--- Vimscript :terminal bypasses tracked callbacks, so paste remains raw.
 function tests.test_builtin_terminal_uses_raw_paste()
   local buf, chan = make_builtin_term("cat")
   vim.paste({ "echo hello", "ls -la" }, -1)
@@ -82,10 +70,7 @@ end
 
 function tests.test_markers_sent_when_bp_enabled()
   local tmp = vim.fn.tempname()
-  local buf, chan = make_term(string.format(
-    "bash -c 'printf \"\\x1b[?2004h\"; cat > %s'",
-    vim.fn.shellescape(tmp)
-  ))
+  local buf, chan = make_term(string.format("bash -c 'printf \"\\x1b[?2004h\"; cat > %s'", vim.fn.shellescape(tmp)))
   vim.wait(800) -- wait for BP enable to be detected via on_stdout
   vim.paste({ "echo " }, 1)
   vim.paste({ "hello" }, 2)

--- a/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
+++ b/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
@@ -105,6 +105,35 @@ function tests.test_markers_sent_when_bp_enabled()
   print("PASS: bracketed-paste markers sent when inner program enables BP")
 end
 
+function tests.test_vimscript_stdout_callback_receives_job_options()
+  vim.g.term_paste_callback_state = nil
+  vim.cmd([[
+    function! TermPasteTestCallback(job_id, data, event) dict
+      let g:term_paste_callback_state = self.callback_state
+    endfunction
+  ]])
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+  local chan = vim.fn.jobstart({ "sh", "-c", "printf callback" }, {
+    term = true,
+    callback_state = "preserved",
+    on_stdout = "TermPasteTestCallback",
+  })
+  vim.wait(1000, function()
+    return vim.g.term_paste_callback_state ~= nil
+  end)
+
+  local state = vim.g.term_paste_callback_state
+  pcall(vim.fn.jobstop, chan)
+  pcall(vim.cmd, "bdelete! " .. buf)
+  vim.cmd("delfunction TermPasteTestCallback")
+  vim.g.term_paste_callback_state = nil
+
+  assert(state == "preserved", "Vimscript callback did not receive its job options dictionary")
+  print("PASS: Vimscript stdout callback receives job options")
+end
+
 function tests.test_jobstart_tracks_ordered_split_bp_output()
   local tmp = vim.fn.tempname()
   local buf = vim.api.nvim_create_buf(false, true)

--- a/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
+++ b/nvim/.config/nvim/tests/term_paste_tilde_spec.lua
@@ -27,6 +27,15 @@ local function make_term(cmd)
   return buf, chan
 end
 
+local function make_builtin_term(cmd)
+  vim.cmd("terminal " .. cmd)
+  local buf = vim.api.nvim_get_current_buf()
+  local chan = vim.b[buf].terminal_job_id
+  vim.cmd("startinsert")
+  vim.wait(500)
+  return buf, chan
+end
+
 local function close_term(buf, chan)
   vim.api.nvim_chan_send(chan, "\4") -- Ctrl-D: EOF for cat
   vim.wait(300)
@@ -61,6 +70,16 @@ end
 
 --- When the inner program HAS enabled bracketed paste mode, the markers must
 --- still be sent so programs like vim handle the paste correctly.
+function tests.test_builtin_terminal_uses_raw_paste()
+  local buf, chan = make_builtin_term("cat")
+  vim.paste({ "echo hello", "ls -la" }, -1)
+  vim.wait(300)
+  local has_tilde = buf_has_tilde(buf)
+  close_term(buf, chan)
+  assert(not has_tilde, "expected no tildes in built-in :terminal buffer with cat")
+  print("PASS: built-in :terminal uses raw paste")
+end
+
 function tests.test_markers_sent_when_bp_enabled()
   local tmp = vim.fn.tempname()
   local buf, chan = make_term(string.format(


### PR DESCRIPTION
## Intent

Fix tilde characters appearing when pasting code from pi-agent into Neovim terminal mode. The vim.paste override in options.lua always wrapped :term pastes with bracketed-paste markers containing literal tilde characters. When the inner program hasn't enabled bracketed paste, the PTY's echoctl setting echoes the ESC byte as caret notation, making the tilde visible. Fix: track bracketed-paste mode via termopen on_stdout wrapper, only send markers when the inner program has opted in. This preserves the original newline-to-j fix for programs that need it (vim, zsh, pi-agent) while eliminating tildes for programs that don't (cat, REPLs).

## What Changed

- Track bracketed-paste mode from terminal job output while preserving existing stdout callbacks.
- Send paste markers only when the nested program opts in; otherwise send raw, reassembled paste content without tilde artifacts.
- Add regression coverage for terminal paste modes and document the updated behavior.

## Risk Assessment

✅ Low: The change is well-bounded, preserves marker behavior for tracked bracketed-paste-aware programs, and uses the explicitly authorized raw-paste fallback for untracked terminals.

## Testing

The base implementation reproduced visible `^[[200~`/`^[[201~` artifacts, while the focused target tests and corrected raw-PTY manual harness verified artifact-free cat pastes, marker wrapping only while enabled, and preserved multiline paste into nested Neovim; no screenshot was available in headless Neovim, so actual terminal-buffer and persisted-output transcripts were captured.

<details>
<summary>Evidence: Base implementation showing visible tilde markers</summary>

```text
^[[200~echo hello
printf world
^[[201~echo hello
printf world
```
</details>
<details>
<summary>Evidence: Fixed cat terminal paste without tilde artifacts</summary>

```text
echo hello
printf world
echo hello
printf world
```
</details>
<details>
<summary>Evidence: Bracketed-paste enable/disable byte transition</summary>

```text
enabled paste bytes: "\27[200~one\27[201~"
disabled paste bytes: "two"
result: enable wrapped; disable raw
```
</details>
<details>
<summary>Evidence: File persisted by actual nested Neovim multiline paste</summary>

```text
alpha
beta
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f6c415d0058c6f173f18659f455c5cb0756074cd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `nvim/.config/nvim/lua/config/options.lua:71` - The detector is not stream-safe: on_stdout may split `\27[?2004h` across callbacks, so it is missed. A coalesced zsh disable→enable sequence is also processed as enable then disable because the checks ignore wire order. Both leave BP falsely disabled and send the next paste raw, contradicting the required “preserves the original newline-to-j fix.” Retain a cross-callback tail and process transitions in byte order.
- 🚨 `nvim/.config/nvim/lua/config/options.lua:64` - Only `vim.fn.termopen` is wrapped. Built-in `:terminal` uses `vim.fn.jobstart(..., { term = true })`, as can other callers, so those buffers never acquire BP state; nested vim/zsh can enable BP yet line 95 still sends raw content. This contradicts the required preservation for vim, zsh, and pi-agent. Track all supported terminal creation paths at a shared wrapper or explicitly authorize a narrower containment scope.
- ℹ️ `nvim/.config/nvim/lua/config/options.lua:96` - The marker and raw branches duplicate the complete multi-phase reassembly flow. Assemble the payload once, then conditionally add markers at send time to reduce complexity and future drift without changing behavior.

🔧 Fix: Track terminal bracketed-paste state across all launch paths
1 error still open:
- 🚨 `nvim/.config/nvim/lua/config/options.lua:117` - Assigning `vim.fn.jobstart` only intercepts Lua calls through that proxy. Built-in `:terminal` loads `term://` via Neovim&#39;s Vimscript `call jobstart(..., {&#39;term&#39;: v:true})`, bypassing this wrapper. Thus `:terminal nvim` can emit `\27[?2004h` while `term_bp_mode[chan]` remains nil; line 151 then sends pasted newlines raw as Ctrl-J. This contradicts the required criterion that the change “preserves the original newline-to-j fix for programs that need it (vim, zsh, pi-agent).” Route the built-in `term://` loader through the shared tracked starter, or explicitly authorize excluding built-in `:terminal`.

🔧 Fix: Default untracked terminals to raw paste
1 warning still open:
- ⚠️ `nvim/.config/nvim/lua/config/options.lua:97` - Forwarding `on_stdout` with a direct Lua call breaks Neovim&#39;s documented callback contract for Vimscript dictionary functions, where `self` must be the job options dictionary. A Lua terminal caller supplying such a callback can now fail or lose its per-job state. Invoke the callback through `call()` with the tracked options dictionary while preserving ordinary Lua callbacks.

🔧 Fix: Preserve Vimscript terminal callback dictionary context
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd /tmp/no-mistakes-evidence/01M0GEWY5A5SXD086N96C9TMWN/baseline &amp;&amp; nvim --headless -u NONE &#39;+luafile tests/term_paste_tilde_spec.lua&#39; &#39;+qa!&#39;` — reproduced three expected failures against the base implementation.</code>
- `cd nvim/.config/nvim && nvim --headless -u NONE '+luafile tests/term_paste_tilde_spec.lua' '+qa!'`
- <code>`cd nvim/.config/nvim &amp;&amp; nvim --headless -u NONE &#39;+luafile /tmp/no-mistakes-evidence/01M0GEWY5A5SXD086N96C9TMWN/baseline-cat.lua&#39; &#39;+qa!&#39;` — captured the original visible tilde regression.</code>
- <code>`cd nvim/.config/nvim &amp;&amp; nvim --headless -u NONE &#39;+luafile /tmp/no-mistakes-evidence/01M0GEWY5A5SXD086N96C9TMWN/manual-e2e.lua&#39; &#39;+qa!&#39;` — exercised cat, bracketed-paste enable/disable transitions, and multiline paste into nested Neovim.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
