### PR TITLE
feat(quiz): add o shortcut to open context files in vim

### DIFF
--- a/pi/.pi/agent/extensions/nvim-open.ts
+++ b/pi/.pi/agent/extensions/nvim-open.ts
@@ -245,7 +245,7 @@ function parseArgs(input: string): string[] {
 function resolveFilePaths(cwd: string, files: string[]): string[] {
 	return files.map((f) => (isAbsolute(f) ? f : resolve(cwd, f)));
 }
-async function openEditor(
+export async function openEditor(
 	cwd: string,
 	rawArgs: string[],
 ): Promise<{ message: string; launched: boolean }> {

--- a/pi/.pi/agent/extensions/quiz-context-files.test.mjs
+++ b/pi/.pi/agent/extensions/quiz-context-files.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const {
+	createJiti,
+} = require("/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs");
+const jiti = createJiti(import.meta.url);
+const { contextFileHint, normalizeContextFiles } = jiti("./user-input/context-files.ts");
+
+const h100SmokeFiles = [
+	"/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/bench_core.py",
+	"/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/reference/fast.cu/h100/matmul.cu",
+];
+
+assert.deepEqual(normalizeContextFiles(undefined), []);
+assert.deepEqual(normalizeContextFiles([" bench_core.py ", "", "reference/fast.cu/h100/matmul.cu"]), [
+	"bench_core.py",
+	"reference/fast.cu/h100/matmul.cu",
+]);
+assert.equal(contextFileHint([]), undefined);
+assert.equal(contextFileHint(["bench_core.py"]), "o open context file");
+assert.equal(contextFileHint(h100SmokeFiles), "o open context files");
+
+console.log("quiz context-file shortcut smoke passed");

--- a/pi/.pi/agent/extensions/quiz.ts
+++ b/pi/.pi/agent/extensions/quiz.ts
@@ -10,6 +10,8 @@ import {
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { openEditor } from "./nvim-open";
+import { contextFileHint, normalizeContextFiles } from "./user-input/context-files";
 import { joinHints, numberShortcutHint, numberShortcutIndex } from "./user-input/option-shortcuts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -120,6 +122,12 @@ const QuizParams = Type.Object({
 				"Defaults to true: options are randomly reordered before display so the correct answer isn't always in the same position. Set to false only when option order is meaningful (e.g. ordered numeric values, or an 'All/None of the above' option that must stay last).",
 		}),
 	),
+	contextFiles: Type.Optional(
+		Type.Array(Type.String(), {
+			description:
+				"Optional file paths that provide context for this quiz question. When present, the quiz panel shows an `o` shortcut; pressing `o` opens these files in vim using the existing /nvim opener. Relative paths resolve from the session cwd.",
+		}),
+	),
 });
 
 function normalizeOptions(
@@ -138,6 +146,12 @@ function normalizeOptions(
 			seen.add(option.value);
 			return true;
 		});
+}
+
+async function openContextFiles(ctx: any, files: string[]): Promise<void> {
+	if (files.length === 0) return;
+	const result = await openEditor(ctx?.cwd ?? process.cwd(), files);
+	ctx?.ui?.notify?.(result.message, "info");
 }
 
 // Fisher-Yates shuffle over a copy. Safe to reorder for display because
@@ -469,6 +483,7 @@ async function askSingleChoice(
 	ctx: any,
 	question: string,
 	context: string | undefined,
+	contextFiles: string[],
 	options: QuizOption[],
 	correctIndices: number[],
 	explanation: string | undefined,
@@ -544,6 +559,13 @@ async function askSingleChoice(
 				}
 
 				// focus === "options"
+				if (data === "o" && contextFiles.length > 0) {
+					void openContextFiles(ctx, contextFiles).catch((error) =>
+						ctx?.ui?.notify?.(`Could not open context files: ${error}`, "warning"),
+					);
+					return;
+				}
+
 				const shortcutIndex = numberShortcutIndex(data, allOptions.length);
 				if (shortcutIndex !== undefined) {
 					const selected = allOptions[shortcutIndex];
@@ -634,7 +656,7 @@ async function askSingleChoice(
 					add(theme.fg("dim", " Type note below • Ctrl+J newline • Enter back to options • Esc cancel"));
 				} else {
 					top.push("");
-					add(theme.fg("dim", ` ${joinHints("↑↓ navigate", numberShortcutHint(allOptions.length, "answer"), "Enter answer", "Tab note", "Esc cancel")}`));
+					add(theme.fg("dim", ` ${joinHints("↑↓ navigate", numberShortcutHint(allOptions.length, "answer"), "Enter answer", contextFileHint(contextFiles), "Tab note", "Esc cancel")}`));
 				}
 
 				pushNoteField(bottom, theme, bw, editor, focus === "note");
@@ -663,6 +685,7 @@ async function askMultiChoice(
 	ctx: any,
 	question: string,
 	context: string | undefined,
+	contextFiles: string[],
 	options: QuizOption[],
 	correctIndices: number[],
 	explanation: string | undefined,
@@ -776,6 +799,13 @@ async function askMultiChoice(
 				}
 
 				// focus === "options"
+				if (data === "o" && contextFiles.length > 0) {
+					void openContextFiles(ctx, contextFiles).catch((error) =>
+						ctx?.ui?.notify?.(`Could not open context files: ${error}`, "warning"),
+					);
+					return;
+				}
+
 				const shortcutIndex = numberShortcutIndex(data, choiceItems.length);
 				if (shortcutIndex !== undefined) {
 					optionIndex = shortcutIndex;
@@ -886,7 +916,7 @@ async function askMultiChoice(
 					add(theme.fg("dim", " Type note below • Ctrl+J newline • Enter back to options • Esc cancel"));
 				} else {
 					top.push("");
-					add(theme.fg("dim", ` ${joinHints("↑↓ navigate", numberShortcutHint(choiceItems.length, "toggle"), "Space toggle", "Enter submit", "Tab note", "Esc cancel")}`));
+					add(theme.fg("dim", ` ${joinHints("↑↓ navigate", numberShortcutHint(choiceItems.length, "toggle"), "Space toggle", "Enter submit", contextFileHint(contextFiles), "Tab note", "Esc cancel")}`));
 				}
 
 				pushNoteField(bottom, theme, bw, editor, focus === "note");
@@ -967,6 +997,7 @@ export default function quiz(pi: ExtensionAPI) {
 			"Anti-guessing hygiene: don't let the correct answer stand out by form (longest, most precise, most hedged, or the only one in the right format). Keep options similar in length, specificity, and phrasing so it can't be picked from shape alone.",
 			"Set multiSelect: true only when more than one option is correct.",
 			"Options are shuffled before display by default, so don't worry about which position you list the correct answer in. Set shuffle: false only when option order is meaningful (ordered values, or an 'All/None of the above' option that must stay last).",
+			"When a quiz needs file context, pass `contextFiles: [\"path/to/file\"]`; the user can press `o` to open those files in vim while the quiz stays active.",
 			"To probe nuance, ask several quick quiz questions and adapt each one based on the previous answers, rather than writing one giant question.",
 			"Don't leak the answer through formatting: keep option phrasing/length even and don't hint which is correct.",
 		],
@@ -974,6 +1005,7 @@ export default function quiz(pi: ExtensionAPI) {
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			const context = params.details?.trim() || undefined;
+			const contextFiles = normalizeContextFiles((params as any).contextFiles);
 			const explanation = params.explanation.trim();
 			const mode: QuizMode = params.multiSelect ? "multi-select" : "single-select";
 
@@ -1031,8 +1063,8 @@ export default function quiz(pi: ExtensionAPI) {
 			return withUILock(async () => {
 				const response =
 					mode === "single-select"
-						? await askSingleChoice(ctx, params.question, context, options, correctIndices, explanation)
-						: await askMultiChoice(ctx, params.question, context, options, correctIndices, explanation);
+						? await askSingleChoice(ctx, params.question, context, contextFiles, options, correctIndices, explanation)
+						: await askMultiChoice(ctx, params.question, context, contextFiles, options, correctIndices, explanation);
 				if (!response) {
 					return cancelledResult(params.question, mode, correctIndices, context);
 				}
@@ -1057,6 +1089,11 @@ export default function quiz(pi: ExtensionAPI) {
 			if (options.length > 0) {
 				const noun = options.length === 1 ? "option" : "options";
 				text += theme.fg("dim", ` (${options.length} ${noun})`);
+			}
+			const contextFiles = normalizeContextFiles((args as any).contextFiles);
+			if (contextFiles.length > 0) {
+				const noun = contextFiles.length === 1 ? "context file" : "context files";
+				text += theme.fg("dim", ` (${contextFiles.length} ${noun})`);
 			}
 			return new Text(text, 0, 0);
 		},

--- a/pi/.pi/agent/extensions/user-input/context-files.ts
+++ b/pi/.pi/agent/extensions/user-input/context-files.ts
@@ -1,0 +1,9 @@
+export function normalizeContextFiles(files: unknown): string[] {
+	if (!Array.isArray(files)) return [];
+	return files.map((file) => String(file).trim()).filter(Boolean);
+}
+
+export function contextFileHint(files: string[]): string | undefined {
+	if (files.length === 0) return undefined;
+	return `o open ${files.length === 1 ? "context file" : "context files"}`;
+}


### PR DESCRIPTION
## Intent

Build the captain's requested `o` shortcut for quiz prompts that need file context.

Captain's request: If a quiz question involves certain files for context to answer it, create a shortcut called `o`. Pressing `o` should open those files in /nvim. Use the H100 matmul lesson as the example to test it. Target repo /Users/aviral/dotfiles; likely files pi/.pi/agent/extensions/quiz.ts, nvim-open.ts, and user-input panel helpers. H100 matmul lesson path: /Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal (bench_core.py, bench_app.py, handout.md, session.md, reference/fast.cu/h100/matmul.cu). Use Ponytail: keep the change minimal, reuse existing /nvim machinery, avoid inventing a new file-opening system. Do not modify the H100 lesson files or live global Pi extension files directly.

Acceptance criteria:
1. Quiz prompts can carry zero or more context files for the current question.
2. When context files are present, the quiz UI renders a clear `o` shortcut hint.
3. Pressing `o` opens the context files via the existing /nvim path or the same implementation that /nvim uses, without breaking the active quiz panel.
4. If there are no context files, `o` is either absent from the hint or produces a harmless/no-op message.
5. Existing quiz behavior still works: number-key selection, arrow navigation, Enter submit, Escape cancel, explanation display, shuffled options, and note field handling.
6. The API/tool schema documents how the caller supplies context files; make the schema change optional and backwards-compatible.
7. Add/update the smallest useful test or smoke for the `o` shortcut and context-file plumbing.
8. Use the H100 matmul lesson files as a realistic manual/smoke example: a quiz whose context files include bench_core.py and reference/fast.cu/h100/matmul.cu, then pressing `o` opens them in Neovim.

Implementation decision already taken (lazy/reuse path): added an optional `contextFiles` string-array schema field to quiz, guarded so it is backwards-compatible; the `o` key handler in both single- and multi-select calls `openEditor` (exported from nvim-open.ts, one-word change) so it reuses the exact /nvim opener (Herdr pane detection + tmux fallback) rather than a new system; pure normalizeContextFiles/contextFileHint helpers live in a shared user-input/context-files.ts so future quiz-like prompts can reuse them; the hint is appended to the shortcut line only when context files exist; renderCall shows the context-file count. Smoke test quiz-context-files.test.mjs uses the H100 matmul bench_core.py and reference/fast.cu/h100/matmul.cu paths as the context fixture.

## What Changed

- Quiz tool adds an optional, backwards-compatible `contextFiles` string-array schema field; single- and multi-select panels render an `o open context file(s)` hint and open the listed files on `o`, and `renderCall` shows the context-file count.
- `openEditor` is exported from `nvim-open.ts` so the `o` handler reuses the existing /nvim opener (Herdr pane + tmux fallback) instead of a new file-opening system.
- New shared `user-input/context-files.ts` exposes `normalizeContextFiles`/`contextFileHint`; `quiz-context-files.test.mjs` smoke-checks them against the H100 matmul `bench_core.py` and `reference/fast.cu/h100/matmul.cu` paths.

## Risk Assessment

✅ Low: The change is well-bounded and minimal: an optional backwards-compatible schema field, two pure helpers, and a tightly guarded non-conflicting key handler that reuses the existing /nvim opener without mutating quiz state, with a meaningful smoke test.

## Testing

Ran the targeted context-file smoke test and a transient integration test that loads the real nvim-open.ts via jiti to prove openEditor is exported/callable and the hint composes into the shortcut line with the H100 fixture; then demonstrated the real /nvim opener end-to-end by invoking openEditor on the two H100 matmul files, which launched nvim in a vertical split with both files (verified via herdr process-info argv and the captured nvim screen). All targeted checks pass; transient tmux session and launched vim pane were torn down and the working tree is clean.

<details>
<summary>Evidence: openEditor result on H100 files</summary>

`openEditor(h100-matmul-modal dir, [bench_core.py, reference/fast.cu/h100/matmul.cu]) => {"message":"Launched vim in a vertical split (pane w57:pN) at /Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal with 2 file(s).","launched":true}`

```text
$ node /tmp/call-openeditor.mjs   # inside throwaway tmux session quiz-o-demo
openEditor(cwd=h100-matmul-modal dir, files=[bench_core.py, reference/fast.cu/h100/matmul.cu])
=> {"message":"Launched vim in a vertical split (pane w57:pN) at /Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal with 2 file(s).","launched":true}

openEditor is the exact function quiz.ts `o` handler calls (imported from nvim-open.ts).
It detected the Herdr environment, found no existing editor pane, and launched nvim
in a vertical split with both H100 matmul context files.
```
</details>
<details>
<summary>Evidence: nvim process argv (both H100 files)</summary>

`foreground_processes[0].argv = ["/Users/aviral/.local/share/bob/nightly/bin/nvim", ".../h100-matmul-modal/bench_core.py", ".../h100-matmul-modal/reference/fast.cu/h100/matmul.cu"], name=nvim, cwd=h100-matmul-modal`

```text
{"id":"cli:pane:process_info","result":{"process_info":{"foreground_process_group_id":54264,"foreground_processes":[{"argv":["/Users/aviral/.local/share/bob/nightly/bin/nvim","/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/bench_core.py","/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/reference/fast.cu/h100/matmul.cu"],"argv0":"nvim","cmdline":"/Users/aviral/.local/share/bob/nightly/bin/nvim /Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/bench_core.py /Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/reference/fast.cu/h100/matmul.cu","cwd":"/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal","name":"nvim","pid":54274},{"argv":["bob","run","nightly","/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/bench_core.py","/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/reference/fast.cu/h100/matmul.cu"],"argv0":"bob","cmdline":"bob run nightly /Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/bench_core.py /Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/reference/fast.cu/h100/matmul.cu","cwd":"/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal","name":"bob","pid":54264}],"pane_id":"w57:pN","shell_pid":54166},"type":"pane_process_info"}}
```
</details>
<details>
<summary>Evidence: Rendered Neovim screen with bench_core.py open</summary>

Source: Rendered Neovim screen with bench_core.py open (local file: <code>/Users/aviral/.no-mistakes/evidence/01M102C204Z6V368N8F8XXVZQZ/o-shortcut-nvim-screen.txt</code>)

```text
Neovim tabline: '1 h100-matmul-modal' | buffer: bench_core.py (BENCH_PARAMS, _NVIDIA_SMI_QUERIES) | statusline: 'h100-matmul-modal a73d11 bench_core.py python 2% 6:1'
```
</details>
<details>
<summary>Evidence: Targeted test outputs</summary>

<code>$ node quiz-context-files.test.mjs -&gt; quiz context-file shortcut smoke passed&#10;$ node quiz-o-integration.test.mjs -&gt; quiz `o` integration smoke passed</code>

```text
$ node quiz-context-files.test.mjs
quiz context-file shortcut smoke passed

$ node /tmp/quiz-o-integration.test.mjs
quiz `o` integration smoke passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4e11b171f88f058d05b8ce1e2df3b4c187061225","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node pi/.pi/agent/extensions/quiz-context-files.test.mjs` (existing smoke: normalizeContextFiles + contextFileHint with H100 fixture)</code>
- <code>`node /tmp/quiz-o-integration.test.mjs` (transient: loads real nvim-open.ts via jiti, asserts openEditor exported &amp; async; composes joinHints+contextFileHint proving `o open context files` appears with H100 files and is absent when empty)</code>
- <code>`node /tmp/call-openeditor.mjs` inside throwaway tmux session -&gt; real openEditor(h100-dir, [bench_core.py, matmul.cu]) returned launched:true</code>
- <code>`herdr pane process-info --pane w57:pN` (nvim argv = both H100 file paths)</code>
- <code>`herdr pane read w57:pN --lines 60` (rendered nvim screen showing bench_core.py open in h100-matmul-modal)</code>
- <code>read quiz.ts `o` handler blocks (single-select L562, multi-select L802) + fallthrough confirming no-context `o` is a clean no-op</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
