### PR TITLE
feat(nvim): mermaid ASCII render via mmdflux + <leader>mm

### DIFF
--- a/docs/neovim-mermaid-render.md
+++ b/docs/neovim-mermaid-render.md
@@ -23,6 +23,33 @@ If `mmdflux` is not on `$PATH`, `<leader>mm` shows
 `mmdflux not installed — see docs/neovim-mermaid-render.md` instead of erroring.
 Nothing auto-installs.
 
+## 80-column width cap
+
+The rendered ASCII/Unicode grid is capped at **80 columns**. mmdflux has no
+documented `--width`/`--columns`/`--term-width` flag; it auto-detects width
+(via `COLUMNS` env or tty size, falling back to a default when stdin is a
+pipe — which is our case). The helper enforces the cap by spawning mmdflux
+with `COLUMNS=80` (and `TERM` preserved) in the `vim.system` env:
+
+```lua
+vim.system({ "mmdflux" }, {
+  stdin = body,
+  env = { COLUMNS = "80", TERM = vim.env.TERM or "xterm-256color" },
+})
+```
+
+The Snacks float width is also clamped to 80 columns so the terminal doesn't
+widen past the rendered art. The cap applies to the v1 on-demand float; any
+future v2 inline render must apply the same `COLUMNS=80` env when spawning
+mmdflux.
+
+**Captain action after install:** run `mmdflux --help` and check for an
+explicit `--width`/`--columns`/`--term-width` flag. If one exists, prefer it
+over the `COLUMNS` env var and update `helpers/mermaid_render.lua` + this doc.
+If mmdflux ignores `COLUMNS` and queries the tty instead (stdin is a pipe, so
+it likely falls back to `COLUMNS` or a default), report that here and switch to
+the flag or a pty wrapper.
+
 ## Install `mmdflux` (captain's step — not auto-installed by this config)
 
 `mmdflux` reads mermaid from stdin and writes ASCII/Unicode (ANSI-colored) to

--- a/docs/neovim-mermaid-render.md
+++ b/docs/neovim-mermaid-render.md
@@ -1,0 +1,87 @@
+# Neovim Mermaid rendering (mmdflux ASCII path)
+
+Mermaid ```` ```mermaid ```` fences render to **ASCII/Unicode art** inside Neovim
+via the [`mmdflux`](https://github.com/kevinswiber/mmdflux) binary — a single
+static Rust binary, **no Node, no headless Chromium, no ImageMagick**. This is
+the v1 surface; the inline-image upgrade is deferred (see
+[Deferred image upgrade](#deferred-image-upgrade) below).
+
+## Surface
+
+- **`<leader>mm`** (defined in `nvim/.config/nvim/lua/plugins/markdown.lua`,
+  render-markdown.nvim `keys` table): with the cursor inside (or on) a
+  ```` ```mermaid ```` fence, runs `mmdflux` on that fence's body and pops the
+  ASCII/Unicode output in a **Snacks terminal float** titled `mermaid render`.
+  The float is a `:terminal` buffer so the terminal driver renders mmdflux's
+  ANSI color (from `classDef`/`linkStyle`) natively. Close with `q` or `<esc>`.
+- Helper: `nvim/.config/nvim/lua/helpers/mermaid_render.lua`. It reuses the
+  treesitter fenced-code-block walk from `helpers/markdown_ansi.lua` (matching
+  `mermaid` instead of `ansi`) and pipes the fence body to
+  `vim.system({ "mmdflux" }, { stdin = body })`.
+
+If `mmdflux` is not on `$PATH`, `<leader>mm` shows
+`mmdflux not installed — see docs/neovim-mermaid-render.md` instead of erroring.
+Nothing auto-installs.
+
+## Install `mmdflux` (captain's step — not auto-installed by this config)
+
+`mmdflux` reads mermaid from stdin and writes ASCII/Unicode (ANSI-colored) to
+stdout. Covers flowchart, class, sequence, state — all of the vault's current
+fences (4 flowcharts).
+
+**macOS (Homebrew):**
+```sh
+brew tap kevinswiber/mmdflux
+brew install mmdflux
+```
+
+**Linux (homelab) / macOS without Homebrew — prebuilt static binary from GitHub
+releases** (covers `linux-x86_64` and `darwin-arm64`):
+```sh
+# Pick the matching tarball from https://github.com/kevinswiber/mmdflux/releases
+ver=v2.6.1          # latest as of writing; check the releases page
+curl -L "https://github.com/kevinswiber/mmdflux/releases/download/${ver}/mmdflux-${ver}-linux-x86_64.tar.gz" | tar xz
+sudo install -m 0755 mmdflux /usr/local/bin/mmdflux
+```
+
+Verify:
+```sh
+echo 'flowchart TD\n  A --> B' | mmdflux
+```
+
+## Validation
+
+After install, open any vault file with a ```` ```mermaid ```` fence (scout
+report §2 lists 4, all flowcharts — `1_projects/.../lab01-cuda-mma/lesson.md`,
+`.../plan.md`, `professor-lessons/h100-matmul-modal/session.md`,
+`3_logs/2025-W50/solver_pool_architecture.md`), place the cursor on the fence,
+and press `<leader>mm`. The float should show the rendered graph with ANSI
+color. The `lesson.md` fence (10-node DAG, `<br/>` multi-line labels,
+branching/joining edges) is the strongest shape test.
+
+## Deferred image upgrade (later, out of scope for v1)
+
+A higher-fidelity inline-image path exists and is the intended eventual upgrade,
+**gated on Herdr's `kitty_graphics` flag graduating from experimental**. It is
+deliberately NOT shipped here. When the flag graduates, the upgrade is:
+
+1. **Herdr config:** `[experimental] kitty_graphics = true` in
+   `~/.config/herdr/config.toml`, then `herdr server reload-config` (or restart).
+   Today this flag is "experimental and disabled by default … enable it only
+   when testing terminal image behavior" (`herdr.dev/docs/configuration`).
+2. **Homelab deps:** `npm install -g @mermaid-js/mermaid-cli` (Node already
+   present) + ImageMagick. `mmdc` emits SVG; ImageMagick converts SVG→PNG for
+   the kitty graphics protocol.
+3. **nvim:** enable the Snacks `image` module in the existing Snacks lazy spec
+   — an `opts` change only (Snacks is already on disk as a dependency for the
+   pickers). Snacks Image has a built-in `convert.mermaid` handler that renders
+   ```` ```mermaid ```` fences inline via `mmdc`→SVG→ImageMagick→PNG, overlaid
+   with a kitty-graphics `U+10EEEE` Unicode placeholder. Covers **all** diagram
+   types (flowchart, sequence, state, ER, gantt, …) pixel-perfect.
+4. **Validate:** `:checkhealth snacks` → `ghostty ✓`, `mmdc ✓`, `magick ✓`,
+   kitty graphics ✓. Ripcord for pivoting back to the ASCII path: escapes never
+   reach Ghostty with the flag on and all deps green; degraded modes
+   (stale-on-reattach, slow cold start) are livable, not pivot triggers.
+
+This ASCII path remains the fallback for copy-pasteable text art and for any
+environment where the image path is unavailable.

--- a/nvim/.config/nvim/lua/helpers/mermaid_render.lua
+++ b/nvim/.config/nvim/lua/helpers/mermaid_render.lua
@@ -110,7 +110,16 @@ function M.render_float()
     return
   end
 
-  local result = vim.system({ "mmdflux" }, { stdin = body, text = true }):wait()
+  -- Cap the rendered grid at 80 columns: mmdflux has no documented --width
+  -- flag and auto-detects width (COLUMNS env / tty size, falling back to a
+  -- default when stdin is a pipe). Set COLUMNS=80 so the piped-stdin path
+  -- targets an 80-column grid; keep TERM so color/width queries resolve. If a
+  -- future mmdflux release adds an explicit --width/--columns/--term-width
+  -- flag, prefer that over the env var (see docs/neovim-mermaid-render.md).
+  local result = vim.system(
+    { "mmdflux" },
+    { stdin = body, text = true, env = { COLUMNS = "80", TERM = vim.env.TERM or "xterm-256color" } }
+  ):wait()
   if result.code ~= 0 then
     vim.notify("mmdflux failed (exit " .. result.code .. "): " .. (result.stderr or ""), vim.log.levels.ERROR)
     return
@@ -131,7 +140,9 @@ function M.render_float()
 
   local win = Snacks.win({
     title = " mermaid render ",
-    width = 0.8,
+    -- Match the 80-column mmdflux grid (COLUMNS=80 above) so the terminal
+    -- float doesn't widen past the rendered art.
+    width = math.min(80, math.floor(vim.o.columns * 0.8)),
     height = 0.8,
     bo = { bufhidden = "wipe" },
     wo = { number = false, relativenumber = false, signcolumn = "no" },

--- a/nvim/.config/nvim/lua/helpers/mermaid_render.lua
+++ b/nvim/.config/nvim/lua/helpers/mermaid_render.lua
@@ -1,0 +1,163 @@
+-- Mermaid → ASCII/Unicode rendering via the `mmdflux` binary.
+--
+-- Reuses the treesitter fenced-code-block walk from helpers/markdown_ansi.lua
+-- (content_node / language / visit pattern) but matches `mermaid` fences and
+-- pipes the fence body to `mmdflux` (reads mermaid from stdin). The v1 surface
+-- is an on-demand Snacks float bound to `<leader>mm` (see plugins/markdown.lua).
+--
+-- Why a `:terminal` float instead of parsing ANSI into nvim highlights:
+-- mmdflux emits ANSI color for `classDef`/`linkStyle` (SGR, 256-color, possibly
+-- truecolor). A :terminal buffer is a real terminal emulator that renders all
+-- of that natively for free; reusing markdown_ansi.lua's SGR→highlight parser
+-- would mean coupling to its mark-generation shape for a one-off float. The
+-- terminal is the cleaner, higher-fidelity choice for the float surface.
+--
+-- The deferred image upgrade (Herdr `kitty_graphics=true` + Snacks Image +
+-- mmdc + ImageMagick) is documented in docs/neovim-mermaid-render.md and is
+-- out of scope here.
+
+local M = {}
+
+-- Mirror of helpers/markdown_ansi.lua content_node / language helpers (kept
+-- local so this helper stands alone without requiring markdown_ansi to load).
+
+local function language(node, buf)
+  for child in node:iter_children() do
+    if child:type() == "info_string" then
+      return vim.trim(vim.treesitter.get_node_text(child, buf))
+    end
+  end
+end
+
+local function content_node(node)
+  for child in node:iter_children() do
+    if child:type() == "code_fence_content" then
+      return child
+    end
+  end
+end
+
+---Find the `mermaid` fenced_code_block node containing 0-indexed buffer row `row`.
+---@param buf integer
+---@param row integer
+---@return TSNode|nil
+local function mermaid_fence_at(buf, row)
+  local parser = vim.treesitter.get_parser(buf, "markdown")
+  local trees = parser:parse()
+  local root = trees[1] and trees[1]:root()
+  if not root then
+    return nil
+  end
+
+  local function walk(node)
+    if node:type() == "fenced_code_block" and language(node, buf) == "mermaid" then
+      local start_row, _, end_row = node:range()
+      if row >= start_row and row <= end_row then
+        return node
+      end
+    end
+    for child in node:iter_children() do
+      local found = walk(child)
+      if found then
+        return found
+      end
+    end
+    return nil
+  end
+
+  return walk(root)
+end
+
+---Extract the body text of a fenced_code_block (between the info string and the
+---closing fence), mirroring markdown_ansi.lua's line-slice logic.
+---@param buf integer
+---@param node TSNode
+---@return string|nil
+local function fence_body(buf, node)
+  local content = content_node(node)
+  if not content then
+    return nil
+  end
+  local start_row, _, end_row, end_col = content:range()
+  local lines = vim.api.nvim_buf_get_lines(buf, start_row, end_row + (end_col > 0 and 1 or 0), false)
+  return table.concat(lines, "\n")
+end
+
+---On-demand: run mmdflux on the mermaid fence under the cursor and pop the
+---ANSI/Unicode output in a Snacks terminal float (`<leader>mm`).
+function M.render_float()
+  if vim.bo.filetype ~= "markdown" and vim.bo.filetype ~= "octo" then
+    vim.notify("mermaid render: not a markdown buffer", vim.log.levels.INFO)
+    return
+  end
+
+  if vim.fn.executable("mmdflux") == 0 then
+    vim.notify("mmdflux not installed — see docs/neovim-mermaid-render.md", vim.log.levels.WARN)
+    return
+  end
+
+  local buf = vim.api.nvim_get_current_buf()
+  local row = vim.api.nvim_win_get_cursor(0)[1] - 1
+  local node = mermaid_fence_at(buf, row)
+  if not node then
+    vim.notify("cursor is not inside a ```mermaid fence", vim.log.levels.INFO)
+    return
+  end
+
+  local body = fence_body(buf, node)
+  if not body or body == "" then
+    vim.notify("mermaid fence is empty", vim.log.levels.INFO)
+    return
+  end
+
+  local result = vim.system({ "mmdflux" }, { stdin = body, text = true }):wait()
+  if result.code ~= 0 then
+    vim.notify("mmdflux failed (exit " .. result.code .. "): " .. (result.stderr or ""), vim.log.levels.ERROR)
+    return
+  end
+
+  local out = result.stdout or ""
+  if out == "" then
+    vim.notify("mmdflux produced no output", vim.log.levels.WARN)
+    return
+  end
+
+  -- Hand the captured ANSI to a :terminal float so the terminal driver renders
+  -- SGR/256-color natively. vim.system already captured stdout; we re-emit it
+  -- through `cat` so the pty interprets the escapes (writing ANSI text directly
+  -- into a buffer does NOT get interpreted by the terminal emulator).
+  local tmp = vim.fn.tempname()
+  vim.fn.writefile(vim.split(out, "\n", { plain = true }), tmp)
+
+  local win = Snacks.win({
+    title = " mermaid render ",
+    width = 0.8,
+    height = 0.8,
+    bo = { bufhidden = "wipe" },
+    wo = { number = false, relativenumber = false, signcolumn = "no" },
+  })
+
+  vim.fn.termopen({ "cat", tmp }, {
+    on_exit = function(_, code)
+      vim.fn.delete(tmp)
+      if code ~= 0 then
+        vim.schedule(function()
+          win:close()
+          vim.notify("mermaid render: display failed", vim.log.levels.ERROR)
+        end)
+      end
+    end,
+  })
+
+  local function close()
+    win:close()
+  end
+  vim.keymap.set("n", "q", close, { buffer = win.buf, nowait = true, silent = true })
+  vim.keymap.set("n", "<esc>", close, { buffer = win.buf, nowait = true, silent = true })
+  vim.keymap.set("t", "q", close, { buffer = win.buf, nowait = true, silent = true })
+  vim.keymap.set("t", "<esc>", close, { buffer = win.buf, nowait = true, silent = true })
+
+  vim.cmd("startinsert")
+end
+
+return M

--- a/nvim/.config/nvim/lua/plugins/markdown.lua
+++ b/nvim/.config/nvim/lua/plugins/markdown.lua
@@ -533,6 +533,16 @@ return {
         end,
         desc = "Find outgoing links from current note",
       },
+      -- <leader>mm = mermaid: render the ```mermaid fence under the cursor to
+      -- ASCII/Unicode via the `mmdflux` binary and pop it in a Snacks float.
+      -- See helpers/mermaid_render.lua and docs/neovim-mermaid-render.md.
+      {
+        "<leader>mm",
+        function()
+          require("helpers.mermaid_render").render_float()
+        end,
+        desc = "Render mermaid fence (mmdflux ASCII)",
+      },
     },
     ---@module 'render-markdown'
     ---@type render.md.UserConfig


### PR DESCRIPTION
## What

Ships the **mmdflux-ASCII-first v1** of mermaid rendering into Neovim, per the revised captain decision (grill report strand 6). The image path (Snacks Image + mmdc + ImageMagick + Herdr `kitty_graphics`) is **deferred** to a later upgrade gated on Herdr's flag graduating from experimental.

## Changes (3 files)

- **`nvim/.config/nvim/lua/helpers/mermaid_render.lua`** (new, ~130 lines) — reuses the treesitter fenced-code-block walk from `helpers/markdown_ansi.lua` (`content_node` at `markdown_ansi.lua:225-231`, `language` at `:234-240`, `visit` at `:244-269`), matching `mermaid` instead of `ansi`. Extracts the fence under the cursor, pipes the body to `vim.system({ "mmdflux" }, { stdin = body })`, and pops the output in a Snacks terminal float titled `mermaid render` (`bufhidden=wipe`, close on `q`/`<esc>`).
- **`nvim/.config/nvim/lua/plugins/markdown.lua`** — `<leader>mm` added to the render-markdown.nvim `keys` table (mnemonic: **m**ermaid), just before the `opts` block at `:537`. `custom_handlers` at `:541-546` (the ANSI handler) is untouched.
- **`docs/neovim-mermaid-render.md`** (new) — install note (Homebrew tap `kevinswiber/mmdflux` + `brew install mmdflux`, or prebuilt `mmdflux-vX.Y.Z-linux-x86_64.tar.gz` / `-darwin-arm64.tar.gz` covering homelab + Mac; single static Rust binary, no Node/Chromium/ImageMagick), the `<leader>mm` surface, and the deferred image upgrade documented as a future step gated on Herdr `kitty_graphics`.

## Design choice: `:terminal` float vs ANSI→highlight parsing

mmdflux emits ANSI color for `classDef`/`linkStyle`. The float is a `:terminal` buffer running `cat` over the captured stdout, so Neovim's built-in terminal emulator renders all SGR / 256-color / truecolor natively for free. The alternative — reusing `markdown_ansi.lua`'s SGR parser (`apply_sgr` at `:54-139`, `group_for` at `:160-175`) to convert ANSI into nvim highlight groups in a normal scratch buffer — would mean coupling to its mark-generation shape for a one-off float and would cap fidelity at what nvim highlights express. The terminal is the cleaner, higher-fidelity choice for the float surface. (The ANSI→highlight parser stays the right tool for an inline virtual-line render, which is the optional v2 stretch and is **not** shipped here.)

## v2 (stretch, not shipped)

Extending `render-markdown.nvim` `custom_handlers` with a `mermaid` handler that renders mmdflux output inline as virtual lines (mirroring `markdown_ansi.lua`), with a content-hash cache per fence, is a natural follow-up. It is riskier/larger (virtual-line layout + render-markdown mark contract + cache invalidation on edit) and is out of scope for this focused v1. Noted as a follow-up.

## Validation

- **Lua load:** `nvim --headless -u NONE -c "luafile lua/helpers/mermaid_render.lua" -c "qa"` → clean. The exact CI gate (`loadfile` parse-only) passes on both touched lua files.
- **mmdflux live smoke:** skipped — `mmdflux` is not on PATH in the worktree (captain installs it per the setup note; this ship is config+helper+keybind+doc only, no homelab install).
- **Fence-walk coverage:** confirmed against all 4 real vault mermaid fences (scout report §2; all flowcharts): `1_projects/.../lab01-cuda-mma/lesson.md` (10-node DAG, `<br/>` multi-line labels, branching/joining edges), `.../plan.md` (linear chain), `professor-lessons/h100-matmul-modal/session.md`, `3_logs/2025-W50/solver_pool_architecture.md` (state-machine with labeled `-->|...|` edges). All are standard `fenced_code_block` nodes with `mermaid` info strings — the walk handles them.
- **No regressions:** `markdown_ansi.lua` and its `custom_handlers` registration (`:541-546`) untouched; no `<leader>m*` keybind collision (only pre-existing `<leader>mu` in `helpers/markdown_links.lua:143`).
- **Scope:** `git status` shows only the new helper + the `markdown.lua` keybind edit + the setup note.

## Out of scope (per brief)

No image path (Snacks Image / mmdc / kitty_graphics), no Herdr config change, no `mmdflux` install on the homelab (captain's step), no vault/firstmate/live-session touches.

## Merge

Do not merge — relayed to the configured merge authority per the direct-PR posture.