### PR TITLE
fix(nvim): gracefully degrade clangd CUDA LSP on macOS, route full LSP to homelab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .envrc
 .todos/
 .lavish/*
+.tmp/
+nvim/.config/github-copilot/
 __pycache__/
 pi/.pi/agent/extensions/tool-call-renderer-thinking-prototype.html
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,16 @@ captain approval).
   kill, and focus actions must continue to target the exact underlying Herdr agent identity.
 - Preserve exact cwd behavior for non-Git directories instead of inventing repository identity.
 
+## CUDA LSP host invariant
+
+NVIDIA ships no CUDA Toolkit for macOS Apple Silicon. `.cu` files get
+local-symbol LSP only on the Mac (document symbols, local go-to-def/hover
+work; CUDA-API symbols like `cudaMalloc`/`__nv_bfloat16` do not). Full
+CUDA LSP needs the homelab/Linux CUDA Toolkit + a compile database.
+`helpers/cuda_lsp.lua` detects this and notifies once per session; do not
+try to stub CUDA headers or silence the clangd CUDA diagnostics. Authoritative
+setup + homelab command: `docs/neovim-cuda-lsp.md`.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/docs/neovim-cuda-lsp.md
+++ b/docs/neovim-cuda-lsp.md
@@ -65,11 +65,13 @@ detected toolkit it is a no-op.
 - A compile database for the lesson tree, or clangd's Makefile fallback. The
   lesson ships a `Makefile` (`nvcc ... -gencode arch=compute_90a,code=sm_90a`);
   generate a compile database with:
+
   ```sh
   cd reference/fast.cu
   bear -- make matmul      # produces compile_commands.json
   # or: cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ... ; ln -s build/compile_commands.json .
   ```
+
 - Neovim with this dotfiles config (`XDG_CONFIG_HOME=dotfiles/nvim/.config`).
 
 ## Homelab validation command + success criteria

--- a/docs/neovim-cuda-lsp.md
+++ b/docs/neovim-cuda-lsp.md
@@ -1,0 +1,114 @@
+# Neovim CUDA LSP (clangd) — host requirements
+
+## Symptom
+
+Opening CUDA reference files (e.g. `reference/fast.cu/h100/matmul.cu` from the
+H100 matmul professor lesson) in Neovim shows a wall of `clangd` / AST
+diagnostics:
+
+- `Cannot find CUDA installation; provide its path via '--cuda-path'`
+- `Cannot find libdevice for sm_52`
+- `'cuda.h' file not found`, `'cuda_runtime.h' file not found`
+- `Unknown type name '__nv_bfloat16'`, `Use of undeclared identifier 'cudaSuccess'`
+
+## Root cause
+
+The captain's MacBook is **macOS Apple Silicon (arm64)**. NVIDIA does not ship a
+CUDA Toolkit for macOS Apple Silicon — there is no `nvcc`, no `cuda.h`,
+`cuda_runtime.h`, `cuda_bf16.h`, `cublas_v2.h`, and no `libdevice.bc`. clangd's
+fallback driver also finds no `compile_commands.json` in the lesson tree, so it
+builds the `.cu` file as plain C++ without CUDA includes. Even passing
+`-x cuda -nocudainc -nocudalib` does not help: the user's explicit
+`#include <cuda.h>` still cannot resolve because the headers do not exist on
+this host.
+
+This is **not** a Neovim/LSP config bug. filetype routing is correct
+(`filetype=cuda` → clangd `languageId=cuda-cpp`), clangd attaches and
+initializes, and the clangd binary (Mason 21.1.8) is fine.
+
+## What works on the Mac (no fix needed)
+
+clangd recovers from the missing CUDA headers and still builds a partial AST, so
+these real LSP features work on macOS today, with zero config changes:
+
+- **Document symbols** — 11 symbols for `matmul.cu` (functions, globals, the 12
+  kernel dispatch cases).
+- **Go-to-definition on local symbols** — `runKernel1` (called in `run_kernel`)
+  resolves to `matmul/matmul_1.cuh:135`; the local `.cuh` includes resolve.
+- **Hover on local symbols** — `void run_kernel(int kernel_num, ...)` returns a
+  proper markdown signature.
+
+## What cannot work on the Mac
+
+Hover / go-to-def / completion / correct type info for the **CUDA API**
+(`cudaMalloc`, `__nv_bfloat16`, `cublasGemmEx`, kernel-launch `<<<>>>` builtins
+need the CUDA frontend headers and libdevice). There is no supported way to
+install those on macOS Apple Silicon, and stubbing them in dotfiles would give
+**incorrect** hover/type info (violating "LSP features must work, not be
+silenced"). So the correct host for full CUDA LSP is the homelab/Linux.
+
+## Durable dotfiles behavior
+
+`nvim/.config/nvim/lua/plugins/clangd.lua` calls
+`require("helpers.cuda_lsp").notify_if_unsupported(bufnr)` on every clangd
+`cuda`-filetype `LspAttach`. On macOS Apple Silicon with no toolkit it emits one
+`WARN` notification per Neovim session explaining the above and routing to the
+homelab. It does **not** silence diagnostics and does **not** stop clangd from
+attaching (so the local-symbol LSP above keeps working). On Linux with a
+detected toolkit it is a no-op.
+
+## Homelab / Linux requirements for full CUDA LSP
+
+- NVIDIA driver + CUDA Toolkit installed (provides `nvcc`, `cuda.h`,
+  `cuda_runtime.h`, `cuda_bf16.h`, `cublas_v2.h`, `libdevice.bc`).
+- `clangd` on PATH (the repo's Mason-managed clangd or a system LLVM clangd).
+- A compile database for the lesson tree, or clangd's Makefile fallback. The
+  lesson ships a `Makefile` (`nvcc ... -gencode arch=compute_90a,code=sm_90a`);
+  generate a compile database with:
+  ```sh
+  cd reference/fast.cu
+  bear -- make matmul      # produces compile_commands.json
+  # or: cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ... ; ln -s build/compile_commands.json .
+  ```
+- Neovim with this dotfiles config (`XDG_CONFIG_HOME=dotfiles/nvim/.config`).
+
+## Homelab validation command + success criteria
+
+On the homelab, from the dotfiles repo root, with `CUDA_PATH` set and
+`compile_commands.json` present in the lesson's `reference/fast.cu`:
+
+```sh
+repo="$HOME/path/to/dotfiles"
+lesson="$HOME/path/to/vault/professor-lessons/h100-matmul-modal"
+file="$lesson/reference/fast.cu/h100/matmul.cu"
+cd "$lesson/reference/fast.cu"
+XDG_CONFIG_HOME="$repo/nvim/.config" \
+  nvim --headless "$file" \
+    "+lua
+      local b=0
+      vim.wait(20000,function()
+        for _,c in ipairs(vim.lsp.get_clients({bufnr=b})) do
+          if c.name=='clangd' then return c.initialized end
+        end return false end,100)
+      local p={textDocument=vim.lsp.util.make_text_document_params(b)}
+      local s=vim.lsp.buf_request_sync(b,'textDocument/documentSymbol',p,8000) or {}
+      local n=0 for _,r in pairs(s) do n=n+(type(r.result)=='table' and #r.result or 0) end
+      print('docSymbols='..n)
+      local nd=0 for _,d in ipairs(vim.diagnostic.get(b)) do
+        if d.severity==1 and (d.source=='clang') then nd=nd+1 end end
+      print('clang_errors='..nd)
+      vim.cmd('qa')"
+```
+
+**Success:** `docSymbols>=11` AND `clang_errors==0` (no `drv_no_cuda_*`,
+`pp_file_not_found` for `cuda.h`, or `unknown_typename` for `__nv_bfloat16`).
+On the Mac the same command yields `clang_errors>0` — that is the expected
+graceful-failure signal, not a regression.
+
+## Versions recorded (captain MacBook, 2026-08-26)
+
+- macOS 15.7.4 (Darwin 24.6.0, arm64-apple-darwin)
+- nvim NVIM v0.12.4
+- clangd 21.1.8 (Mason) / Apple clangd 17.0.0 (CommandLineTools)
+- nvcc: not installed; no CUDA Toolkit under /usr/local, /opt/homebrew,
+  /Library/Developer, $HOME/.local, $HOME/.cache

--- a/nvim/.config/nvim/lua/helpers/cuda_lsp.lua
+++ b/nvim/.config/nvim/lua/helpers/cuda_lsp.lua
@@ -1,0 +1,78 @@
+-- CUDA LSP host-capability detection for clangd.
+--
+-- NVIDIA does not ship a CUDA Toolkit for macOS Apple Silicon, so .cu files
+-- that use the CUDA API (cuda.h, cuda_runtime.h, cuda_bf16.h, cublas_v2.h,
+-- libdevice) cannot get correct hover / go-to-def / type info on the Mac.
+-- clangd still parses the file's own structure, so document symbols and
+-- LOCAL-symbol navigation work there; only CUDA-API symbols stay unresolved
+-- and clangd reports them as errors. This helper detects that condition and
+-- notifies once per session, routing the captain to the homelab/Linux CUDA
+-- toolkit for full CUDA LSP. It does NOT silence diagnostics — the Mac errors
+-- are real "this symbol cannot resolve here" signals, not noise to hide.
+--
+-- Authoritative setup + homelab command: docs/neovim-cuda-lsp.md
+
+local M = {}
+
+local notified = {}
+
+function M.on_macos_apple_silicon()
+  local uname = vim.uv.os_uname()
+  return uname.sysname == "Darwin" and uname.machine == "arm64"
+end
+
+-- True if a CUDA Toolkit is reachable: nvcc on PATH, CUDA_PATH/CUDA_HOME set
+-- with cuda.h, or cuda.h under a common install root.
+function M.toolkit_present()
+  if vim.fn.executable("nvcc") == 1 then
+    return true
+  end
+  local cuda_path = os.getenv("CUDA_PATH") or os.getenv("CUDA_HOME")
+  if cuda_path and vim.fn.filereadable(cuda_path .. "/include/cuda.h") == 1 then
+    return true
+  end
+  for _, root in ipairs({ "/usr/local/cuda", "/opt/cuda", "/Developer/NVIDIA" }) do
+    if vim.fn.filereadable(root .. "/include/cuda.h") == 1 then
+      return true
+    end
+  end
+  return false
+end
+
+-- True only when the host can plausibly provide full CUDA LSP: Linux with a
+-- detected toolkit. macOS is excluded regardless of toolkit presence — the
+-- toolkit is not installable there in practice.
+function M.host_supports_full_cuda()
+  if vim.uv.os_uname().sysname == "Linux" then
+    return M.toolkit_present()
+  end
+  return false
+end
+
+-- Notify once per Neovim session that full CUDA LSP needs the homelab/Linux
+-- toolkit. Safe to call from a clangd LspAttach on every cuda buffer.
+function M.notify_if_unsupported(bufnr)
+  bufnr = bufnr or 0
+  if M.host_supports_full_cuda() then
+    return
+  end
+  if M.on_macos_apple_silicon() and not notified.mac then
+    notified.mac = true
+    vim.schedule(function()
+      vim.notify(
+        "CUDA toolkit not found on macOS Apple Silicon (NVIDIA ships none). "
+          .. "clangd will flag CUDA API symbols (cudaMalloc, __nv_bfloat16, cublas*); "
+          .. "document symbols and local-symbol go-to-def/hover still work. "
+          .. "For full CUDA LSP, open these files on the homelab/Linux CUDA toolkit.",
+        vim.log.levels.WARN
+      )
+    end)
+  end
+end
+
+-- Test hook: clear the once-per-session guard.
+function M._reset_notify_guard()
+  notified = {}
+end
+
+return M

--- a/nvim/.config/nvim/lua/plugins/clangd.lua
+++ b/nvim/.config/nvim/lua/plugins/clangd.lua
@@ -1,6 +1,25 @@
+local cuda_lsp = require("helpers.cuda_lsp")
+
 return {
   {
     "neovim/nvim-lspconfig",
+    -- On macOS Apple Silicon there is no NVIDIA CUDA Toolkit, so .cu files
+    -- get local-symbol LSP only and clangd reports CUDA-API symbols as
+    -- errors. Notify once per session and route to homelab/Linux for full
+    -- CUDA LSP. See docs/neovim-cuda-lsp.md. Does not silence diagnostics.
+    init = function()
+      vim.api.nvim_create_autocmd("LspAttach", {
+        callback = function(args)
+          local client = vim.lsp.get_client_by_id(args.data.client_id)
+          if not client or client.name ~= "clangd" then
+            return
+          end
+          if vim.bo[args.buf].filetype == "cuda" then
+            cuda_lsp.notify_if_unsupported(args.buf)
+          end
+        end,
+      })
+    end,
     opts = {
       servers = {
         clangd = {

--- a/scripts/verify-nvim.lua
+++ b/scripts/verify-nvim.lua
@@ -4825,6 +4825,46 @@ local function validate_workspace_session()
   vim.cmd("silent! %bwipeout!")
 end
 
+local function validate_cuda_lsp()
+  -- Smoke for the clangd CUDA graceful-failure detection in
+  -- helpers/cuda_lsp.lua. Asserts the host-capability booleans are sane for
+  -- the current host and that notify_if_unsupported is safe on a fake cuda
+  -- buffer. End-to-end clangd-attaches-and-returns-symbols is validated
+  -- manually on the real lesson file (see docs/neovim-cuda-lsp.md).
+  -- Prepend the worktree config so the helper resolves before it is stowed
+  -- into the live ~/.config/nvim; harmless once stowed (rtp dedup).
+  vim.opt.rtp:prepend(vim.fn.fnamemodify("nvim/.config/nvim", ":p"))
+  local ok, cuda_lsp = pcall(require, "helpers.cuda_lsp")
+  if not ok then
+    fail("helpers.cuda_lsp not found: " .. tostring(cuda_lsp))
+  end
+  local uname = vim.uv.os_uname()
+
+  if type(cuda_lsp.host_supports_full_cuda()) ~= "boolean" then
+    fail("host_supports_full_cuda must return a boolean")
+  end
+  if type(cuda_lsp.toolkit_present()) ~= "boolean" then
+    fail("toolkit_present must return a boolean")
+  end
+
+  -- macOS Apple Silicon has no NVIDIA CUDA Toolkit, so full CUDA LSP must
+  -- report unsupported there. Linux host support depends on the toolkit.
+  if uname.sysname == "Darwin" and uname.machine == "arm64" then
+    if cuda_lsp.host_supports_full_cuda() then
+      fail("macOS arm64 must not report full CUDA LSP support")
+    end
+  end
+
+  -- notify_if_unsupported must not error on a fake cuda buffer and must be
+  -- idempotent (once-per-session guard).
+  cuda_lsp._reset_notify_guard()
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].filetype = "cuda"
+  cuda_lsp.notify_if_unsupported(buf)
+  cuda_lsp.notify_if_unsupported(buf)
+  vim.api.nvim_buf_delete(buf, { force = true })
+end
+
 local cases = {
   ["agent-keymaps"] = validate_agent_keymaps,
   ["workspace-session"] = validate_workspace_session,
@@ -4840,6 +4880,7 @@ local cases = {
   ["sidekick-herdr-live"] = validate_sidekick_herdr_live,
   ["vault-features"] = validate_vault_features,
   ["vault-work-items"] = validate_vault_work_items,
+  ["cuda-lsp"] = validate_cuda_lsp,
 }
 
 local fn = cases[case]
@@ -4847,7 +4888,7 @@ if not fn then
   fail(
     "unknown VERIFY_NVIM_CASE "
       .. vim.inspect(case)
-      .. "; expected one of: agent-keymaps, workspace-session, weekly-backlog, markdown-formatting, markdown-ansi, inline-ask-edit, sidekick-pi, sidekick-herdr, sidekick-picker-actions, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items"
+      .. "; expected one of: agent-keymaps, workspace-session, weekly-backlog, markdown-formatting, markdown-ansi, inline-ask-edit, sidekick-pi, sidekick-herdr, sidekick-picker-actions, herdr-workspaces, sidekick-herdr-live, vault-features, vault-work-items, cuda-lsp"
   )
 end
 


### PR DESCRIPTION
## Intent

Diagnose and fix the captain's Neovim LSP/clangd errors when opening the H100 CUDA lesson files (reference/fast.cu/h100/matmul.cu) from the vault professor-lessons path. The captain wants real LSP features to work, not merely diagnostics silenced. Lasting config changes target only the dotfiles worktree; do not modify the lesson path, the vault project, or any live global config.

Reproduced on macOS 15.7.4 Apple Silicon (arm64): opening matmul.cu with the repo nvim config shows clangd/AST errors "Cannot find CUDA installation", "Cannot find libdevice for sm_52", "'cuda.h' file not found", "Unknown type name '__nv_bfloat16'", "Use of undeclared identifier 'cudaSuccess'". clangd attaches, filetype=cuda routes to languageId=cuda-cpp, root resolves via the Makefile marker. No compile_commands.json in the lesson tree, so clangd uses a plain-C++ fallback.

Root cause (separating trigger/mask/symptom): NVIDIA ships no CUDA Toolkit for macOS Apple Silicon — no nvcc, no cuda.h/cuda_runtime.h/cuda_bf16.h/cublas_v2.h, no libdevice. Confirmed absent under /usr/local, /opt/homebrew, /Library/DeveloperTools, $HOME/.local, $HOME/.cache. Counterfactual -x cuda -nocudainc -nocudalib removes the drv_no_cuda_* errors but the explicit #include <cuda.h> still fails because the headers genuinely do not exist on this host. This is NOT an nvim/clangd config bug.

What already works on Mac (real LSP, validated headless): documentSymbol=11, go-to-definition on local runKernel1 resolves to matmul/matmul_1.cuh:135, hover on local run_kernel returns a proper markdown signature. Only CUDA-API symbols (cudaMalloc, __nv_bfloat16, cublas*) are unresolved.

Minimal durable fix implemented (does NOT silence diagnostics): helpers/cuda_lsp.lua detects macOS-arm64 + absent toolkit; host_supports_full_cuda() is true only on Linux with a toolkit; on Mac it notifies once per Neovim session that CUDA API LSP needs the homelab/Linux toolkit while confirming local-symbol LSP still works. clangd.lua wires this via an LspAttach autocmd on cuda buffers. No diagnostics suppressed, clangd still attaches so local LSP keeps working. docs/neovim-cuda-lsp.md documents the setup, homelab/Linux requirements (NVIDIA driver + CUDA Toolkit, clangd on PATH, compile_commands.json via bear -- make matmul or cmake, nvim with this config), and the exact homelab validation command + success criteria (docSymbols>=11 AND clang_errors==0). scripts/verify-nvim.lua adds a cuda-lsp smoke case asserting the detection booleans and that notify_if_unsupported is safe + idempotent. AGENTS.md points at the CUDA LSP host invariant.

Approach deliberately ruled out: stubbing CUDA headers or silencing the clangd CUDA diagnostics in dotfiles — that would give incorrect hover/type info (violates the captain's "LSP must work, not be silenced" requirement.

Firstmate accepted decision: ship the Mac partial-LSP graceful-degradation fix on branch fm/h100-cuda-lsp-fix and proceed through the no-mistakes PR path. Homelab/Linux CUDA LSP is a separate future effort, not a blocker for this PR; keep the homelab requirements in docs/neovim-cuda-lsp.md as guidance, not a deliverable.
INTENT
)

## What Changed

- Add `helpers/cuda_lsp.lua` with host-capability detection: `host_supports_full_cuda()` is true only on Linux with a CUDA toolkit, and `notify_if_unsupported()` emits one `WARN` per Neovim session on macOS Apple Silicon without silencing clangd diagnostics.
- Wire `clangd.lua` with an `LspAttach` autocmd that calls `notify_if_unsupported` on `cuda`-filetype buffers, so clangd still attaches and local-symbol LSP (document symbols, local go-to-def/hover) keeps working while CUDA-API symbols stay flagged.
- Add `docs/neovim-cuda-lsp.md` covering the host invariant, homelab/Linux requirements (NVIDIA driver + CUDA Toolkit, clangd, `compile_commands.json` via `bear -- make matmul`), and the validation command with success criteria; record the invariant in `AGENTS.md`, add a `cuda-lsp` smoke case to `scripts/verify-nvim.lua`, and ignore `.tmp/` and `nvim/.config/github-copilot/`.

## Risk Assessment

✅ Low: The change is a small, well-scoped graceful-degradation notification plus docs and a behavioral smoke test; it suppresses no diagnostics, follows the existing LspAttach convention, and introduces no correctness, security, or performance risk.

## Testing

Ran the targeted cuda-lsp smoke test (PASS) and a headless end-to-end validation opening the real vault professor-lesson matmul.cu with the worktree dotfiles config (not live global config), reproducing every user-intent claim: documentSymbol=11, hover on run_kernel yields a markdown signature, go-to-def on runKernel1 resolves to matmul_1.cuh:135, 7 unsilenced clang CUDA errors remain, and the graceful-degradation WARN notification fires exactly once per session (idempotent) with host_supports_full_cuda()=false on macOS arm64. A plain-C control file confirmed the probe methodology was sound (an initial make_position_params() headless bug had falsely shown hover failing; rebuilt positions from nvim_win_get_cursor and re-verified). Evidence transcript saved; worktree left clean at the target commit with transient test artifacts removed.

<details>
<summary>Evidence: CUDA LSP end-to-end validation transcript</summary>

<code>clangd_attached=true filetype=cuda&#10;clangd_root=.../reference/fast.cu&#10;documentSymbol=11 (intent expects 11)&#10;hover(run_kernel@57)=### function `run_kernel` → `void` Parameters: int kernel_num, int M, int N, int K, bf16 * A...&#10;def(runKernel1@63)=matmul_1.cuh:135 (intent expects matmul_1.cuh:135)&#10;hover(main@130)=### function `main` → `int` ```cpp int main() ``` / def(main@130)=matmul.cu:130&#10;clang_errors=7 (intent expects &gt;0 on Mac; NOT silenced)&#10;- Cannot find libdevice for sm_52 ...&#10;- Cannot find CUDA installation; provide path via &#39;--cuda-path&#39; ...&#10;- &#39;cuda.h&#39; file not found&#10;- Unknown type name &#39;__nv_bfloat16&#39;&#10;- Unknown type name &#39;cudaError_t&#39;&#10;host_supports_full_cuda=false / on_macos_apple_silicon=true / toolkit_present=false&#10;warn_fires_first=1 warn_total=1 (idempotent =&gt; total==first)&#10;warn_msg=CUDA toolkit not found on macOS Apple Silicon ... document symbols and local-symbol go-to-def/hover still work. For full CUDA LSP, open these files on the homelab/Linux CUDA toolkit.&#10;# smoke test: scripts/verify-nvim cuda-lsp -&gt; PASS verify-nvim cuda-lsp</code>

```text
# CUDA LSP end-to-end validation — branch fm/h100-cuda-lsp-fix
# host: Darwin 24.6.0 arm64  nvim: NVIM v0.12.4  clangd(mason): clangd version 21.1.8 (https://github.com/llvm/llvm-project 2078da43e25a4623cab2d0d60decddf709aaea28)
# lesson file: /Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/reference/fast.cu/h100/matmul.cu
# config: XDG_CONFIG_HOME=$REPO/nvim/.config (worktree dotfiles, NOT live global)
# command: XDG_CONFIG_HOME=$REPO/nvim/.config nvim --headless $FILE +luafile /tmp/cuda_lsp_consolidated.lua

=== clangd attach ===
clangd_attached=true filetype=cuda
clangd_root=/Users/aviral/.treehouse/vault-278260/2/vault/professor-lessons/h100-matmul-modal/reference/fast.cu
=== local-symbol LSP (intent: 'still works') ===
documentSymbol=11 (intent expects 11)
hover(run_kernel@57)=### function `run_kernel`   |  | --- | → `void`   | Parameters:   | - `int kernel_num` | - `int M` | - `int N` | - `int K` | - `bf16 * A
def(runKernel1@63)=matmul_1.cuh:135 (intent expects matmul_1.cuh:135)
hover(main@130)=### function `main`   |  | --- | → `int`   |  | --- | `` `cpp | int main() | `` `
def(main@130)=matmul.cu:130
=== diagnostics (intent: NOT silenced) ===
clang_errors=7 (intent expects >0 on Mac; errors NOT silenced)
  - Cannot find libdevice for sm_52; provide path to different CUDA installation via '--cuda-path', or pass '-nocu
  - Cannot find CUDA installation; provide its path via '--cuda-path', or pass '-nocudainc' to build without CUDA 
  - 'cuda.h' file not found
  - Unknown type name '__nv_bfloat16'
  - Unknown type name 'cudaError_t'
=== helpers.cuda_lsp graceful-degradation ===
host_supports_full_cuda=false
on_macos_apple_silicon=true
toolkit_present=false
CUDA toolkit not found on macOS Apple Silicon (NVIDIA ships none). clangd will flag CUDA API symbols (cudaMalloc, __nv_bfloat16, cublas*); document symbols and local-symbol go-to-def/hover still work. For full CUDA LSP, open these files on the homelab/Linux CUDA toolkit.
warn_fires_first=1 warn_total=1 (idempotent => total==first)
warn_msg=CUDA toolkit not found on macOS Apple Silicon (NVIDIA ships none). clangd will flag CUDA API symbols (cudaMalloc, __nv_bfloat16, cublas*); document symbols and local-symbol go-to-def/hover still work.

# smoke test: scripts/verify-nvim cuda-lsp
PASS verify-nvim cuda-lsp
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"29003de5711aaef138f27b4240d9bdcd2776988b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `scripts/verify-nvim cuda-lsp`
- `XDG_CONFIG_HOME=$REPO/nvim/.config nvim --headless $LESSON_DIR/h100/matmul.cu +luafile /tmp/cuda_lsp_consolidated.lua (asserts: clangd_attached=true, filetype=cuda, documentSymbol==11, hover(run_kernel@57) -> markdown signature, def(runKernel1@63) -> matmul_1.cuh:135, hover/def(main@130) control, clang_errors==7 not silenced, host_supports_full_cuda==false, notify WARN fires once + idempotent)`
- `XDG_CONFIG_HOME=$REPO/nvim/.config nvim --headless /tmp/plain_ctrl.c +luafile <corrected probe> (methodology control: greet_def hover=OK markdown signature, def=plain_ctrl.c:3 — confirms hover/def work on plain C, isolating the make_position_params() headless bug from real cuda behavior)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `docs/neovim-cuda-lsp.md:4` - Configured formatter prettier (--prose-wrap never, from conform.lua) would unwrap the new doc&#39;s prose into single long lines, which would then violate the project&#39;s own markdownlint AV001 rule (120 visible chars). This is a pre-existing, repo-wide conflict between two configured tools (pre-existing AGENTS.md is likewise non-prettier-conformant), not introduced by this change. The new doc passes the authoritative linter (markdownlint, 0 errors) and matches the repo&#39;s hard-wrapped prose convention. Applying prettier here would break AV001 and rewrite unrelated prose, so it was deliberately not applied. Worth a separate repo-wide follow-up to reconcile conform&#39;s prettier prose-wrap setting with AV001.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
