### PR TITLE
nvim: declare explicit per-filetype indent stance

### DIFF
--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -97,6 +97,18 @@ workflow area rather than plugin files, Lua modules, or implementation structure
 - Python formatting uses Ruff fix and Ruff format.
 - Python formatting prefers project-local `.venv/bin/ruff` when available.
 
+### Indent stance
+
+Per-filetype indent is declared explicitly in `lua/config/indent.lua` (sourced from `autocmds.lua`) rather than inherited implicitly from LazyVim defaults, so the stance survives a LazyVim upgrade or a dropped `.clang-format`.
+
+- C, C++, Objective-C, Objective-C++: spaces, `shiftwidth=2`, `tabstop=2` — matches the LLVM/clang-format default and clangd `--fallback-style=llvm`, so the editor and clang-format-on-save agree at 2 spaces. No global `.clang-format` is shipped; each C project owns its own style.
+- Python: spaces, `shiftwidth=4`, `tabstop=4` — PEP 8.
+- Go: tabs, `shiftwidth=4`, `tabstop=4` — gofmt enforces tabs.
+- Rust: spaces, `shiftwidth=4`, `tabstop=4` — rustfmt default.
+- Lua: spaces, `shiftwidth=2`, `tabstop=2` — StyLua default; matches LazyVim.
+- `smartindent`, `autoindent`, and `shiftround` are left to LazyVim's global defaults and are not re-set.
+- Filetypes not listed keep LazyVim's default unchanged; no stance is imposed where none was named.
+
 ### Diagnostics
 
 - Trouble provides workspace diagnostics.

--- a/nvim/.config/nvim/lua/config/autocmds.lua
+++ b/nvim/.config/nvim/lua/config/autocmds.lua
@@ -7,3 +7,7 @@
 -- Or remove existing autocmds by their group name (which is prefixed with `lazyvim_` for the defaults)
 -- e.g. vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")
 
+-- Declare each language's community-canonical indent explicitly instead of
+-- relying on LazyVim's implicit per-extra defaults. See lua/config/indent.lua.
+require("config.indent")
+

--- a/nvim/.config/nvim/lua/config/indent.lua
+++ b/nvim/.config/nvim/lua/config/indent.lua
@@ -1,0 +1,52 @@
+-- Explicit per-filetype indent stance.
+--
+-- LazyVim ships a global 2-space default and lets extras (go, python, rust)
+-- set their language norms. Without this file the stance is entirely
+-- implicit: a LazyVim upgrade or a dropped .clang-format could silently
+-- break the C editor<->formatter agreement. This declares each language's
+-- community-canonical indent in one owned place so the stance is deliberate
+-- and durable.
+--
+-- smartindent / autoindent / shiftround are left to LazyVim's global
+-- defaults (options.lua does not override them) and are intentionally NOT
+-- re-set here -- re-setting could regress a future LazyVim improvement.
+--
+-- Filetypes not listed below keep LazyVim's default unchanged: we do not
+-- impose a stance where the captain did not name one.
+--
+-- C editor<->formatter agreement: the editor is 2-space here; clang-format
+-- on save (lua/plugins/c.lua via conform) uses the nearest project
+-- .clang-format, falling back to clang-format's built-in LLVM (2-space)
+-- default, which matches clangd --fallback-style=llvm. The two agree at the
+-- default level; a project that ships its own .clang-format owns its style
+-- by design -- no global .clang-format is imposed here.
+--
+-- Sourced from lua/config/autocmds.lua.
+
+--- Community-canonical indent per filetype.
+--- expandtab = true  -> spaces; false -> literal tabs.
+local INDENT = {
+  c = { expandtab = true, shiftwidth = 2, tabstop = 2 }, -- LLVM / clang-format default
+  cpp = { expandtab = true, shiftwidth = 2, tabstop = 2 },
+  objc = { expandtab = true, shiftwidth = 2, tabstop = 2 },
+  objcpp = { expandtab = true, shiftwidth = 2, tabstop = 2 },
+  python = { expandtab = true, shiftwidth = 4, tabstop = 4 }, -- PEP 8
+  go = { expandtab = false, shiftwidth = 4, tabstop = 4 }, -- gofmt enforces tabs
+  rust = { expandtab = true, shiftwidth = 4, tabstop = 4 }, -- rustfmt default
+  lua = { expandtab = true, shiftwidth = 2, tabstop = 2 }, -- StyLua default; matches LazyVim
+}
+
+local group = vim.api.nvim_create_augroup("IndentStance", { clear = true })
+
+vim.api.nvim_create_autocmd("FileType", {
+  group = group,
+  pattern = vim.tbl_keys(INDENT),
+  callback = function(args)
+    local stance = INDENT[args.match]
+    local bo = vim.bo[args.buf]
+    bo.expandtab = stance.expandtab
+    bo.shiftwidth = stance.shiftwidth
+    bo.tabstop = stance.tabstop
+  end,
+  desc = "Declare community-canonical indent for configured filetypes.",
+})


### PR DESCRIPTION
## Why

The captain audited Neovim's indent stance and found it **entirely implicit**: no `shiftwidth`/`tabstop`/`expandtab` set anywhere in the config. C/C++ inherited LazyVim's global 2-space default, while LazyVim extras made Python 4, Rust 4, Go tabs. That per-language mix is fine as a *principle* (each language follows its community norm) but accidental and fragile — a LazyVim upgrade or a dropped `.clang-format` could silently break the C editor↔formatter agreement.

This PR makes the stance **explicit and durable**: follow each language's community norm, but declare it in one owned place.

## What

Adds `lua/config/indent.lua` (sourced from `autocmds.lua`) with an idempotent `IndentStance` augroup and a `FileType` autocmd:

| filetype | expandtab | shiftwidth | tabstop | rationale |
|---|---|---|---|---|
| c, cpp, objc, objcpp | true | 2 | 2 | LLVM/clang-format default; matches clangd `--fallback-style=llvm` |
| python | true | 4 | 4 | PEP 8 |
| go | false (tabs) | 4 | 4 | gofmt enforces tabs |
| rust | true | 4 | 4 | rustfmt default |
| lua | true | 2 | 2 | StyLua default; matches LazyVim |

- `smartindent`/`autoindent`/`shiftround` are left to LazyVim's global defaults and intentionally **not** re-set, so a future LazyVim improvement is not regressed.
- Filetypes not in the table keep LazyVim's default unchanged — no stance is imposed where none was named.
- This **does not remove or fight** the existing LazyVim extras (go/python/rust); it makes their indent explicit in one owned place. Where an extra already set the same value, this just makes it durable.

## C editor↔formatter agreement

The editor is now explicitly 2-space. clang-format-on-save (already wired in `lua/plugins/c.lua` via conform) uses the nearest project `.clang-format`, falling back to clang-format's built-in LLVM (2-space) default — which matches clangd `--fallback-style=llvm`. The two agree at the default level. **No global `.clang-format` is shipped**: the captain affirmed each C project owns its own style; a global one would impose a house style on every C project. The declaration in the autocmd is what makes the agreement durable.

## Note on objc/objcpp

Upstream Neovim maps `.m` → `matlab` and `.mm` → `nroff` by default, so the `objc`/`objcpp` stance applies when that filetype is explicitly set (e.g. by a project ftplugin or modeline). It never fights the matlab/nroff defaults — no filetype remapping is added, which would break matlab users. No conflict with any checked-in file; nothing is reformatted.

## Acceptance

- `nvim --headless '+lua vim.defer_fn(function() vim.cmd("qa") end, 5000)'` loads with no Lua errors.
- `.c` → `expandtab` on, `shiftwidth=2`, `tabstop=2`.
- `.py` → `shiftwidth=4`; `.go` → `noexpandtab`, `tabstop=4`; `.lua` → `shiftwidth=2`.
- No global `.clang-format` added.
- `docs/neovim-current-features.md` updated with an "Indent stance" section.

## Files

- `nvim/.config/nvim/lua/config/indent.lua` (new)
- `nvim/.config/nvim/lua/config/autocmds.lua` (source it)
- `docs/neovim-current-features.md` (document the stance)