### PR TITLE
fix(run-command): restore Neovim output auto-capture

### DIFF
--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -5,7 +5,7 @@ description:
   learning locks in and is understood, not memorized. Use ANY time the user
   wants to learn something hands-on — a tool, a subsystem, a codebase — or
   mentions "professor", "teach me", or "tutor". Based on two teaching principles
-  he has personally verified to work for years. The human types every command
+  he has personally verified to work for years. The human drives every command
   himself; you probe the edges of his knowledge, research and plan the lesson,
   then teach node by node through quizzes, guided commands, and code fixes.
   Provides a **svelte**, well rendered markdown experience for the learner.
@@ -283,11 +283,12 @@ precision.
 
 Hands-on verification — delivered through the **`run-command` extension tool**
 (`pi/.pi/agent/extensions/run-command.ts`). A floating panel above the prompt
-shows the command; he presses `y` to copy it as-is, runs it in his own terminal,
-pastes the output into the response field, and submits. You receive the command
-and his pasted output **together** — grading = output vs. your grounded
-prediction (see Grounding predictions). You never execute the command yourself;
-him typing and running everything is the point.
+supports two user-driven paths: `y` copies the command for manual execution and
+pasted output; `r` runs it in a visible Neovim `:term dm` pane and automatically
+captures output plus exit status. You receive the command and observed output
+**together** — grading = output vs. your grounded prediction (see Grounding
+predictions). Prefer `y` when typing the command is part of the lesson; use `r`
+when observing and interpreting its result is the learning target.
 
 If his output differs from the prediction, that mismatch is diagnostic gold:
 either host state drifted or your model was wrong — find out which. A submission

--- a/pi/.pi/agent/extensions/run-command.ts
+++ b/pi/.pi/agent/extensions/run-command.ts
@@ -197,8 +197,15 @@ async function waitForTerminalJob(socket: string, bufId: number, signal: AbortSi
 	throw new Error("Timed out waiting for `:term dm` terminal job");
 }
 
+// Read a buffer's lines back as one newline-joined string. The join separator
+// MUST be the Lua escape `\n` (written `\\n` in this template literal), NOT a
+// raw newline: the chunk travels JS template -> JSON.stringify (-> `\n`) ->
+// Vim double-quoted string in `--remote-expr`, and Vim unescapes `\n` back to a
+// raw newline. A raw newline inside a Lua short-string literal is a syntax
+// error, so `load(...)` returns nil and `load(...)()` throws "attempt to call a
+// nil value". See issue #184.
 async function readNvimBuffer(socket: string, bufId: number, signal: AbortSignal): Promise<string> {
-	return nvimLua(socket, `return table.concat(vim.api.nvim_buf_get_lines(${bufId}, 0, -1, false), "\n")`, signal);
+	return nvimLua(socket, `return table.concat(vim.api.nvim_buf_get_lines(${bufId}, 0, -1, false), "\\n")`, signal);
 }
 
 // Find an already-open nvim the captain can see (e.g. a `/nvim` split in this


### PR DESCRIPTION
> **Pi-agent cost:** $1.02
> **no-mistakes pipeline:** 273,469 input, 37,171 output, 2,574,336 cache-read, 0 reasoning tokens across 4 steps (model: not recorded)

## Intent

Fix the `r` auto-capture path in the run-command extension (issue #184, regressed by PR #183). Pressing `r` threw `Vim:E5108: attempt to call a nil value` and never auto-submitted output, leaving the captain at manual copy/paste.

Root cause (confirmed empirically against a headless nvim): `readNvimBuffer` embedded a raw newline in its Lua chunk; after JS template → `JSON.stringify` → Vim double-quoted string in `--remote-expr`, Vim unescapes `\n` back to a raw newline that lands **inside** a Lua short-string literal — a syntax error, so `load(...)` returns nil and `load(...)()` throws.

Fix: write the Lua `\n` escape (as `\\n` in the JS template literal) so it survives the JS → JSON → Vim round trip. Both the float and split capture paths share `readNvimBuffer`, so this one-line escaping change repairs both. Verified empirically and by the pipeline's baseline-vs-target e2e test.

## What Changed

- Preserve the Lua `\n` separator when reading Neovim buffers (#184).
- Restore floating and split terminal auto-capture.
- Align professor guidance: manual execution vs Neovim auto-capture.

## Risk Assessment

✅ Low: the focused escaping change restores the required Lua newline representation at the shared buffer-read path without altering other behavior.

## Testing

After supplying the host `JITI_PATH` and widening headless Neovim to avoid test-only marker wrapping, focused helper tests passed and the extension-loaded `r` path reproduced `E5108` on the base commit but auto-submitted stdout, stderr, and exit 7 on the target. No screenshot — this RPC escaping fix changes no visual layout.

<details>
<summary>Evidence: Baseline failure and fixed r auto-capture transcript</summary>

`Base: Vim:E5108 and cancelled capture. Target: status=answered, autoRun=true, exitCode=7, capturedOutput="alpha\nbeta\nstderr-line".`

```text
BASELINE run-command.ts @ c1132bc466343ed281462516b755f76179bd6e0b
status=cancelled
  │  Neovim run failed: Command failed: nvim --server /tmp/pi-r-517378-baseline.sock --remote-expr luaeval("load(...)()", "return table.concat(vim.api.nvim_buf_get_lines(2, 0, -1, false), \"\n\")")                                        │
  │  Lua: Vim:E5108: Lua: [string "luaeval()"]:1: attempt to call a nil value                                                                                                                                                                │

TARGET pi/.pi/agent/extensions/run-command.ts @ ee8a8d76c59fcc53b67d49756cfe5d1964f796f6
status=answered
autoRun=true
exitCode=7
capturedOutput="alpha\nbeta\nstderr-line"
toolResponse:
User pressed r; Pi ran the command in a Neovim `:term dm` pane and captured output.
Command: printf 'alpha\nbeta\n'; printf 'stderr-line\n' >&2; exit 7
Exit status: 7
Output:
alpha
beta
stderr-line
Your prediction was: alpha, beta, and stderr-line; exit status 7

PASS: pressing r auto-captured stdout+stderr and auto-submitted without E5108
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b8fe3091eab6e3b38111f3bbcff8b79085bf01ab","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test pi/.pi/agent/extensions/run-command.test.mjs`
- `JITI_PATH=/home/avirus/.nvm/versions/node/v22.22.3/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs NODE_PATH=/home/avirus/.nvm/versions/node/v22.22.3/lib/node_modules:/home/avirus/.nvm/versions/node/v22.22.3/lib/node_modules/@earendil-works/pi-coding-agent/node_modules node --test pi/.pi/agent/extensions/run-command.test.mjs`
- <code>`git show c1132bc466343ed281462516b755f76179bd6e0b:pi/.pi/agent/extensions/run-command.ts &gt; /tmp/no-mistakes-evidence/01M132P1S6C1P4MZ2ET5MKRKW8/baseline/run-command.ts` plus the matching helper snapshot</code>
- `node /tmp/no-mistakes-evidence/01M132P1S6C1P4MZ2ET5MKRKW8/run-command-r-e2e.mjs | tee /tmp/no-mistakes-evidence/01M132P1S6C1P4MZ2ET5MKRKW8/run-command-r-e2e.txt`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
