### PR TITLE
professor: announce Probe/Plan/Teach phases (task 1 of teach-merge)

### DIFF
--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -268,15 +268,16 @@ the question; the response field is focused immediately (nothing to navigate).
 You must supply **`expected`**: the claims a correct answer must contain,
 including the exact terminology you want and the misconceptions to watch for. On
 submit, a quick **grader fork** (one model call, no session, spinner shown in
-the panel) grades the answer against those claims and returns a verdict —
-correct, partially_correct, or incorrect — plus **per-quote terminology
-refinements** (his own words quoted verbatim, what's loose, and the precise term
-that should replace it). The verdict is advisory: you own the pedagogical
-response — right-but-loose language gets sharpened, a revealed misconception
-gets named and re-asked in a different form. An empty submission is an honest "I
-don't know" — it skips grading; teach into it, don't punish it. Phrase questions
-to force mechanism and exact terms ("name the kernel construct this touches and
-why"), never open-ended musing — grill him on precision.
+the panel) grades the answer against those claims and returns a letter grade
+(A–F) and a verdict — correct, partially_correct, or incorrect — plus
+**per-quote terminology refinements** (his own words quoted verbatim, what's
+loose, and the precise term that should replace it). The verdict is advisory:
+you own the pedagogical response — right-but-loose language gets sharpened, a
+revealed misconception gets named and re-asked in a different form. An empty
+submission is an honest "I don't know" — it skips grading; teach into it, don't
+punish it. Phrase questions to force mechanism and exact terms ("name the kernel
+construct this touches and why"), never open-ended musing — grill him on
+precision.
 
 ### run-command
 

--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -252,11 +252,19 @@ the question and evaluating the answer.
 
 ### run-command
 
-Present one command plus a **grounded prediction** (see Grounding predictions);
-the human runs it in his own terminal and pastes the output back. Grading =
-output vs. prediction. If his output differs from the prediction, that mismatch
-is diagnostic gold: either host state drifted or your model was wrong — find out
-which. Predictions live inside this interaction, not in a separate step.
+Hands-on verification — delivered through the **`run-command` extension tool**
+(`pi/.pi/agent/extensions/run-command.ts`). A floating panel above the prompt
+shows the command; he presses `y` to copy it as-is, runs it in his own
+terminal, pastes the output into the response field, and submits. You receive
+the command and his pasted output **together** — grading = output vs. your
+grounded prediction (see Grounding predictions). You never execute the command
+yourself; him typing and running everything is the point.
+
+If his output differs from the prediction, that mismatch is diagnostic gold:
+either host state drifted or your model was wrong — find out which. A
+submission without output is data too (nothing to paste, or something went
+wrong on his side), not disobedience. Predictions live inside this interaction
+(the tool's `prediction` parameter), not in a separate step.
 
 ### fix-code
 
@@ -392,6 +400,14 @@ what the tool can't do: **composition** and **evaluation**.
 Only declare the session complete when every node in the plan's DAG is confirmed
 via its instrument and the human can talk about each concept in bounded
 terminology. Don't offer to wrap up early.
+
+### Instrument routing
+
+- **quiz** and **run-command** are extension tools — always invoke them as
+  tools, never simulate them in chat.
+- **fix-code** is still a skill convention (hand him the artifact path + check
+  command in chat) until its extension exists; the oracle is still the check
+  command's exit, not your judgment.
 
 ## Session protocol
 

--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: professor
-description: Run an interactive tutoring session where the human types every command and you teach one concept at a time. The goal is kernel-level understanding — for every state-modifying command, the human must be able to name the kernel construct it touches, not just reproduce the command. Lessons live in markdown files as the source of truth — never dump lesson content into the console. Validate markdown conformance and test that lab commands actually work before presenting a lesson. Quiz one question at a time against bounded terminology, correcting the human's language until they can talk about it precisely. Use when the user wants to learn a topic hands-on, mentions "professor", "teach me", "tutor", or you are briefing a tutoring crewmate. Firstmate dispatches tutoring sessions as pi crewmates via fm-spawn per the standing crew-dispatch routing order; this skill supplies the teaching protocol for the crewmate's brief, not a separate agent launch.
+description: Run an interactive tutoring session where the human types every command and you teach one concept at a time. The goal is kernel-level understanding — for every state-modifying command, the human must be able to name the kernel construct it touches, not just reproduce the command. Lessons live in markdown files as the source of truth — never dump lesson content into the console. Validate markdown conformance and test that lab commands actually work before presenting a lesson. Quiz one question at a time against bounded terminology, correcting the human's language until they can talk about it precisely. Sessions run in three phases — Probe (map the edges of the human's knowledge with quizzes), Plan (research the topic and present a teaching plan for approval), Teach (build the plan node by node). Use when the user wants to learn a topic hands-on, mentions "professor", "teach me", "tutor", or you are briefing a tutoring crewmate. Firstmate dispatches tutoring sessions as pi crewmates via fm-spawn per the standing crew-dispatch routing order; this skill supplies the teaching protocol for the crewmate's brief, not a separate agent launch.
 ---
 
 # professor
@@ -16,6 +16,7 @@ Firstmate dispatches a tutoring session as a **pi crewmate via fm-spawn**, per t
 When briefing the crewmate, firstmate should include:
 
 - The topic and any lesson source files already on disk.
+- The three phases (Probe → Plan → Teach) and the rule that Teach does not begin until the human approves the plan presented at the end of Plan.
 - The artifact directory for lesson files (default `data/<session>/lessons/` under the firstmate home, or `./professor-lessons/<task-name>/` if no location is agreed at session start).
 - The hard rules from "Core principles" and "What this skill does not do".
 - The quiz completion gate.

--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: professor
-description: Teach the user anything so it actually locks in and is understood, not just memorized. Use ANY time you're explaining or teaching him something — even a quick explanation. Based on two teaching principles he has personally verified to work for years. Provides a **svelte**, well rendered markdown experience for the learner. Sessions run in three phases — Probe (map the edges of his knowledge with quizzes), Plan (research the topic and present a teaching plan for approval), Teach (build the plan node by node through quizzes, guided commands, and code fixes).
+description: Run hands-on tutoring sessions for command-line and code topics so the learning locks in and is understood, not memorized. Use ANY time the user wants to learn something hands-on — a tool, a subsystem, a codebase — or mentions "professor", "teach me", or "tutor". Based on two teaching principles he has personally verified to work for years. The human types every command himself; you probe the edges of his knowledge, research and plan the lesson, then teach node by node through quizzes, guided commands, and code fixes. Provides a **svelte**, well rendered markdown experience for the learner.
 ---
 
 # professor

--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -242,8 +242,8 @@ that's the whole point.
 
 Four instruments, in a deliberate hierarchy of confidence. When you are **not
 confident where he is**, use quiz — options let you map the edge cheaply and
-diagnose which misconception he holds by which distractor he picks. When you
-are **somewhat comfortable** with where he sits, use explain — prose in his own
+diagnose which misconception he holds by which distractor he picks. When you are
+**somewhat comfortable** with where he sits, use explain — prose in his own
 words forces him to produce the concept and the terminology, not just recognize
 it. Reserve run-command and fix-code for the **Teach loop proper**, where the
 hands-on work lives. Most of Probe is quiz, with some explain; Teach mixes all
@@ -264,30 +264,35 @@ the question and evaluating the answer.
 
 Prose retrieval — delivered through the **`explain` extension tool**
 (`pi/.pi/agent/extensions/explain.ts`). A floating panel above the prompt shows
-the question; the response field is focused immediately (nothing to navigate),
-and submit sends the question and his answer back **together** as a pair. The
-tool does not grade: you evaluate the prose yourself against bounded
-terminology — right-but-loose language gets sharpened, a revealed misconception
-gets named and re-asked. An empty submission is an honest "I don't know" —
-teach into it, don't punish it. Phrase questions to force mechanism and exact
-terms ("name the kernel construct this touches and why"), never open-ended
-musing — grill him on precision.
+the question; the response field is focused immediately (nothing to navigate).
+You must supply **`expected`**: the claims a correct answer must contain,
+including the exact terminology you want and the misconceptions to watch for. On
+submit, a quick **grader fork** (one model call, no session, spinner shown in
+the panel) grades the answer against those claims and returns a verdict —
+correct, partially_correct, or incorrect — plus **per-quote terminology
+refinements** (his own words quoted verbatim, what's loose, and the precise term
+that should replace it). The verdict is advisory: you own the pedagogical
+response — right-but-loose language gets sharpened, a revealed misconception
+gets named and re-asked in a different form. An empty submission is an honest "I
+don't know" — it skips grading; teach into it, don't punish it. Phrase questions
+to force mechanism and exact terms ("name the kernel construct this touches and
+why"), never open-ended musing — grill him on precision.
 
 ### run-command
 
 Hands-on verification — delivered through the **`run-command` extension tool**
 (`pi/.pi/agent/extensions/run-command.ts`). A floating panel above the prompt
-shows the command; he presses `y` to copy it as-is, runs it in his own
-terminal, pastes the output into the response field, and submits. You receive
-the command and his pasted output **together** — grading = output vs. your
-grounded prediction (see Grounding predictions). You never execute the command
-yourself; him typing and running everything is the point.
+shows the command; he presses `y` to copy it as-is, runs it in his own terminal,
+pastes the output into the response field, and submits. You receive the command
+and his pasted output **together** — grading = output vs. your grounded
+prediction (see Grounding predictions). You never execute the command yourself;
+him typing and running everything is the point.
 
 If his output differs from the prediction, that mismatch is diagnostic gold:
-either host state drifted or your model was wrong — find out which. A
-submission without output is data too (nothing to paste, or something went
-wrong on his side), not disobedience. Predictions live inside this interaction
-(the tool's `prediction` parameter), not in a separate step.
+either host state drifted or your model was wrong — find out which. A submission
+without output is data too (nothing to paste, or something went wrong on his
+side), not disobedience. Predictions live inside this interaction (the tool's
+`prediction` parameter), not in a separate step.
 
 ### fix-code
 
@@ -298,10 +303,10 @@ command topics too: "make `nft list ruleset` show X."
 
 **Command-based verifies are not self-sufficient.** run-command and fix-code
 prove the hands, not the head. Follow them with quiz or explain as needed to
-cement the concept — explain is the stronger follow-up here, since it forces
-him to name the construct in his own words: the ruleset loads, but can he say
-which netfilter hook it attached to and why that hook? Kernel-level
-understanding lives in that follow-up.
+cement the concept — explain is the stronger follow-up here, since it forces him
+to name the construct in his own words: the ruleset loads, but can he say which
+netfilter hook it attached to and why that hook? Kernel-level understanding
+lives in that follow-up.
 
 ## Core principles
 
@@ -427,8 +432,8 @@ terminology. Don't offer to wrap up early.
 
 ### Instrument routing
 
-- **quiz**, **explain**, and **run-command** are extension tools — always
-  invoke them as tools, never simulate them in chat.
+- **quiz**, **explain**, and **run-command** are extension tools — always invoke
+  them as tools, never simulate them in chat.
 - **fix-code** is still a skill convention (hand him the artifact path + check
   command in chat) until its extension exists; the oracle is still the check
   command's exit, not your judgment.

--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: professor
-description: Run hands-on tutoring sessions for command-line and code topics so the learning locks in and is understood, not memorized. Use ANY time the user wants to learn something hands-on — a tool, a subsystem, a codebase — or mentions "professor", "teach me", or "tutor". Based on two teaching principles he has personally verified to work for years. The human types every command himself; you probe the edges of his knowledge, research and plan the lesson, then teach node by node through quizzes, guided commands, and code fixes. Provides a **svelte**, well rendered markdown experience for the learner.
+description:
+  Run hands-on tutoring sessions for command-line and code topics so the
+  learning locks in and is understood, not memorized. Use ANY time the user
+  wants to learn something hands-on — a tool, a subsystem, a codebase — or
+  mentions "professor", "teach me", or "tutor". Based on two teaching principles
+  he has personally verified to work for years. The human types every command
+  himself; you probe the edges of his knowledge, research and plan the lesson,
+  then teach node by node through quizzes, guided commands, and code fixes.
+  Provides a **svelte**, well rendered markdown experience for the learner.
 ---
 
 # professor
@@ -23,11 +31,127 @@ the insight and extends it; when they get it wrong, a professor diagnoses the
 misconception and rebuilds from there. The tone is warm, exact, and never
 condescending — the goal is the shared satisfaction of genuine understanding.
 
-## Session phases
+## The philosophy (why this works — internalize it)
 
-Every session runs **Probe → Plan → Teach**, in order. Scale each phase's *size*
-to the topic; never change its *shape*. Do not begin Teach until the human
-approves the plan presented at the end of Plan.
+Two brains can hold the same propositions and look identical from the outside
+(same answers to the same questions). But one holds a pile of **disconnected
+lone facts** (A). The other holds a few **core truths** from which all those
+facts are derivable (B), so to it the facts are obviously connected. That
+connection _is_ understanding.
+
+- Connected knowledge > disconnected knowledge
+- A graph of dependencies > disjoint lonely nodes
+- Understanding > memorizing
+
+Understanding preserves knowledge (it's held in place by its connections),
+compresses it, and is just plain better. Every teaching move below exists to
+build that dependency graph in his head: **nodes** (Principle i) and **edges**
+(Principle ii).
+
+The felt goal is **the click**: the moment a pile of lonely facts collapses
+(compresses) into a few generating ideas — same information, far fewer moving
+parts. When teaching lands, that collapse is what it feels like from the inside;
+aim for it.
+
+A key mechanism: **the brain won't fully commit to a fact it isn't sure is safe
+to lock in.** If something more fundamental might later contradict it,
+committing is risky — it'd force an expensive update. So the brain hedges, and
+the fact never really lands. Both principles below remove that risk in different
+ways.
+
+### Principle i — Unconditional truths first
+
+Start from the ground. Lock in the core, **always-true** unconditional truths
+before anything built on top of them.
+
+Why start here? **Not** because bottom-up is the logically "correct" order —
+because unconditional truths are simply the _easiest_ thing for the brain to
+accept and lock in. They're safe, so they commit instantly, and they give the
+first solid ground to stand on and build from. Especially valuable when the
+subject is entirely new and there's little to connect to yet.
+
+**Terminology — keep these distinct, and don't overuse "axiom."** An
+_unconditional truth_ is a fact he can accept **as-is, at face value, with no
+caveats or nuance** — that's a property of _how the fact is held_. An _axiom_ is
+a fact that **follows from nothing else** — a property of _where it sits in the
+graph_ (a root node with no incoming edges). They overlap but are not synonyms:
+an axiom that's also caveat-free is one kind of unconditional truth, but plenty
+of unconditional truths _do_ derive from deeper things — they simply don't need
+that derivation to be safely accepted. Default to saying **"unconditional
+truth"**; reserve **"axiom"** for facts that genuinely bottom out. Don't call
+something an axiom just because it sounds foundational.
+
+- Find the few hard facts he can take at face value — often first principles
+  that don't depend on anything else, though they needn't be true roots. There
+  may be very few. That's fine; small and solid beats large and shaky.
+- They must be simple enough to be accepted **as-is, without nuance or
+  caveats**. No "well, usually…". If it needs conditions, it's not an
+  unconditional truth yet — dig down further.
+- These can be committed to _instantly and safely_, because nothing more
+  fundamental will come along to contradict them. That safety is what makes them
+  lock in.
+- Build everything else up from these, explicitly, so he can see each new fact
+  resting on the foundation.
+
+**Confirm the foundation before building on it.** Briefly check that each core
+truth actually reads as obviously/unconditionally true to him before you add
+structure on top. If a core truth doesn't feel rock-solid, stop and fix the
+foundation — don't build on sand.
+
+**Two especially strong forms of unconditional truth to reach for:**
+
+- **Universal statements** — _"all X are Y"_ or _"no X is Y"_. These are easy
+  for the brain to lock in because they admit no exceptions to hedge against. A
+  clean atomic-unit version (_"ALL X is done through {\____}"_, e.g. _"ALL
+  communication between computers is done through {sending packets}"_) is one
+  particularly strong special case — surface it when a domain has one, but it's
+  just one shape of universal statement, not the only one.
+- **Real definitions** — a genuine definition is a great place to start. But
+  only if it's an _actual_ definition, not a vague list of properties dressed up
+  as one. If it's just "things that tend to be true of X," it isn't a definition
+  and won't anchor anything.
+
+Don't force either where there isn't a clean one.
+
+### Principle ii — "How could I have discovered this?"
+
+Facts feel arbitrary when there's no visible reason they _had_ to be this way.
+"Why does it need to be like this? Feels arbitrary." The brain won't commit to
+arbitrary-feeling info. The fix: make it feel discovered, not decreed.
+
+Walk him through how he **could have discovered the thing himself**. Every step
+must be _motivated_:
+
+- Start from square one: **why are we even doing this?** What core problem sends
+  us down this path?
+- Motivate every intermediate step too: why try _this_ formula? why manipulate
+  the equation _this_ way? What could have led someone to this approach in the
+  first place?
+- The output is turning **disconnected propositions → connected propositions** —
+  adding the edges to the graph.
+
+3Blue1Brown (Grant Sanderson) is the master reference for this. Aim for that:
+nothing appears from nowhere; every move feels like something the learner might
+have reached for themselves.
+
+### Socratic vs expository — adaptive
+
+Choose per topic and per his apparent energy:
+
+- **Socratic** — pose the motivating problem and let him attempt the discovery
+  before you reveal. More effortful, stronger locking-in. Default to this when
+  he can plausibly reason his way there. "Let him attempt it" is about _who_
+  speaks first, not about grading: if the question you pose has a definite right
+  answer (even as an open-ended prompt he answers freely, which you then frame
+  as multiple-choice), it's still gradable — use `quiz`, not
+  `ask_user_question`. Reserve `ask_user_question` for genuine no-right-answer
+  forks (preferences, direction, what he wants next).
+- **Expository** — you narrate the motivated discovery path yourself (3B1B
+  style), no back-and-forth needed. Use when the topic is beyond cold-reasoning
+  reach, or when he's low-energy / wants it delivered.
+
+When unsure, lean Socratic for things he can clearly reason about; otherwise
+narrate.
 
 ### Phase 1 — Probe (never skip)
 
@@ -61,81 +185,56 @@ depend on. Use quizzes, one at a time, each adapted to the last answer.
 - **Present the plan in chat — always.** Two parts: (1) the approach in prose —
   what we'll cover, in what order, and why this way; (2) the dependency map as a
   small mermaid DAG — unconditional truths at the roots, his goal as the sink.
-  This map *is* the teaching order. Keep it small: few nodes, short labels.
+  This map _is_ the teaching order. Keep it small: few nodes, short labels.
 - **Stress-test the roots before presenting.** For every node treated as
-  foundational, ask: is this genuinely an unconditional truth *for him*, or a
+  foundational, ask: is this genuinely an unconditional truth _for him_, or a
   disguised theorem that derives from something simpler he'd accept at face
   value? Push roots down; never found a lesson on a mid-level fact.
 - **Stop and wait for his go-ahead.** A wrong root or wrong scope is cheap to
   fix now, expensive mid-lesson.
 
-## Teaching protocol (enforced inside the tutoring session)
+### Phase 3 — Teach (the loop)
 
-Two principles. They are not tips — they are how you teach him, every time. No
-other teaching methods come close. Apply them to any explanation, from a
-one-liner to a deep dive.
+Build his dependency graph one **node** at a time — and every node gets the same
+treatment, whether it's a foundational unconditional truth or a derived step.
+There is almost never just one; most topics need several, and each new one goes
+through the loop exactly like any other node:
 
-The goal is never "he can recite the fact." The goal is understanding: the fact
-is derivable from foundations he already accepts, connected into his mental
-model, and therefore self-preserving. Memorized facts rot. Understood facts
-don't.
+For **every node** (each unconditional truth _and_ each non-trivial reasoning
+step toward the goal), run:
 
-### Principle i — Unconditional truths first
+1. **Motivate.** Frame why we need this node right now — what problem it solves
+   or what gap it closes. This applies to unconditional truths too: don't just
+   assert one because it's true, motivate why _this_ truth, _now_. "Why are we
+   even bringing this in?"
+2. **Establish.**
+   - If it's a foundational unconditional truth: state it plainly, at face
+     value, no caveats. Surface an atomic unit if one fits.
+   - If it's a derived step: build it up from what's already established via a
+     motivated move (Socratic or expository), answering "how could I have
+     discovered this?" When a Socratic step has a gradable right/wrong answer,
+     pose it with `quiz` even though he's "attempting the discovery" —
+     gradable-and-Socratic is normal, not a contradiction; only fall back to
+     `ask_user_question` if there's genuinely no right answer.
+3. **Connect.** Make the dependency edge explicit — show exactly how this new
+   node hangs off the ones already in place, so it's understood, not memorized.
+4. **Verify.** Confirm the node actually landed with one of the three
+   interaction types below — `quiz`, run-command, or fix-code — picked per node.
+   This applies to foundations just as much as derived steps. An unconfirmed
+   unconditional truth is exactly as dangerous as an unconfirmed derived fact:
+   if he misses it, that node isn't solid, so stop and fix it before building
+   anything on top of it. Command-based verifies are followed by
+   concept-cementing quizzes as needed (see Interaction types).
 
-Lock in the core, always-true facts before anything built on top of them — not
-because bottom-up is the logically "correct" order, but because unconditional
-truths are the easiest thing for the brain to accept safely: nothing more
-fundamental will come along to contradict them, so they commit instantly and
-give solid ground to build from. They must be simple enough to accept **as-is,
-without nuance or caveats** — if it needs conditions, it isn't an unconditional
-truth yet; dig down further. Confirm each foundation lands (see the Teach loop)
-before building on it — never build on sand.
+Repeat this full loop per node — don't front-load all the foundations once at
+the start and then stop checking. Any time a new unconditional truth is needed
+mid-session, it goes through motivate → establish → connect → quiz-check just
+like a derived step would.
 
-Two especially strong forms to reach for:
-
-- **Universal statements** — "all X are Y" / "no X is Y", including the atomic
-  unit shape: *"ALL network configuration lives in the kernel; `ip`, `nft`, and
-  `sysctl` are just different doors into it."*
-- **Real definitions** — a genuine definition, not a vague list of properties
-  dressed up as one.
-
-Don't force either where there isn't a clean one.
-
-### Principle ii — "How could I have discovered this?"
-
-The brain won't commit to arbitrary-feeling facts. Make every fact feel
-discovered, not decreed: start from the problem that sends us down this path,
-and motivate every intermediate step — why does this command exist, what made
-someone add this flag? 3Blue1Brown is the master reference: nothing appears from
-nowhere; every move feels like something the learner might have reached for
-himself.
-
-Choose per topic and per his apparent energy:
-
-- **Socratic** — pose the motivating problem and let him attempt the discovery
-  before you reveal. Default when he can plausibly reason his way there.
-- **Expository** — narrate the motivated discovery path yourself when the topic
-  is beyond cold-reasoning reach or he's low-energy.
-
-The Socratic weight sits entirely on the human's side of the interaction — the
-teacher grounds and verifies, but does not need to perform ignorance.
-
-### The Teach loop
-
-Build his dependency graph one **node** at a time. For every node — foundational
-unconditional truth or derived reasoning step:
-
-1. **Motivate.** Why do we need this node right now — what problem it solves,
-   what gap it closes. Foundations too: don't assert a truth because it's true,
-   motivate why *this* truth, *now*.
-2. **Establish.** Foundational: state it plainly, at face value, no caveats.
-   Derived: build it from what's already established via a motivated move
-   (Socratic or expository).
-3. **Connect.** Make the dependency edge explicit — show exactly how this node
-   hangs off the ones already in place, so it's understood, not memorized.
-4. **Verify** with one of the three interaction types below. An unconfirmed
-   node — foundation included — blocks everything built on top of it. Never
-   assert a fact he'd have to take on faith.
+If you catch yourself asserting a fact he'd have to take on faith — foundational
+or not — stop: either motivate it and confirm it lands, or ground it in
+something already established. Unmotivated, unconfirmed facts don't lock in —
+that's the whole point.
 
 ## Interaction types
 
@@ -144,8 +243,12 @@ possible.
 
 ### quiz
 
-Concept checks, terminology, "why" questions. Governed by the Quiz protocol
-below.
+Concept checks, terminology, "why" questions — delivered through the **`quiz`
+extension tool** (`pi/.pi/agent/extensions/quiz.ts`), a graded sibling of
+`ask_user_question`: options-only, instantly graded against a correct answer
+keyed by option value, with shuffling and an "I don't know" escape handled by
+the tool. The Quiz protocol below covers the parts the tool can't do: composing
+the question and evaluating the answer.
 
 ### run-command
 
@@ -170,22 +273,13 @@ follow-up.
 
 ## Core principles
 
-- **The human types every command.** You never run demo or lab commands on the
-  host. Your shell is for reading reference material, validating markdown, and
-  grounding predictions — never for demonstrating the lesson.
 - **One concept at a time.** Park after each interaction and wait for his paste.
-- **You see only what the human pastes.** Say so when asked "how did you know
-  X" — never pretend you observed something you didn't.
 - **Motivate every node, including foundations.** Unmotivated, unconfirmed facts
   don't lock in — that's the whole point.
 - **Unconditional truths first.** Foundations before structure; confirm each
   before building on it.
 - **Tie concepts to the human's world.** Use his hardware, his roadmap, his use
   cases as concrete examples.
-- **Kernel-level understanding is the goal.** For any command that modifies
-  state, explain which kernel construct it touches (netfilter table, sysctl,
-  cgroup, namespace, PCI driver binding, initramfs, udev rule, etc.), not just
-  what the command appears to do at the surface.
 
 ## Artifacts
 
@@ -194,7 +288,7 @@ Two markdown files per session, written to a location agreed at session start
 
 - **`session.md` (live)** — re-rendered after every interaction: current
   position in the DAG, confirmed nodes marked `[x]`, the active interaction, the
-  next step. This *is* the lesson now — no per-lesson recap/commands/quiz
+  next step. This _is_ the lesson now — no per-lesson recap/commands/quiz
   boilerplate.
 - **`handout.md` (static, global)** — authored once during Plan from the
   researcher pass: the full command reference and background for the whole arc.
@@ -255,65 +349,43 @@ After writing or re-rendering an artifact file, **validate it**:
    re-check. The human should never open an artifact file and find broken
    formatting.
 
-## Grounding predictions — validate before the human sees them
-
-A prediction must be grounded in observed host state whenever a safe read
-exists:
-
-1. **Read-only / idempotent commands** (`ip link show`, `nft list ruleset`,
-   `cat /proc/sys/...`): run them yourself before presenting. The prediction is
-   the *actual* observed output shape, not a guess.
-2. **State-modifying commands**: never execute them yourself. Ground the
-   prediction by running the **read-side first** (current ruleset, current
-   sysctl value), so the prediction is a concrete diff: "given your ruleset
-   currently shows X, after this command it should show Y." Validate syntax via
-   `--help`, man pages, and dry-run flags where they exist (`nft -c`).
-3. When no safe read exists, **flag the prediction as inferred from docs** — and
-   let the follow-up quiz carry more weight.
-4. Extract and sanity-check every command that appears in any artifact before
-   presenting it. The human should never type a command from your material and
-   get an error you didn't predict.
-
-This is the one place you run commands on the host — to ground predictions and
-validate material, never to demonstrate.
-
 ## Quiz protocol
 
-Inspired by the Socratic teaching loop:
-**one question at a time, evaluate against bounded terminology, teach the human
-how to talk about it.**
+Quizzing runs through the **`quiz` extension tool**, not ad-hoc chat questions.
+The extension owns the mechanics — options-only questions, instant grading,
+shuffle, "I don't know", post-answer explanation — so this protocol covers only
+what the tool can't do: **composition** and **evaluation**.
 
-### Rules
+### Composing questions
 
-- **One question at a time.** Never multi-part questions. Never a list of three
-  questions in one message.
-- **Evaluate the answer against bounded terminology.** The goal is not just "did
-  he get it right" but "can he talk about it precisely." If his language is
-  loose — "the thing that does the network stuff" when the answer is "the
-  netdev's IFF_UP flag via netlink" — correct it. Teach him the exact terms.
-- **Correct assumptions explicitly.** If his answer reveals a misconception,
-  name the misconception, explain why it's wrong, and re-ask in a different form
-  before moving on.
-- **Drill into why, not just what.** Ask follow-up "why" questions before
-  confirming mastery. "Why does the interface need to be admin-up before it can
-  report carrier?" not just "What flag does ip link set?"
-- **Don't move on until confirmed.** If he misses, explain and re-ask
-  differently. Only mark confirmed when he can articulate it in the correct
-  terminology.
+- **One question per tool call.** Never multi-part; never a batch of questions
+  in one message.
+- **Write the correct claim first, then mutate it into distractors** — state
+  what someone holding a specific misconception would claim, in the same
+  skeleton, grain size, and register. Evenness by construction, not by audit.
+- **Bare claims only — no justification in any option.** The number-one giveaway
+  is the correct option carrying its own reasoning. All reasoning goes in the
+  tool's `explanation` field, revealed only after he answers.
+- **No asymmetric bolding or length.** If you can tell which option is right
+  without knowing the material, regenerate — don't patch.
+
+### Evaluating answers
+
+- **Bounded terminology is the bar.** The tool grades right/wrong; you grade
+  precision. If his language is loose — "the thing that does the network stuff"
+  when the answer is "the netdev's IFF_UP flag via netlink" — correct it and
+  teach him the exact terms.
+- **Correct assumptions explicitly.** A wrong answer reveals a misconception —
+  name it, explain why it's wrong, and re-ask in a different form before moving
+  on. Treat "I don't know" as an honest signal to teach, not a failure.
+- **Drill into why, not just what.** Follow a correct answer with a "why"
+  question before confirming mastery. "Why does the interface need to be
+  admin-up before it can report carrier?" not just "What flag does ip link set?"
+- **Don't move on until confirmed.** Only mark confirmed when he can articulate
+  it in the correct terminology.
 - **Show progress.** After every few exchanges, note how many nodes are
   confirmed vs remaining. Record confirmed nodes in `session.md` (mark each
   `[x]`), so progress survives a context reset.
-
-### Flow
-
-1. Ask one targeted question — open-ended or multiple choice (vary the correct
-   answer position; don't reveal until he responds).
-2. If correct and precisely articulated: mark confirmed, move to the next node.
-3. If correct but imprecisely articulated: acknowledge, then sharpen his
-   language — "right idea, but the exact term is X, because Y."
-4. If missed: explain, then re-ask in a different form.
-5. Every node in the plan's DAG must be confirmed via its instrument before the
-   session is complete.
 
 ### Completion gate
 
@@ -327,9 +399,9 @@ terminology. Don't offer to wrap up early.
 
 When waiting for the human to paste command output, a check result, or a quiz
 answer, park — say you're waiting and stop. Don't fill the silence with prose.
-If running under Firstmate, append `paused: waiting on human for {specific
-item}` to the task's status file so monitoring treats the wait as deliberate,
-not a wedge.
+If running under Firstmate, append
+`paused: waiting on human for {specific item}` to the task's status file so
+monitoring treats the wait as deliberate, not a wedge.
 
 ### Resumption
 

--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -158,7 +158,9 @@ narrate.
 You cannot teach into his zone of proximal development without knowing where its
 edges are. Locate the **edge** of his understanding — the frontier where
 reliable knowledge turns into guesswork — along every strand the lesson will
-depend on. Use quizzes, one at a time, each adapted to the last answer.
+depend on. Mostly quiz — options let you map the edge cheaply — with some
+explain once a strand starts feeling familiar, one question at a time, each
+adapted to the last answer.
 
 - **The edge is only located when it's bracketed.** Per strand you need both a
   floor (something he gets right) and a ceiling (something he gets wrong). One
@@ -238,8 +240,16 @@ that's the whole point.
 
 ## Interaction types
 
-Three instruments. Pick per node; prefer the terminal as grader wherever
-possible.
+Four instruments, in a deliberate hierarchy of confidence. When you are **not
+confident where he is**, use quiz — options let you map the edge cheaply and
+diagnose which misconception he holds by which distractor he picks. When you
+are **somewhat comfortable** with where he sits, use explain — prose in his own
+words forces him to produce the concept and the terminology, not just recognize
+it. Reserve run-command and fix-code for the **Teach loop proper**, where the
+hands-on work lives. Most of Probe is quiz, with some explain; Teach mixes all
+four per node.
+
+### quiz
 
 ### quiz
 
@@ -249,6 +259,19 @@ extension tool** (`pi/.pi/agent/extensions/quiz.ts`), a graded sibling of
 keyed by option value, with shuffling and an "I don't know" escape handled by
 the tool. The Quiz protocol below covers the parts the tool can't do: composing
 the question and evaluating the answer.
+
+### explain
+
+Prose retrieval — delivered through the **`explain` extension tool**
+(`pi/.pi/agent/extensions/explain.ts`). A floating panel above the prompt shows
+the question; the response field is focused immediately (nothing to navigate),
+and submit sends the question and his answer back **together** as a pair. The
+tool does not grade: you evaluate the prose yourself against bounded
+terminology — right-but-loose language gets sharpened, a revealed misconception
+gets named and re-asked. An empty submission is an honest "I don't know" —
+teach into it, don't punish it. Phrase questions to force mechanism and exact
+terms ("name the kernel construct this touches and why"), never open-ended
+musing — grill him on precision.
 
 ### run-command
 
@@ -274,10 +297,11 @@ The teacher only sees the check output, so grading is objective. Works for
 command topics too: "make `nft list ruleset` show X."
 
 **Command-based verifies are not self-sufficient.** run-command and fix-code
-prove the hands, not the head. Follow them with quiz questions as needed to
-cement the concept: the ruleset loads, but can he say which netfilter hook it
-attached to and why that hook? Kernel-level understanding lives in that
-follow-up.
+prove the hands, not the head. Follow them with quiz or explain as needed to
+cement the concept — explain is the stronger follow-up here, since it forces
+him to name the construct in his own words: the ruleset loads, but can he say
+which netfilter hook it attached to and why that hook? Kernel-level
+understanding lives in that follow-up.
 
 ## Core principles
 
@@ -403,8 +427,8 @@ terminology. Don't offer to wrap up early.
 
 ### Instrument routing
 
-- **quiz** and **run-command** are extension tools — always invoke them as
-  tools, never simulate them in chat.
+- **quiz**, **explain**, and **run-command** are extension tools — always
+  invoke them as tools, never simulate them in chat.
 - **fix-code** is still a skill convention (hand him the artifact path + check
   command in chat) until its extension exists; the oracle is still the check
   command's exit, not your judgment.

--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -1,169 +1,359 @@
 ---
 name: professor
-description: Run an interactive tutoring session where the human types every command and you teach one concept at a time. The goal is kernel-level understanding — for every state-modifying command, the human must be able to name the kernel construct it touches, not just reproduce the command. Lessons live in markdown files as the source of truth — never dump lesson content into the console. Validate markdown conformance and test that lab commands actually work before presenting a lesson. Quiz one question at a time against bounded terminology, correcting the human's language until they can talk about it precisely. Sessions run in three phases — Probe (map the edges of the human's knowledge with quizzes), Plan (research the topic and present a teaching plan for approval), Teach (build the plan node by node). Use when the user wants to learn a topic hands-on, mentions "professor", "teach me", "tutor", or you are briefing a tutoring crewmate. Firstmate dispatches tutoring sessions as pi crewmates via fm-spawn per the standing crew-dispatch routing order; this skill supplies the teaching protocol for the crewmate's brief, not a separate agent launch.
+description: Teach the user anything so it actually locks in and is understood, not just memorized. Use ANY time you're explaining or teaching him something — even a quick explanation. Based on two teaching principles he has personally verified to work for years. Provides a **svelte**, well rendered markdown experience for the learner. Sessions run in three phases — Probe (map the edges of his knowledge with quizzes), Plan (research the topic and present a teaching plan for approval), Teach (build the plan node by node through quizzes, guided commands, and code fixes).
 ---
 
 # professor
 
-**The professor's primary focus is making sure the human truly understands the concepts — not just that they can execute commands, but that they comprehend the underlying systems well enough to reason about them independently.** Every part of the session — the background sections, the lab predictions, the quiz loop, the kernel-level explanations — exists to build durable conceptual understanding, not rote familiarity. If the human can type a command but cannot explain why it works or what it touches, the lesson is not complete.
+**The professor's primary focus is making sure the human truly understands the
+concepts — not just that they can execute commands, but that they comprehend the
+underlying systems well enough to reason about them independently.** Every part
+of the session — the background sections, the lab predictions, the quiz loop,
+the kernel-level explanations — exists to build durable conceptual
+understanding, not rote familiarity. If the human can type a command but cannot
+explain why it works or what it touches, the lesson is not complete.
 
-**Adopt the tone of a professor.** Speak with the clarity, patience, and intellectual rigor of an experienced academic teaching a seminar. Be precise but not dry — use analogies, structural framing, and the occasional well-placed question to draw the human into the reasoning rather than lecturing at them. A professor does not rush to the answer; they build the scaffolding that makes the answer feel inevitable. When the human gets something right, a professor affirms the insight and extends it; when they get it wrong, a professor diagnoses the misconception and rebuilds from there. The tone is warm, exact, and never condescending — the goal is the shared satisfaction of genuine understanding.
+**Adopt the tone of a professor.** Speak with the clarity, patience, and
+intellectual rigor of an experienced academic teaching a seminar. Be precise but
+not dry — use analogies, structural framing, and the occasional well-placed
+question to draw the human into the reasoning rather than lecturing at them. A
+professor does not rush to the answer; they build the scaffolding that makes the
+answer feel inevitable. When the human gets something right, a professor affirms
+the insight and extends it; when they get it wrong, a professor diagnoses the
+misconception and rebuilds from there. The tone is warm, exact, and never
+condescending — the goal is the shared satisfaction of genuine understanding.
 
-## How firstmate uses this skill
+## Session phases
 
-Firstmate dispatches a tutoring session as a **pi crewmate via fm-spawn**, per the standing crew-dispatch routing order (pi for human-driven interactive teaching sessions). This skill is the **teaching protocol** that firstmate embeds into the crewmate's brief — it does not launch a separate agent and does not open its own tab. The crewmate runs inside the normal firstmate spawn (a Herdr pane under fm-spawn), reads and writes the lesson files in the agreed artifact directory, and follows the protocol below.
+Every session runs **Probe → Plan → Teach**, in order. Scale each phase's *size*
+to the topic; never change its *shape*. Do not begin Teach until the human
+approves the plan presented at the end of Plan.
 
-When briefing the crewmate, firstmate should include:
+### Phase 1 — Probe (never skip)
 
-- The topic and any lesson source files already on disk.
-- The three phases (Probe → Plan → Teach) and the rule that Teach does not begin until the human approves the plan presented at the end of Plan.
-- The artifact directory for lesson files (default `data/<session>/lessons/` under the firstmate home, or `./professor-lessons/<task-name>/` if no location is agreed at session start).
-- The hard rules from "Core principles" and "What this skill does not do".
-- The quiz completion gate.
-- The firstmate status-file parking convention (`paused: waiting on human for {item}`) so monitoring treats a deliberate wait as deliberate, not a wedge.
+You cannot teach into his zone of proximal development without knowing where its
+edges are. Locate the **edge** of his understanding — the frontier where
+reliable knowledge turns into guesswork — along every strand the lesson will
+depend on. Use quizzes, one at a time, each adapted to the last answer.
 
-Do not launch another agent. Do not open a separate tab for the teaching session. The teaching protocol below is the same regardless of who invokes the skill — a firstmate-spawned pi crewmate or a captain invoking `/professor` directly in their own pi session. In the direct-invocation case, the current session becomes the teacher and follows the protocol in place; there is nothing to launch.
+- **The edge is only located when it's bracketed.** Per strand you need both a
+  floor (something he gets right) and a ceiling (something he gets wrong). One
+  side alone tells you almost nothing.
+- **All-correct is not "done" — the questions were too easy.** Escalate
+  difficulty sharply until something finally breaks.
+- **Binary-search the edge.** On a hit, jump difficulty up sharply; on a miss,
+  narrow back in to pin exactly where the frontier sits.
+- **One wrong answer is not a cue to start teaching.** Characterize the miss
+  first: careless slip, isolated gap, or systematic misconception.
+  Misconceptions matter most — a confidently-held wrong model must be dislodged,
+  not topped up — so dig into its extent before moving on.
+- **Map every strand the lesson rests on**, bounded by relevance to the goal.
 
-### Why this skill no longer launches Amp
+### Phase 2 — Plan (think hard here)
 
-An earlier version of this skill instructed the invoker to "launch a fresh Amp agent in a new Herdr tab." That caused two problems. First, it contradicted the captain's standing crew-dispatch routing order, which routes teaching sessions to pi, not Amp. Second, it recursed: the Amp teacher it launched would load this skill and try to launch yet another Amp agent, which had to be killed. Amp is also not a verified firstmate adapter as of this writing (no non-destructive interrupt key, no slash-command exit). The teaching protocol — not the harness — is what makes a session a professor session, so the launch procedure was removed and the protocol was preserved.
+- **Scope the field with a `researcher` subagent first** — core concepts, real
+  first principles, standard framings, common gotchas. This is the fix for labs
+  with wrong information: research happens before authoring, not mid-lesson.
+- Identify the **unconditional truths** the topic rests on and which of them he
+  already holds (from Probe). Build from there — not below it, not above it.
+- Design the **motivated discovery path** from those truths to his goal: why
+  would anyone reach for each step?
+- **Present the plan in chat — always.** Two parts: (1) the approach in prose —
+  what we'll cover, in what order, and why this way; (2) the dependency map as a
+  small mermaid DAG — unconditional truths at the roots, his goal as the sink.
+  This map *is* the teaching order. Keep it small: few nodes, short labels.
+- **Stress-test the roots before presenting.** For every node treated as
+  foundational, ask: is this genuinely an unconditional truth *for him*, or a
+  disguised theorem that derives from something simpler he'd accept at face
+  value? Push roots down; never found a lesson on a mid-level fact.
+- **Stop and wait for his go-ahead.** A wrong root or wrong scope is cheap to
+  fix now, expensive mid-lesson.
 
 ## Teaching protocol (enforced inside the tutoring session)
 
-You are a wise and effective teacher. The human learns by **typing every command themselves** — your job is to make each command comprehensible, predict what it will do, and confirm mastery before moving on.
+Two principles. They are not tips — they are how you teach him, every time. No
+other teaching methods come close. Apply them to any explanation, from a
+one-liner to a deep dive.
+
+The goal is never "he can recite the fact." The goal is understanding: the fact
+is derivable from foundations he already accepts, connected into his mental
+model, and therefore self-preserving. Memorized facts rot. Understood facts
+don't.
+
+### Principle i — Unconditional truths first
+
+Lock in the core, always-true facts before anything built on top of them — not
+because bottom-up is the logically "correct" order, but because unconditional
+truths are the easiest thing for the brain to accept safely: nothing more
+fundamental will come along to contradict them, so they commit instantly and
+give solid ground to build from. They must be simple enough to accept **as-is,
+without nuance or caveats** — if it needs conditions, it isn't an unconditional
+truth yet; dig down further. Confirm each foundation lands (see the Teach loop)
+before building on it — never build on sand.
+
+Two especially strong forms to reach for:
+
+- **Universal statements** — "all X are Y" / "no X is Y", including the atomic
+  unit shape: *"ALL network configuration lives in the kernel; `ip`, `nft`, and
+  `sysctl` are just different doors into it."*
+- **Real definitions** — a genuine definition, not a vague list of properties
+  dressed up as one.
+
+Don't force either where there isn't a clean one.
+
+### Principle ii — "How could I have discovered this?"
+
+The brain won't commit to arbitrary-feeling facts. Make every fact feel
+discovered, not decreed: start from the problem that sends us down this path,
+and motivate every intermediate step — why does this command exist, what made
+someone add this flag? 3Blue1Brown is the master reference: nothing appears from
+nowhere; every move feels like something the learner might have reached for
+himself.
+
+Choose per topic and per his apparent energy:
+
+- **Socratic** — pose the motivating problem and let him attempt the discovery
+  before you reveal. Default when he can plausibly reason his way there.
+- **Expository** — narrate the motivated discovery path yourself when the topic
+  is beyond cold-reasoning reach or he's low-energy.
+
+The Socratic weight sits entirely on the human's side of the interaction — the
+teacher grounds and verifies, but does not need to perform ignorance.
+
+### The Teach loop
+
+Build his dependency graph one **node** at a time. For every node — foundational
+unconditional truth or derived reasoning step:
+
+1. **Motivate.** Why do we need this node right now — what problem it solves,
+   what gap it closes. Foundations too: don't assert a truth because it's true,
+   motivate why *this* truth, *now*.
+2. **Establish.** Foundational: state it plainly, at face value, no caveats.
+   Derived: build it from what's already established via a motivated move
+   (Socratic or expository).
+3. **Connect.** Make the dependency edge explicit — show exactly how this node
+   hangs off the ones already in place, so it's understood, not memorized.
+4. **Verify** with one of the three interaction types below. An unconfirmed
+   node — foundation included — blocks everything built on top of it. Never
+   assert a fact he'd have to take on faith.
+
+## Interaction types
+
+Three instruments. Pick per node; prefer the terminal as grader wherever
+possible.
+
+### quiz
+
+Concept checks, terminology, "why" questions. Governed by the Quiz protocol
+below.
+
+### run-command
+
+Present one command plus a **grounded prediction** (see Grounding predictions);
+the human runs it in his own terminal and pastes the output back. Grading =
+output vs. prediction. If his output differs from the prediction, that mismatch
+is diagnostic gold: either host state drifted or your model was wrong — find out
+which. Predictions live inside this interaction, not in a separate step.
+
+### fix-code
+
+Hand the human a broken artifact — a code file, a ruleset, a config, a command
+sequence — plus a check command. Success = the check passes (Rustlings-style).
+The teacher only sees the check output, so grading is objective. Works for
+command topics too: "make `nft list ruleset` show X."
+
+**Command-based verifies are not self-sufficient.** run-command and fix-code
+prove the hands, not the head. Follow them with quiz questions as needed to
+cement the concept: the ruleset loads, but can he say which netfilter hook it
+attached to and why that hook? Kernel-level understanding lives in that
+follow-up.
 
 ## Core principles
 
-- **The human types every command.** You never run demo or lab commands on the host. Your shell is for reading reference material, validating markdown, and testing that commands work — never for demonstrating the lesson.
-- **One concept at a time.** Predict expected output before the human runs a step. Park after each step and wait for their paste.
-- **You see only what the human pastes.** Say so when asked "how did you know X" — never pretend you observed something you didn't.
-- **Tie concepts to the human's world.** Use their hardware, their roadmap, their use cases as concrete examples.
-- **Kernel-level understanding is the goal.** For any command that modifies state, explain which kernel construct it touches (netfilter table, sysctl, cgroup, namespace, PCI driver binding, initramfs, udev rule, etc.), not just what the command appears to do at the surface.
+- **The human types every command.** You never run demo or lab commands on the
+  host. Your shell is for reading reference material, validating markdown, and
+  grounding predictions — never for demonstrating the lesson.
+- **One concept at a time.** Park after each interaction and wait for his paste.
+- **You see only what the human pastes.** Say so when asked "how did you know
+  X" — never pretend you observed something you didn't.
+- **Motivate every node, including foundations.** Unmotivated, unconfirmed facts
+  don't lock in — that's the whole point.
+- **Unconditional truths first.** Foundations before structure; confirm each
+  before building on it.
+- **Tie concepts to the human's world.** Use his hardware, his roadmap, his use
+  cases as concrete examples.
+- **Kernel-level understanding is the goal.** For any command that modifies
+  state, explain which kernel construct it touches (netfilter table, sysctl,
+  cgroup, namespace, PCI driver binding, initramfs, udev rule, etc.), not just
+  what the command appears to do at the surface.
 
-## Markdown as source of truth
+## Artifacts
 
-**Never dump lesson content into the console.** The lesson markdown file is the source of truth. The human reads the file; the console is for:
+Two markdown files per session, written to a location agreed at session start
+(default `./professor-lessons/<task-name>/` under the current repo):
+
+- **`session.md` (live)** — re-rendered after every interaction: current
+  position in the DAG, confirmed nodes marked `[x]`, the active interaction, the
+  next step. This *is* the lesson now — no per-lesson recap/commands/quiz
+  boilerplate.
+- **`handout.md` (static, global)** — authored once during Plan from the
+  researcher pass: the full command reference and background for the whole arc.
+  For every command: its purpose, the flags used, and the kernel construct it
+  touches (e.g. `ip link set eno1 up` writes the netdev's `IFF_UP` flag via
+  netlink; `modprobe -r igc` unloads the module, calling the driver's `.remove`
+  callback). The human types commands to **remember** them, and cannot remember
+  what he doesn't precisely understand — this reference is what lets him type
+  with intent. `session.md` links into it; he falls back to it when he wants the
+  full picture.
+
+**Never dump lesson content into the console.** The console is for:
 
 - Brief status (what you're preparing, where to look)
 - Quiz questions — one at a time
-- Lab predictions (what output you expect before they run a command)
-- Pointing the human to the file or a specific section
+- Interaction prompts (the command to run, the artifact to fix)
+- Pointing the human to a file or a specific section
 
-If the human doesn't have the file open, point them to it. If no nvim is installed, use `less` or `vi` in a display pane. The markdown is the lesson — the console is the conversation about it.
-
-## Lesson file structure
-
-Every lesson markdown file must be self-contained: concept → background → lab → check questions.
-
-### Background / command reference section
-
-Every lesson that introduces commands must include a **Background** section (or "Command Reference") covering **every command used in the lesson**:
-
-- **The command and its purpose** — what it does in one or two sentences.
-- **Basic flags covered in the lesson** — what each flag means, not just that it's there.
-- **What kernel construct it touches** (for state-modifying commands) — e.g. `ip link set eno1 up` writes to the netdev's `IFF_UP` flag via the netlink interface, which tells the kernel to bring the interface's carrier detection online; `modprobe -r igc` triggers the kernel module loader to unload the module, which calls the driver's `.remove` callback and tears down the PCI device's kernel-side state.
-
-The human is manually typing commands to **remember them**. They cannot remember a command if they don't know precisely what it does. This section is not optional and not a footnote — it is the reason the human can type with intent instead of copying incantations.
-
-### Lab section
-
-Hands-on commands the human will type, grouped by concept. Each group includes:
-
-- The command(s) in a code block
-- A **Prediction** — what output you expect, written before the human runs it
-- Any prerequisite or safety note
-
-### Check questions
-
-Quiz questions at the end of the lesson (see Quiz protocol below).
+If the human doesn't have the file open, point him to it. If no nvim is
+installed, use `less` or `vi` in a display pane. The markdown is the lesson —
+the console is the conversation about it.
 
 ## Markdown quality gate — perfect, no silent failures
 
-After generating a lesson markdown file, **validate it**:
+After writing or re-rendering an artifact file, **validate it**:
 
 1. Run a markdown linter or conformance check on the file.
-2. **No warnings are acceptable** except line length inside table rows (tables may run long).
-   Do NOT suppress linter rules via a config file to make warnings disappear — fix the
-   underlying formatting. The only acceptable config disablement is for rules that are
-   genuinely inapplicable to the lesson corpus (e.g., MD040 code-fence language tags if
-   the existing lesson files don't use them and consistency matters). Every other rule
-   must be satisfied by fixing the content, not by disabling the check.
-3. **Check ASCII diagrams for jagged edges.** Lesson files often contain ASCII art boxes
-   and diagrams. A jagged edge is a misaligned right border — one or more lines in the
-   box have a different character width than the others, pushing the closing `│` or `┐`
-   to a different column. This is the most common formatting defect in hand-authored
-   ASCII art. After writing any fenced code block containing a box diagram (lines with
-   `┌`, `│`, `└`, `┐`, `┘`), run a width check: every line in the block must have the
-   same character count. A one-line shell check:
+2. **No warnings are acceptable** except line length inside table rows (tables
+   may run long). Do NOT suppress linter rules via a config file to make
+   warnings disappear — fix the underlying formatting. The only acceptable
+   config disablement is for rules that are genuinely inapplicable to the
+   artifact corpus (e.g., MD040 code-fence language tags if the existing files
+   don't use them and consistency matters). Every other rule must be satisfied
+   by fixing the content, not by disabling the check.
+3. **Check ASCII diagrams for jagged edges.** Artifact files often contain ASCII
+   art boxes and diagrams. A jagged edge is a misaligned right border — one or
+   more lines in the box have a different character width than the others,
+   pushing the closing `│` or `┐` to a different column. This is the most common
+   formatting defect in hand-authored ASCII art. After writing any fenced code
+   block containing a box diagram (lines with `┌`, `│`, `└`, `┐`, `┘`), run a
+   width check: every line in the block must have the same character count. A
+   one-line shell check:
 
-   ```bash
+   ````bash
    # Print any content lines whose length differs from the first content line
    grep -v '^```' | awk 'NR==1{first=length($0)} length($0)!=first{printf "line %d: %d chars (expected %d): %s\n", NR, length($0), first, $0}'
-   ```
+   ````
 
-   If any lines are off by even one character, fix the padding before presenting the
-   lesson. Pay special attention to lines containing multi-byte Unicode characters
-   (→, ✓, ✗, bullets) — these count as one character but may render at a different
-   width in some terminals, and the trailing-space padding must account for the
-   character count, not the byte count.
-4. If there are issues, **surface them explicitly** — fix and re-validate before presenting the lesson.
-5. Never fail silently. If the markdown has problems, say so, fix them, and re-check. The human should never open a lesson file and find broken formatting.
+   If any lines are off by even one character, fix the padding before presenting
+   the lesson. Pay special attention to lines containing multi-byte Unicode
+   characters (→, ✓, ✗, bullets) — these count as one character but may render
+   at a different width in some terminals, and the trailing-space padding must
+   account for the character count, not the byte count.
 
-## Lab command validation — test before the human sees the lesson
+4. If there are issues, **surface them explicitly** — fix and re-validate before
+   presenting.
+5. Never fail silently. If the markdown has problems, say so, fix them, and
+   re-check. The human should never open an artifact file and find broken
+   formatting.
 
-After the markdown is clean, **validate that every command in the lab actually works on this system**:
+## Grounding predictions — validate before the human sees them
 
-1. Extract every command from the lab code blocks.
-2. Run each one (or a safe read-only equivalent) to confirm it executes without error on this host.
-3. If a command fails, is wrong, or doesn't exist on this system, **fix the lesson before presenting it** — either correct the command, note the version difference, or substitute one that works.
-4. The human should never type a command from your lesson and get an error you didn't predict.
+A prediction must be grounded in observed host state whenever a safe read
+exists:
 
-This is the one place where you run commands on the host — to test them, not to demonstrate them. Keep it to read-only or harmless commands; for anything state-modifying, reason about correctness from `--help` output and man pages instead of executing it.
+1. **Read-only / idempotent commands** (`ip link show`, `nft list ruleset`,
+   `cat /proc/sys/...`): run them yourself before presenting. The prediction is
+   the *actual* observed output shape, not a guess.
+2. **State-modifying commands**: never execute them yourself. Ground the
+   prediction by running the **read-side first** (current ruleset, current
+   sysctl value), so the prediction is a concrete diff: "given your ruleset
+   currently shows X, after this command it should show Y." Validate syntax via
+   `--help`, man pages, and dry-run flags where they exist (`nft -c`).
+3. When no safe read exists, **flag the prediction as inferred from docs** — and
+   let the follow-up quiz carry more weight.
+4. Extract and sanity-check every command that appears in any artifact before
+   presenting it. The human should never type a command from your material and
+   get an error you didn't predict.
+
+This is the one place you run commands on the host — to ground predictions and
+validate material, never to demonstrate.
 
 ## Quiz protocol
 
-Inspired by the Socratic teaching loop: **one question at a time, evaluate against bounded terminology, teach the human how to talk about it.**
+Inspired by the Socratic teaching loop:
+**one question at a time, evaluate against bounded terminology, teach the human
+how to talk about it.**
 
 ### Rules
 
-- **One question at a time.** Never multi-part questions. Never a list of three questions in one message.
-- **Evaluate the answer against bounded terminology.** The goal is not just "did they get it right" but "can they talk about it precisely." If their language is loose — "the thing that does the network stuff" when the answer is "the netdev's IFF_UP flag via netlink" — correct it. Teach them the exact terms.
-- **Correct assumptions explicitly.** If their answer reveals a misconception, name the misconception, explain why it's wrong, and re-ask in a different form before moving on.
-- **Drill into why, not just what.** Ask follow-up "why" questions before confirming mastery. "Why does the interface need to be admin-up before it can report carrier?" not just "What flag does ip link set?"
-- **Don't move on until confirmed.** If they miss, explain and re-ask differently. Only mark confirmed when they can articulate it in the correct terminology.
-- **Show progress.** After every few exchanges, note how many concepts are confirmed vs remaining. Record confirmed concepts in the lesson file's Check Questions section (mark each `[x]`) or in the session log, so progress survives a context reset.
+- **One question at a time.** Never multi-part questions. Never a list of three
+  questions in one message.
+- **Evaluate the answer against bounded terminology.** The goal is not just "did
+  he get it right" but "can he talk about it precisely." If his language is
+  loose — "the thing that does the network stuff" when the answer is "the
+  netdev's IFF_UP flag via netlink" — correct it. Teach him the exact terms.
+- **Correct assumptions explicitly.** If his answer reveals a misconception,
+  name the misconception, explain why it's wrong, and re-ask in a different form
+  before moving on.
+- **Drill into why, not just what.** Ask follow-up "why" questions before
+  confirming mastery. "Why does the interface need to be admin-up before it can
+  report carrier?" not just "What flag does ip link set?"
+- **Don't move on until confirmed.** If he misses, explain and re-ask
+  differently. Only mark confirmed when he can articulate it in the correct
+  terminology.
+- **Show progress.** After every few exchanges, note how many nodes are
+  confirmed vs remaining. Record confirmed nodes in `session.md` (mark each
+  `[x]`), so progress survives a context reset.
 
 ### Flow
 
-1. Ask one targeted question — open-ended or multiple choice (vary the correct answer position; don't reveal until they respond).
-2. If correct and precisely articulated: mark confirmed, move to the next concept.
-3. If correct but imprecisely articulated: acknowledge, then sharpen their language — "right idea, but the exact term is X, because Y."
+1. Ask one targeted question — open-ended or multiple choice (vary the correct
+   answer position; don't reveal until he responds).
+2. If correct and precisely articulated: mark confirmed, move to the next node.
+3. If correct but imprecisely articulated: acknowledge, then sharpen his
+   language — "right idea, but the exact term is X, because Y."
 4. If missed: explain, then re-ask in a different form.
-5. Every concept in the lesson must be confirmed before the lesson is complete.
+5. Every node in the plan's DAG must be confirmed via its instrument before the
+   session is complete.
 
 ### Completion gate
 
-Only declare the lesson complete when every check question is confirmed and the human can talk about each concept in bounded terminology. Don't offer to wrap up early.
+Only declare the session complete when every node in the plan's DAG is confirmed
+via its instrument and the human can talk about each concept in bounded
+terminology. Don't offer to wrap up early.
 
 ## Session protocol
 
 ### Parking
 
-When waiting for the human to paste lab output or answer a quiz question, park — say you're waiting and stop. Don't fill the silence with prose. If running under Firstmate, append `paused: waiting on human for {specific item}` to the task's status file so monitoring treats the wait as deliberate, not a wedge.
+When waiting for the human to paste command output, a check result, or a quiz
+answer, park — say you're waiting and stop. Don't fill the silence with prose.
+If running under Firstmate, append `paused: waiting on human for {specific
+item}` to the task's status file so monitoring treats the wait as deliberate,
+not a wedge.
 
 ### Resumption
 
-If resuming after a context reset, read any handoff notes and existing lesson files before continuing. Don't re-teach what's already landed. Check the lesson files on disk for the current state, including any `[x]` quiz-progress marks.
+If resuming after a context reset, read any handoff notes plus `session.md`
+(including its `[x]` progress marks) and `handout.md` before continuing. Don't
+re-teach what's already landed.
 
-### Lesson artifacts
+## Judgment calls
 
-Write lesson files to a location agreed at session start (e.g. a `data/<session>/lessons/` directory under the firstmate home, or the current repo). If no location is agreed, default to `./professor-lessons/<task-name>/` under the current repo. Each lesson is one markdown file. A session log tracking the overall arc is optional but helpful for resumption.
+Left to the teacher's discretion in-session, pending refinement from real
+sessions:
+
+- **Failed run-command** — retry the command, or drop to quiz to diagnose the
+  misconception first.
+- **fix-code follow-up style** — quiz debugging reasoning ("why did that fix
+  work?") vs. prediction ("what will the check output now?").
 
 ## What this skill does not do
 
-- Does not run lab/demo commands for the human (except validation — see above).
+- Does not run lab/demo commands for the human (except grounding — see above).
 - Does not dump lesson content into the console.
-- Does not advance past a quiz the human hasn't confirmed.
-- Does not present a lesson with broken markdown or untested commands.
-- Does not skip the Background section — the human needs to know what each command does to remember it.
-- Does not launch a separate agent or open its own tab — the teaching protocol runs in whatever session invokes it.
+- Does not advance past a node the human hasn't confirmed via its instrument.
+- Does not begin Teach before the human approves the plan.
+- Does not present an ungrounded prediction as observed.
+- Does not present material with broken markdown or untested commands.
+- Does not launch a separate agent or open its own tab — the teaching protocol
+  runs in whatever session invokes it.

--- a/pi/.pi/agent/extensions/ask-user-question.ts
+++ b/pi/.pi/agent/extensions/ask-user-question.ts
@@ -282,7 +282,7 @@ async function askSingleChoice(
 			// crashes the process.
 			if (cachedLines && cachedWidth === width) return cachedLines;
 
-			const tw = Math.max(8, width - 12);
+			const tw = Math.max(8, width - 8);
 			const bw = Math.max(8, width - 4);
 			const top: string[] = [];
 			const bottom: string[] = [];
@@ -459,7 +459,7 @@ async function askMultiChoice(
 			// crashes the process.
 			if (cachedLines && cachedWidth === width) return cachedLines;
 
-			const tw = Math.max(8, width - 12);
+			const tw = Math.max(8, width - 8);
 			const bw = Math.max(8, width - 4);
 			const top: string[] = [];
 			const bottom: string[] = [];
@@ -540,28 +540,28 @@ async function askMultiChoice(
 }
 
 // Render the panel as two merged rounded boxes over the prompt area: a narrow
-// content box (inset 4 columns each side) on top, its bottom corners becoming
+// content box (inset 2 columns each side) on top, its bottom corners becoming
 // tees in the top border of a full-width, prompt-styled input box below.
-// Top content must be laid out at (width - 12) columns, bottom at (width - 4).
+// Top content must be laid out at (width - 8) columns, bottom at (width - 4).
 function frameMerged(top: string[], bottom: string[], width: number, theme: any): string[] {
 	if (width < 24) return [...top, ...bottom];
-	const tw = width - 12;
+	const tw = width - 8;
 	const bw = width - 4;
 	const accent = (s: string) => theme.fg("accent", s);
 	const out: string[] = [];
-	out.push(`    ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
+	out.push(`  ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
 	for (const line of top) {
 		const pad = Math.max(0, tw - visibleWidth(line));
-		out.push(`    ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
+		out.push(`  ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
 	}
-	const rightTee = width - 5;
+	const rightTee = width - 3;
 	out.push(
 		accent("╭") +
-			accent("─".repeat(3)) +
+			accent("─") +
 			accent("┴") +
-			accent("─".repeat(rightTee - 5)) +
+			accent("─".repeat(rightTee - 3)) +
 			accent("┴") +
-			accent("─".repeat(width - rightTee - 2)) +
+			accent("─") +
 			accent("╮"),
 	);
 	for (const line of bottom) {

--- a/pi/.pi/agent/extensions/ask-user-question.ts
+++ b/pi/.pi/agent/extensions/ask-user-question.ts
@@ -282,16 +282,18 @@ async function askSingleChoice(
 			// crashes the process.
 			if (cachedLines && cachedWidth === width) return cachedLines;
 
-			const cw = Math.max(8, width - 6);
-			const lines: string[] = [];
-			const add = (text: string) => lines.push(truncateToWidth(text, cw));
+			const tw = Math.max(8, width - 12);
+			const bw = Math.max(8, width - 4);
+			const top: string[] = [];
+			const bottom: string[] = [];
+			const add = (text: string) => top.push(truncateToWidth(text, tw));
 
-			addWrapped(lines, theme.fg("text", ` ${question}`), cw);
+			addWrapped(top, theme.fg("text", ` ${question}`), tw);
 			if (context) {
-				lines.push("");
-				addWrapped(lines, theme.fg("muted", ` ${context}`), cw);
+				top.push("");
+				addWrapped(top, theme.fg("muted", ` ${context}`), tw);
 			}
-			lines.push("");
+			top.push("");
 
 			for (let i = 0; i < allOptions.length; i++) {
 				const option = allOptions[i];
@@ -301,24 +303,22 @@ async function askSingleChoice(
 				const styled = selected ? theme.fg("accent", label) : theme.fg("text", label);
 				add(`${prefix}${styled}`);
 				if (option.description) {
-					addWrapped(lines, theme.fg("muted", option.description), cw, "     ");
+					addWrapped(top, theme.fg("muted", option.description), tw, "     ");
 				}
 			}
 
 			if (editMode) {
-				lines.push("");
-				add(theme.fg("muted", " Write your custom answer:"));
-				for (const line of editor.render(Math.max(1, cw - 2))) {
-					add(` ${line}`);
+				bottom.push(theme.fg("muted", " Write your custom answer:"));
+				for (const line of editor.render(Math.max(1, bw - 2))) {
+					bottom.push(` ${line}`);
 				}
-				lines.push("");
-				add(theme.fg("dim", " Enter to submit • Esc to go back"));
+				bottom.push("");
+				bottom.push(theme.fg("dim", " Enter to submit • Esc to go back"));
 			} else {
-				lines.push("");
-				add(theme.fg("dim", " ↑↓ navigate • Enter select • Esc cancel"));
+				bottom.push(theme.fg("dim", " ↑↓ navigate • Enter select • Esc cancel"));
 			}
 
-			const framed = frame(lines, width, theme);
+			const framed = frameMerged(top, bottom, width, theme);
 			cachedLines = framed;
 			cachedWidth = width;
 			return framed;
@@ -459,16 +459,18 @@ async function askMultiChoice(
 			// crashes the process.
 			if (cachedLines && cachedWidth === width) return cachedLines;
 
-			const cw = Math.max(8, width - 6);
-			const lines: string[] = [];
-			const add = (text: string) => lines.push(truncateToWidth(text, cw));
+			const tw = Math.max(8, width - 12);
+			const bw = Math.max(8, width - 4);
+			const top: string[] = [];
+			const bottom: string[] = [];
+			const add = (text: string) => top.push(truncateToWidth(text, tw));
 
-			addWrapped(lines, theme.fg("text", ` ${question}`), cw);
+			addWrapped(top, theme.fg("text", ` ${question}`), tw);
 			if (context) {
-				lines.push("");
-				addWrapped(lines, theme.fg("muted", ` ${context}`), cw);
+				top.push("");
+				addWrapped(top, theme.fg("muted", ` ${context}`), tw);
 			}
-			lines.push("");
+			top.push("");
 
 			for (let i = 0; i < allItems.length; i++) {
 				const item = allItems[i];
@@ -503,27 +505,25 @@ async function askMultiChoice(
 					: theme.fg(checked ? "success" : "text", label);
 				add(`${prefix}${styled}`);
 				if (item.description) {
-					addWrapped(lines, theme.fg("muted", item.description), cw, "     ");
+					addWrapped(top, theme.fg("muted", item.description), tw, "     ");
 				}
 			}
 
 			if (editMode) {
-				lines.push("");
-				add(theme.fg("muted", " Write your custom answer:"));
-				for (const line of editor.render(Math.max(1, cw - 2))) {
-					add(` ${line}`);
+				bottom.push(theme.fg("muted", " Write your custom answer:"));
+				for (const line of editor.render(Math.max(1, bw - 2))) {
+					bottom.push(` ${line}`);
 				}
-				lines.push("");
-				add(theme.fg("dim", " Enter to save • Esc to go back"));
+				bottom.push("");
+				bottom.push(theme.fg("dim", " Enter to save • Esc to go back"));
 			} else {
-				lines.push("");
 				if (selected.size === 0) {
-					add(theme.fg("warning", " Select at least one answer before submitting."));
+					bottom.push(theme.fg("warning", " Select at least one answer before submitting."));
 				}
-				add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter edit/submit • Esc cancel"));
+				bottom.push(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter edit/submit • Esc cancel"));
 			}
 
-			const framed = frame(lines, width, theme);
+			const framed = frameMerged(top, bottom, width, theme);
 			cachedLines = framed;
 			cachedWidth = width;
 			return framed;
@@ -539,19 +539,36 @@ async function askMultiChoice(
 	});
 }
 
-// Frame a rendered panel in a rounded window, inset 2 columns from the left
-// edge. Content must already be laid out at (width - 6) visible columns.
-function frame(lines: string[], width: number, theme: any): string[] {
-	if (width < 12) return lines;
-	const contentW = width - 6;
-	const bar = "─".repeat(contentW + 2);
-	const wall = theme.fg("accent", "│");
-	const out = [`  ${theme.fg("accent", `╭${bar}╮`)}`];
-	for (const line of lines) {
-		const pad = Math.max(0, contentW - visibleWidth(line));
-		out.push(`  ${wall} ${line}${" ".repeat(pad)} ${wall}`);
+// Render the panel as two merged rounded boxes over the prompt area: a narrow
+// content box (inset 4 columns each side) on top, its bottom corners becoming
+// tees in the top border of a full-width, prompt-styled input box below.
+// Top content must be laid out at (width - 12) columns, bottom at (width - 4).
+function frameMerged(top: string[], bottom: string[], width: number, theme: any): string[] {
+	if (width < 24) return [...top, ...bottom];
+	const tw = width - 12;
+	const bw = width - 4;
+	const accent = (s: string) => theme.fg("accent", s);
+	const out: string[] = [];
+	out.push(`    ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
+	for (const line of top) {
+		const pad = Math.max(0, tw - visibleWidth(line));
+		out.push(`    ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
 	}
-	out.push(`  ${theme.fg("accent", `╰${bar}╯`)}`);
+	const rightTee = width - 5;
+	out.push(
+		accent("╭") +
+			accent("─".repeat(3)) +
+			accent("┴") +
+			accent("─".repeat(rightTee - 5)) +
+			accent("┴") +
+			accent("─".repeat(width - rightTee - 2)) +
+			accent("╮"),
+	);
+	for (const line of bottom) {
+		const pad = Math.max(0, bw - visibleWidth(line));
+		out.push(`${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
+	}
+	out.push(accent("╰") + accent("─".repeat(width - 2)) + accent("╯"));
 	return out;
 }
 

--- a/pi/.pi/agent/extensions/ask-user-question.ts
+++ b/pi/.pi/agent/extensions/ask-user-question.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	Editor,
 	type EditorTheme,
@@ -6,9 +6,10 @@ import {
 	Text,
 	matchesKey,
 	truncateToWidth,
+	visibleWidth,
 	wrapTextWithAnsi,
-} from "@mariozechner/pi-tui";
-import { Type } from "@sinclair/typebox";
+} from "@earendil-works/pi-tui";
+import { Type } from "typebox";
 
 interface AskOption {
 	label: string;
@@ -281,14 +282,14 @@ async function askSingleChoice(
 			// crashes the process.
 			if (cachedLines && cachedWidth === width) return cachedLines;
 
+			const cw = Math.max(8, width - 6);
 			const lines: string[] = [];
-			const add = (text: string) => lines.push(truncateToWidth(text, width));
+			const add = (text: string) => lines.push(truncateToWidth(text, cw));
 
-			add(theme.fg("accent", "─".repeat(width)));
-			addWrapped(lines, theme.fg("text", ` ${question}`), width);
+			addWrapped(lines, theme.fg("text", ` ${question}`), cw);
 			if (context) {
 				lines.push("");
-				addWrapped(lines, theme.fg("muted", ` ${context}`), width);
+				addWrapped(lines, theme.fg("muted", ` ${context}`), cw);
 			}
 			lines.push("");
 
@@ -300,14 +301,14 @@ async function askSingleChoice(
 				const styled = selected ? theme.fg("accent", label) : theme.fg("text", label);
 				add(`${prefix}${styled}`);
 				if (option.description) {
-					addWrapped(lines, theme.fg("muted", option.description), width, "     ");
+					addWrapped(lines, theme.fg("muted", option.description), cw, "     ");
 				}
 			}
 
 			if (editMode) {
 				lines.push("");
 				add(theme.fg("muted", " Write your custom answer:"));
-				for (const line of editor.render(Math.max(1, width - 2))) {
+				for (const line of editor.render(Math.max(1, cw - 2))) {
 					add(` ${line}`);
 				}
 				lines.push("");
@@ -317,10 +318,10 @@ async function askSingleChoice(
 				add(theme.fg("dim", " ↑↓ navigate • Enter select • Esc cancel"));
 			}
 
-			add(theme.fg("accent", "─".repeat(width)));
-			cachedLines = lines;
+			const framed = frame(lines, width, theme);
+			cachedLines = framed;
 			cachedWidth = width;
-			return lines;
+			return framed;
 		}
 
 		return {
@@ -458,14 +459,14 @@ async function askMultiChoice(
 			// crashes the process.
 			if (cachedLines && cachedWidth === width) return cachedLines;
 
+			const cw = Math.max(8, width - 6);
 			const lines: string[] = [];
-			const add = (text: string) => lines.push(truncateToWidth(text, width));
+			const add = (text: string) => lines.push(truncateToWidth(text, cw));
 
-			add(theme.fg("accent", "─".repeat(width)));
-			addWrapped(lines, theme.fg("text", ` ${question}`), width);
+			addWrapped(lines, theme.fg("text", ` ${question}`), cw);
 			if (context) {
 				lines.push("");
-				addWrapped(lines, theme.fg("muted", ` ${context}`), width);
+				addWrapped(lines, theme.fg("muted", ` ${context}`), cw);
 			}
 			lines.push("");
 
@@ -502,14 +503,14 @@ async function askMultiChoice(
 					: theme.fg(checked ? "success" : "text", label);
 				add(`${prefix}${styled}`);
 				if (item.description) {
-					addWrapped(lines, theme.fg("muted", item.description), width, "     ");
+					addWrapped(lines, theme.fg("muted", item.description), cw, "     ");
 				}
 			}
 
 			if (editMode) {
 				lines.push("");
 				add(theme.fg("muted", " Write your custom answer:"));
-				for (const line of editor.render(Math.max(1, width - 2))) {
+				for (const line of editor.render(Math.max(1, cw - 2))) {
 					add(` ${line}`);
 				}
 				lines.push("");
@@ -522,10 +523,10 @@ async function askMultiChoice(
 				add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter edit/submit • Esc cancel"));
 			}
 
-			add(theme.fg("accent", "─".repeat(width)));
-			cachedLines = lines;
+			const framed = frame(lines, width, theme);
+			cachedLines = framed;
 			cachedWidth = width;
-			return lines;
+			return framed;
 		}
 
 		return {
@@ -536,6 +537,22 @@ async function askMultiChoice(
 			handleInput,
 		};
 	});
+}
+
+// Frame a rendered panel in a rounded window, inset 2 columns from the left
+// edge. Content must already be laid out at (width - 6) visible columns.
+function frame(lines: string[], width: number, theme: any): string[] {
+	if (width < 12) return lines;
+	const contentW = width - 6;
+	const bar = "─".repeat(contentW + 2);
+	const wall = theme.fg("accent", "│");
+	const out = [`  ${theme.fg("accent", `╭${bar}╮`)}`];
+	for (const line of lines) {
+		const pad = Math.max(0, contentW - visibleWidth(line));
+		out.push(`  ${wall} ${line}${" ".repeat(pad)} ${wall}`);
+	}
+	out.push(`  ${theme.fg("accent", `╰${bar}╯`)}`);
+	return out;
 }
 
 // Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at

--- a/pi/.pi/agent/extensions/ask-user-question.ts
+++ b/pi/.pi/agent/extensions/ask-user-question.ts
@@ -308,14 +308,14 @@ async function askSingleChoice(
 			}
 
 			if (editMode) {
-				bottom.push(theme.fg("muted", " Write your custom answer:"));
-				for (const line of editor.render(Math.max(1, bw - 2))) {
+				top.push("");
+				add(theme.fg("muted", " Write your custom answer below • Enter to submit • Esc to go back"));
+				for (const line of editorInnerLines(editor, Math.max(1, bw - 2))) {
 					bottom.push(` ${line}`);
 				}
-				bottom.push("");
-				bottom.push(theme.fg("dim", " Enter to submit • Esc to go back"));
 			} else {
-				bottom.push(theme.fg("dim", " ↑↓ navigate • Enter select • Esc cancel"));
+				top.push("");
+				add(theme.fg("dim", " ↑↓ navigate • Enter select • Esc cancel"));
 			}
 
 			const framed = frameMerged(top, bottom, width, theme);
@@ -510,17 +510,17 @@ async function askMultiChoice(
 			}
 
 			if (editMode) {
-				bottom.push(theme.fg("muted", " Write your custom answer:"));
-				for (const line of editor.render(Math.max(1, bw - 2))) {
+				top.push("");
+				add(theme.fg("muted", " Write your custom answer below • Enter to save • Esc to go back"));
+				for (const line of editorInnerLines(editor, Math.max(1, bw - 2))) {
 					bottom.push(` ${line}`);
 				}
-				bottom.push("");
-				bottom.push(theme.fg("dim", " Enter to save • Esc to go back"));
 			} else {
+				top.push("");
 				if (selected.size === 0) {
-					bottom.push(theme.fg("warning", " Select at least one answer before submitting."));
+					add(theme.fg("warning", " Select at least one answer before submitting."));
 				}
-				bottom.push(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter edit/submit • Esc cancel"));
+				add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter edit/submit • Esc cancel"));
 			}
 
 			const framed = frameMerged(top, bottom, width, theme);
@@ -570,6 +570,16 @@ function frameMerged(top: string[], bottom: string[], width: number, theme: any)
 	}
 	out.push(accent("╰") + accent("─".repeat(width - 2)) + accent("╯"));
 	return out;
+}
+
+// Strip the Editor's own flat ─ borders (and scroll-rule variants) so the
+// outer rounded box is the only frame — the bottom box then reads as a clean
+// prompt, exactly like the real one.
+function editorInnerLines(editor: any, width: number): string[] {
+	const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+	return editor
+		.render(width)
+		.filter((l: string) => !/^─+$/.test(stripAnsi(l)) && !/^─── [↑↓] \d+ more /.test(stripAnsi(l)));
 }
 
 // Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at

--- a/pi/.pi/agent/extensions/ask-user-question.ts
+++ b/pi/.pi/agent/extensions/ask-user-question.ts
@@ -609,6 +609,51 @@ function withUILock<T>(fn: () => Promise<T>): Promise<T> {
 	return sharedUiLock.withLock(fn);
 }
 
+// Free-text mode: same merged UI — question bubble on top, the answer typed in
+// the prompt-styled box below. Replaces pi's built-in ctx.ui.editor dialog so
+// every user-input surface shares one look.
+async function askFreeText(ctx: any, question: string, context: string | undefined): Promise<string | null> {
+	return ctx.ui.custom<string | null>(
+		(tui: any, theme: any, _kb: any, done: (result: string | null) => void) => {
+			const editor = new Editor(tui, createEditorTheme(theme));
+			editor.focused = true;
+			editor.disableSubmit = true;
+
+			return {
+				render(width: number): string[] {
+					const tw = Math.max(8, width - 8);
+					const bw = Math.max(8, width - 4);
+					const top: string[] = [];
+					const bottom: string[] = [];
+					addWrapped(top, theme.fg("text", ` ${question}`), tw);
+					if (context) {
+						top.push("");
+						addWrapped(top, theme.fg("muted", ` ${context}`), tw);
+					}
+					top.push("");
+					top.push(truncateToWidth(theme.fg("dim", " Enter submit • Ctrl+J newline • Esc cancel"), tw));
+					for (const line of editorInnerLines(editor, Math.max(1, bw - 2))) {
+						bottom.push(` ${line}`);
+					}
+					return frameMerged(top, bottom, width, theme);
+				},
+				invalidate: () => editor.invalidate(),
+				handleInput(data: string) {
+					if (matchesKey(data, Key.enter)) {
+						done(editor.getText().trim());
+						return;
+					}
+					if (matchesKey(data, Key.escape)) {
+						done(null);
+						return;
+					}
+					editor.handleInput(data);
+				},
+			};
+		},
+	);
+}
+
 export default function askUserQuestion(pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "ask_user_question",
@@ -643,9 +688,8 @@ export default function askUserQuestion(pi: ExtensionAPI) {
 
 			return withUILock(async () => {
 				if (mode === "text") {
-					const editorTitle = context ? `${params.question}\n\n${context}` : params.question;
-					const answer = await ctx.ui.editor(editorTitle);
-					if (answer === undefined) {
+					const answer = await askFreeText(ctx, params.question, context);
+					if (answer === null) {
 						return cancelledResult(params.question, mode, context);
 					}
 					return buildResult(params.question, context, mode, [

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -163,6 +163,16 @@ function frameMerged(top: string[], bottom: string[], width: number, theme: any)
 	return out;
 }
 
+// Strip the Editor's own flat ─ borders (and scroll-rule variants) so the
+// outer rounded box is the only frame — the bottom box then reads as a clean
+// prompt, exactly like the real one.
+function editorInnerLines(editor: Editor, width: number): string[] {
+	const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+	return editor
+		.render(width)
+		.filter((l) => !/^─+$/.test(stripAnsi(l)) && !/^─── [↑↓] \d+ more /.test(stripAnsi(l)));
+}
+
 // Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at
 // a time, so ALL pop-up-style tools (quiz, ask_user_question, run-command,
 // explain, ...) must serialize against each other, not just against
@@ -407,15 +417,16 @@ export default function explain(pi: ExtensionAPI) {
 								}
 
 								if (phase === "answering") {
-									for (const line of editor.render(bw)) bottom.push(line);
-									bottom.push("");
-									addB(theme.fg("dim", " Enter — submit · Ctrl+J — new line · Esc — cancel"));
+									top.push("");
+									addT(theme.fg("dim", " Enter — submit · Ctrl+J — new line · Esc — cancel"));
+									for (const line of editorInnerLines(editor, bw)) bottom.push(line);
 								} else if (phase === "grading") {
 									top.push("");
 									addWrapped(top, theme.fg("dim", editor.getText().trim()), tw, " ");
 									top.push("");
 									for (const line of loader.render(tw)) top.push(line);
-									addB(theme.fg("dim", " Esc — abort grading"));
+									top.push("");
+									addT(theme.fg("dim", " Esc — abort grading"));
 								} else {
 									top.push("");
 									addWrapped(top, theme.fg("dim", editor.getText().trim()), tw, " ");
@@ -446,7 +457,8 @@ export default function explain(pi: ExtensionAPI) {
 										addT(theme.fg("warning", ` grading unavailable — ${gradeError ?? "unknown error"}`));
 										addT(theme.fg("dim", " (returned ungraded; the agent will evaluate your answer itself)"));
 									}
-									addB(theme.fg("dim", " Enter — continue"));
+									top.push("");
+									addT(theme.fg("dim", " Enter — continue"));
 								}
 								return frameMerged(top, bottom, width, theme);
 							},

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -7,6 +7,7 @@ import {
 	Text,
 	matchesKey,
 	truncateToWidth,
+	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
@@ -127,6 +128,22 @@ function addWrapped(lines: string[], text: string, width: number, indent = ""): 
 	for (const line of wrapTextWithAnsi(text, contentWidth)) {
 		lines.push(truncateToWidth(`${indent}${line}`, width));
 	}
+}
+
+// Frame a rendered panel in a rounded window, inset 2 columns from the left
+// edge. Content must already be laid out at (width - 6) visible columns.
+function frame(lines: string[], width: number, theme: any): string[] {
+	if (width < 12) return lines;
+	const contentW = width - 6;
+	const bar = "─".repeat(contentW + 2);
+	const wall = theme.fg("accent", "│");
+	const out = [`  ${theme.fg("accent", `╭${bar}╮`)}`];
+	for (const line of lines) {
+		const pad = Math.max(0, contentW - visibleWidth(line));
+		out.push(`  ${wall} ${line}${" ".repeat(pad)} ${wall}`);
+	}
+	out.push(`  ${theme.fg("accent", `╰${bar}╯`)}`);
+	return out;
 }
 
 // Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at
@@ -357,52 +374,52 @@ export default function explain(pi: ExtensionAPI) {
 
 						return {
 							render(width: number): string[] {
+								const cw = Math.max(8, width - 6);
 								const lines: string[] = [];
-								const add = (s: string) => lines.push(truncateToWidth(s, width));
+								const add = (s: string) => lines.push(truncateToWidth(s, cw));
 
-								add(theme.fg("accent", "─".repeat(width)));
 								add(theme.fg("toolTitle", theme.bold(" explain in your own words")));
 								lines.push("");
-								addWrapped(lines, theme.fg("text", question), width, " ");
+								addWrapped(lines, theme.fg("text", question), cw, " ");
 								if (context) {
 									lines.push("");
-									addWrapped(lines, theme.fg("muted", context), width, " ");
+									addWrapped(lines, theme.fg("muted", context), cw, " ");
 								}
 								lines.push("");
 
 								if (phase === "answering") {
-									for (const line of editor.render(width)) lines.push(line);
+									for (const line of editor.render(cw)) lines.push(line);
 									lines.push("");
 									add(theme.fg("dim", " Enter — submit · Ctrl+J — new line · Esc — cancel"));
 								} else if (phase === "grading") {
-									addWrapped(lines, theme.fg("dim", editor.getText().trim()), width, " ");
+									addWrapped(lines, theme.fg("dim", editor.getText().trim()), cw, " ");
 									lines.push("");
-									for (const line of loader.render(width)) lines.push(line);
+									for (const line of loader.render(cw)) lines.push(line);
 									lines.push("");
 									add(theme.fg("dim", " Esc — abort grading"));
 								} else {
-									addWrapped(lines, theme.fg("dim", editor.getText().trim()), width, " ");
+									addWrapped(lines, theme.fg("dim", editor.getText().trim()), cw, " ");
 									lines.push("");
 									if (grading) {
 										add(` ${verdictIcon(grading)}`);
 										if (grading.summary) {
 											lines.push("");
-											addWrapped(lines, theme.fg("text", grading.summary), width, " ");
+											addWrapped(lines, theme.fg("text", grading.summary), cw, " ");
 										}
 										if (grading.verdict !== "correct" && grading.correctAnswer) {
 											lines.push("");
 											add(theme.fg("muted", " correct answer:"));
-											addWrapped(lines, theme.fg("success", grading.correctAnswer), width, "  ");
+											addWrapped(lines, theme.fg("success", grading.correctAnswer), cw, "  ");
 										}
 										if (grading.refinements.length > 0) {
 											lines.push("");
 											add(theme.fg("muted", " terminology:"));
 											for (const r of grading.refinements) {
-												addWrapped(lines, theme.fg("warning", `“${r.quote}”`), width, "  ");
+												addWrapped(lines, theme.fg("warning", `“${r.quote}”`), cw, "  ");
 												const note = [r.issue, r.correction && `→ ${r.correction}`]
 													.filter(Boolean)
 													.join(" — ");
-												if (note) addWrapped(lines, theme.fg("dim", note), width, "    ");
+												if (note) addWrapped(lines, theme.fg("dim", note), cw, "    ");
 											}
 										}
 									} else {
@@ -412,7 +429,7 @@ export default function explain(pi: ExtensionAPI) {
 									lines.push("");
 									add(theme.fg("dim", " Enter — continue"));
 								}
-								return lines;
+								return frame(lines, width, theme);
 							},
 
 							invalidate: () => {

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -3,6 +3,7 @@ import {
 	Editor,
 	type EditorTheme,
 	Key,
+	Loader,
 	Text,
 	matchesKey,
 	truncateToWidth,
@@ -11,29 +12,50 @@ import {
 import { Type } from "typebox";
 
 // ────────────────────────────────────────────────────────────────────────────
-// explain — a PROSE sibling of quiz.
+// explain — a PROSE sibling of quiz, with a grader fork.
 //
 // Where quiz grades a selection against known options, explain asks for an
 // answer in the user's OWN WORDS. That is a more demanding retrieval act: no
 // options to recognize, no shape to pattern-match — the user must produce the
-// concept and the terminology themselves. The tool deliberately does NOT
-// grade: evaluating the prose (precision of terms, hidden misconceptions) is
-// the agent's job, and it happens after submit.
+// concept and the terminology themselves.
+//
+// Grading: the caller supplies `expected` — the claims a correct answer must
+// contain. On submit, the tool makes ONE quick model call (a "grader fork":
+// ctx.modelRegistry.complete with the session's active model, no session, no
+// tools) that grades the answer against those claims and returns a verdict
+// plus per-quote terminology refinements. A spinner is shown while grading.
+// The verdict travels back with the question/answer pair; the calling agent
+// still owns the pedagogical response (re-asking, naming misconceptions).
 //
 // UI: a floating panel above the prompt shows the question (and optional
 // context). The response field is focused immediately — there is nothing to
 // navigate. Enter submits, Ctrl+J inserts a newline (pi convention), Esc
-// cancels. On submit, the question and the user's answer travel together as a
-// question/answer pair for the agent to evaluate.
+// cancels. During grading a spinner replaces the editor; Esc aborts the
+// grade. After grading, the verdict and refinements are shown in the panel;
+// Enter or Esc dismisses.
 // ────────────────────────────────────────────────────────────────────────────
 
 type ExplainStatus = "answered" | "cancelled" | "unavailable";
+type Verdict = "correct" | "partially_correct" | "incorrect";
+
+interface Refinement {
+	quote: string;
+	issue: string;
+	correction: string;
+}
+
+interface Grading {
+	verdict: Verdict;
+	summary: string;
+	refinements: Refinement[];
+}
 
 interface ExplainDetails {
 	status: ExplainStatus;
 	question: string;
 	context?: string;
 	answer?: string;
+	grading?: Grading;
 	message?: string;
 }
 
@@ -42,10 +64,37 @@ const ExplainParams = Type.Object({
 		description:
 			"The single question the user must answer in their own words. Ask exactly one question per tool call. Phrase it to force precise terminology — 'name the kernel construct and explain why', not 'what do you think about X'.",
 	}),
+	expected: Type.String({
+		description:
+			"The claims a correct answer must contain, in your own words — the grader fork grades the user's prose against this. Include the exact terminology you expect and any misconceptions to watch for. Not shown to the user.",
+	}),
 	details: Type.Optional(
 		Type.String({ description: "Optional extra context or instructions shown under the question." }),
 	),
 });
+
+const GRADER_SYSTEM_PROMPT = `You are grading a learner's free-text answer to a technical question. The teacher supplies the claims a correct answer must contain ("expected"). Grade the learner's answer against those claims, not against your own general knowledge.
+
+Output ONLY a JSON object — no markdown fences, no prose before or after — with exactly these keys:
+
+{
+  "verdict": "correct" | "partially_correct" | "incorrect",
+  "summary": "1-2 sentences: why this verdict",
+  "refinements": [
+    {
+      "quote": "an exact substring copied from the learner's answer",
+      "issue": "what is wrong or loose about it",
+      "correction": "the precise terminology or claim that should replace it"
+    }
+  ]
+}
+
+Grading rules:
+- "correct" means every required claim is present and accurately stated, with acceptable terminology. Minor phrasing differences are fine.
+- "partially_correct" means the core idea is right but a required claim is missing, or terminology is loose enough to matter.
+- "incorrect" means a required claim is wrong or the core mechanism is misunderstood.
+- refinements must quote the learner's own words verbatim — never invent quotes. Include every spot where terminology is wrong, loose, or a claim is factually off. An empty array means nothing needs refinement.
+- Do not penalize the learner for omitting things the expected claims do not require.`;
 
 function createEditorTheme(theme: any): EditorTheme {
 	return {
@@ -101,24 +150,54 @@ function buildDetails(
 	question: string,
 	context: string | undefined,
 	answer?: string,
+	grading?: Grading,
 	message?: string,
 ): ExplainDetails {
-	return { status, question, context, answer, message };
+	return { status, question, context, answer, grading, message };
 }
 
 function cancelledResult(question: string, context?: string) {
 	const message = "User cancelled explain";
 	return {
 		content: [{ type: "text" as const, text: message }],
-		details: buildDetails("cancelled", question, context, undefined, message),
+		details: buildDetails("cancelled", question, context, undefined, undefined, message),
 	};
 }
 
 function unavailableResult(question: string, message: string, context?: string) {
 	return {
 		content: [{ type: "text" as const, text: message }],
-		details: buildDetails("unavailable", question, context, undefined, message),
+		details: buildDetails("unavailable", question, context, undefined, undefined, message),
 	};
+}
+
+function extractGrading(raw: string): Grading | undefined {
+	const start = raw.indexOf("{");
+	const end = raw.lastIndexOf("}");
+	if (start === -1 || end <= start) return undefined;
+	try {
+		const parsed = JSON.parse(raw.slice(start, end + 1));
+		const verdict: Verdict =
+			parsed.verdict === "correct" || parsed.verdict === "incorrect" ? parsed.verdict : "partially_correct";
+		const refinements: Refinement[] = Array.isArray(parsed.refinements)
+			? parsed.refinements
+					.filter((r: any) => r && typeof r.quote === "string" && r.quote.length > 0)
+					.map((r: any) => ({
+						quote: String(r.quote),
+						issue: String(r.issue ?? ""),
+						correction: String(r.correction ?? ""),
+					}))
+			: [];
+		return { verdict, summary: String(parsed.summary ?? ""), refinements };
+	} catch {
+		return undefined;
+	}
+}
+
+interface PanelResult {
+	answer: string;
+	grading?: Grading;
+	gradeError?: string;
 }
 
 export default function explain(pi: ExtensionAPI) {
@@ -126,19 +205,21 @@ export default function explain(pi: ExtensionAPI) {
 		name: "explain",
 		label: "explain",
 		description:
-			"Ask the user to answer ONE question in their own words — a prose retrieval check, more demanding than quiz's multiple choice because there are no options to recognize. Use it to ground terminology ('name the kernel construct this touches and why') and to surface misconceptions that multiple choice can't reach. The tool does not grade: you receive the question and the user's prose answer together and evaluate precision yourself. For gradable questions with a known correct option set, use quiz; for preferences with no right answer, use ask_user_question.",
+			"Ask the user to answer ONE question in their own words — a prose retrieval check, more demanding than quiz's multiple choice because there are no options to recognize. Use it to ground terminology ('name the kernel construct this touches and why') and to surface misconceptions that multiple choice can't reach. You MUST supply `expected`: the claims a correct answer must contain. On submit, a quick grader model call grades the answer against those claims and returns a verdict (correct / partially_correct / incorrect) plus per-quote terminology refinements — you still own the pedagogical follow-up. For gradable questions with a known correct option set, use quiz; for preferences with no right answer, use ask_user_question.",
 		promptSnippet:
-			"Use explain to make the user answer one question in their own words (terminology grounding, mechanism explanations). You grade the prose yourself after submit.",
+			"Use explain to make the user answer one question in their own words; a grader fork scores it against your `expected` claims and returns a verdict plus terminology refinements.",
 		promptGuidelines: [
 			"ONE question per call. Phrase it to force precise terminology and mechanism, not vibes — 'why does X need Y' or 'name the construct and what it does', never 'what are your thoughts on X'.",
+			"Always supply `expected`: the claims a correct answer must contain, including the exact terms you want and the misconceptions to watch for. The grader grades against this, not general knowledge.",
 			"Prefer explain over quiz when you are somewhat confident where the user's understanding sits and want to verify precision of language; prefer quiz when you are still mapping the edge.",
-			"Evaluate the returned answer against bounded terminology: right-but-loose language gets corrected ('right idea, the exact term is X because Y'); a revealed misconception gets named and re-asked in a different form.",
-			"An empty or near-empty submission is an honest 'I don't know' — treat it as a genuine gap to teach into, not a failure.",
+			"Act on the verdict: correct-but-loose refinements get named and sharpened in your reply; partially_correct or incorrect means stop, diagnose, and re-ask in a different form before moving on.",
+			"An empty or near-empty submission is an honest 'I don't know' — treat it as a genuine gap to teach into, not a failure. Empty answers skip grading.",
 		],
 		parameters: ExplainParams,
 
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			const question = params.question.trim();
+			const expected = params.expected.trim();
 			const context = params.details?.trim() || undefined;
 
 			if (signal?.aborted) {
@@ -147,21 +228,84 @@ export default function explain(pi: ExtensionAPI) {
 			if (!question) {
 				return unavailableResult(question, "explain requires a non-empty question", context);
 			}
+			if (!expected) {
+				return unavailableResult(question, "explain requires `expected` (the claims a correct answer must contain)", context);
+			}
 			if (!ctx.hasUI) {
 				return unavailableResult(question, "explain requires interactive mode UI", context);
 			}
+			if (!ctx.model) {
+				return unavailableResult(question, "explain requires an active model for the grader fork", context);
+			}
+
+			const grade = async (answer: string): Promise<{ grading?: Grading; gradeError?: string }> => {
+				const graderPrompt =
+					`Question asked of the learner:\n${question}\n\n` +
+					`Expected — the claims a correct answer must contain:\n${expected}\n\n` +
+					`Learner's answer (their own words):\n${answer}`;
+				try {
+					const response = await ctx.modelRegistry.complete(ctx.model!, {
+						systemPrompt: GRADER_SYSTEM_PROMPT,
+						messages: [{ role: "user", content: graderPrompt, timestamp: Date.now() } as any],
+					});
+					const raw = response.content
+						.filter((c: any) => c.type === "text")
+						.map((c: any) => c.text)
+						.join("\n");
+					const grading = extractGrading(raw);
+					if (!grading) return { gradeError: `grader returned unparseable output: ${raw.slice(0, 200)}` };
+					return { grading };
+				} catch (err: any) {
+					if (signal?.aborted) return { gradeError: "aborted" };
+					return { gradeError: `grader call failed: ${err?.message ?? String(err)}` };
+				}
+			};
 
 			return withUILock(async () => {
-				const answer = await ctx.ui.custom<string | null>(
-					(tui: any, theme: any, _kb: any, done: (result: string | null) => void) => {
-						// The response field owns the whole interaction — there is nothing
-						// else to navigate, so it is focused immediately. Enter must NOT
-						// submit inside the editor (its submit path clears the buffer), so
+				const result = await ctx.ui.custom<PanelResult | null>(
+					(tui: any, theme: any, _kb: any, done: (result: PanelResult | null) => void) => {
+						// The response field owns the first phase — there is nothing else
+						// to navigate, so it is focused immediately. Enter must NOT submit
+						// inside the editor (its submit path clears the buffer), so
 						// disableSubmit and let the host own Enter. Ctrl+J still inserts a
 						// newline (pi convention) for multi-line prose.
 						const editor = new Editor(tui, createEditorTheme(theme));
 						editor.focused = true;
 						editor.disableSubmit = true;
+
+						const loader = new Loader(
+							tui,
+							(s: string) => theme.fg("accent", s),
+							(s: string) => theme.fg("muted", s),
+							" grading…",
+						);
+
+						let phase: "answering" | "grading" | "verdict" = "answering";
+						let grading: Grading | undefined;
+						let gradeError: string | undefined;
+
+						const verdictIcon = (v: Verdict): string => {
+							if (v === "correct") return theme.fg("success", "✓ correct");
+							if (v === "incorrect") return theme.fg("error", "✗ incorrect");
+							return theme.fg("warning", "◐ partially correct");
+						};
+
+						const startGrading = (answer: string) => {
+							phase = "grading";
+							loader.start();
+							tui.requestRender();
+							void grade(answer).then((res) => {
+								loader.stop();
+								if (res.gradeError === "aborted") {
+									done(null);
+									return;
+								}
+								grading = res.grading;
+								gradeError = res.gradeError;
+								phase = "verdict";
+								tui.requestRender();
+							});
+						};
 
 						return {
 							render(width: number): string[] {
@@ -177,9 +321,44 @@ export default function explain(pi: ExtensionAPI) {
 									addWrapped(lines, theme.fg("muted", context), width, " ");
 								}
 								lines.push("");
-								for (const line of editor.render(width)) lines.push(line);
-								lines.push("");
-								add(theme.fg("dim", " Enter — submit · Ctrl+J — new line · Esc — cancel"));
+
+								if (phase === "answering") {
+									for (const line of editor.render(width)) lines.push(line);
+									lines.push("");
+									add(theme.fg("dim", " Enter — submit · Ctrl+J — new line · Esc — cancel"));
+								} else if (phase === "grading") {
+									addWrapped(lines, theme.fg("dim", editor.getText().trim()), width, " ");
+									lines.push("");
+									for (const line of loader.render(width)) lines.push(line);
+									lines.push("");
+									add(theme.fg("dim", " Esc — abort grading"));
+								} else {
+									addWrapped(lines, theme.fg("dim", editor.getText().trim()), width, " ");
+									lines.push("");
+									if (grading) {
+										add(` ${verdictIcon(grading.verdict)}`);
+										if (grading.summary) {
+											lines.push("");
+											addWrapped(lines, theme.fg("text", grading.summary), width, " ");
+										}
+										if (grading.refinements.length > 0) {
+											lines.push("");
+											add(theme.fg("muted", " terminology:"));
+											for (const r of grading.refinements) {
+												addWrapped(lines, theme.fg("warning", `“${r.quote}”`), width, "  ");
+												const note = [r.issue, r.correction && `→ ${r.correction}`]
+													.filter(Boolean)
+													.join(" — ");
+												if (note) addWrapped(lines, theme.fg("dim", note), width, "    ");
+											}
+										}
+									} else {
+										add(theme.fg("warning", ` grading unavailable — ${gradeError ?? "unknown error"}`));
+										add(theme.fg("dim", " (returned ungraded; the agent will evaluate your answer itself)"));
+									}
+									lines.push("");
+									add(theme.fg("dim", " Enter — continue"));
+								}
 								return lines;
 							},
 
@@ -188,32 +367,70 @@ export default function explain(pi: ExtensionAPI) {
 							},
 
 							handleInput(data: string) {
-								if (matchesKey(data, Key.enter)) {
-									done(editor.getText().trim());
+								if (phase === "answering") {
+									if (matchesKey(data, Key.enter)) {
+										const answer = editor.getText().trim();
+										if (!answer) {
+											// Empty answer = honest "I don't know"; skip grading.
+											done({ answer: "" });
+											return;
+										}
+										startGrading(answer);
+										return;
+									}
+									if (matchesKey(data, Key.escape)) {
+										done(null);
+										return;
+									}
+									editor.handleInput(data);
 									return;
 								}
-								if (matchesKey(data, Key.escape)) {
-									done(null);
+								if (phase === "grading") {
+									if (matchesKey(data, Key.escape)) {
+										loader.stop();
+										done(null);
+									}
 									return;
 								}
-								editor.handleInput(data);
+								// verdict
+								if (matchesKey(data, Key.enter) || matchesKey(data, Key.escape)) {
+									done({ answer: editor.getText().trim(), grading, gradeError });
+								}
 							},
 						};
 					},
 				);
 
-				if (answer === null) {
+				if (result === null) {
 					return cancelledResult(question, context);
 				}
 				let text: string;
-				if (answer) {
-					text = `Question: ${question}\nUser's answer (their own words):\n${answer}`;
+				if (result.answer) {
+					text = `Question: ${question}\nUser's answer (their own words):\n${result.answer}`;
+					if (result.grading) {
+						const g = result.grading;
+						text += `\n\nGrader verdict: ${g.verdict.toUpperCase()}\n${g.summary}`;
+						if (g.refinements.length > 0) {
+							text += `\nTerminology refinements:`;
+							for (const r of g.refinements) {
+								text += `\n- "${r.quote}" — ${r.issue}${r.correction ? ` → ${r.correction}` : ""}`;
+							}
+						}
+						text +=
+							`\n\nAct on the verdict: correct = affirm and extend; partially_correct = name what was ` +
+							`missing or loose and sharpen it; incorrect = stop, diagnose the misconception, and re-ask ` +
+							`in a different form before moving on. The verdict is advisory — you own the final call.`;
+					} else {
+						text +=
+							`\n\n(Grader fork unavailable: ${result.gradeError ?? "unknown error"}. Evaluate the prose ` +
+							`yourself against your expected claims.)`;
+					}
 				} else {
 					text = `Question: ${question}\nUser submitted an EMPTY answer — treat this as an honest "I don't know": a genuine gap to teach into, not a failure.`;
 				}
 				return {
 					content: [{ type: "text" as const, text }],
-					details: buildDetails("answered", question, context, answer || undefined),
+					details: buildDetails("answered", question, context, result.answer || undefined, result.grading),
 				};
 			});
 		},
@@ -243,6 +460,23 @@ export default function explain(pi: ExtensionAPI) {
 				}
 			} else {
 				lines.push(theme.fg("warning", " (empty answer — treated as “I don't know”)"));
+			}
+			if (details.grading) {
+				const g = details.grading;
+				const icon =
+					g.verdict === "correct"
+						? theme.fg("success", "✓ correct")
+						: g.verdict === "incorrect"
+							? theme.fg("error", "✗ incorrect")
+							: theme.fg("warning", "◐ partially correct");
+				lines.push(theme.fg("muted", "─ grader ─"));
+				lines.push(` ${icon}`);
+				if (g.summary) lines.push(theme.fg("dim", ` ${g.summary}`));
+				for (const r of g.refinements) {
+					lines.push(theme.fg("warning", `  “${r.quote}”`));
+					const note = [r.issue, r.correction && `→ ${r.correction}`].filter(Boolean).join(" — ");
+					if (note) lines.push(theme.fg("dim", `    ${note}`));
+				}
 			}
 			return new Text(lines.join("\n"), 0, 0);
 		},

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -82,12 +82,12 @@ Output ONLY a JSON object — no markdown fences, no prose before or after — w
 {
   "verdict": "correct" | "partially_correct" | "incorrect",
   "grade": "A" | "B" | "C" | "D" | "F",
-  "summary": "1-2 sentences: why this verdict",
+  "summary": "one terse sentence, <=15 words: why this verdict",
   "refinements": [
     {
       "quote": "an exact substring copied from the learner's answer",
-      "issue": "what is wrong or loose about it",
-      "correction": "the precise terminology or claim that should replace it"
+      "issue": "what is wrong or loose, <=10 words, no preamble",
+      "correction": "the precise term or claim only — no explanation, no sentence"
     }
   ]
 }
@@ -104,7 +104,7 @@ Letter grade rubric:
 - D: mostly wrong, but shows a fragment of real understanding worth building on.
 - F: fundamentally wrong, a systematic misconception, or no engagement with the question.
 The verdict and grade must agree: correct = A or B; partially_correct = C; incorrect = D or F.
-- refinements must quote the learner's own words verbatim — never invent quotes. Include every spot where terminology is wrong, loose, or a claim is factually off. An empty array means nothing needs refinement.
+- refinements must quote the learner's own words verbatim — never invent quotes. Include every spot where terminology is wrong, loose, or a claim is factually off. Keep issue and correction terse — labels, not prose. An empty array means nothing needs refinement.
 - Do not penalize the learner for omitting things the expected claims do not require.`;
 
 function createEditorTheme(theme: any): EditorTheme {
@@ -434,10 +434,7 @@ export default function explain(pi: ExtensionAPI) {
 								text += `\n- "${r.quote}" — ${r.issue}${r.correction ? ` → ${r.correction}` : ""}`;
 							}
 						}
-						text +=
-							`\n\nAct on the verdict: correct = affirm and extend; partially_correct = name what was ` +
-							`missing or loose and sharpen it; incorrect = stop, diagnose the misconception, and re-ask ` +
-							`in a different form before moving on. The verdict is advisory — you own the final call.`;
+						text += `\n\nVerdict is advisory — you own the final call and the follow-up.`;
 					} else {
 						text +=
 							`\n\n(Grader fork unavailable: ${result.gradeError ?? "unknown error"}. Evaluate the prose ` +

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -1,0 +1,250 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	Editor,
+	type EditorTheme,
+	Key,
+	Text,
+	matchesKey,
+	truncateToWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+// ────────────────────────────────────────────────────────────────────────────
+// explain — a PROSE sibling of quiz.
+//
+// Where quiz grades a selection against known options, explain asks for an
+// answer in the user's OWN WORDS. That is a more demanding retrieval act: no
+// options to recognize, no shape to pattern-match — the user must produce the
+// concept and the terminology themselves. The tool deliberately does NOT
+// grade: evaluating the prose (precision of terms, hidden misconceptions) is
+// the agent's job, and it happens after submit.
+//
+// UI: a floating panel above the prompt shows the question (and optional
+// context). The response field is focused immediately — there is nothing to
+// navigate. Enter submits, Ctrl+J inserts a newline (pi convention), Esc
+// cancels. On submit, the question and the user's answer travel together as a
+// question/answer pair for the agent to evaluate.
+// ────────────────────────────────────────────────────────────────────────────
+
+type ExplainStatus = "answered" | "cancelled" | "unavailable";
+
+interface ExplainDetails {
+	status: ExplainStatus;
+	question: string;
+	context?: string;
+	answer?: string;
+	message?: string;
+}
+
+const ExplainParams = Type.Object({
+	question: Type.String({
+		description:
+			"The single question the user must answer in their own words. Ask exactly one question per tool call. Phrase it to force precise terminology — 'name the kernel construct and explain why', not 'what do you think about X'.",
+	}),
+	details: Type.Optional(
+		Type.String({ description: "Optional extra context or instructions shown under the question." }),
+	),
+});
+
+function createEditorTheme(theme: any): EditorTheme {
+	return {
+		borderColor: (s) => theme.fg("accent", s),
+		selectList: {
+			selectedPrefix: (t) => theme.fg("accent", t),
+			selectedText: (t) => theme.fg("accent", t),
+			description: (t) => theme.fg("muted", t),
+			scrollInfo: (t) => theme.fg("dim", t),
+			noMatch: (t) => theme.fg("warning", t),
+		},
+	};
+}
+
+function addWrapped(lines: string[], text: string, width: number, indent = ""): void {
+	const contentWidth = Math.max(1, width - indent.length);
+	for (const line of wrapTextWithAnsi(text, contentWidth)) {
+		lines.push(truncateToWidth(`${indent}${line}`, width));
+	}
+}
+
+// Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at
+// a time, so ALL pop-up-style tools (quiz, ask_user_question, run-command,
+// explain, ...) must serialize against each other, not just against
+// themselves. We stash one mutex on globalThis so separate extension files can
+// share it without importing each other.
+const SHARED_UI_LOCK_KEY = "__piSharedUiLock";
+function getSharedUiLock() {
+	const g = globalThis as any;
+	if (!g[SHARED_UI_LOCK_KEY]) {
+		let chain: Promise<void> = Promise.resolve();
+		g[SHARED_UI_LOCK_KEY] = {
+			withLock<T>(fn: () => T | Promise<T>): Promise<T> {
+				const prev = chain;
+				let release: () => void;
+				chain = new Promise<void>((r) => {
+					release = r;
+				});
+				return prev.then(fn).finally(() => release!());
+			},
+		};
+	}
+	return g[SHARED_UI_LOCK_KEY] as { withLock<T>(fn: () => T | Promise<T>): Promise<T> };
+}
+const sharedUiLock = getSharedUiLock();
+
+function withUILock<T>(fn: () => Promise<T>): Promise<T> {
+	return sharedUiLock.withLock(fn);
+}
+
+function buildDetails(
+	status: ExplainStatus,
+	question: string,
+	context: string | undefined,
+	answer?: string,
+	message?: string,
+): ExplainDetails {
+	return { status, question, context, answer, message };
+}
+
+function cancelledResult(question: string, context?: string) {
+	const message = "User cancelled explain";
+	return {
+		content: [{ type: "text" as const, text: message }],
+		details: buildDetails("cancelled", question, context, undefined, message),
+	};
+}
+
+function unavailableResult(question: string, message: string, context?: string) {
+	return {
+		content: [{ type: "text" as const, text: message }],
+		details: buildDetails("unavailable", question, context, undefined, message),
+	};
+}
+
+export default function explain(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "explain",
+		label: "explain",
+		description:
+			"Ask the user to answer ONE question in their own words — a prose retrieval check, more demanding than quiz's multiple choice because there are no options to recognize. Use it to ground terminology ('name the kernel construct this touches and why') and to surface misconceptions that multiple choice can't reach. The tool does not grade: you receive the question and the user's prose answer together and evaluate precision yourself. For gradable questions with a known correct option set, use quiz; for preferences with no right answer, use ask_user_question.",
+		promptSnippet:
+			"Use explain to make the user answer one question in their own words (terminology grounding, mechanism explanations). You grade the prose yourself after submit.",
+		promptGuidelines: [
+			"ONE question per call. Phrase it to force precise terminology and mechanism, not vibes — 'why does X need Y' or 'name the construct and what it does', never 'what are your thoughts on X'.",
+			"Prefer explain over quiz when you are somewhat confident where the user's understanding sits and want to verify precision of language; prefer quiz when you are still mapping the edge.",
+			"Evaluate the returned answer against bounded terminology: right-but-loose language gets corrected ('right idea, the exact term is X because Y'); a revealed misconception gets named and re-asked in a different form.",
+			"An empty or near-empty submission is an honest 'I don't know' — treat it as a genuine gap to teach into, not a failure.",
+		],
+		parameters: ExplainParams,
+
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const question = params.question.trim();
+			const context = params.details?.trim() || undefined;
+
+			if (signal?.aborted) {
+				return cancelledResult(question, context);
+			}
+			if (!question) {
+				return unavailableResult(question, "explain requires a non-empty question", context);
+			}
+			if (!ctx.hasUI) {
+				return unavailableResult(question, "explain requires interactive mode UI", context);
+			}
+
+			return withUILock(async () => {
+				const answer = await ctx.ui.custom<string | null>(
+					(tui: any, theme: any, _kb: any, done: (result: string | null) => void) => {
+						// The response field owns the whole interaction — there is nothing
+						// else to navigate, so it is focused immediately. Enter must NOT
+						// submit inside the editor (its submit path clears the buffer), so
+						// disableSubmit and let the host own Enter. Ctrl+J still inserts a
+						// newline (pi convention) for multi-line prose.
+						const editor = new Editor(tui, createEditorTheme(theme));
+						editor.focused = true;
+						editor.disableSubmit = true;
+
+						return {
+							render(width: number): string[] {
+								const lines: string[] = [];
+								const add = (s: string) => lines.push(truncateToWidth(s, width));
+
+								add(theme.fg("accent", "─".repeat(width)));
+								add(theme.fg("toolTitle", theme.bold(" explain in your own words")));
+								lines.push("");
+								addWrapped(lines, theme.fg("text", question), width, " ");
+								if (context) {
+									lines.push("");
+									addWrapped(lines, theme.fg("muted", context), width, " ");
+								}
+								lines.push("");
+								for (const line of editor.render(width)) lines.push(line);
+								lines.push("");
+								add(theme.fg("dim", " Enter — submit · Ctrl+J — new line · Esc — cancel"));
+								return lines;
+							},
+
+							invalidate: () => {
+								editor.invalidate();
+							},
+
+							handleInput(data: string) {
+								if (matchesKey(data, Key.enter)) {
+									done(editor.getText().trim());
+									return;
+								}
+								if (matchesKey(data, Key.escape)) {
+									done(null);
+									return;
+								}
+								editor.handleInput(data);
+							},
+						};
+					},
+				);
+
+				if (answer === null) {
+					return cancelledResult(question, context);
+				}
+				let text: string;
+				if (answer) {
+					text = `Question: ${question}\nUser's answer (their own words):\n${answer}`;
+				} else {
+					text = `Question: ${question}\nUser submitted an EMPTY answer — treat this as an honest "I don't know": a genuine gap to teach into, not a failure.`;
+				}
+				return {
+					content: [{ type: "text" as const, text }],
+					details: buildDetails("answered", question, context, answer || undefined),
+				};
+			});
+		},
+
+		renderCall(args, theme) {
+			return new Text(theme.fg("toolTitle", theme.bold("explain ")) + theme.fg("muted", String(args.question ?? "")), 0, 0);
+		},
+
+		renderResult(result, _options, theme) {
+			const details = result.details as ExplainDetails | undefined;
+			if (!details) {
+				const first = result.content[0];
+				return new Text(first?.type === "text" ? first.text : "", 0, 0);
+			}
+			if (details.status === "cancelled") {
+				return new Text(theme.fg("warning", details.message || "Cancelled"), 0, 0);
+			}
+			if (details.status === "unavailable") {
+				return new Text(theme.fg("warning", details.message || "Unavailable"), 0, 0);
+			}
+			const lines: string[] = [];
+			lines.push(theme.fg("toolTitle", theme.bold("explain ")) + theme.fg("text", details.question));
+			if (details.answer) {
+				lines.push(theme.fg("muted", "─ answer ─"));
+				for (const line of details.answer.split("\n")) {
+					lines.push(theme.fg("dim", ` ${line}`));
+				}
+			} else {
+				lines.push(theme.fg("warning", " (empty answer — treated as “I don't know”)"));
+			}
+			return new Text(lines.join("\n"), 0, 0);
+		},
+	});
+}

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -182,6 +182,29 @@ function unavailableResult(question: string, message: string, context?: string) 
 	};
 }
 
+// The grader fork should be fast: prefer a small, cheap model over the
+// session's active model (which may be a slow reasoning model). Override with
+// PI_EXPLAIN_GRADER_MODEL="provider/model-id"; otherwise walk a preference
+// list of widely-available fast models, and finally fall back to ctx.model.
+function pickGraderModel(ctx: any): any {
+	const override = process.env.PI_EXPLAIN_GRADER_MODEL;
+	if (override) {
+		const slash = override.indexOf("/");
+		const m = slash > 0 ? ctx.modelRegistry.find(override.slice(0, slash), override.slice(slash + 1)) : undefined;
+		if (m) return m;
+	}
+	for (const [provider, id] of [
+		["anthropic", "claude-haiku-4-5"],
+		["openai", "gpt-4o-mini"],
+		["google", "gemini-2.5-flash"],
+		["fireworks", "deepseek-v4-flash-0731"],
+	] as const) {
+		const m = ctx.modelRegistry.find(provider, id);
+		if (m && (!ctx.modelRegistry.hasConfiguredAuth || ctx.modelRegistry.hasConfiguredAuth(m))) return m;
+	}
+	return ctx.model;
+}
+
 function extractGrading(raw: string): Grading | undefined {
 	const start = raw.indexOf("{");
 	const end = raw.lastIndexOf("}");
@@ -252,20 +275,22 @@ export default function explain(pi: ExtensionAPI) {
 			if (!ctx.hasUI) {
 				return unavailableResult(question, "explain requires interactive mode UI", context);
 			}
-			if (!ctx.model) {
-				return unavailableResult(question, "explain requires an active model for the grader fork", context);
-			}
-
 			const grade = async (answer: string): Promise<{ grading?: Grading; gradeError?: string }> => {
+				const model = pickGraderModel(ctx);
 				const graderPrompt =
 					`Question asked of the learner:\n${question}\n\n` +
 					`Expected — the claims a correct answer must contain:\n${expected}\n\n` +
 					`Learner's answer (their own words):\n${answer}`;
 				try {
-					const response = await ctx.modelRegistry.complete(ctx.model!, {
-						systemPrompt: GRADER_SYSTEM_PROMPT,
-						messages: [{ role: "user", content: graderPrompt, timestamp: Date.now() } as any],
-					});
+					const response = await ctx.modelRegistry.complete(
+						model,
+						{
+							systemPrompt: GRADER_SYSTEM_PROMPT,
+							messages: [{ role: "user", content: graderPrompt, timestamp: Date.now() } as any],
+						},
+						// Fast grading: small output budget, deterministic, thinking off.
+						{ signal, maxTokens: 800, temperature: 0, reasoning: "off" } as any,
+					);
 					const raw = response.content
 						.filter((c: any) => c.type === "text")
 						.map((c: any) => c.text)
@@ -278,6 +303,8 @@ export default function explain(pi: ExtensionAPI) {
 					return { gradeError: `grader call failed: ${err?.message ?? String(err)}` };
 				}
 			};
+
+			const graderModelId = pickGraderModel(ctx)?.id ?? "session model";
 
 			return withUILock(async () => {
 				const result = await ctx.ui.custom<PanelResult | null>(
@@ -295,7 +322,7 @@ export default function explain(pi: ExtensionAPI) {
 							tui,
 							(s: string) => theme.fg("accent", s),
 							(s: string) => theme.fg("muted", s),
-							" grading…",
+							 ` grading… (${graderModelId})`,
 						);
 
 						let phase: "answering" | "grading" | "verdict" = "answering";

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -130,19 +130,36 @@ function addWrapped(lines: string[], text: string, width: number, indent = ""): 
 	}
 }
 
-// Frame a rendered panel in a rounded window, inset 2 columns from the left
-// edge. Content must already be laid out at (width - 6) visible columns.
-function frame(lines: string[], width: number, theme: any): string[] {
-	if (width < 12) return lines;
-	const contentW = width - 6;
-	const bar = "─".repeat(contentW + 2);
-	const wall = theme.fg("accent", "│");
-	const out = [`  ${theme.fg("accent", `╭${bar}╮`)}`];
-	for (const line of lines) {
-		const pad = Math.max(0, contentW - visibleWidth(line));
-		out.push(`  ${wall} ${line}${" ".repeat(pad)} ${wall}`);
+// Render the panel as two merged rounded boxes over the prompt area: a narrow
+// content box (inset 4 columns each side) on top, its bottom corners becoming
+// tees in the top border of a full-width, prompt-styled input box below.
+// Top content must be laid out at (width - 12) columns, bottom at (width - 4).
+function frameMerged(top: string[], bottom: string[], width: number, theme: any): string[] {
+	if (width < 24) return [...top, ...bottom];
+	const tw = width - 12;
+	const bw = width - 4;
+	const accent = (s: string) => theme.fg("accent", s);
+	const out: string[] = [];
+	out.push(`    ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
+	for (const line of top) {
+		const pad = Math.max(0, tw - visibleWidth(line));
+		out.push(`    ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
 	}
-	out.push(`  ${theme.fg("accent", `╰${bar}╯`)}`);
+	const rightTee = width - 5;
+	out.push(
+		accent("╭") +
+			accent("─".repeat(3)) +
+			accent("┴") +
+			accent("─".repeat(rightTee - 5)) +
+			accent("┴") +
+			accent("─".repeat(width - rightTee - 2)) +
+			accent("╮"),
+	);
+	for (const line of bottom) {
+		const pad = Math.max(0, bw - visibleWidth(line));
+		out.push(`${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
+	}
+	out.push(accent("╰") + accent("─".repeat(width - 2)) + accent("╯"));
 	return out;
 }
 
@@ -374,62 +391,64 @@ export default function explain(pi: ExtensionAPI) {
 
 						return {
 							render(width: number): string[] {
-								const cw = Math.max(8, width - 6);
-								const lines: string[] = [];
-								const add = (s: string) => lines.push(truncateToWidth(s, cw));
+								const tw = Math.max(8, width - 12);
+								const bw = Math.max(8, width - 4);
+								const top: string[] = [];
+								const bottom: string[] = [];
+								const addT = (s: string) => top.push(truncateToWidth(s, tw));
+								const addB = (s: string) => bottom.push(truncateToWidth(s, bw));
 
-								add(theme.fg("toolTitle", theme.bold(" explain in your own words")));
-								lines.push("");
-								addWrapped(lines, theme.fg("text", question), cw, " ");
+								addT(theme.fg("toolTitle", theme.bold(" explain in your own words")));
+								top.push("");
+								addWrapped(top, theme.fg("text", question), tw, " ");
 								if (context) {
-									lines.push("");
-									addWrapped(lines, theme.fg("muted", context), cw, " ");
+									top.push("");
+									addWrapped(top, theme.fg("muted", context), tw, " ");
 								}
-								lines.push("");
 
 								if (phase === "answering") {
-									for (const line of editor.render(cw)) lines.push(line);
-									lines.push("");
-									add(theme.fg("dim", " Enter — submit · Ctrl+J — new line · Esc — cancel"));
+									for (const line of editor.render(bw)) bottom.push(line);
+									bottom.push("");
+									addB(theme.fg("dim", " Enter — submit · Ctrl+J — new line · Esc — cancel"));
 								} else if (phase === "grading") {
-									addWrapped(lines, theme.fg("dim", editor.getText().trim()), cw, " ");
-									lines.push("");
-									for (const line of loader.render(cw)) lines.push(line);
-									lines.push("");
-									add(theme.fg("dim", " Esc — abort grading"));
+									top.push("");
+									addWrapped(top, theme.fg("dim", editor.getText().trim()), tw, " ");
+									top.push("");
+									for (const line of loader.render(tw)) top.push(line);
+									addB(theme.fg("dim", " Esc — abort grading"));
 								} else {
-									addWrapped(lines, theme.fg("dim", editor.getText().trim()), cw, " ");
-									lines.push("");
+									top.push("");
+									addWrapped(top, theme.fg("dim", editor.getText().trim()), tw, " ");
+									top.push("");
 									if (grading) {
-										add(` ${verdictIcon(grading)}`);
+										addT(` ${verdictIcon(grading)}`);
 										if (grading.summary) {
-											lines.push("");
-											addWrapped(lines, theme.fg("text", grading.summary), cw, " ");
+											top.push("");
+											addWrapped(top, theme.fg("text", grading.summary), tw, " ");
 										}
 										if (grading.verdict !== "correct" && grading.correctAnswer) {
-											lines.push("");
-											add(theme.fg("muted", " correct answer:"));
-											addWrapped(lines, theme.fg("success", grading.correctAnswer), cw, "  ");
+											top.push("");
+											addT(theme.fg("muted", " correct answer:"));
+											addWrapped(top, theme.fg("success", grading.correctAnswer), tw, "  ");
 										}
 										if (grading.refinements.length > 0) {
-											lines.push("");
-											add(theme.fg("muted", " terminology:"));
+											top.push("");
+											addT(theme.fg("muted", " terminology:"));
 											for (const r of grading.refinements) {
-												addWrapped(lines, theme.fg("warning", `“${r.quote}”`), cw, "  ");
+												addWrapped(top, theme.fg("warning", `“${r.quote}”`), tw, "  ");
 												const note = [r.issue, r.correction && `→ ${r.correction}`]
 													.filter(Boolean)
 													.join(" — ");
-												if (note) addWrapped(lines, theme.fg("dim", note), cw, "    ");
+												if (note) addWrapped(top, theme.fg("dim", note), tw, "    ");
 											}
 										}
 									} else {
-										add(theme.fg("warning", ` grading unavailable — ${gradeError ?? "unknown error"}`));
-										add(theme.fg("dim", " (returned ungraded; the agent will evaluate your answer itself)"));
+										addT(theme.fg("warning", ` grading unavailable — ${gradeError ?? "unknown error"}`));
+										addT(theme.fg("dim", " (returned ungraded; the agent will evaluate your answer itself)"));
 									}
-									lines.push("");
-									add(theme.fg("dim", " Enter — continue"));
+									addB(theme.fg("dim", " Enter — continue"));
 								}
-								return frame(lines, width, theme);
+								return frameMerged(top, bottom, width, theme);
 							},
 
 							invalidate: () => {

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -49,6 +49,7 @@ interface Grading {
 	verdict: Verdict;
 	grade: LetterGrade;
 	summary: string;
+	correctAnswer: string;
 	refinements: Refinement[];
 }
 
@@ -83,6 +84,7 @@ Output ONLY a JSON object — no markdown fences, no prose before or after — w
   "verdict": "correct" | "partially_correct" | "incorrect",
   "grade": "A" | "B" | "C" | "D" | "F",
   "summary": "one terse sentence, <=15 words: why this verdict",
+  "correctAnswer": "the correct answer, <=40 words, precise terminology — composed from the expected claims, not your outside knowledge",
   "refinements": [
     {
       "quote": "an exact substring copied from the learner's answer",
@@ -230,7 +232,7 @@ function extractGrading(raw: string): Grading | undefined {
 						correction: String(r.correction ?? ""),
 					}))
 			: [];
-		return { verdict, grade, summary: String(parsed.summary ?? ""), refinements };
+		return { verdict, grade, summary: String(parsed.summary ?? ""), correctAnswer: String(parsed.correctAnswer ?? ""), refinements };
 	} catch {
 		return undefined;
 	}
@@ -387,6 +389,11 @@ export default function explain(pi: ExtensionAPI) {
 											lines.push("");
 											addWrapped(lines, theme.fg("text", grading.summary), width, " ");
 										}
+										if (grading.verdict !== "correct" && grading.correctAnswer) {
+											lines.push("");
+											add(theme.fg("muted", " correct answer:"));
+											addWrapped(lines, theme.fg("success", grading.correctAnswer), width, "  ");
+										}
 										if (grading.refinements.length > 0) {
 											lines.push("");
 											add(theme.fg("muted", " terminology:"));
@@ -456,6 +463,7 @@ export default function explain(pi: ExtensionAPI) {
 					if (result.grading) {
 						const g = result.grading;
 						text += `\n\nGrader verdict: ${g.verdict.toUpperCase()} (grade: ${g.grade})\n${g.summary}`;
+						if (g.correctAnswer) text += `\nCorrect answer: ${g.correctAnswer}`;
 						if (g.refinements.length > 0) {
 							text += `\nTerminology refinements:`;
 							for (const r of g.refinements) {
@@ -515,6 +523,7 @@ export default function explain(pi: ExtensionAPI) {
 				lines.push(theme.fg("muted", "─ grader ─"));
 				lines.push(` ${icon}`);
 				if (g.summary) lines.push(theme.fg("dim", ` ${g.summary}`));
+				if (g.verdict !== "correct" && g.correctAnswer) lines.push(theme.fg("success", ` correct: ${g.correctAnswer}`));
 				for (const r of g.refinements) {
 					lines.push(theme.fg("warning", `  “${r.quote}”`));
 					const note = [r.issue, r.correction && `→ ${r.correction}`].filter(Boolean).join(" — ");

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -194,6 +194,7 @@ function pickGraderModel(ctx: any): any {
 		if (m) return m;
 	}
 	for (const [provider, id] of [
+		["fireworks", "glm-fast-latest"],
 		["anthropic", "claude-haiku-4-5"],
 		["openai", "gpt-4o-mini"],
 		["google", "gemini-2.5-flash"],
@@ -288,8 +289,8 @@ export default function explain(pi: ExtensionAPI) {
 							systemPrompt: GRADER_SYSTEM_PROMPT,
 							messages: [{ role: "user", content: graderPrompt, timestamp: Date.now() } as any],
 						},
-						// Fast grading: small output budget, deterministic, thinking off.
-						{ signal, maxTokens: 800, temperature: 0, reasoning: "off" } as any,
+						// Fast grading: glm-fast-latest at medium reasoning, small output budget, deterministic.
+						{ signal, maxTokens: 800, temperature: 0, reasoning: "medium" } as any,
 					);
 					const raw = response.content
 						.filter((c: any) => c.type === "text")

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -131,28 +131,28 @@ function addWrapped(lines: string[], text: string, width: number, indent = ""): 
 }
 
 // Render the panel as two merged rounded boxes over the prompt area: a narrow
-// content box (inset 4 columns each side) on top, its bottom corners becoming
+// content box (inset 2 columns each side) on top, its bottom corners becoming
 // tees in the top border of a full-width, prompt-styled input box below.
-// Top content must be laid out at (width - 12) columns, bottom at (width - 4).
+// Top content must be laid out at (width - 8) columns, bottom at (width - 4).
 function frameMerged(top: string[], bottom: string[], width: number, theme: any): string[] {
 	if (width < 24) return [...top, ...bottom];
-	const tw = width - 12;
+	const tw = width - 8;
 	const bw = width - 4;
 	const accent = (s: string) => theme.fg("accent", s);
 	const out: string[] = [];
-	out.push(`    ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
+	out.push(`  ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
 	for (const line of top) {
 		const pad = Math.max(0, tw - visibleWidth(line));
-		out.push(`    ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
+		out.push(`  ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
 	}
-	const rightTee = width - 5;
+	const rightTee = width - 3;
 	out.push(
 		accent("╭") +
-			accent("─".repeat(3)) +
+			accent("─") +
 			accent("┴") +
-			accent("─".repeat(rightTee - 5)) +
+			accent("─".repeat(rightTee - 3)) +
 			accent("┴") +
-			accent("─".repeat(width - rightTee - 2)) +
+			accent("─") +
 			accent("╮"),
 	);
 	for (const line of bottom) {
@@ -401,7 +401,7 @@ export default function explain(pi: ExtensionAPI) {
 
 						return {
 							render(width: number): string[] {
-								const tw = Math.max(8, width - 12);
+								const tw = Math.max(8, width - 8);
 								const bw = Math.max(8, width - 4);
 								const top: string[] = [];
 								const bottom: string[] = [];

--- a/pi/.pi/agent/extensions/explain.ts
+++ b/pi/.pi/agent/extensions/explain.ts
@@ -37,6 +37,7 @@ import { Type } from "typebox";
 
 type ExplainStatus = "answered" | "cancelled" | "unavailable";
 type Verdict = "correct" | "partially_correct" | "incorrect";
+type LetterGrade = "A" | "B" | "C" | "D" | "F";
 
 interface Refinement {
 	quote: string;
@@ -46,6 +47,7 @@ interface Refinement {
 
 interface Grading {
 	verdict: Verdict;
+	grade: LetterGrade;
 	summary: string;
 	refinements: Refinement[];
 }
@@ -79,6 +81,7 @@ Output ONLY a JSON object — no markdown fences, no prose before or after — w
 
 {
   "verdict": "correct" | "partially_correct" | "incorrect",
+  "grade": "A" | "B" | "C" | "D" | "F",
   "summary": "1-2 sentences: why this verdict",
   "refinements": [
     {
@@ -93,6 +96,14 @@ Grading rules:
 - "correct" means every required claim is present and accurately stated, with acceptable terminology. Minor phrasing differences are fine.
 - "partially_correct" means the core idea is right but a required claim is missing, or terminology is loose enough to matter.
 - "incorrect" means a required claim is wrong or the core mechanism is misunderstood.
+
+Letter grade rubric:
+- A: every required claim present, accurate, and stated with precise terminology.
+- B: all required claims present and right, but terminology is loose in places.
+- C: the core idea is right, but a required claim is missing or one claim is off.
+- D: mostly wrong, but shows a fragment of real understanding worth building on.
+- F: fundamentally wrong, a systematic misconception, or no engagement with the question.
+The verdict and grade must agree: correct = A or B; partially_correct = C; incorrect = D or F.
 - refinements must quote the learner's own words verbatim — never invent quotes. Include every spot where terminology is wrong, loose, or a claim is factually off. An empty array means nothing needs refinement.
 - Do not penalize the learner for omitting things the expected claims do not require.`;
 
@@ -179,6 +190,13 @@ function extractGrading(raw: string): Grading | undefined {
 		const parsed = JSON.parse(raw.slice(start, end + 1));
 		const verdict: Verdict =
 			parsed.verdict === "correct" || parsed.verdict === "incorrect" ? parsed.verdict : "partially_correct";
+		const grade: LetterGrade = ["A", "B", "C", "D", "F"].includes(parsed.grade)
+			? parsed.grade
+			: verdict === "correct"
+				? "B"
+				: verdict === "partially_correct"
+					? "C"
+					: "F";
 		const refinements: Refinement[] = Array.isArray(parsed.refinements)
 			? parsed.refinements
 					.filter((r: any) => r && typeof r.quote === "string" && r.quote.length > 0)
@@ -188,7 +206,7 @@ function extractGrading(raw: string): Grading | undefined {
 						correction: String(r.correction ?? ""),
 					}))
 			: [];
-		return { verdict, summary: String(parsed.summary ?? ""), refinements };
+		return { verdict, grade, summary: String(parsed.summary ?? ""), refinements };
 	} catch {
 		return undefined;
 	}
@@ -284,10 +302,10 @@ export default function explain(pi: ExtensionAPI) {
 						let grading: Grading | undefined;
 						let gradeError: string | undefined;
 
-						const verdictIcon = (v: Verdict): string => {
-							if (v === "correct") return theme.fg("success", "✓ correct");
-							if (v === "incorrect") return theme.fg("error", "✗ incorrect");
-							return theme.fg("warning", "◐ partially correct");
+						const verdictIcon = (g: Grading): string => {
+							if (g.verdict === "correct") return theme.fg("success", `✓ correct — grade ${g.grade}`);
+							if (g.verdict === "incorrect") return theme.fg("error", `✗ incorrect — grade ${g.grade}`);
+							return theme.fg("warning", `◐ partially correct — grade ${g.grade}`);
 						};
 
 						const startGrading = (answer: string) => {
@@ -336,7 +354,7 @@ export default function explain(pi: ExtensionAPI) {
 									addWrapped(lines, theme.fg("dim", editor.getText().trim()), width, " ");
 									lines.push("");
 									if (grading) {
-										add(` ${verdictIcon(grading.verdict)}`);
+										add(` ${verdictIcon(grading)}`);
 										if (grading.summary) {
 											lines.push("");
 											addWrapped(lines, theme.fg("text", grading.summary), width, " ");
@@ -409,7 +427,7 @@ export default function explain(pi: ExtensionAPI) {
 					text = `Question: ${question}\nUser's answer (their own words):\n${result.answer}`;
 					if (result.grading) {
 						const g = result.grading;
-						text += `\n\nGrader verdict: ${g.verdict.toUpperCase()}\n${g.summary}`;
+						text += `\n\nGrader verdict: ${g.verdict.toUpperCase()} (grade: ${g.grade})\n${g.summary}`;
 						if (g.refinements.length > 0) {
 							text += `\nTerminology refinements:`;
 							for (const r of g.refinements) {
@@ -465,10 +483,10 @@ export default function explain(pi: ExtensionAPI) {
 				const g = details.grading;
 				const icon =
 					g.verdict === "correct"
-						? theme.fg("success", "✓ correct")
+						? theme.fg("success", `✓ correct — grade ${g.grade}`)
 						: g.verdict === "incorrect"
-							? theme.fg("error", "✗ incorrect")
-							: theme.fg("warning", "◐ partially correct");
+							? theme.fg("error", `✗ incorrect — grade ${g.grade}`)
+							: theme.fg("warning", `◐ partially correct — grade ${g.grade}`);
 				lines.push(theme.fg("muted", "─ grader ─"));
 				lines.push(` ${icon}`);
 				if (g.summary) lines.push(theme.fg("dim", ` ${g.summary}`));

--- a/pi/.pi/agent/extensions/quiz.ts
+++ b/pi/.pi/agent/extensions/quiz.ts
@@ -1,0 +1,1062 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	Editor,
+	type EditorTheme,
+	Key,
+	Text,
+	matchesKey,
+	truncateToWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+// ────────────────────────────────────────────────────────────────────────────
+// quiz — a GRADED sibling of ask_user_question.
+//
+// Where ask_user_question collects a preference/decision with no notion of
+// right or wrong, `quiz` poses a question that HAS a correct answer, grades the
+// user's selection instantly, and shows tight feedback (✓/✗ + the correct
+// answer + an optional explanation) to both the user and the agent.
+//
+// It is intentionally options-only: single-select or multi-select. There is no
+// free-text mode and no "Other" option, because a free-text answer can't be
+// graded against a correct index.
+// ────────────────────────────────────────────────────────────────────────────
+
+interface QuizOption {
+	label: string;
+	value: string;
+	description?: string;
+}
+
+interface DisplayOption extends QuizOption {
+	id: string;
+	index: number;
+	isSubmit?: boolean;
+}
+
+interface OptionAnswer {
+	label: string;
+	value: string;
+	index: number; // 1-based, matches the number shown to the user
+}
+
+// The always-present "I don't know" choice. It is NOT a real option: it never
+// participates in shuffling, has no correct-answer value, and produces a
+// distinct signal (dontKnow) rather than a right/wrong grade — so an honest
+// "I don't know" is never confused with a lucky or unlucky guess.
+const DONT_KNOW_VALUE = "__dont_know__";
+const DONT_KNOW_LABEL = "I don't know";
+const DONT_KNOW_INDEX = 0; // real options are 1-based; submit uses -1
+
+// Unified response from either ask* component. answers holds the real
+// selections (empty when dontKnow); note is the optional free-text the user
+// typed in the always-present note field (kept only when non-empty).
+interface QuizResponse {
+	dontKnow: boolean;
+	note?: string;
+	answers: OptionAnswer[];
+}
+
+type QuizStatus = "answered" | "cancelled" | "unavailable";
+type QuizMode = "single-select" | "multi-select";
+
+interface DisplayedOption {
+	index: number; // 1-based, in the final (possibly shuffled) display order
+	label: string;
+}
+
+interface QuizResultDetails {
+	status: QuizStatus;
+	question: string;
+	context?: string;
+	mode: QuizMode;
+	answers: OptionAnswer[];
+	correctIndices: number[];
+	options?: DisplayedOption[]; // full option list in display order, for the transcript
+	correct?: boolean;
+	dontKnow?: boolean; // user selected "I don't know" instead of guessing
+	note?: string; // optional free-text from the always-present note field (any answer)
+	explanation?: string;
+	message?: string;
+}
+
+const OptionSchema = Type.Object({
+	label: Type.String({ description: "Display label for the answer option." }),
+	value: Type.Optional(
+		Type.String({ description: "Optional machine-readable value returned for the option. Defaults to the label." }),
+	),
+	description: Type.Optional(Type.String({ description: "Optional extra detail shown below the option." })),
+});
+
+const QuizParams = Type.Object({
+	question: Type.String({
+		description: "The single quiz question to ask. Ask exactly one question per tool call.",
+	}),
+	details: Type.Optional(
+		Type.String({ description: "Optional extra context or instructions shown under the question." }),
+	),
+	options: Type.Array(OptionSchema, {
+		description:
+			"The answer options (2 or more). Options only — there is no free-text mode. Give each option a stable `value`; you reference the correct one by that value in correctAnswer.",
+		minItems: 2,
+	}),
+	multiSelect: Type.Optional(
+		Type.Boolean({ description: "Set to true when more than one option is correct and the user must select all of them." }),
+	),
+	correctAnswer: Type.Union([Type.String(), Type.Array(Type.String())], {
+		description:
+			'REQUIRED. The correct answer as the option value(s) — the `value` field of the option you intend. Single-select: a single string (e.g. "mercury"). Multi-select: an array of strings (e.g. ["belize", "niue"]); the user is only correct if their selection matches this set exactly. Always pass the value, not a position number — this is self-checking and prevents miscounting.',
+	}),
+	explanation: Type.String({
+		description:
+			"REQUIRED. Explanation revealed AFTER the user answers (shown whether they got it right or wrong). Use it to reinforce why the correct answer is correct.",
+	}),
+	shuffle: Type.Optional(
+		Type.Boolean({
+			description:
+				"Defaults to true: options are randomly reordered before display so the correct answer isn't always in the same position. Set to false only when option order is meaningful (e.g. ordered numeric values, or an 'All/None of the above' option that must stay last).",
+		}),
+	),
+});
+
+function normalizeOptions(
+	options: Array<{ label: string; value?: string; description?: string }> | undefined,
+): QuizOption[] {
+	const seen = new Set<string>();
+	return (options || [])
+		.map((option) => ({
+			label: option.label.trim(),
+			value: option.value?.trim() || option.label.trim(),
+			description: option.description?.trim() || undefined,
+		}))
+		.filter((option) => {
+			if (option.label.length === 0) return false;
+			if (seen.has(option.value)) throw new Error(`duplicate option value "${option.value}"`);
+			seen.add(option.value);
+			return true;
+		});
+}
+
+// Fisher-Yates shuffle over a copy. Safe to reorder for display because
+// correctAnswer is keyed by value, not position — indices are resolved AFTER
+// shuffling, so grading always matches what the user actually sees.
+function shuffleOptions(options: QuizOption[]): QuizOption[] {
+	const out = [...options];
+	for (let i = out.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[out[i], out[j]] = [out[j], out[i]];
+	}
+	return out;
+}
+
+// Resolve author-supplied option value(s) to 1-based indices. Keying by value
+// (not position) makes the correct answer self-documenting: the author writes
+// `correctAnswer: "mercury"` and a typo becomes a hard error instead of a
+// silent wrong grade.
+// The harness sometimes delivers a multi-select `correctAnswer` array as a
+// JSON-stringified string (e.g. '["a", "b"]') instead of a real array, because
+// the schema union lists String first. Detect that case and parse it back into
+// an array so grading resolves against real option values. A plain single value
+// is wrapped as-is.
+function coerceCorrectAnswer(correctAnswer: string | string[]): string[] {
+	if (Array.isArray(correctAnswer)) return correctAnswer;
+	const trimmed = correctAnswer.trim();
+	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (Array.isArray(parsed)) return parsed.map((v) => String(v));
+		} catch {
+			// Not valid JSON — fall through and treat as a single literal value.
+		}
+	}
+	return [correctAnswer];
+}
+
+function resolveCorrect(
+	correctAnswer: string | string[] | undefined,
+	options: QuizOption[],
+): { indices: number[]; error?: string } {
+	if (correctAnswer === undefined) return { indices: [], error: "correctAnswer is required" };
+	const arr = coerceCorrectAnswer(correctAnswer);
+	if (arr.length === 0) return { indices: [], error: "correctAnswer is required" };
+	const byValue = new Map(options.map((o, i) => [o.value, i + 1]));
+	const indices: number[] = [];
+	for (const raw of arr) {
+		const v = typeof raw === "string" ? raw.trim() : raw;
+		const idx = byValue.get(v);
+		if (idx === undefined) {
+			const known = options.map((o) => `"${o.value}"`).join(", ");
+			return { indices: [], error: `correctAnswer "${v}" does not match any option value (${known})` };
+		}
+		indices.push(idx);
+	}
+	return { indices: Array.from(new Set(indices)).sort((a, b) => a - b) };
+}
+
+function createEditorTheme(theme: any): EditorTheme {
+	return {
+		borderColor: (s) => theme.fg("accent", s),
+		selectList: {
+			selectedPrefix: (t) => theme.fg("accent", t),
+			selectedText: (t) => theme.fg("accent", t),
+			description: (t) => theme.fg("muted", t),
+			scrollInfo: (t) => theme.fg("dim", t),
+			noMatch: (t) => theme.fg("warning", t),
+		},
+	};
+}
+
+function addWrapped(lines: string[], text: string, width: number, indent = ""): void {
+	const contentWidth = Math.max(1, width - indent.length);
+	for (const line of wrapTextWithAnsi(text, contentWidth)) {
+		lines.push(truncateToWidth(`${indent}${line}`, width));
+	}
+}
+
+function isCorrect(selectedIndices: number[], correctIndices: number[]): boolean {
+	if (selectedIndices.length !== correctIndices.length) return false;
+	const a = [...selectedIndices].sort((x, y) => x - y);
+	const b = [...correctIndices].sort((x, y) => x - y);
+	return a.every((v, i) => v === b[i]);
+}
+
+function buildStructuredResult(
+	status: QuizStatus,
+	question: string,
+	mode: QuizMode,
+	answers: OptionAnswer[],
+	correctIndices: number[],
+	correct: boolean | undefined,
+	explanation: string | undefined,
+	context?: string,
+	message?: string,
+	options?: DisplayedOption[],
+	dontKnow?: boolean,
+	note?: string,
+): QuizResultDetails {
+	return { status, question, context, mode, answers, correctIndices, options, correct, dontKnow, note, explanation, message };
+}
+
+function cancelledResult(question: string, mode: QuizMode, correctIndices: number[], context?: string) {
+	const message = "User cancelled the quiz";
+	return {
+		content: [{ type: "text" as const, text: message }],
+		details: buildStructuredResult("cancelled", question, mode, [], correctIndices, undefined, undefined, context, message),
+	};
+}
+
+function unavailableResult(question: string, mode: QuizMode, message: string, correctIndices: number[], context?: string) {
+	return {
+		content: [{ type: "text" as const, text: message }],
+		details: buildStructuredResult("unavailable", question, mode, [], correctIndices, undefined, undefined, context, message),
+	};
+}
+
+function formatOptionRef(options: QuizOption[], index: number): string {
+	const opt = options.find((o, i) => i + 1 === index);
+	return `${index}. ${opt ? opt.label : "(unknown)"}`;
+}
+
+function buildResult(
+	question: string,
+	context: string | undefined,
+	mode: QuizMode,
+	options: QuizOption[],
+	response: QuizResponse,
+	correctIndices: number[],
+	explanation: string | undefined,
+) {
+	const { dontKnow, note, answers } = response;
+	const selectedIndices = answers.map((a) => a.index);
+	// "I don't know" is never counted as correct — it's a distinct outcome.
+	const correct = dontKnow ? false : isCorrect(selectedIndices, correctIndices);
+	const correctStr = correctIndices.map((i) => formatOptionRef(options, i)).join(", ");
+	const displayedOptions: DisplayedOption[] = options.map((o, i) => ({ index: i + 1, label: o.label }));
+
+	let text: string;
+	if (dontKnow) {
+		// Make the signal explicit for the agent: the user did NOT guess, so this
+		// is a genuine knowledge gap, not a wrong answer to correct against.
+		text = `User selected "I don't know" — they did not attempt an answer (a genuine knowledge gap, not a wrong guess).`;
+		text += `\nCorrect: ${correctStr}`;
+		if (note) text += `\nUser's note: ${note}`;
+	} else {
+		const verdict = correct ? "correctly" : "incorrectly";
+		const selectedStr = answers.map((a) => `${a.index}. ${a.label}`).join(", ");
+		text = `User answered ${verdict}.\nSelected: ${selectedStr}\nCorrect: ${correctStr}`;
+		if (note) text += `\nUser's note: ${note}`;
+	}
+	if (explanation) text += `\nExplanation: ${explanation}`;
+
+	return {
+		content: [{ type: "text" as const, text }],
+		details: buildStructuredResult(
+			"answered",
+			question,
+			mode,
+			answers,
+			correctIndices,
+			correct,
+			explanation,
+			context,
+			undefined,
+			displayedOptions,
+			dontKnow,
+			note,
+		),
+	};
+}
+
+// Shared feedback block, rendered after the user submits.
+function renderFeedback(
+	lines: string[],
+	theme: any,
+	width: number,
+	options: QuizOption[],
+	selectedIndices: number[],
+	correctIndices: number[],
+	explanation: string | undefined,
+	dontKnow = false,
+	note?: string,
+): void {
+	const add = (text: string) => lines.push(truncateToWidth(text, width));
+	const correct = !dontKnow && isCorrect(selectedIndices, correctIndices);
+	const selectedSet = new Set(selectedIndices);
+	const correctSet = new Set(correctIndices);
+
+	lines.push("");
+	for (let i = 0; i < options.length; i++) {
+		const index = i + 1;
+		const opt = options[i];
+		const isSelected = selectedSet.has(index);
+		const isKey = correctSet.has(index);
+		let marker: string;
+		let color: string;
+		if (dontKnow) {
+			// No guess was made — only reveal the correct answer(s); never show ✗.
+			marker = isKey ? "✓" : " ";
+			color = isKey ? "success" : "dim";
+		} else if (isSelected && isKey) {
+			marker = "✓";
+			color = "success";
+		} else if (isSelected && !isKey) {
+			marker = "✗";
+			color = "error";
+		} else if (!isSelected && isKey) {
+			// correct answer the user missed
+			marker = "✓";
+			color = "success";
+		} else {
+			marker = " ";
+			color = "dim";
+		}
+		add(theme.fg(color, ` ${marker} ${index}. ${opt.label}`));
+	}
+
+	lines.push("");
+	if (dontKnow) {
+		add(theme.fg("warning", " · You said: I don't know"));
+		const correctStr = correctIndices.map((i) => formatOptionRef(options, i)).join(", ");
+		addWrapped(lines, theme.fg("muted", `Correct answer: ${correctStr}`), width, " ");
+	} else if (correct) {
+		add(theme.fg("success", " ✓ Correct!"));
+	} else {
+		add(theme.fg("error", " ✗ Incorrect."));
+		const correctStr = correctIndices.map((i) => formatOptionRef(options, i)).join(", ");
+		addWrapped(lines, theme.fg("muted", `Correct answer: ${correctStr}`), width, " ");
+	}
+	if (note) {
+		addWrapped(lines, theme.fg("muted", `Your note: ${note}`), width, " ");
+	}
+	if (explanation) {
+		lines.push("");
+		addWrapped(lines, theme.fg("text", explanation), width, " ");
+	}
+	lines.push("");
+	add(theme.fg("dim", " Enter/Esc to continue"));
+}
+
+// Top border + question + optional context. Shared by both components.
+function pushHeader(lines: string[], theme: any, width: number, question: string, context: string | undefined): void {
+	lines.push(truncateToWidth(theme.fg("accent", "─".repeat(width)), width));
+	addWrapped(lines, theme.fg("text", question), width, " ");
+	if (context) {
+		lines.push("");
+		addWrapped(lines, theme.fg("muted", context), width, " ");
+	}
+}
+
+// The "I don't know" row in the selection list — visually separated and dimmed
+// so it reads as distinct from the real, gradable options.
+function pushDontKnowRow(lines: string[], theme: any, width: number, focused: boolean): void {
+	lines.push("");
+	const prefix = focused ? theme.fg("accent", "> ") : "  ";
+	const styled = focused ? theme.fg("accent", DONT_KNOW_LABEL) : theme.fg("dim", DONT_KNOW_LABEL);
+	lines.push(truncateToWidth(`${prefix}${styled}`, width));
+}
+
+// Persistent, always-present note field rendered under the options during the
+// select phase. Applies to ANY answer (including "I don't know") and is only
+// surfaced to the agent when non-empty.
+function pushNoteField(lines: string[], theme: any, width: number, editor: Editor, focused: boolean): void {
+	lines.push("");
+	const label = focused ? theme.fg("accent", "Note (optional):") : theme.fg("muted", "Note (optional):");
+	addWrapped(lines, label, width, " ");
+	for (const line of editor.render(width)) lines.push(line);
+}
+
+// Build the note Editor. `disableSubmit` is set because Enter must NOT submit
+// here: the editor's submit path clears the buffer, which would wipe the note.
+// Instead the host intercepts Enter to return focus to the options while
+// keeping the text. Ctrl+J still inserts a newline (pi convention), so
+// multi-line notes work.
+function makeNoteEditor(tui: any, theme: any): Editor {
+	const editor = new Editor(tui, createEditorTheme(theme));
+	editor.focused = false;
+	editor.disableSubmit = true;
+	return editor;
+}
+
+async function askSingleChoice(
+	ctx: any,
+	question: string,
+	context: string | undefined,
+	options: QuizOption[],
+	correctIndices: number[],
+	explanation: string | undefined,
+): Promise<QuizResponse | null> {
+	const allOptions: DisplayOption[] = options.map((option, index) => ({
+		...option,
+		id: `option:${index}`,
+		index: index + 1,
+	}));
+	const dontKnowNav = allOptions.length; // nav index of the "I don't know" row
+
+	return ctx.ui.custom<QuizResponse | null>(
+		(tui: any, theme: any, _kb: any, done: (result: QuizResponse | null) => void) => {
+			let optionIndex = 0;
+			let phase: "select" | "feedback" = "select";
+			let focus: "options" | "note" = "options";
+			let chosen: OptionAnswer | null = null;
+			let dontKnow = false;
+			const editor = makeNoteEditor(tui, theme);
+			let cachedLines: string[] | undefined;
+			let cachedWidth = -1;
+
+			function refresh() {
+				cachedLines = undefined;
+				tui.requestRender();
+			}
+
+			function noteText(): string | undefined {
+				const t = editor.getText().trim();
+				return t.length ? t : undefined;
+			}
+
+			function toOptions() {
+				focus = "options";
+				editor.focused = false;
+				refresh();
+			}
+
+			function response(): QuizResponse {
+				const note = noteText();
+				return dontKnow
+					? { dontKnow: true, note, answers: [] }
+					: { dontKnow: false, note, answers: chosen ? [chosen] : [] };
+			}
+
+			function handleInput(data: string) {
+				if (phase === "feedback") {
+					if (matchesKey(data, Key.enter) || matchesKey(data, Key.escape)) {
+						done(response());
+					}
+					return;
+				}
+
+				// Tab toggles focus between the options list and the note field.
+				if (matchesKey(data, Key.tab)) {
+					focus = focus === "options" ? "note" : "options";
+					editor.focused = focus === "note";
+					refresh();
+					return;
+				}
+
+				if (focus === "note") {
+					// Enter and Esc both return to the options and keep the note text.
+					// (Enter must be intercepted here: the editor's own submit clears
+					// the buffer. Ctrl+J still reaches the editor as a newline.)
+					if (matchesKey(data, Key.enter) || matchesKey(data, Key.escape)) {
+						toOptions();
+						return;
+					}
+					editor.handleInput(data);
+					tui.requestRender();
+					return;
+				}
+
+				// focus === "options"
+				if (matchesKey(data, Key.up)) {
+					optionIndex = Math.max(0, optionIndex - 1);
+					refresh();
+					return;
+				}
+				if (matchesKey(data, Key.down)) {
+					optionIndex = Math.min(dontKnowNav, optionIndex + 1);
+					refresh();
+					return;
+				}
+				if (matchesKey(data, Key.enter)) {
+					if (optionIndex === dontKnowNav) {
+						dontKnow = true;
+						chosen = null;
+					} else {
+						const selected = allOptions[optionIndex];
+						chosen = { label: selected.label, value: selected.value, index: selected.index };
+						dontKnow = false;
+					}
+					phase = "feedback";
+					refresh();
+					return;
+				}
+				if (matchesKey(data, Key.escape)) {
+					done(null);
+				}
+			}
+
+			function render(width: number): string[] {
+				// The cache MUST be keyed on width: pi-tui calls requestRender() but NOT
+				// invalidate() on terminal resize, so render() can be re-entered with a
+				// new width. Returning stale wider lines trips the TUI width guard and
+				// crashes the process.
+				if (cachedLines && cachedWidth === width) return cachedLines;
+
+				const lines: string[] = [];
+				const add = (text: string) => lines.push(truncateToWidth(text, width));
+				pushHeader(lines, theme, width, question, context);
+
+				if (phase === "feedback") {
+					renderFeedback(
+						lines,
+						theme,
+						width,
+						options,
+						chosen ? [chosen.index] : [],
+						correctIndices,
+						explanation,
+						dontKnow,
+						noteText(),
+					);
+					add(theme.fg("accent", "─".repeat(width)));
+					cachedLines = lines;
+					cachedWidth = width;
+					return lines;
+				}
+
+				lines.push("");
+				for (let i = 0; i < allOptions.length; i++) {
+					const option = allOptions[i];
+					const selected = focus === "options" && i === optionIndex;
+					const prefix = selected ? theme.fg("accent", "> ") : "  ";
+					const label = `${option.index}. ${option.label}`;
+					const styled = selected ? theme.fg("accent", label) : theme.fg("text", label);
+					add(`${prefix}${styled}`);
+					if (option.description) {
+						addWrapped(lines, theme.fg("muted", option.description), width, "     ");
+					}
+				}
+
+				pushDontKnowRow(lines, theme, width, focus === "options" && optionIndex === dontKnowNav);
+
+				pushNoteField(lines, theme, width, editor, focus === "note");
+
+				lines.push("");
+				if (focus === "note") {
+					add(theme.fg("dim", " Type note • Ctrl+J newline • Enter back to options • Tab options • Esc back"));
+				} else {
+					add(theme.fg("dim", " ↑↓ navigate • Enter answer • Tab note • Esc cancel"));
+				}
+				add(theme.fg("accent", "─".repeat(width)));
+				// Not cached when the note is focused: the editor renders a live cursor.
+				if (focus !== "note") {
+					cachedLines = lines;
+					cachedWidth = width;
+				}
+				return lines;
+			}
+
+			return {
+				render,
+				invalidate: () => {
+					cachedLines = undefined;
+					editor.invalidate();
+				},
+				handleInput,
+			};
+		},
+	);
+}
+
+async function askMultiChoice(
+	ctx: any,
+	question: string,
+	context: string | undefined,
+	options: QuizOption[],
+	correctIndices: number[],
+	explanation: string | undefined,
+): Promise<QuizResponse | null> {
+	const DONT_KNOW_ID = "dont-know";
+	const choiceItems: DisplayOption[] = options.map((option, index) => ({
+		...option,
+		id: `option:${index}`,
+		index: index + 1,
+	}));
+	const dontKnowItem: DisplayOption = {
+		id: DONT_KNOW_ID,
+		label: DONT_KNOW_LABEL,
+		value: DONT_KNOW_VALUE,
+		index: DONT_KNOW_INDEX,
+	};
+	const submitItem: DisplayOption = { id: "submit", label: "Submit", value: "__submit__", index: -1, isSubmit: true };
+	const allItems: DisplayOption[] = [...choiceItems, dontKnowItem, submitItem];
+
+	return ctx.ui.custom<QuizResponse | null>(
+		(tui: any, theme: any, _kb: any, done: (result: QuizResponse | null) => void) => {
+			let optionIndex = 0;
+			let phase: "select" | "feedback" = "select";
+			let focus: "options" | "note" = "options";
+			const editor = makeNoteEditor(tui, theme);
+			let cachedLines: string[] | undefined;
+			let cachedWidth = -1;
+			const selected = new Map<string, OptionAnswer>();
+
+			function refresh() {
+				cachedLines = undefined;
+				tui.requestRender();
+			}
+
+			function noteText(): string | undefined {
+				const t = editor.getText().trim();
+				return t.length ? t : undefined;
+			}
+
+			function toOptions() {
+				focus = "options";
+				editor.focused = false;
+				refresh();
+			}
+
+			const choseDontKnow = () => selected.has(DONT_KNOW_ID);
+			const realAnswers = () =>
+				sortAnswers(Array.from(selected.values()).filter((a) => a.index !== DONT_KNOW_INDEX));
+
+			function response(): QuizResponse {
+				const note = noteText();
+				return choseDontKnow()
+					? { dontKnow: true, note, answers: [] }
+					: { dontKnow: false, note, answers: realAnswers() };
+			}
+
+			// "I don't know" is exclusive: choosing it clears real selections, and
+			// choosing any real option clears "I don't know".
+			function toggleOption(item: DisplayOption) {
+				if (item.id === DONT_KNOW_ID) {
+					if (selected.has(DONT_KNOW_ID)) {
+						selected.delete(DONT_KNOW_ID);
+					} else {
+						selected.clear();
+						selected.set(DONT_KNOW_ID, { label: item.label, value: item.value, index: item.index });
+					}
+				} else {
+					selected.delete(DONT_KNOW_ID);
+					if (selected.has(item.id)) {
+						selected.delete(item.id);
+					} else {
+						selected.set(item.id, { label: item.label, value: item.value, index: item.index });
+					}
+				}
+				refresh();
+			}
+
+			function submit() {
+				if (selected.size === 0) return;
+				phase = "feedback";
+				refresh();
+			}
+
+			function handleInput(data: string) {
+				if (phase === "feedback") {
+					if (matchesKey(data, Key.enter) || matchesKey(data, Key.escape)) {
+						done(response());
+					}
+					return;
+				}
+
+				// Tab toggles focus between the options list and the note field.
+				if (matchesKey(data, Key.tab)) {
+					focus = focus === "options" ? "note" : "options";
+					editor.focused = focus === "note";
+					refresh();
+					return;
+				}
+
+				if (focus === "note") {
+					// Enter and Esc both return to the options and keep the note text.
+					// (Enter must be intercepted here: the editor's own submit clears
+					// the buffer. Ctrl+J still reaches the editor as a newline.)
+					if (matchesKey(data, Key.enter) || matchesKey(data, Key.escape)) {
+						toOptions();
+						return;
+					}
+					editor.handleInput(data);
+					tui.requestRender();
+					return;
+				}
+
+				// focus === "options"
+				if (matchesKey(data, Key.up)) {
+					optionIndex = Math.max(0, optionIndex - 1);
+					refresh();
+					return;
+				}
+				if (matchesKey(data, Key.down)) {
+					optionIndex = Math.min(allItems.length - 1, optionIndex + 1);
+					refresh();
+					return;
+				}
+
+				const current = allItems[optionIndex];
+				if (matchesKey(data, Key.space)) {
+					if (current.isSubmit) return;
+					toggleOption(current);
+					return;
+				}
+
+				if (matchesKey(data, Key.enter)) {
+					if (current.isSubmit) {
+						submit();
+						return;
+					}
+					toggleOption(current);
+					return;
+				}
+
+				if (matchesKey(data, Key.escape)) {
+					done(null);
+				}
+			}
+
+			function render(width: number): string[] {
+				// The cache MUST be keyed on width: pi-tui calls requestRender() but NOT
+				// invalidate() on terminal resize, so render() can be re-entered with a
+				// new width. Returning stale wider lines trips the TUI width guard and
+				// crashes the process.
+				if (cachedLines && cachedWidth === width) return cachedLines;
+
+				const lines: string[] = [];
+				const add = (text: string) => lines.push(truncateToWidth(text, width));
+				pushHeader(lines, theme, width, question, context);
+
+				if (phase === "feedback") {
+					renderFeedback(
+						lines,
+						theme,
+						width,
+						options,
+						realAnswers().map((a) => a.index),
+						correctIndices,
+						explanation,
+						choseDontKnow(),
+						noteText(),
+					);
+					add(theme.fg("accent", "─".repeat(width)));
+					cachedLines = lines;
+					cachedWidth = width;
+					return lines;
+				}
+
+				lines.push("");
+				for (let i = 0; i < allItems.length; i++) {
+					const item = allItems[i];
+					const isFocused = focus === "options" && i === optionIndex;
+					const prefix = isFocused ? theme.fg("accent", "> ") : "  ";
+
+					if (item.isSubmit) {
+						const label = selected.size > 0 ? `✓ ${item.label} (${selected.size} selected)` : `○ ${item.label}`;
+						const styled = isFocused
+							? theme.fg("accent", label)
+							: theme.fg(selected.size > 0 ? "success" : "dim", label);
+						add(`${prefix}${styled}`);
+						continue;
+					}
+
+					if (item.id === DONT_KNOW_ID) {
+						lines.push(""); // visual separation from the real options
+						const checked = selected.has(item.id);
+						const label = `${checked ? "[x]" : "[ ]"} ${item.label}`;
+						const styled = isFocused ? theme.fg("accent", label) : theme.fg(checked ? "warning" : "dim", label);
+						add(`${prefix}${styled}`);
+						continue;
+					}
+
+					const checked = selected.has(item.id);
+					const marker = checked ? "[x]" : "[ ]";
+					const label = `${marker} ${item.index}. ${item.label}`;
+					const styled = isFocused ? theme.fg("accent", label) : theme.fg(checked ? "success" : "text", label);
+					add(`${prefix}${styled}`);
+					if (item.description) {
+						addWrapped(lines, theme.fg("muted", item.description), width, "     ");
+					}
+				}
+
+				pushNoteField(lines, theme, width, editor, focus === "note");
+
+				lines.push("");
+				if (selected.size === 0) {
+					add(theme.fg("warning", " Select at least one answer before submitting."));
+				}
+				if (focus === "note") {
+					add(theme.fg("dim", " Type note • Ctrl+J newline • Enter back to options • Tab options • Esc back"));
+				} else {
+					add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter submit • Tab note • Esc cancel"));
+				}
+				add(theme.fg("accent", "─".repeat(width)));
+				// Not cached when the note is focused: the editor renders a live cursor.
+				if (focus !== "note") {
+					cachedLines = lines;
+					cachedWidth = width;
+				}
+				return lines;
+			}
+
+			return {
+				render,
+				invalidate: () => {
+					cachedLines = undefined;
+					editor.invalidate();
+				},
+				handleInput,
+			};
+		},
+	);
+}
+
+function sortAnswers(answers: OptionAnswer[]): OptionAnswer[] {
+	return [...answers].sort((a, b) => a.index - b.index);
+}
+
+// Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at
+// a time, so ALL pop-up-style tools (quiz, ask_user_question, ...) must
+// serialize against each other, not just against themselves. We stash one
+// mutex on globalThis so separate extension files can share it without
+// importing each other.
+const SHARED_UI_LOCK_KEY = "__piSharedUiLock";
+function getSharedUiLock() {
+	const g = globalThis as any;
+	if (!g[SHARED_UI_LOCK_KEY]) {
+		let chain: Promise<void> = Promise.resolve();
+		g[SHARED_UI_LOCK_KEY] = {
+			withLock<T>(fn: () => T | Promise<T>): Promise<T> {
+				const prev = chain;
+				let release: () => void;
+				chain = new Promise<void>((r) => { release = r; });
+				return prev.then(fn).finally(() => release!());
+			},
+		};
+	}
+	return g[SHARED_UI_LOCK_KEY] as { withLock<T>(fn: () => T | Promise<T>): Promise<T> };
+}
+const sharedUiLock = getSharedUiLock();
+
+function withUILock<T>(fn: () => Promise<T>): Promise<T> {
+	return sharedUiLock.withLock(fn);
+}
+
+export default function quiz(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "quiz",
+		label: "quiz",
+		description:
+			"Ask the user a GRADED question with a known correct answer, then instantly grade and give feedback. Unlike ask_user_question (which collects preferences/decisions with no right answer), quiz always has a correct answer supplied by you, marks the user's selection right/wrong (✓/✗), reveals the correct answer, and can show an explanation. Use it to (1) assess what the learner already understands before teaching, and (2) run tight practice/retrieval loops after explaining, or probe understanding whenever you're unsure they've got it. Options-only: single-select or multi-select, plus an automatic 'I don't know' choice so the user can signal a genuine gap instead of guessing. An always-present optional note field (Tab to focus it) lets the user attach a free-text note to ANY answer; it reaches you only when non-empty. No free-text answers — for non-graded questions use ask_user_question instead.",
+		promptSnippet:
+			"Use the quiz tool to test the user with a graded multiple-choice or multi-select question (required correct answer + required explanation). For non-graded questions, use ask_user_question.",
+		promptGuidelines: [
+			"quiz is GRADED; ask_user_question is not. If the question has a correct answer, use quiz. If you just need a preference, decision, or open-ended input, use ask_user_question.",
+			'correctAnswer is REQUIRED and is the option value, not a position number. Single-select: one string (e.g. "mercury"). Multi-select: an array of strings (e.g. ["belize", "niue"]).',
+			"Always pass the option's `value` string as correctAnswer — it is self-checking and prevents miscounting positions. A value that matches no option is a hard error.",
+			"explanation is REQUIRED — always say why the correct answer is correct.",
+			"Multi-select is graded as an exact-set match: the user is correct only if they select every correct option and no incorrect ones.",
+			"There is no free-text mode. An 'I don't know' choice is ALWAYS added automatically — provide ONLY the real, gradable options (at least two). Never add your own uncertainty/opt-out option like 'I don't know', 'I'm not sure', or 'Not sure'; that is handled for you and a manual one would be redundant or gradable-as-wrong.",
+			"If a result comes back as dontKnow, the user honestly did not know and did NOT guess — treat it as a genuine knowledge gap to teach into, not as a wrong answer.",
+			"Any answer (right, wrong, or 'I don't know') may carry an optional free-text `note` the user typed in the always-present note field. When present it reflects what they were thinking or unsure about — read it and let it steer your follow-up. It is omitted entirely when empty.",
+			"Treat each wrong answer (distractor) as a diagnostic probe, not just filler: make it a specific, believable mistake the user might actually hold — a common misconception, or an adjacent/easily-confused concept — so that WHICH wrong answer they pick reveals WHICH nuance of their understanding is off. You learn far more from a targeted wrong choice than from a binary right/wrong, and the choice tells you exactly which gap to teach into next (and what the explanation should address).",
+			"Guardrail: every distractor must be unambiguously wrong on the intended reading — tempting, but a real error, not a defensible alternative. Don't drift into trick questions.",
+			"Anti-guessing hygiene: don't let the correct answer stand out by form (longest, most precise, most hedged, or the only one in the right format). Keep options similar in length, specificity, and phrasing so it can't be picked from shape alone.",
+			"Set multiSelect: true only when more than one option is correct.",
+			"Options are shuffled before display by default, so don't worry about which position you list the correct answer in. Set shuffle: false only when option order is meaningful (ordered values, or an 'All/None of the above' option that must stay last).",
+			"To probe nuance, ask several quick quiz questions and adapt each one based on the previous answers, rather than writing one giant question.",
+			"Don't leak the answer through formatting: keep option phrasing/length even and don't hint which is correct.",
+		],
+		parameters: QuizParams,
+
+		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const context = params.details?.trim() || undefined;
+			const explanation = params.explanation.trim();
+			const mode: QuizMode = params.multiSelect ? "multi-select" : "single-select";
+
+			let options: QuizOption[];
+			try {
+				options = normalizeOptions(params.options);
+			} catch (e) {
+				return unavailableResult(params.question, mode, `quiz ${(e as Error).message}`, [], context);
+			}
+
+			// Shuffle for display (default on) BEFORE resolving correct indices, so
+			// grading matches the order the user sees.
+			if (params.shuffle !== false) {
+				options = shuffleOptions(options);
+			}
+
+			// Emit the true (post-shuffle) display order immediately, before the UI
+			// blocks on the user's answer. Listeners such as md-log rely on this to
+			// show the question in the SAME order the user actually sees it, instead
+			// of the pre-shuffle order the agent originally wrote in its tool call.
+			// Deliberately omits correctIndices/explanation — this fires before the
+			// user has answered and must not leak the answer.
+			onUpdate?.({
+				content: [{ type: "text", text: "Awaiting user response..." }],
+				details: { options: options.map((o, i) => ({ index: i + 1, label: o.label })) },
+			});
+
+			const { indices: correctIndices, error: correctError } = resolveCorrect(
+				params.correctAnswer as string | string[],
+				options,
+			);
+
+			if (signal?.aborted) {
+				return cancelledResult(params.question, mode, correctIndices, context);
+			}
+
+			if (options.length < 2) {
+				return unavailableResult(
+					params.question,
+					mode,
+					"quiz requires at least two options",
+					correctIndices,
+					context,
+				);
+			}
+
+			if (correctError) {
+				return unavailableResult(params.question, mode, `quiz ${correctError}`, correctIndices, context);
+			}
+
+			if (!ctx.hasUI) {
+				return unavailableResult(params.question, mode, "quiz requires interactive mode UI", correctIndices, context);
+			}
+
+			return withUILock(async () => {
+				const response =
+					mode === "single-select"
+						? await askSingleChoice(ctx, params.question, context, options, correctIndices, explanation)
+						: await askMultiChoice(ctx, params.question, context, options, correctIndices, explanation);
+				if (!response) {
+					return cancelledResult(params.question, mode, correctIndices, context);
+				}
+				return buildResult(params.question, context, mode, options, response, correctIndices, explanation);
+			});
+		},
+
+		renderCall(args, theme) {
+			// NOTE: never render correctAnswer or explanation here — it would leak
+			// the answer into the transcript before the user responds. We also do NOT
+			// enumerate the options here: they are shuffled at execute time, so any
+			// order shown during streaming would be stale/misleading. The full option
+			// list is rendered — in its true display order — by renderResult after the
+			// user answers.
+			const options = normalizeOptions(
+				args.options as Array<{ label: string; value?: string; description?: string }> | undefined,
+			);
+			let text = theme.fg("toolTitle", theme.bold("quiz ")) + theme.fg("muted", args.question);
+			if (args.multiSelect) {
+				text += theme.fg("dim", " [multi-select]");
+			}
+			if (options.length > 0) {
+				const noun = options.length === 1 ? "option" : "options";
+				text += theme.fg("dim", ` (${options.length} ${noun})`);
+			}
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, _options, theme) {
+			const details = result.details as QuizResultDetails | undefined;
+			if (!details) {
+				const first = result.content[0];
+				return new Text(first?.type === "text" ? first.text : "", 0, 0);
+			}
+
+			if (details.status === "cancelled") {
+				return new Text(theme.fg("warning", details.message || "Cancelled"), 0, 0);
+			}
+			if (details.status === "unavailable") {
+				return new Text(theme.fg("warning", details.message || "quiz unavailable"), 0, 0);
+			}
+
+			const correctSet = new Set(details.correctIndices);
+			const selectedSet = new Set(details.answers.map((a) => a.index));
+			const lines: string[] = [];
+
+			// Full option list in the true (shuffled) display order, with ✓/✗ marks.
+			// Falls back to just the selected answers for older results that predate
+			// details.options.
+			const displayed =
+				details.options && details.options.length > 0
+					? details.options
+					: details.answers.map((a) => ({ index: a.index, label: a.label }));
+
+			for (const opt of displayed) {
+				const isSelected = selectedSet.has(opt.index);
+				const isKey = correctSet.has(opt.index);
+				let mark: string;
+				let body: string;
+				if (details.dontKnow) {
+					// No guess — only reveal the correct answer(s); never show ✗.
+					mark = isKey ? theme.fg("success", "✓ ") : "  ";
+					body = isKey ? theme.fg("success", `${opt.index}. ${opt.label}`) : theme.fg("dim", `${opt.index}. ${opt.label}`);
+				} else if (isSelected && isKey) {
+					mark = theme.fg("success", "✓ ");
+					body = theme.fg("accent", `${opt.index}. ${opt.label}`);
+				} else if (isSelected && !isKey) {
+					mark = theme.fg("error", "✗ ");
+					body = theme.fg("error", `${opt.index}. ${opt.label}`);
+				} else if (!isSelected && isKey) {
+					mark = theme.fg("success", "✓ ");
+					body = theme.fg("success", `${opt.index}. ${opt.label}`);
+				} else {
+					mark = "  ";
+					body = theme.fg("dim", `${opt.index}. ${opt.label}`);
+				}
+				lines.push(`${mark}${body}`);
+			}
+
+			lines.push("");
+			const verdict = details.dontKnow
+				? theme.fg("warning", "I don't know")
+				: details.correct
+					? theme.fg("success", "Correct!")
+					: theme.fg("error", "Incorrect");
+			lines.push(verdict);
+
+			if (details.note) {
+				lines.push(theme.fg("muted", `Note: ${details.note}`));
+			}
+
+			if (details.explanation) {
+				lines.push(theme.fg("muted", details.explanation));
+			}
+
+			return new Text(lines.join("\n"), 0, 0);
+		},
+	});
+}

--- a/pi/.pi/agent/extensions/quiz.ts
+++ b/pi/.pi/agent/extensions/quiz.ts
@@ -6,6 +6,7 @@ import {
 	Text,
 	matchesKey,
 	truncateToWidth,
+	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
@@ -377,9 +378,25 @@ function renderFeedback(
 	add(theme.fg("dim", " Enter/Esc to continue"));
 }
 
-// Top border + question + optional context. Shared by both components.
+// Frame a rendered panel in a rounded window, inset 2 columns from the left
+// edge. Content must already be laid out at (width - 6) visible columns.
+function frame(lines: string[], width: number, theme: any): string[] {
+	if (width < 12) return lines;
+	const contentW = width - 6;
+	const bar = "─".repeat(contentW + 2);
+	const wall = theme.fg("accent", "│");
+	const out = [`  ${theme.fg("accent", `╭${bar}╮`)}`];
+	for (const line of lines) {
+		const pad = Math.max(0, contentW - visibleWidth(line));
+		out.push(`  ${wall} ${line}${" ".repeat(pad)} ${wall}`);
+	}
+	out.push(`  ${theme.fg("accent", `╰${bar}╯`)}`);
+	return out;
+}
+
+// Question + optional context. Shared by both components. (The frame provides
+// the border now; no flat top bar.)
 function pushHeader(lines: string[], theme: any, width: number, question: string, context: string | undefined): void {
-	lines.push(truncateToWidth(theme.fg("accent", "─".repeat(width)), width));
 	addWrapped(lines, theme.fg("text", question), width, " ");
 	if (context) {
 		lines.push("");
@@ -532,15 +549,16 @@ async function askSingleChoice(
 				// crashes the process.
 				if (cachedLines && cachedWidth === width) return cachedLines;
 
+				const cw = Math.max(8, width - 6);
 				const lines: string[] = [];
-				const add = (text: string) => lines.push(truncateToWidth(text, width));
-				pushHeader(lines, theme, width, question, context);
+				const add = (text: string) => lines.push(truncateToWidth(text, cw));
+				pushHeader(lines, theme, cw, question, context);
 
 				if (phase === "feedback") {
 					renderFeedback(
 						lines,
 						theme,
-						width,
+						cw,
 						options,
 						chosen ? [chosen.index] : [],
 						correctIndices,
@@ -548,10 +566,10 @@ async function askSingleChoice(
 						dontKnow,
 						noteText(),
 					);
-					add(theme.fg("accent", "─".repeat(width)));
-					cachedLines = lines;
+					const framed = frame(lines, width, theme);
+					cachedLines = framed;
 					cachedWidth = width;
-					return lines;
+					return framed;
 				}
 
 				lines.push("");
@@ -563,13 +581,13 @@ async function askSingleChoice(
 					const styled = selected ? theme.fg("accent", label) : theme.fg("text", label);
 					add(`${prefix}${styled}`);
 					if (option.description) {
-						addWrapped(lines, theme.fg("muted", option.description), width, "     ");
+						addWrapped(lines, theme.fg("muted", option.description), cw, "     ");
 					}
 				}
 
-				pushDontKnowRow(lines, theme, width, focus === "options" && optionIndex === dontKnowNav);
+				pushDontKnowRow(lines, theme, cw, focus === "options" && optionIndex === dontKnowNav);
 
-				pushNoteField(lines, theme, width, editor, focus === "note");
+				pushNoteField(lines, theme, cw, editor, focus === "note");
 
 				lines.push("");
 				if (focus === "note") {
@@ -577,13 +595,13 @@ async function askSingleChoice(
 				} else {
 					add(theme.fg("dim", " ↑↓ navigate • Enter answer • Tab note • Esc cancel"));
 				}
-				add(theme.fg("accent", "─".repeat(width)));
+				const framed = frame(lines, width, theme);
 				// Not cached when the note is focused: the editor renders a live cursor.
 				if (focus !== "note") {
-					cachedLines = lines;
+					cachedLines = framed;
 					cachedWidth = width;
 				}
-				return lines;
+				return framed;
 			}
 
 			return {
@@ -754,15 +772,16 @@ async function askMultiChoice(
 				// crashes the process.
 				if (cachedLines && cachedWidth === width) return cachedLines;
 
+				const cw = Math.max(8, width - 6);
 				const lines: string[] = [];
-				const add = (text: string) => lines.push(truncateToWidth(text, width));
-				pushHeader(lines, theme, width, question, context);
+				const add = (text: string) => lines.push(truncateToWidth(text, cw));
+				pushHeader(lines, theme, cw, question, context);
 
 				if (phase === "feedback") {
 					renderFeedback(
 						lines,
 						theme,
-						width,
+						cw,
 						options,
 						realAnswers().map((a) => a.index),
 						correctIndices,
@@ -770,10 +789,10 @@ async function askMultiChoice(
 						choseDontKnow(),
 						noteText(),
 					);
-					add(theme.fg("accent", "─".repeat(width)));
-					cachedLines = lines;
+					const framed = frame(lines, width, theme);
+					cachedLines = framed;
 					cachedWidth = width;
-					return lines;
+					return framed;
 				}
 
 				lines.push("");
@@ -806,11 +825,11 @@ async function askMultiChoice(
 					const styled = isFocused ? theme.fg("accent", label) : theme.fg(checked ? "success" : "text", label);
 					add(`${prefix}${styled}`);
 					if (item.description) {
-						addWrapped(lines, theme.fg("muted", item.description), width, "     ");
+						addWrapped(lines, theme.fg("muted", item.description), cw, "     ");
 					}
 				}
 
-				pushNoteField(lines, theme, width, editor, focus === "note");
+				pushNoteField(lines, theme, cw, editor, focus === "note");
 
 				lines.push("");
 				if (selected.size === 0) {
@@ -821,13 +840,13 @@ async function askMultiChoice(
 				} else {
 					add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter submit • Tab note • Esc cancel"));
 				}
-				add(theme.fg("accent", "─".repeat(width)));
+				const framed = frame(lines, width, theme);
 				// Not cached when the note is focused: the editor renders a live cursor.
 				if (focus !== "note") {
-					cachedLines = lines;
+					cachedLines = framed;
 					cachedWidth = width;
 				}
-				return lines;
+				return framed;
 			}
 
 			return {

--- a/pi/.pi/agent/extensions/quiz.ts
+++ b/pi/.pi/agent/extensions/quiz.ts
@@ -379,28 +379,28 @@ function renderFeedback(
 }
 
 // Render the panel as two merged rounded boxes over the prompt area: a narrow
-// content box (inset 4 columns each side) on top, its bottom corners becoming
+// content box (inset 2 columns each side) on top, its bottom corners becoming
 // tees in the top border of a full-width, prompt-styled input box below.
-// Top content must be laid out at (width - 12) columns, bottom at (width - 4).
+// Top content must be laid out at (width - 8) columns, bottom at (width - 4).
 function frameMerged(top: string[], bottom: string[], width: number, theme: any): string[] {
 	if (width < 24) return [...top, ...bottom];
-	const tw = width - 12;
+	const tw = width - 8;
 	const bw = width - 4;
 	const accent = (s: string) => theme.fg("accent", s);
 	const out: string[] = [];
-	out.push(`    ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
+	out.push(`  ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
 	for (const line of top) {
 		const pad = Math.max(0, tw - visibleWidth(line));
-		out.push(`    ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
+		out.push(`  ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
 	}
-	const rightTee = width - 5;
+	const rightTee = width - 3;
 	out.push(
 		accent("╭") +
-			accent("─".repeat(3)) +
+			accent("─") +
 			accent("┴") +
-			accent("─".repeat(rightTee - 5)) +
+			accent("─".repeat(rightTee - 3)) +
 			accent("┴") +
-			accent("─".repeat(width - rightTee - 2)) +
+			accent("─") +
 			accent("╮"),
 	);
 	for (const line of bottom) {
@@ -578,7 +578,7 @@ async function askSingleChoice(
 				// crashes the process.
 				if (cachedLines && cachedWidth === width) return cachedLines;
 
-				const tw = Math.max(8, width - 12);
+				const tw = Math.max(8, width - 8);
 				const bw = Math.max(8, width - 4);
 				const top: string[] = [];
 				const bottom: string[] = [];
@@ -804,7 +804,7 @@ async function askMultiChoice(
 				// crashes the process.
 				if (cachedLines && cachedWidth === width) return cachedLines;
 
-				const tw = Math.max(8, width - 12);
+				const tw = Math.max(8, width - 8);
 				const bw = Math.max(8, width - 4);
 				const top: string[] = [];
 				const bottom: string[] = [];

--- a/pi/.pi/agent/extensions/quiz.ts
+++ b/pi/.pi/agent/extensions/quiz.ts
@@ -430,14 +430,26 @@ function pushDontKnowRow(lines: string[], theme: any, width: number, focused: bo
 	lines.push(truncateToWidth(`${prefix}${styled}`, width));
 }
 
-// Persistent, always-present note field rendered under the options during the
-// select phase. Applies to ANY answer (including "I don't know") and is only
-// surfaced to the agent when non-empty.
+// Strip the Editor's own flat ─ borders (and scroll-rule variants) so the
+// outer rounded box is the only frame — the bottom box then reads as a clean
+// prompt, exactly like the real one.
+function editorInnerLines(editor: Editor, width: number): string[] {
+	const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+	return editor
+		.render(width)
+		.filter((l) => !/^─+$/.test(stripAnsi(l)) && !/^─── [↑↓] \d+ more /.test(stripAnsi(l)));
+}
+
+// Persistent, always-present note field in the prompt-styled bottom box.
+// Applies to ANY answer (including "I don't know") and is only surfaced to the
+// agent when non-empty. Empty + unfocused collapses to a dim placeholder so the
+// bottom box keeps the prompt silhouette.
 function pushNoteField(lines: string[], theme: any, width: number, editor: Editor, focused: boolean): void {
-	lines.push("");
-	const label = focused ? theme.fg("accent", "Note (optional):") : theme.fg("muted", "Note (optional):");
-	addWrapped(lines, label, width, " ");
-	for (const line of editor.render(width)) lines.push(line);
+	if (!focused && editor.getText().trim().length === 0) {
+		lines.push(theme.fg("dim", " note (optional) — Tab to write"));
+		return;
+	}
+	for (const line of editorInnerLines(editor, width)) lines.push(line);
 }
 
 // Build the note Editor. `disableSubmit` is set because Enter must NOT submit
@@ -606,13 +618,15 @@ async function askSingleChoice(
 
 				pushDontKnowRow(top, theme, tw, focus === "options" && optionIndex === dontKnowNav);
 
-				pushNoteField(bottom, theme, bw, editor, focus === "note");
-
 				if (focus === "note") {
-					bottom.push(theme.fg("dim", " Type note • Ctrl+J newline • Enter back to options • Tab options • Esc back"));
+					top.push("");
+					add(theme.fg("dim", " Type note below • Ctrl+J newline • Enter back to options • Esc cancel"));
 				} else {
-					bottom.push(theme.fg("dim", " ↑↓ navigate • Enter answer • Tab note • Esc cancel"));
+					top.push("");
+					add(theme.fg("dim", " ↑↓ navigate • Enter answer • Tab note • Esc cancel"));
 				}
+
+				pushNoteField(bottom, theme, bw, editor, focus === "note");
 				const framed = frameMerged(top, bottom, width, theme);
 				// Not cached when the note is focused: the editor renders a live cursor.
 				if (focus !== "note") {
@@ -849,15 +863,17 @@ async function askMultiChoice(
 					}
 				}
 
-				pushNoteField(bottom, theme, bw, editor, focus === "note");
-
-				if (selected.size === 0) {
-					bottom.push(theme.fg("warning", " Select at least one answer before submitting."));
-				}
 				if (focus === "note") {
-					bottom.push(theme.fg("dim", " Type note • Ctrl+J newline • Enter back to options • Tab options • Esc back"));
+					top.push("");
+					add(theme.fg("dim", " Type note below • Ctrl+J newline • Enter back to options • Esc cancel"));
 				} else {
-					bottom.push(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter submit • Tab note • Esc cancel"));
+					top.push("");
+					add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter submit • Tab note • Esc cancel"));
+				}
+
+				pushNoteField(bottom, theme, bw, editor, focus === "note");
+				if (selected.size === 0 && focus !== "note") {
+					bottom.push(theme.fg("warning", " Select at least one answer before submitting."));
 				}
 				const framed = frameMerged(top, bottom, width, theme);
 				// Not cached when the note is focused: the editor renders a live cursor.

--- a/pi/.pi/agent/extensions/quiz.ts
+++ b/pi/.pi/agent/extensions/quiz.ts
@@ -378,19 +378,36 @@ function renderFeedback(
 	add(theme.fg("dim", " Enter/Esc to continue"));
 }
 
-// Frame a rendered panel in a rounded window, inset 2 columns from the left
-// edge. Content must already be laid out at (width - 6) visible columns.
-function frame(lines: string[], width: number, theme: any): string[] {
-	if (width < 12) return lines;
-	const contentW = width - 6;
-	const bar = "─".repeat(contentW + 2);
-	const wall = theme.fg("accent", "│");
-	const out = [`  ${theme.fg("accent", `╭${bar}╮`)}`];
-	for (const line of lines) {
-		const pad = Math.max(0, contentW - visibleWidth(line));
-		out.push(`  ${wall} ${line}${" ".repeat(pad)} ${wall}`);
+// Render the panel as two merged rounded boxes over the prompt area: a narrow
+// content box (inset 4 columns each side) on top, its bottom corners becoming
+// tees in the top border of a full-width, prompt-styled input box below.
+// Top content must be laid out at (width - 12) columns, bottom at (width - 4).
+function frameMerged(top: string[], bottom: string[], width: number, theme: any): string[] {
+	if (width < 24) return [...top, ...bottom];
+	const tw = width - 12;
+	const bw = width - 4;
+	const accent = (s: string) => theme.fg("accent", s);
+	const out: string[] = [];
+	out.push(`    ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
+	for (const line of top) {
+		const pad = Math.max(0, tw - visibleWidth(line));
+		out.push(`    ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
 	}
-	out.push(`  ${theme.fg("accent", `╰${bar}╯`)}`);
+	const rightTee = width - 5;
+	out.push(
+		accent("╭") +
+			accent("─".repeat(3)) +
+			accent("┴") +
+			accent("─".repeat(rightTee - 5)) +
+			accent("┴") +
+			accent("─".repeat(width - rightTee - 2)) +
+			accent("╮"),
+	);
+	for (const line of bottom) {
+		const pad = Math.max(0, bw - visibleWidth(line));
+		out.push(`${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
+	}
+	out.push(accent("╰") + accent("─".repeat(width - 2)) + accent("╯"));
 	return out;
 }
 
@@ -549,16 +566,18 @@ async function askSingleChoice(
 				// crashes the process.
 				if (cachedLines && cachedWidth === width) return cachedLines;
 
-				const cw = Math.max(8, width - 6);
-				const lines: string[] = [];
-				const add = (text: string) => lines.push(truncateToWidth(text, cw));
-				pushHeader(lines, theme, cw, question, context);
+				const tw = Math.max(8, width - 12);
+				const bw = Math.max(8, width - 4);
+				const top: string[] = [];
+				const bottom: string[] = [];
+				const add = (text: string) => top.push(truncateToWidth(text, tw));
+				pushHeader(top, theme, tw, question, context);
 
 				if (phase === "feedback") {
 					renderFeedback(
-						lines,
+						top,
 						theme,
-						cw,
+						tw,
 						options,
 						chosen ? [chosen.index] : [],
 						correctIndices,
@@ -566,13 +585,13 @@ async function askSingleChoice(
 						dontKnow,
 						noteText(),
 					);
-					const framed = frame(lines, width, theme);
+					const framed = frameMerged(top, bottom, width, theme);
 					cachedLines = framed;
 					cachedWidth = width;
 					return framed;
 				}
 
-				lines.push("");
+				top.push("");
 				for (let i = 0; i < allOptions.length; i++) {
 					const option = allOptions[i];
 					const selected = focus === "options" && i === optionIndex;
@@ -581,21 +600,20 @@ async function askSingleChoice(
 					const styled = selected ? theme.fg("accent", label) : theme.fg("text", label);
 					add(`${prefix}${styled}`);
 					if (option.description) {
-						addWrapped(lines, theme.fg("muted", option.description), cw, "     ");
+						addWrapped(top, theme.fg("muted", option.description), tw, "     ");
 					}
 				}
 
-				pushDontKnowRow(lines, theme, cw, focus === "options" && optionIndex === dontKnowNav);
+				pushDontKnowRow(top, theme, tw, focus === "options" && optionIndex === dontKnowNav);
 
-				pushNoteField(lines, theme, cw, editor, focus === "note");
+				pushNoteField(bottom, theme, bw, editor, focus === "note");
 
-				lines.push("");
 				if (focus === "note") {
-					add(theme.fg("dim", " Type note • Ctrl+J newline • Enter back to options • Tab options • Esc back"));
+					bottom.push(theme.fg("dim", " Type note • Ctrl+J newline • Enter back to options • Tab options • Esc back"));
 				} else {
-					add(theme.fg("dim", " ↑↓ navigate • Enter answer • Tab note • Esc cancel"));
+					bottom.push(theme.fg("dim", " ↑↓ navigate • Enter answer • Tab note • Esc cancel"));
 				}
-				const framed = frame(lines, width, theme);
+				const framed = frameMerged(top, bottom, width, theme);
 				// Not cached when the note is focused: the editor renders a live cursor.
 				if (focus !== "note") {
 					cachedLines = framed;
@@ -772,16 +790,18 @@ async function askMultiChoice(
 				// crashes the process.
 				if (cachedLines && cachedWidth === width) return cachedLines;
 
-				const cw = Math.max(8, width - 6);
-				const lines: string[] = [];
-				const add = (text: string) => lines.push(truncateToWidth(text, cw));
-				pushHeader(lines, theme, cw, question, context);
+				const tw = Math.max(8, width - 12);
+				const bw = Math.max(8, width - 4);
+				const top: string[] = [];
+				const bottom: string[] = [];
+				const add = (text: string) => top.push(truncateToWidth(text, tw));
+				pushHeader(top, theme, tw, question, context);
 
 				if (phase === "feedback") {
 					renderFeedback(
-						lines,
+						top,
 						theme,
-						cw,
+						tw,
 						options,
 						realAnswers().map((a) => a.index),
 						correctIndices,
@@ -789,13 +809,13 @@ async function askMultiChoice(
 						choseDontKnow(),
 						noteText(),
 					);
-					const framed = frame(lines, width, theme);
+					const framed = frameMerged(top, bottom, width, theme);
 					cachedLines = framed;
 					cachedWidth = width;
 					return framed;
 				}
 
-				lines.push("");
+				top.push("");
 				for (let i = 0; i < allItems.length; i++) {
 					const item = allItems[i];
 					const isFocused = focus === "options" && i === optionIndex;
@@ -811,7 +831,7 @@ async function askMultiChoice(
 					}
 
 					if (item.id === DONT_KNOW_ID) {
-						lines.push(""); // visual separation from the real options
+						top.push(""); // visual separation from the real options
 						const checked = selected.has(item.id);
 						const label = `${checked ? "[x]" : "[ ]"} ${item.label}`;
 						const styled = isFocused ? theme.fg("accent", label) : theme.fg(checked ? "warning" : "dim", label);
@@ -825,22 +845,21 @@ async function askMultiChoice(
 					const styled = isFocused ? theme.fg("accent", label) : theme.fg(checked ? "success" : "text", label);
 					add(`${prefix}${styled}`);
 					if (item.description) {
-						addWrapped(lines, theme.fg("muted", item.description), cw, "     ");
+						addWrapped(top, theme.fg("muted", item.description), tw, "     ");
 					}
 				}
 
-				pushNoteField(lines, theme, cw, editor, focus === "note");
+				pushNoteField(bottom, theme, bw, editor, focus === "note");
 
-				lines.push("");
 				if (selected.size === 0) {
-					add(theme.fg("warning", " Select at least one answer before submitting."));
+					bottom.push(theme.fg("warning", " Select at least one answer before submitting."));
 				}
 				if (focus === "note") {
-					add(theme.fg("dim", " Type note • Ctrl+J newline • Enter back to options • Tab options • Esc back"));
+					bottom.push(theme.fg("dim", " Type note • Ctrl+J newline • Enter back to options • Tab options • Esc back"));
 				} else {
-					add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter submit • Tab note • Esc cancel"));
+					bottom.push(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter submit • Tab note • Esc cancel"));
 				}
-				const framed = frame(lines, width, theme);
+				const framed = frameMerged(top, bottom, width, theme);
 				// Not cached when the note is focused: the editor renders a live cursor.
 				if (focus !== "note") {
 					cachedLines = framed;

--- a/pi/.pi/agent/extensions/run-command.ts
+++ b/pi/.pi/agent/extensions/run-command.ts
@@ -6,6 +6,7 @@ import {
 	Text,
 	matchesKey,
 	truncateToWidth,
+	visibleWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
@@ -76,6 +77,22 @@ function addWrapped(lines: string[], text: string, width: number, indent = ""): 
 	}
 }
 
+// Frame a rendered panel in a rounded window, inset 2 columns from the left
+// edge. Content must already be laid out at (width - 6) visible columns.
+function frame(lines: string[], width: number, theme: any): string[] {
+	if (width < 12) return lines;
+	const contentW = width - 6;
+	const bar = "─".repeat(contentW + 2);
+	const wall = theme.fg("accent", "│");
+	const out = [`  ${theme.fg("accent", `╭${bar}╮`)}`];
+	for (const line of lines) {
+		const pad = Math.max(0, contentW - visibleWidth(line));
+		out.push(`  ${wall} ${line}${" ".repeat(pad)} ${wall}`);
+	}
+	out.push(`  ${theme.fg("accent", `╰${bar}╯`)}`);
+	return out;
+}
+
 // Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at
 // a time, so ALL pop-up-style tools (quiz, ask_user_question, run-command, ...)
 // must serialize against each other, not just against themselves. We stash one
@@ -136,14 +153,14 @@ async function askRunCommand(
 
 			return {
 				render(width: number): string[] {
+					const cw = Math.max(8, width - 6);
 					const lines: string[] = [];
-					const add = (s: string) => lines.push(truncateToWidth(s, width));
+					const add = (s: string) => lines.push(truncateToWidth(s, cw));
 
-					add(theme.fg("accent", "─".repeat(width)));
 					add(theme.fg("toolTitle", theme.bold(" run this command")));
 					if (context) {
 						lines.push("");
-						addWrapped(lines, theme.fg("muted", context), width, " ");
+						addWrapped(lines, theme.fg("muted", context), cw, " ");
 					}
 					lines.push("");
 					// The command, verbatim, in a visually distinct block.
@@ -154,7 +171,7 @@ async function askRunCommand(
 					addWrapped(
 						lines,
 						theme.fg("dim", "y — copy command · run it in your own terminal · paste the output below"),
-						width,
+						cw,
 						" ",
 					);
 					if (copied) {
@@ -165,8 +182,8 @@ async function askRunCommand(
 						focus === "editor"
 							? theme.fg("accent", "Output (paste what you saw):")
 							: theme.fg("muted", "Output (paste what you saw) — Tab to focus:");
-					addWrapped(lines, label, width, " ");
-					for (const line of editor.render(width)) lines.push(line);
+					addWrapped(lines, label, cw, " ");
+					for (const line of editor.render(cw)) lines.push(line);
 					lines.push("");
 					add(
 						theme.fg(
@@ -174,7 +191,7 @@ async function askRunCommand(
 							focus === "editor" ? " Enter — submit · Tab — unfocus · Esc — cancel" : " Tab — focus output · Esc — cancel",
 						),
 					);
-					return lines;
+					return frame(lines, width, theme);
 				},
 
 				invalidate: () => {

--- a/pi/.pi/agent/extensions/run-command.ts
+++ b/pi/.pi/agent/extensions/run-command.ts
@@ -78,28 +78,28 @@ function addWrapped(lines: string[], text: string, width: number, indent = ""): 
 }
 
 // Render the panel as two merged rounded boxes over the prompt area: a narrow
-// content box (inset 4 columns each side) on top, its bottom corners becoming
+// content box (inset 2 columns each side) on top, its bottom corners becoming
 // tees in the top border of a full-width, prompt-styled input box below.
-// Top content must be laid out at (width - 12) columns, bottom at (width - 4).
+// Top content must be laid out at (width - 8) columns, bottom at (width - 4).
 function frameMerged(top: string[], bottom: string[], width: number, theme: any): string[] {
 	if (width < 24) return [...top, ...bottom];
-	const tw = width - 12;
+	const tw = width - 8;
 	const bw = width - 4;
 	const accent = (s: string) => theme.fg("accent", s);
 	const out: string[] = [];
-	out.push(`    ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
+	out.push(`  ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
 	for (const line of top) {
 		const pad = Math.max(0, tw - visibleWidth(line));
-		out.push(`    ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
+		out.push(`  ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
 	}
-	const rightTee = width - 5;
+	const rightTee = width - 3;
 	out.push(
 		accent("╭") +
-			accent("─".repeat(3)) +
+			accent("─") +
 			accent("┴") +
-			accent("─".repeat(rightTee - 5)) +
+			accent("─".repeat(rightTee - 3)) +
 			accent("┴") +
-			accent("─".repeat(width - rightTee - 2)) +
+			accent("─") +
 			accent("╮"),
 	);
 	for (const line of bottom) {
@@ -180,7 +180,7 @@ async function askRunCommand(
 
 			return {
 				render(width: number): string[] {
-					const tw = Math.max(8, width - 12);
+					const tw = Math.max(8, width - 8);
 					const bw = Math.max(8, width - 4);
 					const top: string[] = [];
 					const bottom: string[] = [];

--- a/pi/.pi/agent/extensions/run-command.ts
+++ b/pi/.pi/agent/extensions/run-command.ts
@@ -1,0 +1,349 @@
+import { copyToClipboard, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	Editor,
+	type EditorTheme,
+	Key,
+	Text,
+	matchesKey,
+	truncateToWidth,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+// ────────────────────────────────────────────────────────────────────────────
+// run-command — a hands-on sibling of quiz.
+//
+// Where quiz verifies the HEAD (concepts, terminology), run-command verifies
+// the HANDS: the agent presents ONE command with a grounded prediction, the
+// user runs it in their own terminal, and pastes the output back. The agent
+// never executes the command — the user types everything, which is the point.
+//
+// UI: a floating panel above the prompt shows the command (and optional
+// context/prediction). Pressing `y` yanks the command to the system clipboard
+// as-is. The user runs it elsewhere, returns, types/pastes the output into the
+// response field (Tab to focus), and submits. On submit, the command and the
+// user's pasted output travel together so the agent grades output vs.
+// prediction without ever having seen the terminal.
+// ────────────────────────────────────────────────────────────────────────────
+
+interface RunCommandResponse {
+	output: string;
+}
+
+type RunCommandStatus = "answered" | "cancelled" | "unavailable";
+
+interface RunCommandDetails {
+	status: RunCommandStatus;
+	command: string;
+	prediction?: string;
+	context?: string;
+	output?: string;
+	copied?: boolean; // user pressed `y` — the command was yanked at least once
+	message?: string;
+}
+
+const RunCommandParams = Type.Object({
+	command: Type.String({
+		description:
+			"The single command the user should run, exactly as they should type it. One command per tool call — never a batch.",
+	}),
+	prediction: Type.String({
+		description:
+			"REQUIRED. What output you expect, grounded in observed host state (you ran the idempotent/read-side equivalent yourself) or flagged as inferred from docs. Grading is output vs. this prediction.",
+	}),
+	details: Type.Optional(
+		Type.String({ description: "Optional extra context or safety notes shown above the command." }),
+	),
+});
+
+function createEditorTheme(theme: any): EditorTheme {
+	return {
+		borderColor: (s) => theme.fg("accent", s),
+		selectList: {
+			selectedPrefix: (t) => theme.fg("accent", t),
+			selectedText: (t) => theme.fg("accent", t),
+			description: (t) => theme.fg("muted", t),
+			scrollInfo: (t) => theme.fg("dim", t),
+			noMatch: (t) => theme.fg("warning", t),
+		},
+	};
+}
+
+function addWrapped(lines: string[], text: string, width: number, indent = ""): void {
+	const contentWidth = Math.max(1, width - indent.length);
+	for (const line of wrapTextWithAnsi(text, contentWidth)) {
+		lines.push(truncateToWidth(`${indent}${line}`, width));
+	}
+}
+
+// Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at
+// a time, so ALL pop-up-style tools (quiz, ask_user_question, run-command, ...)
+// must serialize against each other, not just against themselves. We stash one
+// mutex on globalThis so separate extension files can share it without
+// importing each other.
+const SHARED_UI_LOCK_KEY = "__piSharedUiLock";
+function getSharedUiLock() {
+	const g = globalThis as any;
+	if (!g[SHARED_UI_LOCK_KEY]) {
+		let chain: Promise<void> = Promise.resolve();
+		g[SHARED_UI_LOCK_KEY] = {
+			withLock<T>(fn: () => T | Promise<T>): Promise<T> {
+				const prev = chain;
+				let release: () => void;
+				chain = new Promise<void>((r) => {
+					release = r;
+				});
+				return prev.then(fn).finally(() => release!());
+			},
+		};
+	}
+	return g[SHARED_UI_LOCK_KEY] as { withLock<T>(fn: () => T | Promise<T>): Promise<T> };
+}
+const sharedUiLock = getSharedUiLock();
+
+function withUILock<T>(fn: () => Promise<T>): Promise<T> {
+	return sharedUiLock.withLock(fn);
+}
+
+interface AskResult {
+	response: RunCommandResponse | null;
+	copied: boolean;
+}
+
+async function askRunCommand(
+	ctx: any,
+	command: string,
+	prediction: string,
+	context: string | undefined,
+): Promise<AskResult> {
+	let copied = false;
+
+	const result = await ctx.ui.custom<RunCommandResponse | null>(
+		(tui: any, theme: any, _kb: any, done: (result: RunCommandResponse | null) => void) => {
+			// The response field. Enter must NOT submit inside the editor (its submit
+			// path clears the buffer), so disableSubmit and let the host own Enter.
+			// Ctrl+J still inserts a newline (pi convention) for multi-line output.
+			const editor = new Editor(tui, createEditorTheme(theme));
+			editor.focused = false;
+			editor.disableSubmit = true;
+
+			let focus: "editor" | "none" = "none";
+
+			function outputText(): string | undefined {
+				const t = editor.getText().trim();
+				return t.length ? t : undefined;
+			}
+
+			return {
+				render(width: number): string[] {
+					const lines: string[] = [];
+					const add = (s: string) => lines.push(truncateToWidth(s, width));
+
+					add(theme.fg("accent", "─".repeat(width)));
+					add(theme.fg("toolTitle", theme.bold(" run this command")));
+					if (context) {
+						lines.push("");
+						addWrapped(lines, theme.fg("muted", context), width, " ");
+					}
+					lines.push("");
+					// The command, verbatim, in a visually distinct block.
+					for (const line of command.split("\n")) {
+						add(` ${theme.fg("success", theme.bold(line))}`);
+					}
+					lines.push("");
+					addWrapped(
+						lines,
+						theme.fg("dim", "y — copy command · run it in your own terminal · paste the output below"),
+						width,
+						" ",
+					);
+					if (copied) {
+						add(theme.fg("success", " ✓ copied to clipboard"));
+					}
+					lines.push("");
+					const label =
+						focus === "editor"
+							? theme.fg("accent", "Output (paste what you saw):")
+							: theme.fg("muted", "Output (paste what you saw) — Tab to focus:");
+					addWrapped(lines, label, width, " ");
+					for (const line of editor.render(width)) lines.push(line);
+					lines.push("");
+					add(
+						theme.fg(
+							"dim",
+							focus === "editor" ? " Enter — submit · Tab — unfocus · Esc — cancel" : " Tab — focus output · Esc — cancel",
+						),
+					);
+					return lines;
+				},
+
+				handleInput(data: string) {
+					if (focus === "editor") {
+						if (matchesKey(data, Key.enter)) {
+							done({ output: outputText() ?? "" });
+							return;
+						}
+						if (matchesKey(data, Key.tab)) {
+							focus = "none";
+							editor.focused = false;
+							return;
+						}
+						if (matchesKey(data, Key.escape)) {
+							done(null);
+							return;
+						}
+						editor.handleInput(data);
+						return;
+					}
+
+					// Unfocused: y yanks the command as-is, Tab focuses the field.
+					if (data === "y") {
+						copyToClipboard(command)
+							.then(() => {
+								copied = true;
+								tui.requestRender();
+							})
+							.catch(() => {});
+						return;
+					}
+					if (matchesKey(data, Key.tab)) {
+						focus = "editor";
+						editor.focused = true;
+						return;
+					}
+					if (matchesKey(data, Key.enter)) {
+						// Submitting with an empty field is almost always an accident —
+						// focus the field instead of submitting nothing.
+						if (!outputText()) {
+							focus = "editor";
+							editor.focused = true;
+							return;
+						}
+						done({ output: outputText()! });
+						return;
+					}
+					if (matchesKey(data, Key.escape)) {
+						done(null);
+						return;
+					}
+				},
+			};
+		},
+	);
+
+	return { response: result, copied };
+}
+
+function buildDetails(
+	status: RunCommandStatus,
+	command: string,
+	prediction: string | undefined,
+	context: string | undefined,
+	output?: string,
+	copied?: boolean,
+	message?: string,
+): RunCommandDetails {
+	return { status, command, prediction, context, output, copied, message };
+}
+
+function cancelledResult(command: string, prediction: string | undefined, context?: string) {
+	const message = "User cancelled run-command";
+	return {
+		content: [{ type: "text" as const, text: message }],
+		details: buildDetails("cancelled", command, prediction, context, undefined, undefined, message),
+	};
+}
+
+function unavailableResult(command: string, prediction: string | undefined, message: string, context?: string) {
+	return {
+		content: [{ type: "text" as const, text: message }],
+		details: buildDetails("unavailable", command, prediction, context, undefined, undefined, message),
+	};
+}
+
+export default function runCommand(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "run-command",
+		label: "run-command",
+		description:
+			"Have the user run ONE command hands-on and report what they saw. A floating panel shows the command; the user presses y to copy it as-is, runs it in their own terminal, pastes the output into the response field, and submits. You receive the command and the pasted output together — grade the output against your prediction. You NEVER execute the command yourself: the user typing and running everything is the point. Use it for teaching labs and any hands-on verification where the user must do the doing.",
+		promptSnippet:
+			"Use run-command to have the user execute one command hands-on (with a grounded prediction) and paste back the output. You never run it yourself.",
+		promptGuidelines: [
+			"ONE command per call — never a batch. The panel shows exactly what you pass in `command`, verbatim.",
+			"prediction is REQUIRED and must be grounded: run the idempotent/read-only equivalent yourself first and predict the actual observed output; for state-modifying commands, run the read-side (current ruleset/sysctl value) and predict a concrete diff. When no safe read exists, say the prediction is inferred from docs.",
+			"Grade the returned output against your prediction. A mismatch is diagnostic: either host state drifted or your model was wrong — determine which before moving on.",
+			"The user may submit partial or empty output if something went wrong on their side — treat that as data, not as disobedience.",
+			"Follow up with a quiz to cement the concept when the node needs it — run-command proves the hands, not the head.",
+		],
+		parameters: RunCommandParams,
+
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const command = params.command.trim();
+			const prediction = params.prediction.trim();
+			const context = params.details?.trim() || undefined;
+
+			if (signal?.aborted) {
+				return cancelledResult(command, prediction, context);
+			}
+			if (!command) {
+				return unavailableResult(command, prediction, "run-command requires a non-empty command", context);
+			}
+			if (!ctx.hasUI) {
+				return unavailableResult(command, prediction, "run-command requires interactive mode UI", context);
+			}
+
+			return withUILock(async () => {
+				const { response, copied } = await askRunCommand(ctx, command, prediction, context);
+				if (!response) {
+					return cancelledResult(command, prediction, context);
+				}
+				const output = response.output.trim();
+				let text: string;
+				if (output) {
+					text = `User ran the command and pasted output.\nCommand: ${command}\nOutput:\n${output}`;
+				} else {
+					text = `User submitted WITHOUT output — the command produced nothing they could paste, or something went wrong on their side.\nCommand: ${command}`;
+				}
+				if (copied) text += `\n(They copied the command via the panel's y key.)`;
+				text += `\nYour prediction was: ${prediction}`;
+				return {
+					content: [{ type: "text" as const, text }],
+					details: buildDetails("answered", command, prediction, context, output || undefined, copied),
+				};
+			});
+		},
+
+		renderCall(args, theme) {
+			let text = theme.fg("toolTitle", theme.bold("run-command ")) + theme.fg("muted", String(args.command ?? ""));
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, _options, theme) {
+			const details = result.details as RunCommandDetails | undefined;
+			if (!details) {
+				const first = result.content[0];
+				return new Text(first?.type === "text" ? first.text : "", 0, 0);
+			}
+			if (details.status === "cancelled") {
+				return new Text(theme.fg("warning", details.message || "Cancelled"), 0, 0);
+			}
+			if (details.status === "unavailable") {
+				return new Text(theme.fg("warning", details.message || "Unavailable"), 0, 0);
+			}
+			const lines: string[] = [];
+			lines.push(theme.fg("toolTitle", theme.bold("run-command ")) + theme.fg("text", details.command));
+			if (details.output) {
+				lines.push(theme.fg("muted", `─ output (${details.output.split("\n").length} lines) ─`));
+				for (const line of details.output.split("\n").slice(0, 20)) {
+					lines.push(theme.fg("dim", ` ${line}`));
+				}
+				const extra = details.output.split("\n").length - 20;
+				if (extra > 0) lines.push(theme.fg("dim", ` … ${extra} more lines`));
+			} else {
+				lines.push(theme.fg("warning", " (no output submitted)"));
+			}
+			return new Text(lines.join("\n"), 0, 0);
+		},
+	});
+}

--- a/pi/.pi/agent/extensions/run-command.ts
+++ b/pi/.pi/agent/extensions/run-command.ts
@@ -110,6 +110,16 @@ function frameMerged(top: string[], bottom: string[], width: number, theme: any)
 	return out;
 }
 
+// Strip the Editor's own flat ─ borders (and scroll-rule variants) so the
+// outer rounded box is the only frame — the bottom box then reads as a clean
+// prompt, exactly like the real one.
+function editorInnerLines(editor: Editor, width: number): string[] {
+	const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+	return editor
+		.render(width)
+		.filter((l) => !/^─+$/.test(stripAnsi(l)) && !/^─── [↑↓] \d+ more /.test(stripAnsi(l)));
+}
+
 // Shared UI mutex. ctx.ui.custom()/editor can only handle one active call at
 // a time, so ALL pop-up-style tools (quiz, ask_user_question, run-command, ...)
 // must serialize against each other, not just against themselves. We stash one
@@ -199,17 +209,20 @@ async function askRunCommand(
 					}
 					const label =
 						focus === "editor"
-							? theme.fg("accent", "Output (paste what you saw):")
-							: theme.fg("muted", "Output (paste what you saw) — Tab to focus:");
-					addWrapped(bottom, label, bw, " ");
-					for (const line of editor.render(bw)) bottom.push(line);
-					bottom.push("");
-					addB(
+							? theme.fg("accent", "Output (paste what you saw below):")
+							: theme.fg("muted", "Output (paste what you saw below) — Tab to focus:");
+					addWrapped(top, label, tw, " ");
+					addT(
 						theme.fg(
 							"dim",
 							focus === "editor" ? " Enter — submit · Tab — unfocus · Esc — cancel" : " Tab — focus output · Esc — cancel",
 						),
 					);
+					if (focus !== "editor" && editor.getText().trim().length === 0) {
+						bottom.push(theme.fg("dim", " output — Tab to paste"));
+					} else {
+						for (const line of editorInnerLines(editor, bw)) bottom.push(line);
+					}
 					return frameMerged(top, bottom, width, theme);
 				},
 

--- a/pi/.pi/agent/extensions/run-command.ts
+++ b/pi/.pi/agent/extensions/run-command.ts
@@ -77,19 +77,36 @@ function addWrapped(lines: string[], text: string, width: number, indent = ""): 
 	}
 }
 
-// Frame a rendered panel in a rounded window, inset 2 columns from the left
-// edge. Content must already be laid out at (width - 6) visible columns.
-function frame(lines: string[], width: number, theme: any): string[] {
-	if (width < 12) return lines;
-	const contentW = width - 6;
-	const bar = "─".repeat(contentW + 2);
-	const wall = theme.fg("accent", "│");
-	const out = [`  ${theme.fg("accent", `╭${bar}╮`)}`];
-	for (const line of lines) {
-		const pad = Math.max(0, contentW - visibleWidth(line));
-		out.push(`  ${wall} ${line}${" ".repeat(pad)} ${wall}`);
+// Render the panel as two merged rounded boxes over the prompt area: a narrow
+// content box (inset 4 columns each side) on top, its bottom corners becoming
+// tees in the top border of a full-width, prompt-styled input box below.
+// Top content must be laid out at (width - 12) columns, bottom at (width - 4).
+function frameMerged(top: string[], bottom: string[], width: number, theme: any): string[] {
+	if (width < 24) return [...top, ...bottom];
+	const tw = width - 12;
+	const bw = width - 4;
+	const accent = (s: string) => theme.fg("accent", s);
+	const out: string[] = [];
+	out.push(`    ${accent("╭")}${accent("─".repeat(tw + 2))}${accent("╮")}`);
+	for (const line of top) {
+		const pad = Math.max(0, tw - visibleWidth(line));
+		out.push(`    ${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
 	}
-	out.push(`  ${theme.fg("accent", `╰${bar}╯`)}`);
+	const rightTee = width - 5;
+	out.push(
+		accent("╭") +
+			accent("─".repeat(3)) +
+			accent("┴") +
+			accent("─".repeat(rightTee - 5)) +
+			accent("┴") +
+			accent("─".repeat(width - rightTee - 2)) +
+			accent("╮"),
+	);
+	for (const line of bottom) {
+		const pad = Math.max(0, bw - visibleWidth(line));
+		out.push(`${accent("│")} ${line}${" ".repeat(pad)} ${accent("│")}`);
+	}
+	out.push(accent("╰") + accent("─".repeat(width - 2)) + accent("╯"));
 	return out;
 }
 
@@ -153,45 +170,47 @@ async function askRunCommand(
 
 			return {
 				render(width: number): string[] {
-					const cw = Math.max(8, width - 6);
-					const lines: string[] = [];
-					const add = (s: string) => lines.push(truncateToWidth(s, cw));
+					const tw = Math.max(8, width - 12);
+					const bw = Math.max(8, width - 4);
+					const top: string[] = [];
+					const bottom: string[] = [];
+					const addT = (s: string) => top.push(truncateToWidth(s, tw));
+					const addB = (s: string) => bottom.push(truncateToWidth(s, bw));
 
-					add(theme.fg("toolTitle", theme.bold(" run this command")));
+					addT(theme.fg("toolTitle", theme.bold(" run this command")));
 					if (context) {
-						lines.push("");
-						addWrapped(lines, theme.fg("muted", context), cw, " ");
+						top.push("");
+						addWrapped(top, theme.fg("muted", context), tw, " ");
 					}
-					lines.push("");
+					top.push("");
 					// The command, verbatim, in a visually distinct block.
 					for (const line of command.split("\n")) {
-						add(` ${theme.fg("success", theme.bold(line))}`);
+						addT(` ${theme.fg("success", theme.bold(line))}`);
 					}
-					lines.push("");
+					top.push("");
 					addWrapped(
-						lines,
+						top,
 						theme.fg("dim", "y — copy command · run it in your own terminal · paste the output below"),
-						cw,
+						tw,
 						" ",
 					);
 					if (copied) {
-						add(theme.fg("success", " ✓ copied to clipboard"));
+						addT(theme.fg("success", " ✓ copied to clipboard"));
 					}
-					lines.push("");
 					const label =
 						focus === "editor"
 							? theme.fg("accent", "Output (paste what you saw):")
 							: theme.fg("muted", "Output (paste what you saw) — Tab to focus:");
-					addWrapped(lines, label, cw, " ");
-					for (const line of editor.render(cw)) lines.push(line);
-					lines.push("");
-					add(
+					addWrapped(bottom, label, bw, " ");
+					for (const line of editor.render(bw)) bottom.push(line);
+					bottom.push("");
+					addB(
 						theme.fg(
 							"dim",
 							focus === "editor" ? " Enter — submit · Tab — unfocus · Esc — cancel" : " Tab — focus output · Esc — cancel",
 						),
 					);
-					return frame(lines, width, theme);
+					return frameMerged(top, bottom, width, theme);
 				},
 
 				invalidate: () => {

--- a/pi/.pi/agent/extensions/run-command.ts
+++ b/pi/.pi/agent/extensions/run-command.ts
@@ -177,6 +177,10 @@ async function askRunCommand(
 					return lines;
 				},
 
+				invalidate: () => {
+					editor.invalidate();
+				},
+
 				handleInput(data: string) {
 					if (focus === "editor") {
 						if (matchesKey(data, Key.enter)) {


### PR DESCRIPTION
## What

Task 1 of the incremental merge of the `teach` skill into `professor`:

- Frontmatter description now names the three session phases — **Probe** (map knowledge edges with quizzes), **Plan** (research + present a plan for approval), **Teach** (build node by node).
- Firstmate briefing bullets carry the phases plus the rule that Teach waits for plan approval.

## Deliberately out of scope

- The existing "lesson files" phrasing (artifact bullet, description) is untouched — task 7 renames lessons → `session.md`/`handout.md` artifacts, so editing it now would double-touch the same lines.

Full task list was agreed in-session; remaining tasks add the Probe/Plan sections, interaction types (`run-command`, `fix-code`), and artifact restructure.