### PR TITLE
feat(pi): add number shortcuts to option prompts

### DIFF
--- a/pi/.pi/agent/extensions/ask-user-question.ts
+++ b/pi/.pi/agent/extensions/ask-user-question.ts
@@ -10,6 +10,7 @@ import {
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { joinHints, numberShortcutHint, numberShortcutIndex } from "./user-input/option-shortcuts";
 
 interface AskOption {
 	label: string;
@@ -244,6 +245,18 @@ async function askSingleChoice(
 				return;
 			}
 
+			const shortcutIndex = numberShortcutIndex(data, options.length);
+			if (shortcutIndex !== undefined) {
+				const selected = allOptions[shortcutIndex];
+				done({
+					type: "option",
+					label: selected.label,
+					value: selected.value,
+					index: selected.index!,
+				});
+				return;
+			}
+
 			if (matchesKey(data, Key.up)) {
 				optionIndex = Math.max(0, optionIndex - 1);
 				refresh();
@@ -315,7 +328,7 @@ async function askSingleChoice(
 				}
 			} else {
 				top.push("");
-				add(theme.fg("dim", " ↑↓ navigate • Enter select • Esc cancel"));
+				add(theme.fg("dim", ` ${joinHints("↑↓ navigate", numberShortcutHint(options.length, "select"), "Enter select", "Esc cancel")}`));
 			}
 
 			const framed = frameMerged(top, bottom, width, theme);
@@ -398,6 +411,13 @@ async function askMultiChoice(
 				}
 				editor.handleInput(data);
 				refresh();
+				return;
+			}
+
+			const shortcutIndex = numberShortcutIndex(data, choiceItems.length);
+			if (shortcutIndex !== undefined) {
+				optionIndex = shortcutIndex;
+				toggleOption(choiceItems[shortcutIndex]);
 				return;
 			}
 
@@ -520,7 +540,7 @@ async function askMultiChoice(
 				if (selected.size === 0) {
 					add(theme.fg("warning", " Select at least one answer before submitting."));
 				}
-				add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter edit/submit • Esc cancel"));
+				add(theme.fg("dim", ` ${joinHints("↑↓ navigate", numberShortcutHint(choiceItems.length, "toggle"), "Space toggle", "Enter edit/submit", "Esc cancel")}`));
 			}
 
 			const framed = frameMerged(top, bottom, width, theme);

--- a/pi/.pi/agent/extensions/quiz.ts
+++ b/pi/.pi/agent/extensions/quiz.ts
@@ -10,6 +10,7 @@ import {
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { joinHints, numberShortcutHint, numberShortcutIndex } from "./user-input/option-shortcuts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // quiz — a GRADED sibling of ask_user_question.
@@ -543,6 +544,16 @@ async function askSingleChoice(
 				}
 
 				// focus === "options"
+				const shortcutIndex = numberShortcutIndex(data, allOptions.length);
+				if (shortcutIndex !== undefined) {
+					const selected = allOptions[shortcutIndex];
+					chosen = { label: selected.label, value: selected.value, index: selected.index };
+					dontKnow = false;
+					phase = "feedback";
+					refresh();
+					return;
+				}
+
 				if (matchesKey(data, Key.up)) {
 					optionIndex = Math.max(0, optionIndex - 1);
 					refresh();
@@ -623,7 +634,7 @@ async function askSingleChoice(
 					add(theme.fg("dim", " Type note below • Ctrl+J newline • Enter back to options • Esc cancel"));
 				} else {
 					top.push("");
-					add(theme.fg("dim", " ↑↓ navigate • Enter answer • Tab note • Esc cancel"));
+					add(theme.fg("dim", ` ${joinHints("↑↓ navigate", numberShortcutHint(allOptions.length, "answer"), "Enter answer", "Tab note", "Esc cancel")}`));
 				}
 
 				pushNoteField(bottom, theme, bw, editor, focus === "note");
@@ -765,6 +776,13 @@ async function askMultiChoice(
 				}
 
 				// focus === "options"
+				const shortcutIndex = numberShortcutIndex(data, choiceItems.length);
+				if (shortcutIndex !== undefined) {
+					optionIndex = shortcutIndex;
+					toggleOption(choiceItems[shortcutIndex]);
+					return;
+				}
+
 				if (matchesKey(data, Key.up)) {
 					optionIndex = Math.max(0, optionIndex - 1);
 					refresh();
@@ -868,7 +886,7 @@ async function askMultiChoice(
 					add(theme.fg("dim", " Type note below • Ctrl+J newline • Enter back to options • Esc cancel"));
 				} else {
 					top.push("");
-					add(theme.fg("dim", " ↑↓ navigate • Space toggle • Enter submit • Tab note • Esc cancel"));
+					add(theme.fg("dim", ` ${joinHints("↑↓ navigate", numberShortcutHint(choiceItems.length, "toggle"), "Space toggle", "Enter submit", "Tab note", "Esc cancel")}`));
 				}
 
 				pushNoteField(bottom, theme, bw, editor, focus === "note");

--- a/pi/.pi/agent/extensions/user-input/option-shortcuts.test.mjs
+++ b/pi/.pi/agent/extensions/user-input/option-shortcuts.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { createJiti } = require("/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs");
+const jiti = createJiti(import.meta.url);
+const { joinHints, numberShortcutHint, numberShortcutIndex } = jiti("./option-shortcuts.ts");
+
+assert.equal(numberShortcutIndex("1", 3), 0);
+assert.equal(numberShortcutIndex("3", 3), 2);
+assert.equal(numberShortcutIndex("9", 12), 8);
+assert.equal(numberShortcutIndex("0", 12), undefined);
+assert.equal(numberShortcutIndex("a", 12), undefined);
+assert.equal(numberShortcutIndex("2", 1), undefined);
+assert.equal(numberShortcutIndex("9", 8), undefined);
+assert.equal(numberShortcutIndex("10", 12), undefined);
+
+assert.equal(numberShortcutHint(0, "select"), undefined);
+assert.equal(numberShortcutHint(1, "select"), "1 select");
+assert.equal(numberShortcutHint(3, "toggle"), "1-3 toggle");
+assert.equal(numberShortcutHint(12, "select"), "1-9 select first nine");
+assert.equal(joinHints("↑↓ navigate", undefined, "Enter select"), "↑↓ navigate • Enter select");
+
+console.log("option shortcut tests passed");

--- a/pi/.pi/agent/extensions/user-input/option-shortcuts.test.mjs
+++ b/pi/.pi/agent/extensions/user-input/option-shortcuts.test.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const { createJiti } = require("/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs");
+const {
+	createJiti,
+} = require("/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs");
 const jiti = createJiti(import.meta.url);
 const { joinHints, numberShortcutHint, numberShortcutIndex } = jiti("./option-shortcuts.ts");
 

--- a/pi/.pi/agent/extensions/user-input/option-shortcuts.ts
+++ b/pi/.pi/agent/extensions/user-input/option-shortcuts.ts
@@ -1,0 +1,19 @@
+export const NUMBER_SHORTCUT_LIMIT = 9;
+
+export function numberShortcutIndex(data: string, optionCount: number): number | undefined {
+	if (!/^[1-9]$/.test(data)) return undefined;
+	const index = Number(data) - 1;
+	if (index >= Math.min(optionCount, NUMBER_SHORTCUT_LIMIT)) return undefined;
+	return index;
+}
+
+export function numberShortcutHint(optionCount: number, action: string): string | undefined {
+	const last = Math.min(optionCount, NUMBER_SHORTCUT_LIMIT);
+	if (last <= 0) return undefined;
+	const keys = last === 1 ? "1" : `1-${last}`;
+	return optionCount > NUMBER_SHORTCUT_LIMIT ? `${keys} ${action} first nine` : `${keys} ${action}`;
+}
+
+export function joinHints(...hints: Array<string | undefined>): string {
+	return hints.filter(Boolean).join(" • ");
+}


### PR DESCRIPTION
## Intent

Implement the captain's requested keyboard shortcut behavior for Pi user-input prompts in the dotfiles Pi extension code. The ask_user_question prompt currently shows multiple-choice options, but selecting an option required moving the cursor down to the option. Update the extension code so pressing a number selects the matching option directly, consistently across ask_user_question, quiz, and related user-input extension panels that present numbered options. Keep the solution minimal and local to the user-input panel behavior in this isolated worktree. Acceptance: in single-select option prompts, pressing 1-9 selects that visible option immediately and submits it; in multi-select option prompts, pressing a number toggles that visible option while the existing confirmation key still submits; with more than nine options, 1-9 work for the first nine and existing navigation still works for all options; free-form text inputs still accept numeric text because number shortcuts apply only while focus is in an option-list control, not in a text field; existing arrow-key, Enter, Escape, Tab, and free-form/Other flows keep working; add or update automated tests or the smallest local testable unit and run relevant checks plus a manual or scripted smoke for ask_user_question and quiz. The captain manually tested the launched Pi agent with this change loaded and confirmed it works. Continue the no-mistakes delivery path and open a PR for fm/pi-input-number-select.

## What Changed

- Added 1-9 keyboard shortcuts for numbered option rows in `ask_user_question` and `quiz` prompts.
- Single-select shortcuts submit the chosen option immediately; multi-select shortcuts toggle the option while leaving existing submit flows intact.
- Added shared user-input shortcut helpers, hint text updates, and a focused unit test for shortcut index/hint behavior.

## Risk Assessment

✅ Low: The change is small and localized to option-list input handling, with shortcut parsing constrained to 1-9 and bypassed whenever text/note editing is focused.

## Testing

I inspected the changed files, ran the focused helper test, then ran a headless scripted UI smoke through the public extension tool interfaces; after fixing only the smoke harness path/key/terminal stubs, the final checks passed and captured rendered TUI panels plus result payloads. No screenshot was captured because this phase did not launch a live interactive Pi TUI; the evidence artifact records the actual rendered panel output from the component renderer.

<details>
<summary>Evidence: Scripted ask_user_question and quiz number-shortcut smoke transcript</summary>

```text
# Pi user-input number shortcut smoke


## ask_user_question single-select number submits: initial render
  ╭──────────────────────────────────────────────────────────────────────────────────╮
  │  Pick one option                                                                 │
  │                                                                                  │
  │ > 1. Alpha                                                                       │
  │   2. Beta                                                                        │
  │   3. Gamma                                                                       │
  │   Other                                                                          │
  │                                                                                  │
  │  ↑↓ navigate • 1-3 select • Enter select • Esc cancel                            │
╭─┴──────────────────────────────────────────────────────────────────────────────────┴─╮
╰──────────────────────────────────────────────────────────────────────────────────────╯

## ask_user_question single-select number submits: result
{
  "content": [
    {
      "type": "text",
      "text": "User selected: 2. Beta"
    }
  ],
  "details": {
    "status": "answered",
    "question": "Pick one option",
    "mode": "single-select",
    "answers": [
      {
        "type": "option",
        "label": "Beta",
        "value": "b",
        "index": 2
      }
    ]
  },
  "updates": []
}

## ask_user_question >9 shortcut picks ninth: initial render
  ╭──────────────────────────────────────────────────────────────────────────────────╮
  │  Pick ninth out of twelve                                                        │
  │                                                                                  │
  │ > 1. Choice 1                                                                    │
  │   2. Choice 2                                                                    │
  │   3. Choice 3                                                                    │
  │   4. Choice 4                                                                    │
  │   5. Choice 5                                                                    │
  │   6. Choice 6                                                                    │
  │   7. Choice 7                                                                    │
  │   8. Choice 8                                                                    │
  │   9. Choice 9                                                                    │
  │   10. Choice 10                                                                  │
  │   11. Choice 11                                                                  │
  │   12. Choice 12                                                                  │
  │   Other                                                                          │
  │                                                                                  │
  │  ↑↓ navigate • 1-9 select first nine • Enter select • Esc cancel                 │
╭─┴──────────────────────────────────────────────────────────────────────────────────┴─╮
╰──────────────────────────────────────────────────────────────────────────────────────╯

## ask_user_question >9 shortcut picks ninth: result
{
  "content": [
    {
      "type": "text",
      "text": "User selected: 9. Choice 9"
    }
  ],
  "details": {
    "status": "answered",
    "question": "Pick ninth out of twelve",
    "mode": "single-select",
    "answers": [
      {
        "type": "option",
        "label": "Choice 9",
        "value": "v9",
        "index": 9
      }
    ]
  },
  "updates": []
}

## ask_user_question >9 navigation reaches tenth: initial render
  ╭──────────────────────────────────────────────────────────────────────────────────╮
  │  Pick tenth out of twelve by navigation                                          │
  │                                                                                  │
  │ > 1. Choice 1                                                                    │
  │   2. Choice 2                                                                    │
  │   3. Choice 3                                                                    │
  │   4. Choice 4                                                                    │
  │   5. Choice 5                                                                    │
  │   6. Choice 6                                                                    │
  │   7. Choice 7                                                                    │
  │   8. Choice 8                                                                    │
  │   9. Choice 9                                                                    │
  │   10. Choice 10                                                                  │
  │   11. Choice 11                                                                  │
  │   12. Choice 12                                                                  │
  │   Other                                                                          │
  │                                                                                  │
  │  ↑↓ navigate • 1-9 select first nine • Enter select • Esc cancel                 │
╭─┴──────────────────────────────────────────────────────────────────────────────────┴─╮
╰──────────────────────────────────────────────────────────────────────────────────────╯

## ask_user_question >9 navigation reaches tenth: after Down
  ╭──────────────────────────────────────────────────────────────────────────────────╮
  │  Pick tenth out of twelve by navigation                                          │
  │                                                                                  │
  │   1. Choice 1                                                                    │
  │ > 2. Choice 2                                                                    │
  │   3. Choice 3                                                                    │
  │   4. Choice 4                                                                    │
  │   5. Choice 5                              

... [62987 bytes truncated] ...

────────────────────────────────────────────────────────────────────────╯

## quiz note focused numeric text: after Tab
  ╭──────────────────────────────────────────────────────────────────────────────────╮
  │  Numeric note should remain note text                                            │
  │                                                                                  │
  │   1. Alpha                                                                       │
  │   2. Beta                                                                        │
  │                                                                                  │
  │   I don't know                                                                   │
  │                                                                                  │
  │  Type note below • Ctrl+J newline • Enter back to options • Esc cancel           │
╭─┴──────────────────────────────────────────────────────────────────────────────────┴─╮
│ _pi:c[7m [0m                                                                                    │
╰──────────────────────────────────────────────────────────────────────────────────────╯

## quiz note focused numeric text: after "2"
  ╭──────────────────────────────────────────────────────────────────────────────────╮
  │  Numeric note should remain note text                                            │
  │                                                                                  │
  │   1. Alpha                                                                       │
  │   2. Beta                                                                        │
  │                                                                                  │
  │   I don't know                                                                   │
  │                                                                                  │
  │  Type note below • Ctrl+J newline • Enter back to options • Esc cancel           │
╭─┴──────────────────────────────────────────────────────────────────────────────────┴─╮
│ 2_pi:c[7m [0m                                                                                   │
╰──────────────────────────────────────────────────────────────────────────────────────╯

## quiz note focused numeric text: after Enter
  ╭──────────────────────────────────────────────────────────────────────────────────╮
  │  Numeric note should remain note text                                            │
  │                                                                                  │
  │ > 1. Alpha                                                                       │
  │   2. Beta                                                                        │
  │                                                                                  │
  │   I don't know                                                                   │
  │                                                                                  │
  │  ↑↓ navigate • 1-2 answer • Enter answer • Tab note • Esc cancel                 │
╭─┴──────────────────────────────────────────────────────────────────────────────────┴─╮
│ 2[7m [0m                                                                                   │
╰──────────────────────────────────────────────────────────────────────────────────────╯

## quiz note focused numeric text: after "1"
  ╭──────────────────────────────────────────────────────────────────────────────────╮
  │  Numeric note should remain note text                                            │
  │                                                                                  │
  │  ✓ 1. Alpha                                                                      │
  │    2. Beta                                                                       │
  │                                                                                  │
  │  ✓ Correct!                                                                      │
  │  Your note: 2                                                                    │
  │                                                                                  │
  │  Alpha is correct.                                                               │
  │                                                                                  │
  │  Enter/Esc to continue                                                           │
╭─┴──────────────────────────────────────────────────────────────────────────────────┴─╮
╰──────────────────────────────────────────────────────────────────────────────────────╯

## quiz note focused numeric text: result
{
  "content": [
    {
      "type": "text",
      "text": "User answered correctly.\nSelected: 1. Alpha\nCorrect: 1. Alpha\nUser's note: 2\nExplanation: Alpha is correct."
    }
  ],
  "details": {
    "status": "answered",
    "question": "Numeric note should remain note text",
    "mode": "single-select",
    "answers": [
      {
        "label": "Alpha",
        "value": "a",
        "index": 1
      }
    ],
    "correctIndices": [
      1
    ],
    "options": [
      {
        "index": 1,
        "label": "Alpha"
      },
      {
        "index": 2,
        "label": "Beta"
      }
    ],
    "correct": true,
    "dontKnow": false,
    "note": "2",
    "explanation": "Alpha is correct."
  },
  "updates": [
    {
      "content": [
        {
          "type": "text",
          "text": "Awaiting user response..."
        }
      ],
      "details": {
        "options": [
          {
            "index": 1,
            "label": "Alpha"
          },
          {
            "index": 2,
            "label": "Beta"
          }
        ]
      }
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Smoke harness used to produce transcript</summary>

```text
import assert from "node:assert/strict";
import { createRequire } from "node:module";
import { writeFileSync } from "node:fs";
import { dirname, join, resolve } from "node:path";

const require = createRequire(import.meta.url);
const { createJiti } = require("/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs");
const Input = { enter: "\r", down: "\x1b[B", up: "\x1b[A", tab: "\t", escape: "\x1b" };

const worktree = resolve(process.env.WORKTREE || process.cwd());
const jiti = createJiti(join(worktree, "pi/.pi/agent/extensions/ask-user-question.ts"));
const askUserQuestion = jiti(join(worktree, "pi/.pi/agent/extensions/ask-user-question.ts")).default;
const quiz = jiti(join(worktree, "pi/.pi/agent/extensions/quiz.ts")).default;

const theme = {
  fg: (_name, text) => String(text),
  bold: (text) => String(text),
};

function register(extension) {
  let tool;
  extension({ registerTool(t) { tool = t; } });
  assert.ok(tool, "tool registered");
  return tool;
}

function printableInput(input) {
  if (input === Input.enter) return "Enter";
  if (input === Input.down) return "Down";
  if (input === Input.up) return "Up";
  if (input === Input.tab) return "Tab";
  if (input === Input.escape) return "Escape";
  return JSON.stringify(input);
}

function makeCtx(inputs, transcript, label) {
  return {
    hasUI: true,
    ui: {
      custom(factory) {
        return new Promise((resolveCustom, reject) => {
          let doneCalled = false;
          let doneValue;
          const tui = { terminal: { rows: 30, columns: 88 }, requestRender() {} };
          const done = (value) => {
            doneCalled = true;
            doneValue = value;
          };
          const component = factory(tui, theme, undefined, done);
          const render = (step) => {
            transcript.push(`\n## ${label}: ${step}`);
            transcript.push(component.render(88).join("\n"));
          };
          try {
            render("initial render");
            for (const input of inputs) {
              if (doneCalled) break;
              component.handleInput(input);
              if (!doneCalled) render(`after ${printableInput(input)}`);
            }
            if (!doneCalled) throw new Error(`${label} did not complete after scripted inputs`);
            resolveCustom(doneValue);
          } catch (error) {
            reject(error);
          }
        });
      },
    },
  };
}

async function runTool(tool, params, inputs, transcript, label) {
  const updates = [];
  const result = await tool.execute(
    `${label}-call`,
    params,
    new AbortController().signal,
    (update) => updates.push(update),
    makeCtx(inputs, transcript, label),
  );
  transcript.push(`\n## ${label}: result`);
  transcript.push(JSON.stringify({ content: result.content, details: result.details, updates }, null, 2));
  return result;
}

const askTool = register(askUserQuestion);
const quizTool = register(quiz);
const transcript = ["# Pi user-input number shortcut smoke\n"];
const numberedOptions = (n) => Array.from({ length: n }, (_, i) => ({ label: `Choice ${i + 1}`, value: `v${i + 1}` }));

const askSingle = await runTool(
  askTool,
  {
    question: "Pick one option",
    options: [
      { label: "Alpha", value: "a" },
      { label: "Beta", value: "b" },
      { label: "Gamma", value: "c" },
    ],
  },
  ["2"],
  transcript,
  "ask_user_question single-select number submits",
);
assert.equal(askSingle.details.mode, "single-select");
assert.deepEqual(askSingle.details.answers.map((a) => [a.type, a.index, a.value]), [["option", 2, "b"]]);

const askNineOfTwelve = await runTool(
  askTool,
  { question: "Pick ninth out of twelve", options: numberedOptions(12) },
  ["9"],
  transcript,
  "ask_user_question >9 shortcut picks ninth",
);
assert.deepEqual(askNineOfTwelve.details.answers.map((a) => [a.type, a.index, a.value]), [["option", 9, "v9"]]);

const askTenthByNavigation = await runTool(
  askTool,
  { question: "Pick tenth out of twelve by navigation", options: numberedOptions(12) },
  [Input.down, Input.down, Input.down, Input.down, Input.down, Input.down, Input.down, Input.down, Input.down, Input.enter],
  transcript,
  "ask_user_question >9 navigation reaches tenth",
);
assert.deepEqual(askTenthByNavigation.details.answers.map((a) => [a.type, a.index, a.value]), [["option", 10, "v10"]]);

const askMulti = await runTool(
  askTool,
  {
    question: "Pick several options",
    options: [
      { label: "Alpha", value: "a" },
      { label: "Beta", value: "b" },
      { label: "Gamma", value: "c" },
    ],
    multiSelect: true,
  },
  ["2", Input.down, Input.down, Input.down, Input.enter],
  transcript,
  "ask_user_question multi-select number toggles",
);
assert.equal(askMulti.details.mode, "multi-select");
assert.deepEqual(askMulti.details.answers.map((a) => [a.type, a.index, a.value]), [["option", 2, "b"]]);

const askOtherNumeric = await runTool(
  askTool,
  {
    question: "Type another answer",
    options: [{ label: "Alpha", value: "a" }],
  },
  [Input.down, Input.enter, "7", Input.enter],
  transcript,
  "ask_user_question Other numeric text",
);
assert.equal(askOtherNumeric.details.mode, "single-select");
assert.deepEqual(askOtherNumeric.details.answers.map((a) => [a.type, a.value]), [["other", "7"]]);

const quizSingle = await runTool(
  quizTool,
  {
    question: "Which option is correct?",
    options: [
      { label: "Alpha", value: "a" },
      { label: "Beta", value: "b" },
      { label: "Gamma", value: "c" },
    ],
    correctAnswer: "b",
    explanation: "Beta is the keyed correct answer.",
    shuffle: false,
  },
  ["2", Input.enter],
  transcript,
  "quiz single-select number answers",
);
assert.equal(quizSingle.details.mode, "single-select");
assert.equal(quizSingle.details.correct, true);
assert.deepEqual(quizSingle.details.answers.map((a) => [a.index, a.value]), [[2, "b"]]);

const quizNineOfTwelve = await runTool(
  quizTool,
  {
    question: "Which of twelve is correct?",
    options: numberedOptions(12),
    correctAnswer: "v9",
    explanation: "Choice 9 is correct.",
    shuffle: false,
  },
  ["9", Input.enter],
  transcript,
  "quiz >9 shortcut answers ninth",
);
assert.equal(quizNineOfTwelve.details.correct, true);
assert.deepEqual(quizNineOfTwelve.details.answers.map((a) => [a.index, a.value]), [[9, "v9"]]);

const quizMulti = await runTool(
  quizTool,
  {
    question: "Which options are correct?",
    options: [
      { label: "Alpha", value: "a" },
      { label: "Beta", value: "b" },
      { label: "Gamma", value: "c" },
    ],
    multiSelect: true,
    correctAnswer: ["b", "c"],
    explanation: "Beta and Gamma are correct.",
    shuffle: false,
  },
  ["2", "3", Input.down, Input.down, Input.enter, Input.enter],
  transcript,
  "quiz multi-select numbers toggle then submit",
);
assert.equal(quizMulti.details.mode, "multi-select");
assert.equal(quizMulti.details.correct, true);
assert.deepEqual(quizMulti.details.answers.map((a) => [a.index, a.value]), [[2, "b"], [3, "c"]]);

const quizNoteNumeric = await runTool(
  quizTool,
  {
    question: "Numeric note should remain note text",
    options: [
      { label: "Alpha", value: "a" },
      { label: "Beta", value: "b" },
    ],
    correctAnswer: "a",
    explanation: "Alpha is correct.",
    shuffle: false,
  },
  [Input.tab, "2", Input.enter, "1", Input.enter],
  transcript,
  "quiz note focused numeric text",
);
assert.equal(quizNoteNumeric.details.note, "2");
assert.deepEqual(quizNoteNumeric.details.answers.map((a) => [a.index, a.value]), [[1, "a"]]);

const out = join(dirname(new URL(import.meta.url).pathname), "user-input-number-shortcuts-smoke.md");
writeFileSync(out, transcript.join("\n") + "\n", "utf8");
console.log(`smoke passed; transcript: ${out}`);
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cc66be5c07f5e3b4a3559a6e221ad67e12ce1172","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short && git diff --stat 6a149a4abb3fa07186fe026b85d9956fd102746e..HEAD && git diff --name-only 6a149a4abb3fa07186fe026b85d9956fd102746e..HEAD`
- `node pi/.pi/agent/extensions/user-input/option-shortcuts.test.mjs`
- `NODE_PATH=/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules:/opt/homebrew/lib/node_modules node /Users/aviral/.no-mistakes/evidence/01M0ZVC2032FT2ERYQKMZXBEY8/user-input-number-shortcuts-smoke.mjs`
- <code>Scripted smoke exercised `ask_user_question` single-select numeric submit, multi-select numeric toggle then Submit, &gt;9-option shortcut/navigation behavior, numeric Other text, `quiz` single-select numeric answer, `quiz` multi-select numeric toggles then Submit, and numeric text while the quiz note field was focused.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
