### PR TITLE
pi: add /mobile command for constrained responses

### DIFF
--- a/pi/.pi/agent/extensions/mobile-mode.ts
+++ b/pi/.pi/agent/extensions/mobile-mode.ts
@@ -1,0 +1,40 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const MOBILE_PROMPT = [
+	"",
+	"## MOBILE MODE ACTIVE",
+	"",
+	"You are responding on a mobile terminal that is 80 columns wide and 21 rows tall.",
+	"Your entire response MUST fit within that viewport.",
+	"",
+	"Rules:",
+	"- Keep every line at most 80 characters.",
+	"- Keep the total response at most 21 lines (including blank lines and code blocks).",
+	"- Use short, dense prose. No filler. No preamble.",
+	"- If the answer needs more than 26 lines, give a ONE-sentence summary instead.",
+	"  That single sentence must capture the key point and fit on one line (≤80 chars).",
+	"- Prefer code blocks only when essential; keep them tiny.",
+	"",
+].join("\n");
+
+export default function (pi: ExtensionAPI) {
+	let mobile = false;
+
+	pi.registerCommand("mobile", {
+		description: "Toggle mobile mode — constrains responses to 80×21",
+		handler: async (_args, ctx) => {
+			mobile = !mobile;
+			ctx.ui.notify(
+				mobile ? "Mobile mode ON — responses constrained to 80×21" : "Mobile mode OFF",
+				"info",
+			);
+		},
+	});
+
+	pi.on("before_agent_start", (event, _ctx) => {
+		if (!mobile) return undefined;
+		return {
+			systemPrompt: event.systemPrompt + MOBILE_PROMPT,
+		};
+	});
+}

--- a/pi/.pi/agent/settings.json
+++ b/pi/.pi/agent/settings.json
@@ -8,7 +8,8 @@
     "git/github.com/amosblomqvist/pi-config/extensions/youtube-search/index.ts"
   ],
   "extensions": [
-    "-extensions/transcript-scroll.ts"
+    "-extensions/transcript-scroll.ts",
+    "+extensions/mobile-mode.ts"
   ],
   "lastChangelogVersion": "0.82.1",
   "defaultProvider": "openai-codex",


### PR DESCRIPTION
## Feature

A `/mobile` slash command that toggles mobile mode on/off. When active, it injects a system prompt instructing the agent to constrain responses to **80 columns × 21 rows**.

If the answer needs more than 21 lines, the agent gives a **one-sentence summary** instead (≤80 chars).

## How it works

- `pi.registerCommand("mobile")` toggles a boolean flag
- `before_agent_start` appends the constraint prompt to the system prompt when mobile mode is active
- `ctx.ui.notify()` confirms the toggle state

## Files

- `pi/.pi/agent/extensions/mobile-mode.ts` — the extension
- `pi/.pi/agent/settings.json` — adds `+extensions/mobile-mode.ts` to the extensions array