### PR TITLE
feat(pi): show the no-mistakes TUI in the visible Herdr pane

### DIFF
--- a/agents/.agents/skills/no-mistakes/SKILL.md
+++ b/agents/.agents/skills/no-mistakes/SKILL.md
@@ -18,12 +18,15 @@ respond, status, logs, abort, sync) through the `no_mistakes_axi` tool instead
 of running `no-mistakes axi` in the bash tool. (The bare `no-mistakes axi` home
 view takes no subcommand, so it is not a tool target — use `no-mistakes axi
 status` through the tool to inspect state.)
-The tool opens the command in a visible Herdr pane to the right of the agent
-pane so the captain can watch the pipeline run live, then returns the same
-structured TOON you would have read from bash stdout (plus the exit code).
-Everything below about reading gates, responding, escalating `ask-user`,
-syncing, and looping until an `outcome:` applies unchanged — only the
-invocation surface changes.
+For `run` and `respond`, the tool runs the axi call detached in the background
+and opens the rich `no-mistakes` TUI (`no-mistakes attach`) in a Herdr pane to
+the right of the agent pane so the captain can watch the pipeline run as an
+interactive UI — this is expected; you still receive the structured TOON the
+background axi call captured and drive the gate on it exactly as below. For
+quick inspections (status/logs/sync/abort) the pane shows the raw axi text.
+If the TUI cannot be shown (`attach` unavailable, no active run, or Herdr not
+present), the tool falls back to the raw axi text pane or an inline run and
+still returns the TOON — only the captain's view changes, never the gate.
 
 Pass `args` = everything after `no-mistakes axi` (e.g.
 `run --intent "ship the feature"`, `respond --action fix --findings r1`,

--- a/pi/.pi/agent/extensions/no-mistakes-pane.test.mjs
+++ b/pi/.pi/agent/extensions/no-mistakes-pane.test.mjs
@@ -19,7 +19,7 @@ const jitiPath = process.env.JITI_PATH
 	: "/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs";
 const { createJiti } = require(jitiPath);
 const jiti = createJiti(import.meta.url);
-const { buildPaneScript, extractMarkedOutput } = jiti("./no-mistakes-pane/capture.ts");
+const { buildPaneScript, extractMarkedOutput, buildBackgroundScript, buildAttachScript, hasStartMarker, wantsTuiPane, TUI_SUBCOMMANDS } = jiti("./no-mistakes-pane/capture.ts");
 
 // ---------------------------------------------------------------------------
 // buildPaneScript: run the generated script under bash with a stub
@@ -126,6 +126,176 @@ const { buildPaneScript, extractMarkedOutput } = jiti("./no-mistakes-pane/captur
 
 	// No START marker at all (e.g. empty file before the command prints).
 	assert.deepEqual(extractMarkedOutput("", token), { complete: false });
+}
+
+// ---------------------------------------------------------------------------
+// wantsTuiPane: only run/respond (and not their --help) get the TUI pane;
+// status/logs/sync/abort keep the text pane.
+// ---------------------------------------------------------------------------
+{
+	assert.equal(wantsTuiPane(["run", "--intent", "ship it"], "run"), true, "run gets the TUI pane");
+	assert.equal(wantsTuiPane(["respond", "--action", "fix", "--findings", "r1"], "respond"), true, "respond gets the TUI pane");
+	assert.equal(wantsTuiPane(["run", "--yes"], "run"), true, "run --yes still gets the TUI pane");
+
+	// --help / -h are quick introspections that never start a pipeline run.
+	assert.equal(wantsTuiPane(["run", "--help"], "run"), false, "run --help stays on the text pane");
+	assert.equal(wantsTuiPane(["respond", "-h"], "respond"), false, "respond -h stays on the text pane");
+
+	// Quick inspections never get the TUI pane.
+	for (const sub of ["status", "logs", "sync", "abort", "axi"]) {
+		assert.equal(wantsTuiPane([sub], sub), false, `${sub} stays on the text pane`);
+	}
+
+	// The TUI set is exactly run + respond.
+	assert.deepEqual([...TUI_SUBCOMMANDS].sort(), ["respond", "run"]);
+}
+
+// ---------------------------------------------------------------------------
+// buildBackgroundScript: run the generated background script under bash with
+// a stub no-mistakes on PATH and assert the TUI-pane capture behavior — the
+// TOON stdout (between START/END markers, exit code on END) lands in outFile,
+// progress stderr goes to errFile (NOT the capture file, since there is no
+// visible terminal for it), and a done sentinel is touched when the run ends.
+// ---------------------------------------------------------------------------
+{
+	const token = `bg${process.pid}`;
+	const stubDir = mkdtempSync(join(tmpdir(), "pi-nm-bg-"));
+	try {
+		const outFile = join(stubDir, "capture.out");
+		const errFile = join(stubDir, "capture.err");
+		const doneFile = join(stubDir, "capture.done");
+		const scriptFile = join(stubDir, "run.sh");
+		const stubPath = join(stubDir, "no-mistakes");
+		const exitCode = 7;
+		writeFileSync(
+			stubPath,
+			[
+				"#!/bin/sh",
+				'printf "arg=%s\n" "$@"', // TOON-ish stdout -> capture file
+				'printf "PROGRESS_NOISE\n" 1>&2', // stderr -> errFile, NOT outFile
+				`exit ${exitCode}`,
+				"",
+			].join("\n"),
+		);
+		chmodSync(stubPath, 0o755);
+
+		const args = ["run", "--intent", "ship the TUI pane feature"];
+		writeFileSync(scriptFile, buildBackgroundScript(args, token, outFile, errFile, doneFile));
+
+		const ran = spawnSync("bash", [scriptFile], {
+			encoding: "utf-8",
+			env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+		});
+		assert.equal(ran.status, 0, `background script should exit 0; stderr: ${ran.stderr}`);
+
+		// The done sentinel is touched once the run ends.
+		assert.ok(existsSync(doneFile), "done sentinel is touched after the background run ends");
+
+		const fileContents = readFileSync(outFile, "utf-8");
+		const parsed = extractMarkedOutput(fileContents, token);
+		assert.equal(parsed.complete, true, "END marker lands in the background capture file");
+		assert.equal(parsed.exitCode, exitCode, "exit code rides the END marker");
+		assert.ok(parsed.output.includes("arg=ship the TUI pane feature"), "multi-word intent survives as one argv entry");
+		assert.match(parsed.output, /arg=axi/, "subcommand arg round-trips");
+
+		// stdout-only capture: stderr progress never reaches outFile.
+		assert.doesNotMatch(fileContents, /PROGRESS_NOISE/, "stderr never reaches the background capture file");
+		assert.match(readFileSync(errFile, "utf-8"), /PROGRESS_NOISE/, "stderr is redirected to errFile");
+
+		// START marker is detectable for the pre-attach wait.
+		assert.equal(hasStartMarker(fileContents, token), true, "START marker is detectable");
+		assert.equal(hasStartMarker("", token), false, "empty buffer has no START marker");
+	} finally {
+		rmSync(stubDir, { recursive: true, force: true });
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildAttachScript: the attach wrapper retries `no-mistakes attach` until
+// the background run's done sentinel appears, then stops. Verify the
+// retry-until-done behavior with a stub `no-mistakes` that records each attach
+// attempt and a done file written after the first attempt.
+// ---------------------------------------------------------------------------
+{
+	const stubDir = mkdtempSync(join(tmpdir(), "pi-nm-attach-"));
+	try {
+		const doneFile = join(stubDir, "capture.done");
+		const scriptFile = join(stubDir, "attach.sh");
+		const logFile = join(stubDir, "attach.log");
+		const stubPath = join(stubDir, "no-mistakes");
+		// Stub `no-mistakes attach`: log the attempt, then touch the done file on
+		// the first call so the wrapper stops retrying after one iteration.
+		writeFileSync(
+			stubPath,
+			[
+				"#!/bin/sh",
+				'echo "attach-call" >> "$ATTACH_LOG"',
+				'if [ ! -f "$DONE" ]; then touch "$DONE"; fi',
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		chmodSync(stubPath, 0o755);
+
+		// Bounded to a small retry count so the test is fast; the real extension
+		// uses 240 × 0.5s. Use a tiny interval via a stub `sleep`.
+		writeFileSync(join(stubDir, "sleep"), ["#!/bin/sh", "exit 0", ""].join("\n"));
+		chmodSync(join(stubDir, "sleep"), 0o755);
+
+		writeFileSync(scriptFile, buildAttachScript(doneFile, 240, "0.001"));
+		const ran = spawnSync("bash", [scriptFile], {
+			encoding: "utf-8",
+			env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}`, DONE: doneFile, ATTACH_LOG: logFile },
+		});
+		assert.equal(ran.status, 0, `attach wrapper should exit 0; stderr: ${ran.stderr}`);
+		assert.ok(existsSync(doneFile), "done sentinel was created by the stub attach");
+
+		const calls = readFileSync(logFile, "utf-8").trim().split("\n");
+		// The wrapper calls attach once; the done file appears, so it stops without
+		// spinning through all 240 retries.
+		assert.equal(calls.length, 1, `attach is retried only until done appears (got ${calls.length} calls)`);
+	} finally {
+		rmSync(stubDir, { recursive: true, force: true });
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildAttachScript: when the done sentinel already exists (background run
+// finished before attach even started), the wrapper skips calling attach
+// entirely — no retry noise, no daemon contact.
+// ---------------------------------------------------------------------------
+{
+	const stubDir = mkdtempSync(join(tmpdir(), "pi-nm-attach-pre-"));
+	try {
+		const doneFile = join(stubDir, "capture.done");
+		const scriptFile = join(stubDir, "attach.sh");
+		const logFile = join(stubDir, "attach.log");
+		const stubPath = join(stubDir, "no-mistakes");
+		writeFileSync(
+			stubPath,
+			[
+				"#!/bin/sh",
+				'echo "attach-call" >> "$ATTACH_LOG"',
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		chmodSync(stubPath, 0o755);
+		writeFileSync(join(stubDir, "sleep"), ["#!/bin/sh", "exit 0", ""].join("\n"));
+		chmodSync(join(stubDir, "sleep"), 0o755);
+
+		// Done file already exists before the wrapper starts.
+		writeFileSync(doneFile, "");
+		writeFileSync(scriptFile, buildAttachScript(doneFile, 240, "0.001"));
+		const ran = spawnSync("bash", [scriptFile], {
+			encoding: "utf-8",
+			env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}`, DONE: doneFile, ATTACH_LOG: logFile },
+		});
+		assert.equal(ran.status, 0, `attach wrapper should exit 0 when done already exists; stderr: ${ran.stderr}`);
+		assert.ok(!existsSync(logFile) || readFileSync(logFile, "utf-8").trim() === "", "attach is not called when done already exists");
+	} finally {
+		rmSync(stubDir, { recursive: true, force: true });
+	}
 }
 
 console.log("no-mistakes-pane capture tests passed");

--- a/pi/.pi/agent/extensions/no-mistakes-pane.ts
+++ b/pi/.pi/agent/extensions/no-mistakes-pane.ts
@@ -1,15 +1,19 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile, execFileSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
 import {
+	buildAttachScript,
+	buildBackgroundScript,
 	buildPaneScript,
 	extractMarkedOutput,
+	hasStartMarker,
 	NM_PANE_TIMEOUT_MS,
+	wantsTuiPane,
 } from "./no-mistakes-pane/capture";
 
 // ---------------------------------------------------------------------------
@@ -108,6 +112,77 @@ function launchNmPane(cwd: string, scriptFile: string, label: string): string | 
 function cancelPane(paneId: string): void {
 	herdrOkSync(["pane", "send-text", paneId, "\x03"]);
 	herdrOkSync(["pane", "close", paneId]);
+}
+
+/** Cached result of `no-mistakes attach --help` — true when this no-mistakes
+ *  build has the `attach` subcommand at all. Help is a local cobra call that
+ *  does not touch the daemon run state, so checking it is daemon-safe. */
+let attachAvailableCache: boolean | undefined;
+function attachAvailable(): boolean {
+	if (attachAvailableCache !== undefined) return attachAvailableCache;
+	try {
+		execFileSync("no-mistakes", ["attach", "--help"], {
+			timeout: HERDR_TIMEOUT_MS,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		attachAvailableCache = true;
+	} catch {
+		attachAvailableCache = false;
+	}
+	return attachAvailableCache;
+}
+
+/** Spawn a detached background bash script (the axi capture driver) that
+ *  survives this tool call. Returns its process-group pid for cleanup, or
+ *  null if the spawn failed. */
+function spawnBackground(scriptFile: string, cwd: string): number | null {
+	try {
+		const child = spawn("bash", [scriptFile], {
+			cwd,
+			detached: true,
+			stdio: "ignore",
+		});
+		child.unref();
+		return child.pid ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** Send SIGINT to the background script's process group (mirrors the Ctrl-C
+ *  the text pane sends to an in-pane axi run), then best-effort kill the pid.
+ *  This disconnects the axi client; it never restarts the shared daemon. */
+function killBackground(pid: number): void {
+	try {
+		process.kill(-pid, "SIGINT");
+	} catch {
+		/* process group may already be gone */
+	}
+	try {
+		process.kill(pid, "SIGINT");
+	} catch {
+		/* pid may already be gone */
+	}
+}
+
+/** Poll the capture file for the START marker so we know the background axi
+ *  run actually began (and did not fail to spawn) before we attach a TUI to
+ *  it. Bounded by `timeoutMs` so a spawn failure falls back quickly. */
+async function waitForStart(
+	outFile: string,
+	token: string,
+	timeoutMs: number,
+	signal: AbortSignal,
+): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (true) {
+		if (signal.aborted) return false;
+		if (existsSync(outFile) && hasStartMarker(readFileSync(outFile, "utf-8"), token)) {
+			return true;
+		}
+		if (Date.now() >= deadline) return false;
+		await sleep(POLL_MS, signal).catch(() => {});
+	}
 }
 
 function sleep(ms: number, signal: AbortSignal): Promise<void> {
@@ -214,6 +289,105 @@ async function runNmInlineSafe(
 	}
 }
 
+/** Attach-pane retry budget: 240 tries × 0.5s = up to 2min of startup-race
+ *  retries. Once `no-mistakes attach` attaches it blocks for the whole run
+ *  (up to NM_PANE_TIMEOUT_MS), so the loop count only advances on failed
+ *  attach attempts, not while the TUI is live. */
+const ATTACH_MAX_TRIES = 240;
+const ATTACH_INTERVAL_SEC = "0.5";
+/** How long to wait for the background axi run to print its START marker
+ *  before deciding the spawn failed and falling back to the text pane. */
+const START_WAIT_MS = 3000;
+
+type TuiPaneOutcome =
+	| { fallback: true }
+	| { result: PaneRunResult; cancelled?: boolean; message?: string };
+
+/**
+ * TUI-pane path (run/respond): run `no-mistakes axi <args>` detached in the
+ * background so it drives the daemon run and captures the TOON to a marked
+ * temp file, while `no-mistakes attach` runs in the visible Herdr pane so the
+ * captain watches the rich TUI of that same run. Returns the captured result
+ * (same shape as the text pane), or `{ fallback: true }` when the background
+ * run could not start or the pane could not be opened — in which case the
+ * caller falls back to the current text-pane behavior. Never restarts the
+ * shared daemon; on timeout/abort only the detached axi client is signaled.
+ */
+async function runTuiPane(
+	args: string[],
+	subcommand: string,
+	cwd: string,
+	signal: AbortSignal,
+	timeoutMs: number,
+): Promise<TuiPaneOutcome> {
+	const token = randomUUID().replace(/-/g, "");
+	const outFile = `${tmpdir()}/pi-nm-${token}.out`;
+	const errFile = `${tmpdir()}/pi-nm-${token}.err`;
+	const doneFile = `${tmpdir()}/pi-nm-${token}.done`;
+	const bgScript = `${tmpdir()}/pi-nm-${token}.bg.sh`;
+	const attachScript = `${tmpdir()}/pi-nm-${token}.attach.sh`;
+	writeFileSync(outFile, "");
+	writeFileSync(bgScript, buildBackgroundScript(args, token, outFile, errFile, doneFile));
+	writeFileSync(attachScript, buildAttachScript(doneFile, ATTACH_MAX_TRIES, ATTACH_INTERVAL_SEC));
+
+	const bgPid = spawnBackground(bgScript, cwd);
+	if (!bgPid) {
+		unlinkSafe(outFile);
+		unlinkSafe(bgScript);
+		unlinkSafe(attachScript);
+		return { fallback: true };
+	}
+
+	// Wait for the background axi run to begin before attaching the TUI, so
+	// `no-mistakes attach` finds an active run to attach to.
+	const started = await waitForStart(outFile, token, START_WAIT_MS, signal);
+	if (!started) {
+		killBackground(bgPid);
+		unlinkSafe(outFile);
+		unlinkSafe(errFile);
+		unlinkSafe(doneFile);
+		unlinkSafe(bgScript);
+		unlinkSafe(attachScript);
+		return { fallback: true };
+	}
+
+	const paneId = launchNmPane(cwd, attachScript, `attach ${subcommand}`);
+	if (!paneId) {
+		killBackground(bgPid);
+		unlinkSafe(outFile);
+		unlinkSafe(errFile);
+		unlinkSafe(doneFile);
+		unlinkSafe(bgScript);
+		unlinkSafe(attachScript);
+		return { fallback: true };
+	}
+
+	try {
+		const r = await pollNmPane(outFile, token, paneId, signal, timeoutMs);
+		if (r.timedOut) {
+			cancelPane(paneId);
+			killBackground(bgPid);
+		}
+		return { result: r };
+	} catch (err) {
+		cancelPane(paneId);
+		killBackground(bgPid);
+		const partial = partialOutput(outFile, token);
+		return {
+			result: { output: partial, exitCode: -1, paneId, timedOut: false },
+			cancelled: true,
+			message: err instanceof Error ? err.message : "cancelled",
+		};
+	} finally {
+		unlinkSafe(outFile);
+		unlinkSafe(errFile);
+		unlinkSafe(doneFile);
+		unlinkSafe(bgScript);
+		unlinkSafe(attachScript);
+		herdrOkSync(["pane", "close", paneId]);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // quote-aware argument parsing (so the agent can pass --intent "long string")
 // ---------------------------------------------------------------------------
@@ -288,12 +462,12 @@ export default function noMistakesPane(pi: ExtensionAPI) {
 		name: "no_mistakes_axi",
 		label: "no-mistakes (visible pane)",
 		description:
-			"Run a `no-mistakes axi` subcommand (run/respond/status/logs/abort/sync) in a visible Herdr pane beside the agent pane, live, and return the structured TOON result the agent drives the gate on. Use this INSTEAD of running `no-mistakes axi` in the bash tool so the captain can watch the pipeline run. The pane shows progress live; the agent receives the same TOON (findings, gate, outcome, branch_sync, help) it would have read from bash stdout, plus the exit code. Falls back to an inline run when no TUI/Herdr is available.",
+			"Drive a `no-mistakes axi` subcommand (run/respond/status/logs/abort/sync) and return the structured TOON result the agent drives the gate on. Use this INSTEAD of running `no-mistakes axi` in the bash tool so the captain can watch the pipeline. For `run`/`respond`, the visible Herdr pane shows the rich `no-mistakes` TUI (`no-mistakes attach`) of the same daemon run the axi call is driving; for quick inspections (status/logs/sync/abort) the pane shows the raw axi text. In either case the agent receives the same structured TOON (findings, gate, outcome, branch_sync, help) plus the exit code, and drives the gate exactly as if it had read bash stdout. Falls back to the current text pane when `attach` is unavailable, and to an inline run when no TUI/Herdr is available.",
 		promptSnippet:
 			"Use no_mistakes_axi (not bash) to drive every no-mistakes axi call so the run is visible in a Herdr pane beside the agent.",
 		promptGuidelines: [
 			"Pass `args` = everything after `no-mistakes axi` (e.g. `run --intent \"...\"`, `respond --action fix --findings r1`, `status`). Quote multi-word values.",
-			"The command opens in a Herdr pane to the right of the agent and runs visibly; you still receive the structured TOON result to drive the gate (read every return; on a gate:, respond; loop until an outcome:).",
+			"The command opens in a Herdr pane to the right of the agent and runs visibly; for `run`/`respond` the pane shows the `no-mistakes` TUI (`no-mistakes attach`), and for other subcommands it shows the raw axi text. Either way you still receive the structured TOON result to drive the gate (read every return; on a gate:, respond; loop until an outcome:).",
 			"axi run and axi respond block for several minutes at review/test/CI steps — that is normal; do not cancel or re-issue because it seems slow. Allow a long timeout.",
 			"If a return has no parseable TOON (cancelled/timeout), the tool says so explicitly; use `no-mistakes axi status` via this same tool to inspect, or re-drive.",
 			"ask-user findings are never yours to resolve — escalate per the no-mistakes skill; this tool only changes the invocation surface, not gate authority.",
@@ -338,6 +512,45 @@ export default function noMistakesPane(pi: ExtensionAPI) {
 			}
 
 			// Visible-pane path.
+			//
+			// run/respond get the rich `no-mistakes attach` TUI in the visible pane
+			// while the axi capture runs detached in the background and the agent
+			// still reads the marked TOON to drive the gate. Falls back to the
+			// text-pane path below if `attach` is unavailable or the background run
+			// cannot start — the gate must never fail because the TUI could not be
+			// shown. status/logs/sync/abort keep the text pane (attaching a TUI to
+			// a status query does not make sense).
+			if (wantsTuiPane(args, subcommand) && attachAvailable()) {
+				const tui = await runTuiPane(args, subcommand, cwd, sig, timeoutMs);
+				if (!("fallback" in tui)) {
+					const r = tui.result;
+					if (tui.cancelled) {
+						const text = formatOutput(r.output, r.exitCode, "cancelled");
+						return textResult(
+							`no-mistakes axi ${subcommand} was cancelled; TUI pane closed.\n${text}`,
+							{ status: "cancelled", subcommand, paneId: r.paneId, output: r.output, message: tui.message },
+						);
+					}
+					if (r.timedOut) {
+						const text = formatOutput(r.output, r.exitCode, "timeout");
+						return textResult(
+							`no-mistakes axi ${subcommand} timed out after ${timeoutMs / 1000}s; TUI pane cancelled.\n${text}`,
+							{ status: "timeout", subcommand, exitCode: r.exitCode, paneId: r.paneId, output: r.output, message: "timed out" },
+						);
+					}
+					const text = formatOutput(r.output, r.exitCode, "visible (tui)");
+					return textResult(text, {
+						status: "visible",
+						subcommand,
+						exitCode: r.exitCode,
+						paneId: r.paneId,
+						output: r.output,
+						message: "TUI pane (no-mistakes attach)",
+					});
+				}
+				// fallback: continue to the text-pane path below.
+			}
+
 			const token = randomUUID().replace(/-/g, "");
 			const outFile = `${tmpdir()}/pi-nm-${token}.out`;
 			const scriptFile = `${tmpdir()}/pi-nm-${token}.sh`;

--- a/pi/.pi/agent/extensions/no-mistakes-pane/capture.ts
+++ b/pi/.pi/agent/extensions/no-mistakes-pane/capture.ts
@@ -1,10 +1,22 @@
-// Pure helpers for running a `no-mistakes axi` command in a visible Herdr
-// pane and capturing its structured TOON stdout back to the agent.
+// Pure helpers for running a `no-mistakes axi` command and capturing its
+// structured TOON stdout back to the agent, with two pane modes:
 //
-// The pane shows the run live (stdout via `tee` + stderr directly to the
-// terminal) while a clean copy of stdout — the TOON the agent drives on — is
-// written to a temp file between START/END markers that also carry the exit
-// code. `extractMarkedOutput` pulls that structured result back out.
+//  - TEXT pane (status/logs/sync/abort, and fallback): `buildPaneScript` runs
+//    `no-mistakes axi <args>` IN the visible Herdr pane. stdout (the TOON) is
+//    teed to a temp file between START/END markers while stderr (progress)
+//    streams live to the terminal. The captain watches the raw axi text.
+//
+//  - TUI pane (run/respond): `buildBackgroundScript` runs `no-mistakes axi
+//    <args>` detached in the BACKGROUND, capturing the TOON to the same marked
+//    temp file (stderr → a separate log file). `buildAttachScript` runs
+//    `no-mistakes attach` in the visible pane, retrying until the background
+//    run is active, so the captain watches the rich no-mistakes TUI of that
+//    same daemon run. The agent still reads the marked TOON to drive the gate.
+//
+// `no-mistakes axi run` and `no-mistakes attach` are two views of one daemon
+// run: axi drives it (and streams TOON), attach renders its interactive TUI.
+// attach is read-only with respect to the daemon, so retrying it during the
+// startup race is daemon-safe.
 //
 // These functions are split out so they can be unit-tested without a live
 // Herdr or no-mistakes daemon (see no-mistakes-pane.test.mjs).
@@ -24,7 +36,8 @@ function shellQuote(value: string): string {
 }
 
 /**
- * Build the bash script that runs `no-mistakes axi <args>` in a Herdr pane.
+ * Build the bash script that runs `no-mistakes axi <args>` IN a Herdr pane
+ * (text-pane mode).
  *
  * stdout (the START/END markers plus the command's TOON stdout) is piped
  * through `tee` so the captain sees it live AND a clean copy lands in
@@ -54,8 +67,80 @@ export function buildPaneScript(args: string[], token: string, outFile: string):
 	].join("\n");
 }
 
+/**
+ * Build the bash script that runs `no-mistakes axi <args>` DETACHED in the
+ * background (TUI-pane mode). stdout (START/END markers + TOON) is teed to
+ * `outFile`; stderr (progress) is redirected to `errFile` (there is no
+ * visible terminal for it here — the visible pane shows `no-mistakes attach`
+ * instead). After the command exits and the END marker lands, a `doneFile`
+ * sentinel is touched so the attach wrapper knows it can stop retrying.
+ *
+ * The caller spawns this with `detached: true` and `stdio: 'ignore'`, then
+ * polls `outFile` for the END marker exactly as in text-pane mode.
+ */
+export function buildBackgroundScript(
+	args: string[],
+	token: string,
+	outFile: string,
+	errFile: string,
+	doneFile: string,
+): string {
+	const start = `__NM_START_${token}__`;
+	const end = `__NM_END_${token}__`;
+	const cmd = ["no-mistakes", "axi", ...args].map(shellQuote).join(" ");
+	return [
+		`OUT=${shellQuote(outFile)}`,
+		`ERR=${shellQuote(errFile)}`,
+		`DONE=${shellQuote(doneFile)}`,
+		`{`,
+		`  printf '%s\\n' ${shellQuote(start)}`,
+		`  ${cmd} 2>"$ERR"`,
+		`  __nm_status=$?`,
+		`  printf '%s:%s\\n' ${shellQuote(end)} "$__nm_status"`,
+		`} | tee "$OUT" >/dev/null`,
+		`touch "$DONE"`,
+		"",
+	].join("\n");
+}
+
+/**
+ * Build the bash script that runs `no-mistakes attach` in the visible Herdr
+ * pane (TUI-pane mode). attach renders the interactive TUI of the active
+ * daemon run — the same run the background `axi <args>` is driving.
+ *
+ * attach needs an active run to attach to, and there is a startup race: the
+ * background axi run may not have registered with the daemon yet when attach
+ * first runs. attach is read-only w.r.t. the daemon, so this wrapper simply
+ * retries it until either it attaches (then it blocks for the whole run and
+ * exits when the run ends) or the background run completes (sentinel
+ * `doneFile` appears, meaning the run — successful or failed — is over and
+ * there is nothing left to watch). Bounded by `maxTries` × `intervalSec` so a
+ * permanently-unattachable run does not spin forever.
+ */
+export function buildAttachScript(doneFile: string, maxTries: number, intervalSec: string): string {
+	return [
+		`DONE=${shellQuote(doneFile)}`,
+		`i=0`,
+		`while [ "$i" -lt ${maxTries} ]; do`,
+		`  [ -f "$DONE" ] && break`,
+		`  no-mistakes attach 2>/dev/null`,
+		`  [ -f "$DONE" ] && break`,
+		`  i=$((i+1))`,
+		`  sleep ${intervalSec}`,
+		`done`,
+		"",
+	].join("\n");
+}
+
 function stripAnsi(text: string): string {
 	return text.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "").replace(/\r/g, "");
+}
+
+/** True once the START marker has landed in the captured buffer (the
+ *  background axi run has begun and is writing to `outFile`). */
+export function hasStartMarker(buffer: string, token: string): boolean {
+	const start = `__NM_START_${token}__`;
+	return stripAnsi(buffer).includes(start);
 }
 
 /**
@@ -84,4 +169,26 @@ export function extractMarkedOutput(buffer: string, token: string): MarkedOutput
 		out.push(line);
 	}
 	return { complete: false, output: out.join("\n").trim() };
+}
+
+// ---------------------------------------------------------------------------
+// TUI-pane decision logic
+// ---------------------------------------------------------------------------
+
+/**
+ * axi subcommands that drive a long pipeline run the captain wants to watch
+ * in the rich `no-mistakes attach` TUI. Quick inspections (status/logs/sync/
+ * abort) keep the text-pane behavior — attaching a TUI to a status query does
+ * not make sense.
+ */
+export const TUI_SUBCOMMANDS = new Set(["run", "respond"]);
+
+/**
+ * Should this `axi <args>` call get the TUI pane (run/respond, unless the user
+ * is just asking for `--help`)? `--help`/`-h` are quick introspections that
+ * never start a pipeline run, so they stay on the text-pane path.
+ */
+export function wantsTuiPane(args: string[], subcommand: string): boolean {
+	if (!TUI_SUBCOMMANDS.has(subcommand)) return false;
+	return !args.some((a) => a === "--help" || a === "-h");
 }


### PR DESCRIPTION
## Summary

The visible Herdr pane for the `no_mistakes_axi` tool now shows the **`no-mistakes` TUI** (`no-mistakes attach`) for `axi run`/`respond`, instead of the raw axi text dump, while the agent still drives the gate via the returned structured TOON. The gate-driving safety flow is unchanged.

## What changed

**Option A (captain's chosen flow): agent drives, pane shows the rich interactive UI.**

`no-mistakes axi run` and `no-mistakes attach` are two views of one daemon run: `axi run` drives it and streams TOON; `attach` renders its interactive TUI. The new TUI-pane path:

1. Runs `no-mistakes axi <args>` **detached in the background**, capturing the TOON to the same marked temp file (`START`/`END` markers + exit code, same capture machinery as before). This is the agent's result source.
2. Splits the Herdr pane and launches `no-mistakes attach` in it, so the captain watches the rich TUI of that same run. `attach` needs an active run, so the wrapper retries (`buildAttachScript`) until it attaches or the background run completes (a `done` sentinel) — daemon-safe because `attach` is read-only.
3. When the background axi run completes (`END` marker), reads the TOON from the temp file, closes the TUI pane, and returns the TOON (+ exit code) to the agent — exactly as today.

The agent-visible difference is **none**: same TOON, same gate loop. The captain-visible difference: the right pane shows the interactive TUI (progress, steps, findings, gates as a UI) instead of scrolling TOON text.

### Subcommand routing decision

- **`run` and `respond`** → TUI pane (they drive long pipeline runs the captain wants to watch). `--yes` variants also get the TUI.
- **`run --help` / `respond -h`** → text pane (quick introspection; never starts a run).
- **`status` / `logs` / `sync` / `abort`** → text pane (unchanged). Attaching a TUI to a status query does not make sense.

### Fallback / edge cases

- `no-mistakes attach` subcommand missing (older build) → pre-flight `attach --help` fails → **current text-pane behavior** (run `axi <args>` in the pane).
- Background axi run fails to start (no `START` marker within 3s) → kill it, **fall back to text pane**.
- Pane split/launch fails → **fall back to text pane**, then to inline.
- Runtime `attach` failure (no active run yet, daemon hiccup) → the retry wrapper keeps trying until the background run completes; the gate always completes via the background TOON capture. We deliberately do **not** kill/restart the background run to swap panes mid-run, because that risks the shared daemon run.
- No TUI / no Herdr (headless, print/rpc/json modes) → existing inline fallback, unchanged.
- Timeout/abort → the TUI pane is cancelled and **only the detached axi client** is signaled (SIGINT to its process group, mirroring the Ctrl-C the text pane sends). The shared `no-mistakes` daemon is **never** restarted or updated.
- `NM_PANE_TIMEOUT_MS` (30 min) behavior intact.

## Files

- `pi/.pi/agent/extensions/no-mistakes-pane/capture.ts` — added `buildBackgroundScript`, `buildAttachScript`, `hasStartMarker`, and `wantsTuiPane` / `TUI_SUBCOMMANDS` decision logic. Existing `buildPaneScript` / `extractMarkedOutput` / `NM_PANE_TIMEOUT_MS` unchanged.
- `pi/.pi/agent/extensions/no-mistakes-pane.ts` — added `attachAvailable`, `spawnBackground`, `killBackground`, `waitForStart`, `runTuiPane`; wired the TUI branch into `execute` ahead of the existing text-pane path with automatic fallback. Updated the tool `description` and `promptGuidelines` to describe the TUI pane.
- `agents/.agents/skills/no-mistakes/SKILL.md` — updated the "Invoke axi through the `no_mistakes_axi` tool" section so the agent knows the pane shows the `no-mistakes` TUI for run/respond (expected) and raw text for quick inspections. **Gate-driving instructions (run/respond/status/logs/abort/sync, gate reading, outcome loop, ask-user escalation) are untouched.**
- `pi/.pi/agent/extensions/no-mistakes-pane.test.mjs` — added coverage for `wantsTuiPane`, `buildBackgroundScript` (TOON capture, stderr→errFile, done sentinel, START marker detection), and `buildAttachScript` (retry-until-done, skip when done already present). Existing capture tests stay green.

## Cited structure (current, pre-change)

- Tool registration: `pi/.pi/agent/extensions/no-mistakes-pane.ts:287` (`pi.registerTool({ name: "no_mistakes_axi", ... })`).
- Capture helpers: `pi/.pi/agent/extensions/no-mistakes-pane/capture.ts` (`buildPaneScript`, `extractMarkedOutput`, `NM_PANE_TIMEOUT_MS`).
- Tests: `pi/.pi/agent/extensions/no-mistakes-pane.test.mjs`.
- Skill: `agents/.agents/skills/no-mistakes/SKILL.md` "Invoke axi through the `no_mistakes_axi` tool" section.

## Validation

- `node --test pi/.pi/agent/extensions/no-mistakes-pane.test.mjs` — **passing** (existing + new tests).
- TypeScript: the dotfiles has no extension typecheck step; verified the extension transpiles and loads cleanly via jiti (default export is a function). No `tsc` is installed in this environment.
- Manual smoke: **not run live** against the shared `no-mistakes` daemon, per the task constraint (another ship may have an in-flight `no_mistakes_axi` run in the primary checkout). The new helpers are exercised by unit tests with stub `no-mistakes` binaries; the live `/no-mistakes` → TUI-pane behavior should be smoke-tested by the captain in a clean scratch repo after merge.

## Constraints honored

- Touched only `pi/.pi/agent/extensions/no-mistakes-pane*` and `agents/.agents/skills/no-mistakes/SKILL.md`. No `run-command*` files touched.
- Shared `no-mistakes` daemon never restarted/updated.
- Agent gate-driving instructions in the skill unchanged; only the pane-description wording updated.
- Stayed inside the isolated dotfiles worktree; pushed only `fm/no-mistakes-ui-pane`.
