### PR TITLE
fix(nvim): disable noice duplicate LSP signature-help popup

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -66,3 +66,32 @@ Intermittent OSC52 clipboard errors occur when using Neovide, disrupting copy/pa
 - OSC52 is critical for SSH clipboard sharing functionality
 - Goal is to use Neovide as primary frontend for remote development
 - Error occurs "every now and then" (intermittent)
+
+---
+
+### 3. Duplicated LSP Signature-Help Popup
+
+**Status:** Fixed (branch `fm/nvim-signature-help-dupe`)
+**Severity:** Medium
+**Component:** Neovim LSP / blink.cmp / noice.nvim
+
+**Description:**
+While typing a function call (e.g. `matmul_kernel(A, B,` with clangd attached),
+two signature-help floats rendered simultaneously: a bordered float with
+active-parameter highlight (blink.cmp) and a second unhighlighted float
+(noice.nvim). Both auto-triggered on LSP trigger characters (`(`, `,`).
+
+**Root Cause:**
+`noice.nvim`'s `lsp.signature.auto_open` (enabled by default) and
+`blink.cmp`'s `signature.enabled = true` both auto-request
+`textDocument/signatureHelp` on trigger characters, each rendering its own
+float. The `vim.lsp.handlers["textDocument/signatureHelp"]` override in
+`lsp.lua` (border only) was not the duplicate source — both providers bypass
+the handler with their own callbacks.
+
+**Fix:**
+Disabled noice's signature handler (`lsp.signature.enabled = false` in the
+noice spec in `neovide.lua`). Blink.cmp remains the sole signature-help
+provider, with `treesitter_highlighting = true` (explicit) and
+`border = "rounded"`. The `lsp.lua` handler override is retained for manual
+`<C-k>` triggers.

--- a/nvim/.config/nvim/lua/plugins/blink-cmp.lua
+++ b/nvim/.config/nvim/lua/plugins/blink-cmp.lua
@@ -123,6 +123,7 @@ return {
         enabled = true,
         window = {
           border = "rounded",
+          treesitter_highlighting = true,
         },
       },
     },

--- a/nvim/.config/nvim/lua/plugins/neovide.lua
+++ b/nvim/.config/nvim/lua/plugins/neovide.lua
@@ -78,6 +78,12 @@ return {
       { "<C-b>", false, mode = { "n", "i", "s" } },
     },
     opts = function(_, opts)
+      -- Disable noice's signature help. blink.cmp provides the sole
+      -- signature-help popup (tree-sitter highlighted, active-parameter
+      -- highlight). Without this, both noice and blink.cmp auto-trigger
+      -- on LSP trigger characters and render stacked duplicate floats.
+      opts.lsp = opts.lsp or {}
+      opts.lsp.signature = vim.tbl_deep_extend("force", opts.lsp.signature or {}, { enabled = false })
       opts.routes = opts.routes or {}
       table.insert(opts.routes, {
         filter = {


### PR DESCRIPTION
> **Cost:** 3 files changed, 36 insertions, 0 deletions. Two config lines + BUGS.md entry.

## Intent

Fix duplicated LSP signature-help popup in Neovim. Two floats appeared while typing function calls: blink.cmp's bordered float and noice's unhighlighted duplicate.

## What Changed

- Disabled noice's `lsp.signature` handler entirely
- Set blink.cmp `treesitter_highlighting = true` explicitly
- Retained `lsp.lua` border override for manual `<C-k>`
- Documented root cause and fix in `BUGS.md` issue #3

## Root Cause

Noice and blink.cmp both auto-trigger `textDocument/signatureHelp` on LSP trigger characters, each rendering its own float. The `lsp.lua` handler override was not the duplicate source — both providers bypass it with their own callbacks.

## Testing

- Verified noice signature autocmds are absent (no auto-trigger)
- Verified `vim.lsp.buf.signature_help` is native (noice override removed)
- Verified blink.cmp signature enabled with tree-sitter highlighting
- Verified `lsp.lua` handler override still applied for manual triggers
- Confirmed cpp and lua tree-sitter parsers installed for highlighting

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"17e33582b9d7f785cab2dd555d6f6a194c9bafbf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ Disabling noice's `lsp.signature` handler is the correct minimal fix for the duplicated signature-help popup. With noice's handler off, blink.cmp remains the sole auto-trigger provider with tree-sitter highlighting and active-parameter highlight, and `lsp.lua`'s manual `<C-k>` border override is unaffected.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
