### PR TITLE
mermaid render: drop dead COLUMNS=80, size float to natural width with horizontal scroll

### DIFF
--- a/docs/neovim-mermaid-render.md
+++ b/docs/neovim-mermaid-render.md
@@ -23,32 +23,40 @@ If `mmdflux` is not on `$PATH`, `<leader>mm` shows
 `mmdflux not installed — see docs/neovim-mermaid-render.md` instead of erroring.
 Nothing auto-installs.
 
-## 80-column width cap
+## Natural width + horizontal scroll (no width cap)
 
-The rendered ASCII/Unicode grid is capped at **80 columns**. mmdflux has no
-documented `--width`/`--columns`/`--term-width` flag; it auto-detects width
-(via `COLUMNS` env or tty size, falling back to a default when stdin is a
-pipe — which is our case). The helper enforces the cap by spawning mmdflux
-with `COLUMNS=80` (and `TERM` preserved) in the `vim.system` env:
+mmdflux renders at the **graph's natural width** — it has no
+`--width`/`--columns`/`--term-width` flag (`mmdflux --help` confirms) and
+**ignores both `COLUMNS` env and tty winsize** when stdin is a pipe (which is
+our case). Empirically, the 4 real vault fences render at 51–372 visible
+columns (`flowchart LR` layouts run widest); 3 of 4 exceed 80.
+
+Because there is no width flag, the helper does **not** pass `COLUMNS` (an
+earlier `COLUMNS=80` env was a no-op and has been removed); only `TERM` is
+preserved so color queries resolve:
 
 ```lua
 vim.system({ "mmdflux" }, {
   stdin = body,
-  env = { COLUMNS = "80", TERM = vim.env.TERM or "xterm-256color" },
+  env = { TERM = vim.env.TERM or "xterm-256color" },
 })
 ```
 
-The Snacks float width is also clamped to 80 columns so the terminal doesn't
-widen past the rendered art. The cap applies to the v1 on-demand float; any
-future v2 inline render must apply the same `COLUMNS=80` env when spawning
-mmdflux.
+The Snacks float is sized to the diagram's natural width (visible columns,
+ANSI SGR stripped), capped at the editor width so the float never overflows
+the screen. Narrow graphs get a narrow float; wide graphs fill the editor.
+The float window is opened with `wrap = false`, so a diagram wider than the
+window scrolls **left/right** (`zl`/`zh`, or the terminal's own scroll)
+instead of wrapping at the edge. No output is truncated.
 
-**Captain action after install:** run `mmdflux --help` and check for an
-explicit `--width`/`--columns`/`--term-width` flag. If one exists, prefer it
-over the `COLUMNS` env var and update `helpers/mermaid_render.lua` + this doc.
-If mmdflux ignores `COLUMNS` and queries the tty instead (stdin is a pipe, so
-it likely falls back to `COLUMNS` or a default), report that here and switch to
-the flag or a pty wrapper.
+Note: because the float is a `:terminal` buffer, the pty column count tracks
+the window width, so a diagram wider than the editor still wraps at the
+editor edge inside the terminal. That is the inherent limit of the `:terminal`
+path; for a true hard cap on ultra-wide `LR` layouts, the real fix is an
+upstream `--width` flag on `kevinswiber/mmdflux` — a feature request the
+captain can file if a hard cap is ever wanted. (A scratch-buffer path would
+preserve unlimited horizontal scroll but loses mmdflux's native ANSI color,
+which is the reason the v1 chose `:terminal`.)
 
 ## Install `mmdflux` (captain's step — not auto-installed by this config)
 

--- a/nvim/.config/nvim/lua/helpers/mermaid_render.lua
+++ b/nvim/.config/nvim/lua/helpers/mermaid_render.lua
@@ -110,15 +110,16 @@ function M.render_float()
     return
   end
 
-  -- Cap the rendered grid at 80 columns: mmdflux has no documented --width
-  -- flag and auto-detects width (COLUMNS env / tty size, falling back to a
-  -- default when stdin is a pipe). Set COLUMNS=80 so the piped-stdin path
-  -- targets an 80-column grid; keep TERM so color/width queries resolve. If a
-  -- future mmdflux release adds an explicit --width/--columns/--term-width
-  -- flag, prefer that over the env var (see docs/neovim-mermaid-render.md).
+  -- mmdflux renders at the graph's natural width: it has no --width flag
+  -- (`mmdflux --help` confirms) and ignores both COLUMNS env and tty winsize
+  -- when stdin is a pipe. So we do NOT pass COLUMNS (it was a no-op); only
+  -- TERM is preserved so color queries resolve. The float is sized to fit the
+  -- output up to the editor width, and `wrap = false` lets the user scroll
+  -- left/right (zl/zh) for diagrams wider than the window instead of wrapping
+  -- (see docs/neovim-mermaid-render.md).
   local result = vim.system(
     { "mmdflux" },
-    { stdin = body, text = true, env = { COLUMNS = "80", TERM = vim.env.TERM or "xterm-256color" } }
+    { stdin = body, text = true, env = { TERM = vim.env.TERM or "xterm-256color" } }
   ):wait()
   if result.code ~= 0 then
     vim.notify("mmdflux failed (exit " .. result.code .. "): " .. (result.stderr or ""), vim.log.levels.ERROR)
@@ -138,14 +139,30 @@ function M.render_float()
   local tmp = vim.fn.tempname()
   vim.fn.writefile(vim.split(out, "\n", { plain = true }), tmp)
 
+  -- Size the float to the diagram's natural width (strip ANSI SGR to measure
+  -- visible columns), capped at the editor width minus border room. Narrow
+  -- graphs get a narrow float; wide ones fill the editor and scroll via
+  -- `wrap = false` rather than being clamped/wrapped at a fixed 80.
+  local visual = out:gsub("\x1b%[[0-9;]*m", "")
+  local max_w = 1
+  for line in visual:gmatch("[^\n]*") do
+    max_w = math.max(max_w, vim.fn.strdisplaywidth(line))
+  end
+  local width = math.min(math.max(1, vim.o.columns - 2), max_w)
+
   local win = Snacks.win({
     title = " mermaid render ",
-    -- Match the 80-column mmdflux grid (COLUMNS=80 above) so the terminal
-    -- float doesn't widen past the rendered art.
-    width = math.min(80, math.floor(vim.o.columns * 0.8)),
+    width = width,
     height = 0.8,
     bo = { bufhidden = "wipe" },
-    wo = { number = false, relativenumber = false, signcolumn = "no" },
+    wo = {
+      number = false,
+      relativenumber = false,
+      signcolumn = "no",
+      -- Show the full natural-width art; long lines scroll left/right
+      -- (zl/zh) instead of wrapping at the window edge.
+      wrap = false,
+    },
   })
 
   vim.fn.termopen({ "cat", tmp }, {


### PR DESCRIPTION
Follow-up to #181 (mermaid-mmdflux-nvim). mmdflux has **no width control** — it has no \`--width\`/\`--columns\`/\`--term-width\` flag (\`mmdflux --help\` confirms) and ignores both \`COLUMNS\` env and tty winsize when stdin is a pipe, rendering at the graph's natural width. The captain's 4 real vault fences render at 51–372 visible columns; 3 of 4 exceed 80. The shipped \`COLUMNS=80\` env was a no-op, and the float was clamped to 80 cols, which wrapped wider diagrams.

## Changes

### \`helpers/mermaid_render.lua\`
- **Removed the no-op \`COLUMNS=80\` env** from the \`vim.system({ 'mmdflux' }, ...)\` spawn (the old env was at the spawn ~line 124 pre-edit; mmdflux ignores it). \`TERM\` is preserved so color queries resolve. No width-related env or flag added (none exists).
- **Float sized to natural width, not clamped to 80.** The old clamp was \`width = math.min(80, math.floor(vim.o.columns * 0.8))\`. The new code measures the diagram's visible columns (ANSI SGR stripped via \`out:gsub(\"\\\\x1b%[[0-9;]*m\", \"\")\`, then \`vim.fn.strdisplaywidth\` per line) and sizes the float to \`min(editor columns − 2, max line width)\` — narrow graphs get a narrow float, wide graphs fill the editor.
- **\`wo.wrap = false\`** on the float window so a diagram wider than the window scrolls left/right (\`zl\`/\`zh\`) instead of wrapping at the edge. No output is truncated.
- Unchanged from #181: treesitter fence walk (\`mermaid_fence_at\`/\`fence_body\`), the \`:terminal\` float choice for native ANSI color, \`<leader>mm\`, the graceful \`mmdflux not installed\` notice, and \`q\`/\`<esc>\` close.

### \`docs/neovim-mermaid-render.md\`
- Replaced the \"80-column width cap\" section with an honest **natural width + horizontal scroll** note: mmdflux renders at natural width (no flag exists), the float is sized to fit it (capped at editor width) with \`wrap = false\`, and wide \`LR\` diagrams scroll rather than wrap. Documents the inherent \`:terminal\` pty-width limit (a diagram wider than the editor still wraps at the editor edge inside the terminal) and points to an upstream \`--width\` flag on \`kevinswiber/mmdflux\` as the real hard-cap fix if the captain ever wants one. Notes the earlier \`COLUMNS=80\` env was removed because it was a no-op.

## Validation
- \`nvim --headless -u NONE -c \"luafile nvim/.config/nvim/lua/helpers/mermaid_render.lua\" -c \"qa\"\` → exit 0 (loads clean).
- \`grep -n COLUMNS nvim/.config/nvim/lua/helpers/mermaid_render.lua\` → only comment lines explaining why it is **not** used; no functional use.
- \`grep -n wrap …mermaid_render.lua\` → \`wrap = false\` present on the float \`wo\`.
- \`git status\` shows only the helper + the doc edit.

mmdflux was not run live (crewmate worktree is isolated; the binary is on the homelab only).

## Structural citations (pre-edit line numbers in \`mermaid_render.lua\`)
- \`COLUMNS=80\` env spawn: the \`vim.system({ 'mmdflux' }, { stdin = body, text = true, env = { COLUMNS = '80', TERM = ... } })\` block.
- Float width clamp to 80: \`width = math.min(80, math.floor(vim.o.columns * 0.8))\` in the \`Snacks.win({ ... })\` call.
- Float \`wo\` (where \`wrap = false\` was added): the \`wo = { number = false, relativenumber = false, signcolumn = 'no' }\` table.