### PR TITLE
feat(pi): vendor interactive-subagents with a Herdr surface layer

### DIFF
--- a/docs/neovim-current-features.md
+++ b/docs/neovim-current-features.md
@@ -416,6 +416,15 @@ Per-filetype indent is declared explicitly in `lua/config/indent.lua` (sourced f
 - Sidekick has floating UI for prompts, answers, and diff previews.
 - Sidekick answers and diffs can be applied, rejected, yanked, or cleared from the current line.
 
+### Interactive subagents (pi extension)
+
+- The `pi-interactive-subagents` extension is vendored at `pi/.pi/agent/extensions/interactive-subagents/` and loads via the existing `~/.pi/agent/extensions` symlink; it is a dotfiles fork of `amosblomqvist/pi-interactive-subagents`.
+- It adds the `subagent`, `subagent_message`, `subagents_list`, and sub-agent-only `ask_question` tools to pi, plus the bundled `scout`, `researcher`, and `worker` agents (`agents/*.md`).
+- The upstream extension spawns sub-agents in tmux panes. This fork adds a **Herdr surface layer** (`pi-extension/subagents/herdr.ts`) that drives panes through the `herdr` CLI (`herdr pane split/send-text/send-keys/read/close`), and a dispatcher (`surface.ts`) that auto-selects Herdr when `HERDR_ENV=1` + `HERDR_PANE_ID` are set, falling back to tmux when `TMUX` is set.
+- On the captain's host pi runs under Herdr, so the active surface is Herdr; tmux remains available as the fallback for pi sessions started inside `tmux new -A -s pi 'pi'`.
+- Known gap: Herdr has no `select-layout even-horizontal` equivalent, so sub-agent pane rebalancing is a no-op on the Herdr surface (panes keep the split ratio set at creation); this is cosmetic and does not affect spawning, watching, or result steering.
+- Extension deps are pi-runtime peer packages (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, `@earendil-works/pi-ai`); no global npm installs and no runtime npm install is needed. `interactive-subagents.test.mjs` smoke-loads the surface dispatcher and Herdr detection.
+
 ## Notetaking features
 
 ### Markdown editing

--- a/pi/.pi/agent/extensions/interactive-subagents.test.mjs
+++ b/pi/.pi/agent/extensions/interactive-subagents.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+
+const require = createRequire(import.meta.url);
+
+// Allow CI / other hosts to supply jiti via JITI_PATH; otherwise fall back to
+// the captain's macOS homebrew pi install AND the Linux nvm homelab install.
+const jitiCandidates = [
+	process.env.JITI_PATH,
+	"/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs",
+	"/home/avirus/.nvm/versions/node/v22.22.3/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs",
+].filter(Boolean);
+const jitiPath = jitiCandidates.find((p) => p && existsSync(p));
+if (!jitiPath) {
+	console.error(
+		"jiti not found. Set JITI_PATH to jiti.cjs for your pi install.",
+	);
+	process.exit(1);
+}
+const { createJiti } = require(jitiPath);
+const jiti = createJiti(import.meta.url);
+
+// --- Surface dispatcher loads cleanly and re-exports the index.ts contract ---
+const surface = jiti("./interactive-subagents/pi-extension/subagents/surface.ts");
+
+// Every symbol index.ts imports from ./surface.ts must be present.
+for (const name of [
+	"isMuxAvailable",
+	"muxSetupHint",
+	"createSurface",
+	"sendCommand",
+	"sendLongCommand",
+	"pollForExit",
+	"closeSurface",
+	"shellEscape",
+	"readScreen",
+]) {
+	assert.equal(typeof surface[name], "function", `surface.${name} must be a function`);
+}
+assert.equal(typeof surface.readScreenAsync, "function", "surface.readScreenAsync must be a function");
+assert.equal(typeof surface.__pollForExitTest__, "object", "surface.__pollForExitTest__ must be exported");
+
+// shellEscape is a pure string helper shared by both surfaces.
+assert.equal(surface.shellEscape("simple"), "'simple'");
+assert.equal(surface.shellEscape("it's"), "'it'\\''s'");
+
+// muxSetupHint never throws and returns a non-empty string regardless of surface.
+assert.ok(typeof surface.muxSetupHint() === "string" && surface.muxSetupHint().length > 0);
+
+// --- Herdr surface detection (gated on the captain's live Herdr env) ---
+const herdr = jiti("./interactive-subagents/pi-extension/subagents/herdr.ts");
+
+// Simulate running under Herdr (the captain's primary surface).
+const savedHerdrEnv = process.env.HERDR_ENV;
+const savedHerdrPane = process.env.HERDR_PANE_ID;
+process.env.HERDR_ENV = "1";
+process.env.HERDR_PANE_ID = "w44:p2";
+try {
+	assert.equal(herdr.isHerdrAvailable(), true, "isHerdrAvailable under HERDR_ENV=1 + HERDR_PANE_ID + herdr on PATH");
+	assert.equal(herdr.isMuxAvailable(), true, "herdr.isMuxAvailable mirrors isHerdrAvailable");
+} finally {
+	process.env.HERDR_ENV = savedHerdrEnv;
+	process.env.HERDR_PANE_ID = savedHerdrPane;
+}
+
+// Without Herdr env, isHerdrAvailable is false (no false positives).
+process.env.HERDR_ENV = "";
+process.env.HERDR_PANE_ID = "";
+assert.equal(herdr.isHerdrAvailable(), false, "isHerdrAvailable false when Herdr env absent");
+
+// --- pollForExit sidecar decoding (surface-agnostic logic) ---
+const { interpretExitSidecar } = herdr.__pollForExitTest__;
+assert.deepEqual(interpretExitSidecar({ type: "error", errorMessage: "boom" }), {
+	reason: "error",
+	exitCode: 1,
+	errorMessage: "boom",
+});
+assert.deepEqual(interpretExitSidecar({ type: "error" }), {
+	reason: "error",
+	exitCode: 1,
+	errorMessage: "Subagent exited with stopReason=error (no errorMessage in sidecar).",
+});
+assert.deepEqual(interpretExitSidecar({}), { reason: "done", exitCode: 0 });
+
+console.log("interactive-subagents surface smoke passed");

--- a/pi/.pi/agent/extensions/interactive-subagents/.gitignore
+++ b/pi/.pi/agent/extensions/interactive-subagents/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+config.json
+.DS_Store
+.memory/

--- a/pi/.pi/agent/extensions/interactive-subagents/LICENSE
+++ b/pi/.pi/agent/extensions/interactive-subagents/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HazAT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pi/.pi/agent/extensions/interactive-subagents/README.md
+++ b/pi/.pi/agent/extensions/interactive-subagents/README.md
@@ -1,0 +1,193 @@
+# pi-interactive-subagents
+
+Async subagents for [pi](https://github.com/badlogic/pi-mono), running in tmux panes. Spawn a sub-agent, keep working in the main session, and get the result steered back when it finishes. Fully non-blocking.
+
+**tmux-only fork.** See [Acknowledgements](#acknowledgements) for the upstream project, which also supports cmux, zellij, and WezTerm.
+
+## How it works
+
+`subagent()` returns immediately. The sub-agent runs in its own tmux pane — a right split off the parent pi pane, so pane creation never steals keyboard focus. A live widget above the input tracks every running sub-agent, and when one finishes, its result is steered into the main session as a notification that triggers a new turn.
+
+```
+╭─ Subagents ──────────────────────────── 2 running ─╮
+│ 00:23  scout      active · bash 7m                 │
+│ 00:45  scout-2    waiting 2m                       │
+╰────────────────────────────────────────────────────╯
+```
+
+Spawn several in parallel — they run concurrently and steer results back independently as each finishes.
+
+Panes are kept evenly sized: the extension re-applies an `even-horizontal` layout after every spawn and exit (debounced). The layout is a single constant, `SUBAGENT_TMUX_LAYOUT` in `pi-extension/subagents/tmux.ts` — change it to any named tmux layout (`main-vertical`, `tiled`, …).
+
+If your shell startup is slow and launch commands get dropped before the prompt is ready, raise the delay:
+
+```bash
+export PI_SUBAGENT_SHELL_READY_DELAY_MS=2500   # default: 500
+```
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `subagent` | Spawn a sub-agent in a dedicated tmux pane (async) |
+| `subagent_message` | Message a sub-agent by name — steers it if running, resumes its session if finished |
+| `subagents_list` | List available agent definitions |
+| `ask_question` | *(sub-agent sessions only)* Ask the orchestrator a question and wait for the reply |
+
+There is also a `/subagent <agent> <task>` command for spawning directly.
+
+### Spawning
+
+```typescript
+subagent({ agent: "scout", task: "Analyze the auth module" });
+subagent({ agent: "worker", name: "dark-mode", task: "Implement the dark mode toggle" });
+```
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `agent` | string | required | Which agent to spawn (must be known and permitted) |
+| `task` | string | required | Task prompt |
+| `name` | string | agent name | Display name for the pane and widget. Must be unique — duplicates are auto-suffixed (`scout`, `scout-2`, …) |
+| `model` | string | agent's model | Override the model for this spawn |
+| `cwd` | string | agent's `cwd` | Working directory (see [Role folders](#role-folders)) |
+
+### Messaging
+
+`subagent_message` is addressed **by name only**. Names are unique per session and persist after a sub-agent finishes, so the same name works either way:
+
+```typescript
+subagent_message({ name: "scout", message: "Also check the auth middleware" });
+```
+
+- **Running** — the message is typed into the live pane (newlines flattened) and picked up at the next turn boundary. The call returns immediately; the eventual completion still arrives as a steer message.
+- **Finished** — the session is resumed with the message as the follow-up task, like a fresh spawn: fire-and-forget, always autonomous, result steered back later. The resumed run reclaims its original name.
+
+Every spawn records name → session file in `artifacts/<sessionId>/subagent-registry.json`, so names stay addressable across pi restarts. A nested sub-agent that spawns children gets its own registry keyed by its own session id. Resume is refused with a clear error (listing known names) if the name isn't registered, the session file is gone, or the session predates sandboxed resume.
+
+**Resume replays the original sandbox.** At spawn time the fully-resolved loadout — tool allowlist, backing extensions, model, thinking level, system prompt, spawn whitelist, cwd — is snapshotted to `<session>.loadout.json`. Resume rebuilds the exact same restricted process from that snapshot rather than relaunching unrestricted.
+
+### ask_question
+
+A sub-agent can ask its orchestrator a single freeform question when requirements are ambiguous or a decision materially affects the work. The session **stays open** (parked as `waiting`) instead of exiting; the parent is notified with the sub-agent's name, replies via `subagent_message({ name, message })`, and the reply arrives as the sub-agent's next turn. Parallel questions are supported — each waiting sub-agent has its own name.
+
+If the reply arrives while the sub-agent is still mid-turn, it is absorbed into the current turn — either way the question is marked answered and the session exits normally when the work is done. If the parent never replies, the pane stays open until a human closes it. Only available inside sub-agent sessions.
+
+## Bundled agents
+
+| Agent | Model | Tools | Role |
+| ----- | ----- | ----- | ---- |
+| **scout** | `openrouter/z-ai/glm-5.3` | `read`, `grep`, `find`, `ls` | Fast read-only codebase recon |
+| **researcher** | `openrouter/z-ai/glm-5.3` | `web_search`, `web_fetch`, `safe_bash` | Web research, synthesized into a sourced brief |
+| **worker** | `openrouter/z-ai/glm-5.3` | `read`, `write`, `edit`, `bash`, `web_search`, `web_fetch` + spawning | General implementer; may spawn `scout` and `researcher` |
+
+All three are autonomous (`auto-exit: true`) and carry their identity in the system prompt (`system-prompt: append`).
+
+## Custom agents
+
+Place a `.md` file in `.pi/agents/` (project) or `~/.pi/agent/agents/` (global). Discovery priority: **project > global > package-bundled** — a project-local file overrides a bundled agent with the same name.
+
+```markdown
+---
+name: my-agent
+description: Does something specific
+model: openrouter/z-ai/glm-5.3
+thinking: medium
+tools: read, edit, write, safe_bash, web_search
+session-mode: lineage-only
+auto-exit: true
+---
+
+You are a specialized agent that does X...
+```
+
+### Frontmatter reference
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `name` | string | Agent name (used in `agent: "my-agent"`) |
+| `description` | string | Shown in `subagents_list` |
+| `model` | string | Default model |
+| `thinking` | string | `minimal`, `low`, `medium`, or `high` |
+| `tools` | string | Strict tool allowlist. Built-ins: `read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`. Extension-backed: `web_search`, `web_fetch`, `safe_bash`, `video_extract`, `youtube_search`, `google_image_search`. Only the extensions backing the listed tools are loaded into the child |
+| `subagent_agents` | string | Comma-separated agent names this agent may spawn. **Presence of this field grants the spawning toolset** (`subagent`, `subagent_message`, `subagents_list`) and restricts spawn targets to the list. Omit it and the agent cannot spawn at all |
+| `skills` | string | Comma-separated skill names to auto-load |
+| `session-mode` | string | `standalone` (default), `lineage-only`, or `fork` — see below |
+| `system-prompt` | string | `append` or `replace`: pass the body as the child's `--append-system-prompt` / `--system-prompt`. Omit and the body is prepended to the task prompt instead |
+| `auto-exit` | boolean | Auto-shutdown when the agent finishes (see below) |
+| `interactive` | boolean | Whether stall/recovery transitions wake the parent (see below) |
+| `cwd` | string | Default working directory |
+| `disable-model-invocation` | boolean | Hide from `subagents_list`; still spawnable by explicit name |
+| `cli` | string | `claude` runs the agent via the Claude Code CLI instead of pi |
+
+### session-mode
+
+- `standalone` — fresh session, no lineage link to the caller (default)
+- `lineage-only` — fresh session with `parentSession` linkage for discovery/fork UX, but no copied turns
+- `fork` — child session seeded with the caller's conversation context
+
+### auto-exit
+
+With `auto-exit: true`, the session shuts down when the agent's turn ends — the agent just writes its final message and stops (there is no "done" tool). The last assistant message becomes the summary returned to the parent. Recommended for all autonomous agents.
+
+Notes:
+
+- **Manual input does not strand an auto-exit sub-agent.** If a human types into the pane, the session still closes once that turn completes normally — only an escape/abort leaves it open.
+- **Auto-exit is suppressed while work is in flight:** the session parks as `waiting` instead of exiting when an `ask_question` is still unanswered, or when the agent's own child sub-agents are still running (a worker can stop after dispatching children and stays open until the last result returns).
+
+### interactive
+
+Controls whether `stalled`/`recovered` status transitions send a steer message to the parent session. Defaults to the inverse of `auto-exit`: autonomous agents get stall pings; user-driven agents stay quiet (the user is already working in that pane — the widget still updates). Set explicitly to override.
+
+## Tool access control
+
+Access is **whitelist-only**. Every sub-agent process is launched with `--no-extensions` (extension discovery disabled) and `--tools <allowlist>`; only the extensions backing the listed tools are loaded back in explicitly. There is no default toolset and no deny-list — an agent gets exactly what its frontmatter lists. The restriction survives resume via the loadout snapshot.
+
+Spawns must name a known agent at **every** depth. A top-level session may spawn anything discoverable; a sub-agent may only spawn the agents in its `subagent_agents` list (enforced via `PI_SUBAGENT_ALLOWED`). There is no agentless spawn route, so a child can never escalate to a full-toolset profile by omitting its agent.
+
+Extensions can register additional tools for sub-agents at runtime via `registerToolExtension(name, path)` on the `__pi_interactive_subagents` process global.
+
+## Role folders
+
+`cwd` starts a sub-agent in a directory with its own config, so role-specific setups (CLAUDE.md, skills, extensions) apply:
+
+```
+project/
+└── agents/
+    ├── game-designer/   ← CLAUDE.md, .pi/…
+    └── sre/             ← CLAUDE.md, .pi/…
+```
+
+```typescript
+subagent({ agent: "worker", cwd: "agents/sre", task: "Review the deployment pipeline" });
+```
+
+Set a per-agent default with `cwd:` in frontmatter.
+
+## Status widget & configuration
+
+The widget tracks each sub-agent from a runtime activity snapshot written by the child: `starting`, `active` (turn/provider/tool work), `waiting` (open for input or another stage), `stalled` (no valid snapshot for too long), or `running` (fallback). Sub-agent sessions also show their own tools widget — toggle it with `Ctrl+Alt+O`. Completion messages expand with `Ctrl+O`.
+
+Status display is configured via `config.json` in the extension directory (copy `config.json.example`; it's gitignored):
+
+```json
+{
+  "status": { "enabled": true }
+}
+```
+
+## Requirements
+
+- [pi](https://github.com/badlogic/pi-mono)
+- [tmux](https://github.com/tmux/tmux)
+
+```bash
+tmux new -A -s pi 'pi'
+```
+
+## Acknowledgements
+
+Forked from [HazAT/pi-interactive-subagents](https://github.com/HazAT/pi-interactive-subagents), which originated the subagent architecture, the multi-multiplexer surface layer, and the status widget; its supervision features were inspired by [RepoPrompt](https://repoprompt.com/).
+
+## License
+
+MIT

--- a/pi/.pi/agent/extensions/interactive-subagents/agents/researcher.md
+++ b/pi/.pi/agent/extensions/interactive-subagents/agents/researcher.md
@@ -1,0 +1,51 @@
+---
+name: researcher
+description: Web researcher — searches the web and synthesizes findings
+tools: web_search, web_fetch, safe_bash
+model: openrouter/z-ai/glm-5.3
+thinking: medium
+system-prompt: append
+auto-exit: true
+---
+
+You are a research specialist. Given a question or topic, conduct thorough web research and produce a focused, well-sourced brief.
+
+You operate in an isolated context with no knowledge of any prior conversation. All necessary context is in the task description.
+
+Process:
+1. Break the question into 2-4 searchable facets
+2. Search with `web_search` using varied angles
+3. Read the answers. Identify what's well-covered, what has gaps.
+4. For the 2-3 most promising source URLs, use `web_fetch` to get full page content
+5. Synthesize everything into a brief that directly answers the question
+
+Search strategy — always vary your angles:
+- Direct answer query (the obvious one)
+- Authoritative source query (official docs, specs, primary sources)
+- Practical experience query (case studies, benchmarks, real-world usage)
+- Recent developments query (only if the topic is time-sensitive)
+
+Evaluation — what to keep vs drop:
+- Official docs and primary sources outweigh blog posts and forum threads
+- Recent sources outweigh stale ones
+- Sources that directly address the question outweigh tangentially related ones
+- Drop: SEO filler, outdated info, beginner tutorials (unless that's the audience)
+
+If the first round of searches doesn't fully answer the question, search again with refined queries targeting the gaps.
+
+Your FINAL assistant message is your entire deliverable — it must stand alone, using this format:
+
+## Summary
+2-3 sentence direct answer.
+
+## Findings
+Numbered findings with inline source citations:
+1. **Finding** — explanation. [Source](url)
+2. **Finding** — explanation. [Source](url)
+
+## Sources
+- Kept: Source Title (url) — why relevant
+- Dropped: Source Title — why excluded
+
+## Gaps
+What couldn't be answered. Suggested next steps.

--- a/pi/.pi/agent/extensions/interactive-subagents/agents/scout.md
+++ b/pi/.pi/agent/extensions/interactive-subagents/agents/scout.md
@@ -1,0 +1,40 @@
+---
+name: scout
+description: Fast codebase recon — explores files, finds patterns, maps architecture
+tools: read, grep, find, ls
+model: openrouter/z-ai/glm-5.3
+thinking: low
+system-prompt: append
+auto-exit: true
+---
+
+You are a scout agent. Quickly investigate a codebase and return structured findings.
+
+You operate in an isolated context with no knowledge of any prior conversation. All necessary context is in the task description. You are read-only: never build, test, or modify anything.
+
+Thoroughness (infer from task, default medium):
+- Quick: Targeted lookups, key files only
+- Medium: Follow imports, read critical sections
+- Thorough: Trace all dependencies, check tests/types
+
+Strategy:
+1. grep/find to locate relevant code
+2. Read key sections (not entire files)
+3. Identify types, interfaces, key functions
+4. Note dependencies between files
+
+Your FINAL assistant message is your entire deliverable — it must stand alone, using this format:
+
+## Files Found
+List with exact line ranges:
+1. `path/to/file.ts` (lines 10-50) — Description
+2. `path/to/other.ts` (lines 100-150) — Description
+
+## Key Code
+Critical types, interfaces, or functions with actual code snippets.
+
+## Architecture
+Brief explanation of how the pieces connect.
+
+## Start Here
+Which file to look at first and why.

--- a/pi/.pi/agent/extensions/interactive-subagents/agents/worker.md
+++ b/pi/.pi/agent/extensions/interactive-subagents/agents/worker.md
@@ -1,0 +1,79 @@
+---
+name: worker
+description: General-purpose worker — reads, writes, and edits code
+tools: read, write, edit, bash, web_search, web_fetch
+subagent_agents: scout, researcher
+model: openrouter/z-ai/glm-5.3
+thinking: high
+system-prompt: append
+auto-exit: true
+---
+
+You are a worker agent. You operate in an isolated context — you have no knowledge of any prior conversation. All necessary context will be provided in the task description.
+
+You run in your own pane and work autonomously to complete the assigned task. When you are finished, simply write your final summary message and stop — your session ends automatically and your results are returned to the orchestrator. Do not announce that you are finishing; just produce the answer. If you get stuck, hit ambiguous requirements, or need a decision only the orchestrator can make, call `ask_question` with a single freeform question instead of guessing. Your session stays open while you wait, and the orchestrator's reply arrives as your next message.
+
+Guidelines:
+- Read files before editing to understand existing code
+- Make targeted edits, not wholesale rewrites
+- Use `bash` for running commands (tests, builds, installs, etc.)
+- If something fails, diagnose and fix it
+- Your FINAL assistant message should summarize what you did and what changed
+
+## Delegation — protecting your context window
+
+Your context is finite. Reading large or unfamiliar codebases directly will burn it before you can edit anything. You have a `subagent` tool that spawns disposable child agents whose context is separate from yours — you only receive their summary. Use it.
+
+You can dispatch:
+- **scout** — read-only recon (read, grep, find, ls). Returns a structured map of files, line ranges, and key snippets. Cheap (haiku). Use for *exploring unfamiliar territory*.
+- **researcher** — web research (web_search, web_fetch). Returns a sourced brief. Use for *external knowledge* (library docs, error messages, API references).
+
+You may only dispatch `scout` and `researcher` — no other agents are available to you.
+
+**Always select the agent with the `agent` field**, e.g. `subagent({ agent: "scout", name: "recon", task: "…" })`. The `name` field is only a cosmetic pane label — it does NOT pick the agent. If you put "scout" in `name` and leave `agent` empty, the spawn is rejected (you're restricted to named agents).
+
+### When to dispatch a scout vs. read directly
+
+Dispatch a scout when:
+- The task brief names a feature/area but not specific files ("fix the auth flow", "add a field to user settings")
+- You'd need to grep + read 5+ files just to orient
+- You only need to know *where* something lives or *what shape* it has, not its full source
+
+Read directly when:
+- The brief gives you explicit file paths
+- You already know the file you need to edit
+- You need the exact bytes for an `edit` call (scouts return summaries, not verbatim source — re-read the 1–3 files you actually edit)
+
+A good rhythm: **scout to find, read to edit.** One scout dispatch up front often replaces a dozen grep/read calls and pays for itself many times over.
+
+### When to dispatch a researcher vs. web_fetch directly
+
+Dispatch a researcher when:
+- The question is open-ended ("what's the idiomatic way to X in library Y")
+- You'd need to search + read 3+ pages to triangulate
+- You want sources synthesized, not raw HTML in your context
+
+Fetch directly when:
+- You already have the exact URL (a known docs page, a GitHub issue)
+- You need a single specific piece of information from one page
+
+### Parallelism
+
+If you need two independent investigations (e.g. "map the auth code" AND "look up the library's session API"), emit multiple `subagent` tool calls in the same turn — they run in parallel automatically. Don't serialize independent work. After spawning, the results arrive as steer messages — don't poll or fabricate them.
+
+After dispatching subagents you can just say what you're waiting for and stop the turn — your session will **not** close while children are still running. It stays open until every child has reported back, then wakes you with each result. Don't spin in a loop trying to "check" on them.
+
+### What a subagent doesn't replace
+
+Subagents can't edit files for you. You still do the `edit`/`write` calls yourself, with the focused context the scouts gave you. Treat them as a context-protecting prefetch, not a substitute for thinking.
+
+## Output format when done
+
+## Changes Made
+- `path/to/file.ts` — what changed and why
+
+## Verification
+How you verified the changes work (tests run, build succeeded, etc.)
+
+## Notes
+Any caveats, follow-up items, or decisions made.

--- a/pi/.pi/agent/extensions/interactive-subagents/config.json.example
+++ b/pi/.pi/agent/extensions/interactive-subagents/config.json.example
@@ -1,0 +1,5 @@
+{
+  "status": {
+    "enabled": true
+  }
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/package.json
+++ b/pi/.pi/agent/extensions/interactive-subagents/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "pi-interactive-subagents-herdr",
+  "version": "3.7.2-herdr.1",
+  "description": "Interactive subagents for pi - spawn, orchestrate, and manage sub-agent sessions in Herdr or tmux (dotfiles fork with a Herdr surface layer)",
+  "keywords": [
+    "pi-package"
+  ],
+  "license": "MIT",
+  "author": "Amos Blomqvist",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/amosblomqvist/pi-interactive-subagents"
+  },
+  "forkNotes": {
+    "upstream": "amosblomqvist/pi-interactive-subagents@main",
+    "changes": [
+      "Added pi-extension/subagents/herdr.ts — Herdr pane surface (herdr pane split/send-text/send-keys/read/close).",
+      "Added pi-extension/subagents/surface.ts — auto-detect dispatcher (Herdr via HERDR_ENV/HERDR_PANE_ID, else tmux via TMUX).",
+      "index.ts imports ./surface.ts instead of ./tmux.ts; tmux.ts kept intact as the fallback surface.",
+      "Remapped @mariozechner/* and @sinclair/typebox imports to @earendil-works/* (captain's pi publish names).",
+      "Known gap: Herdr has no select-layout even-horizontal equivalent, so pane rebalancing is a no-op on the Herdr surface."
+    ]
+  },
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/test.ts",
+    "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "@earendil-works/pi-ai": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./pi-extension/subagents/index.ts"
+    ]
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "@earendil-works/pi-ai": "*"
+  }
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/activity.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/activity.ts
@@ -1,0 +1,511 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type SubagentActivityPhase = "starting" | "active" | "waiting" | "done";
+export type SubagentActivityScope = "agent" | "turn" | "provider" | "streaming" | "tool";
+
+export type SubagentActivityEvent =
+  | "session_start"
+  | "input"
+  | "before_agent_start"
+  | "agent_start"
+  | "agent_end"
+  | "turn_start"
+  | "turn_end"
+  | "before_provider_request"
+  | "after_provider_response"
+  | "message_update"
+  | "tool_execution_start"
+  | "tool_call"
+  | "tool_execution_update"
+  | "tool_result"
+  | "tool_execution_end"
+  | "ask_question"
+  | "session_shutdown";
+
+export interface SubagentActivityState {
+  version: 1;
+  runningChildId: string;
+  createdAt: number;
+  updatedAt: number;
+  sequence: number;
+  latestEvent: SubagentActivityEvent;
+  phase: SubagentActivityPhase;
+  agentActive: boolean;
+  turnActive: boolean;
+  providerActive: boolean;
+  toolActive: boolean;
+  activeScope?: SubagentActivityScope;
+  activeSince?: number;
+  waitingSince?: number;
+  turnIndex?: number;
+  messageEventType?: string;
+  toolCallId?: string;
+  toolName?: string;
+  toolStartedAt?: number;
+  toolEndedAt?: number;
+}
+
+export type ActivityReadResult =
+  | { ok: true; activity: SubagentActivityState }
+  | { ok: false; reason: "missing" | "invalid" | "wrong-id"; error?: string };
+
+export type SubagentShutdownReason = "quit" | "reload" | "new" | "resume" | "fork";
+
+export interface SubagentActivityRecorder {
+  sessionStart(): void;
+  input(): void;
+  beforeAgentStart(): void;
+  agentStart(): void;
+  agentEndWaiting(): void;
+  agentEndDone(): void;
+  turnStart(turnIndex?: number): void;
+  turnEnd(turnIndex?: number): void;
+  beforeProviderRequest(): void;
+  afterProviderResponse(): void;
+  messageUpdate(messageEventType?: string): void;
+  toolExecutionStart(toolCallId?: string, toolName?: string): void;
+  toolCall(toolCallId?: string, toolName?: string): void;
+  toolExecutionUpdate(toolCallId?: string, toolName?: string): void;
+  toolResult(toolCallId?: string, toolName?: string): void;
+  toolExecutionEnd(toolCallId?: string, toolName?: string): void;
+  askQuestion(): void;
+  sessionShutdown(reason: SubagentShutdownReason): void;
+}
+
+const ACTIVITY_UPDATE_THROTTLE_MS = 500;
+const MAX_WRITE_FAILURES = 3;
+const KNOWN_PHASES = new Set<SubagentActivityPhase>(["starting", "active", "waiting", "done"]);
+const KNOWN_SCOPES = new Set<SubagentActivityScope>(["agent", "turn", "provider", "streaming", "tool"]);
+const KNOWN_EVENTS = new Set<SubagentActivityEvent>([
+  "session_start",
+  "input",
+  "before_agent_start",
+  "agent_start",
+  "agent_end",
+  "turn_start",
+  "turn_end",
+  "before_provider_request",
+  "after_provider_response",
+  "message_update",
+  "tool_execution_start",
+  "tool_call",
+  "tool_execution_update",
+  "tool_result",
+  "tool_execution_end",
+  "ask_question",
+  "session_shutdown",
+]);
+const MAX_ACTIVITY_STRING_LENGTH = 200;
+
+export function getSubagentActivityFile(artifactDir: string, runningChildId: string): string {
+  return join(artifactDir, "subagent-activity", `${runningChildId}.json`);
+}
+
+function requireObject(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function validateFiniteNumber(object: Record<string, unknown>, fieldName: string): string | null {
+  return Number.isFinite(object[fieldName]) ? null : `${fieldName} must be finite`;
+}
+
+function validateOptionalFiniteNumber(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  return value == null || Number.isFinite(value) ? null : `${fieldName} must be finite when present`;
+}
+
+function validateInteger(object: Record<string, unknown>, fieldName: string): string | null {
+  return Number.isInteger(object[fieldName]) ? null : `${fieldName} must be an integer`;
+}
+
+function validateOptionalInteger(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  return value == null || Number.isInteger(value) ? null : `${fieldName} must be an integer when present`;
+}
+
+function validateBoolean(object: Record<string, unknown>, fieldName: string): string | null {
+  return typeof object[fieldName] === "boolean" ? null : `${fieldName} must be a boolean`;
+}
+
+function validateOptionalActivityString(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  if (value == null) return null;
+  if (typeof value !== "string") return `${fieldName} must be a string when present`;
+  if (/\r|\n/.test(value)) return `${fieldName} must not contain newlines`;
+  return value.length <= MAX_ACTIVITY_STRING_LENGTH ? null : `${fieldName} is too long`;
+}
+
+function invalidActivity(error: string): ActivityReadResult {
+  return { ok: false, reason: "invalid", error };
+}
+
+function validateActivity(value: unknown, expectedRunningChildId: string): ActivityReadResult {
+  const object = requireObject(value);
+  if (!object) return invalidActivity("activity must be an object");
+  if (object.version !== 1) return invalidActivity("unsupported activity version");
+  if (typeof object.runningChildId !== "string") return invalidActivity("runningChildId must be a string");
+  if (object.runningChildId !== expectedRunningChildId) return { ok: false, reason: "wrong-id" };
+  if (typeof object.latestEvent !== "string" || !KNOWN_EVENTS.has(object.latestEvent as SubagentActivityEvent)) {
+    return invalidActivity("unknown latestEvent");
+  }
+  if (typeof object.phase !== "string" || !KNOWN_PHASES.has(object.phase as SubagentActivityPhase)) {
+    return invalidActivity("unknown activity phase");
+  }
+  if (
+    object.activeScope != null &&
+    (typeof object.activeScope !== "string" || !KNOWN_SCOPES.has(object.activeScope as SubagentActivityScope))
+  ) {
+    return invalidActivity("unknown activeScope");
+  }
+
+  const validationError = [
+    validateFiniteNumber(object, "createdAt"),
+    validateFiniteNumber(object, "updatedAt"),
+    validateInteger(object, "sequence"),
+    validateBoolean(object, "agentActive"),
+    validateBoolean(object, "turnActive"),
+    validateBoolean(object, "providerActive"),
+    validateBoolean(object, "toolActive"),
+    validateOptionalFiniteNumber(object, "activeSince"),
+    validateOptionalFiniteNumber(object, "waitingSince"),
+    validateOptionalInteger(object, "turnIndex"),
+    validateOptionalFiniteNumber(object, "toolStartedAt"),
+    validateOptionalFiniteNumber(object, "toolEndedAt"),
+    validateOptionalActivityString(object, "messageEventType"),
+    validateOptionalActivityString(object, "toolCallId"),
+    validateOptionalActivityString(object, "toolName"),
+  ].find((error) => error != null);
+  if (validationError) return invalidActivity(validationError);
+
+  return { ok: true, activity: object as unknown as SubagentActivityState };
+}
+
+export function readSubagentActivityFile(
+  activityFile: string,
+  expectedRunningChildId: string,
+): ActivityReadResult {
+  if (!existsSync(activityFile)) return { ok: false, reason: "missing" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(activityFile, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: "invalid", error: message };
+  }
+
+  return validateActivity(parsed, expectedRunningChildId);
+}
+
+export function writeSubagentActivityFile(activityFile: string, activity: SubagentActivityState): void {
+  const dir = dirname(activityFile);
+  mkdirSync(dir, { recursive: true });
+  const tempFile = join(dir, `${activity.runningChildId}.json.${process.pid}.${activity.sequence}.tmp`);
+
+  try {
+    writeFileSync(tempFile, `${JSON.stringify(activity)}\n`, "utf8");
+    renameSync(tempFile, activityFile);
+  } catch (error) {
+    try {
+      unlinkSync(tempFile);
+    } catch (cleanupError) {
+      // Temp cleanup is best effort; preserve the original write/rename failure
+      void cleanupError;
+    }
+    throw error;
+  }
+}
+
+function createNoopRecorder(): SubagentActivityRecorder {
+  return {
+    sessionStart() {},
+    input() {},
+    beforeAgentStart() {},
+    agentStart() {},
+    agentEndWaiting() {},
+    agentEndDone() {},
+    turnStart() {},
+    turnEnd() {},
+    beforeProviderRequest() {},
+    afterProviderResponse() {},
+    messageUpdate() {},
+    toolExecutionStart() {},
+    toolCall() {},
+    toolExecutionUpdate() {},
+    toolResult() {},
+    toolExecutionEnd() {},
+    askQuestion() {},
+    sessionShutdown() {},
+  };
+}
+
+function clearActiveState(activity: SubagentActivityState): void {
+  activity.agentActive = false;
+  activity.turnActive = false;
+  activity.providerActive = false;
+  activity.toolActive = false;
+  delete activity.activeScope;
+  delete activity.activeSince;
+}
+
+function refreshActiveScope(activity: SubagentActivityState): void {
+  if (activity.toolActive) {
+    activity.phase = "active";
+    activity.activeScope = "tool";
+    return;
+  }
+  if (activity.providerActive) {
+    activity.phase = "active";
+    activity.activeScope = "provider";
+    return;
+  }
+  if (activity.turnActive) {
+    activity.phase = "active";
+    activity.activeScope = "turn";
+    return;
+  }
+  if (activity.agentActive) {
+    activity.phase = "active";
+    activity.activeScope = "agent";
+    return;
+  }
+  delete activity.activeScope;
+  delete activity.activeSince;
+}
+
+function markActive(
+  activity: SubagentActivityState,
+  scope: SubagentActivityScope,
+  now: number,
+  resetActiveSince = false,
+): void {
+  activity.phase = "active";
+  activity.activeScope = scope;
+  if (activity.activeSince == null || resetActiveSince) activity.activeSince = now;
+  delete activity.waitingSince;
+}
+
+export function createSubagentActivityRecorder(params: {
+  runningChildId?: string;
+  activityFile?: string;
+  now?: () => number;
+}): SubagentActivityRecorder {
+  const runningChildId = params.runningChildId?.trim();
+  const activityFile = params.activityFile?.trim();
+  if (!runningChildId || !activityFile) return createNoopRecorder();
+
+  const now = params.now ?? (() => Date.now());
+  const createdAt = now();
+  const activity: SubagentActivityState = {
+    version: 1,
+    runningChildId,
+    createdAt,
+    updatedAt: createdAt,
+    sequence: 0,
+    latestEvent: "session_start",
+    phase: "starting",
+    agentActive: false,
+    turnActive: false,
+    providerActive: false,
+    toolActive: false,
+  };
+
+  let disabled = false;
+  let failureCount = 0;
+  let lastFlushAt = 0;
+  let pendingFlush: ReturnType<typeof setTimeout> | null = null;
+
+  function clearPendingFlush(): void {
+    if (!pendingFlush) return;
+    clearTimeout(pendingFlush);
+    pendingFlush = null;
+  }
+
+  function disable(): void {
+    disabled = true;
+    clearPendingFlush();
+  }
+
+  function flushNow(): void {
+    if (disabled) return;
+    try {
+      writeSubagentActivityFile(activityFile, activity);
+      lastFlushAt = now();
+      failureCount = 0;
+    } catch {
+      failureCount += 1;
+      if (failureCount >= MAX_WRITE_FAILURES) disable();
+    }
+  }
+
+  function scheduleFlush(): void {
+    if (disabled || pendingFlush) return;
+
+    const remainingMs = Math.max(0, ACTIVITY_UPDATE_THROTTLE_MS - (now() - lastFlushAt));
+    if (remainingMs === 0) {
+      flushNow();
+      return;
+    }
+
+    pendingFlush = setTimeout(() => {
+      pendingFlush = null;
+      flushNow();
+    }, remainingMs);
+  }
+
+  function record(
+    latestEvent: SubagentActivityEvent,
+    update: (current: SubagentActivityState, now: number) => void,
+    flush: "immediate" | "throttled",
+  ): void {
+    if (disabled) return;
+    if (flush === "immediate") clearPendingFlush();
+
+    const observedAt = now();
+    activity.latestEvent = latestEvent;
+    activity.updatedAt = observedAt;
+    activity.sequence += 1;
+    update(activity, observedAt);
+
+    if (flush === "immediate") flushNow();
+    else scheduleFlush();
+  }
+
+  function markDone(latestEvent: SubagentActivityEvent): void {
+    record(latestEvent, (current) => {
+      current.phase = "done";
+      clearActiveState(current);
+      delete current.waitingSince;
+    }, "immediate");
+    disable();
+  }
+
+  return {
+    sessionStart() {
+      record("session_start", (current) => {
+        current.phase = "starting";
+        clearActiveState(current);
+        delete current.waitingSince;
+      }, "immediate");
+    },
+    input() {
+      record("input", () => {}, "immediate");
+    },
+    beforeAgentStart() {
+      record("before_agent_start", (current, observedAt) => {
+        current.agentActive = true;
+        markActive(current, "agent", observedAt);
+      }, "immediate");
+    },
+    agentStart() {
+      record("agent_start", (current, observedAt) => {
+        current.agentActive = true;
+        markActive(current, "agent", observedAt);
+      }, "immediate");
+    },
+    agentEndWaiting() {
+      record("agent_end", (current, observedAt) => {
+        clearActiveState(current);
+        current.phase = "waiting";
+        current.waitingSince = observedAt;
+      }, "immediate");
+    },
+    agentEndDone() {
+      markDone("agent_end");
+    },
+    turnStart(turnIndex) {
+      record("turn_start", (current, observedAt) => {
+        current.agentActive = true;
+        current.turnActive = true;
+        if (turnIndex != null) current.turnIndex = turnIndex;
+        markActive(current, current.toolActive || current.providerActive ? current.activeScope ?? "turn" : "turn", observedAt);
+      }, "immediate");
+    },
+    turnEnd(turnIndex) {
+      record("turn_end", (current) => {
+        current.turnActive = false;
+        current.providerActive = false;
+        current.toolActive = false;
+        if (turnIndex != null) current.turnIndex = turnIndex;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    beforeProviderRequest() {
+      record("before_provider_request", (current, observedAt) => {
+        current.providerActive = true;
+        markActive(current, "provider", observedAt, true);
+      }, "immediate");
+    },
+    afterProviderResponse() {
+      record("after_provider_response", (current) => {
+        current.providerActive = false;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    messageUpdate(messageEventType) {
+      record("message_update", (current, observedAt) => {
+        current.agentActive = true;
+        current.turnActive = true;
+        current.messageEventType = messageEventType;
+        if (!current.toolActive) markActive(current, "streaming", observedAt);
+      }, "throttled");
+    },
+    toolExecutionStart(toolCallId, toolName) {
+      record("tool_execution_start", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId;
+        current.toolName = toolName;
+        current.toolStartedAt = observedAt;
+        markActive(current, "tool", observedAt, true);
+      }, "immediate");
+    },
+    toolCall(toolCallId, toolName) {
+      record("tool_call", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        markActive(current, "tool", observedAt);
+      }, "immediate");
+    },
+    toolExecutionUpdate(toolCallId, toolName) {
+      record("tool_execution_update", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        markActive(current, "tool", observedAt);
+      }, "throttled");
+    },
+    toolResult(toolCallId, toolName) {
+      record("tool_result", (current) => {
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    toolExecutionEnd(toolCallId, toolName) {
+      record("tool_execution_end", (current, observedAt) => {
+        current.toolActive = false;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        current.toolEndedAt = observedAt;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    askQuestion() {
+      // The subagent paused to ask the orchestrator a question. Park it in the
+      // "waiting" phase (do NOT disable the recorder) so the status widget shows
+      // it as waiting and recording resumes when the answer arrives.
+      record("ask_question", (current, observedAt) => {
+        clearActiveState(current);
+        current.phase = "waiting";
+        current.waitingSince = observedAt;
+      }, "immediate");
+    },
+    sessionShutdown(reason) {
+      if (reason === "quit") markDone("session_shutdown");
+      else disable();
+    },
+  };
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/herdr.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/herdr.ts
@@ -1,0 +1,340 @@
+/**
+ * Herdr surface layer — pane control via the `herdr` CLI socket API.
+ *
+ * Mirrors the export contract of ./tmux.ts so index.ts can target either
+ * multiplexer through ./surface.ts. Panes are identified by Herdr pane ids
+ * (e.g. `w44:p2`). Splits always target the parent pi's pane
+ * (`HERDR_PANE_ID`) so they follow the agent rather than the user's focus.
+ *
+ * Herdr has no `select-layout even-horizontal` equivalent, so pane rebalancing
+ * is a no-op here (panes stay at the split ratio given at creation time). This
+ * is the one functional gap vs the tmux surface; it is cosmetic and never
+ * blocks spawning or watching.
+ */
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+// ── Availability ──
+
+const commandAvailability = new Map<string, boolean>();
+
+function hasCommand(command: string): boolean {
+  if (commandAvailability.has(command)) {
+    return commandAvailability.get(command)!;
+  }
+
+  let available = false;
+  try {
+    execFileSync("sh", ["-c", `command -v ${command}`], { stdio: "ignore" });
+    available = true;
+  } catch {
+    available = false;
+  }
+
+  commandAvailability.set(command, available);
+  return available;
+}
+
+/**
+ * True when running inside Herdr with the `herdr` binary on PATH.
+ * Herdr sets `HERDR_ENV=1` and `HERDR_PANE_ID` on every process it manages
+ * (the parent pi's pane id lives in `HERDR_PANE_ID`, the tmux analogue of
+ * `TMUX_PANE`).
+ */
+export function isHerdrAvailable(): boolean {
+  return process.env.HERDR_ENV === "1" && !!process.env.HERDR_PANE_ID && hasCommand("herdr");
+}
+
+/** Surface-agnostic gate (matches the ./tmux.ts `isMuxAvailable` contract). */
+export function isMuxAvailable(): boolean {
+  return isHerdrAvailable();
+}
+
+export function muxSetupHint(): string {
+  return "Start pi inside Herdr (`herdr` — panes are managed by the Herdr server).";
+}
+
+function requireHerdr(): void {
+  if (!isHerdrAvailable()) {
+    throw new Error(`Herdr is required for subagents. ${muxSetupHint()}`);
+  }
+}
+
+// ── Shell helpers ──
+
+export function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+// ── Herdr CLI helpers ──
+
+/**
+ * Parse the new pane id out of `herdr pane split` JSON stdout, e.g.
+ * `{"id":"cli:pane:split","result":{"pane":{"pane_id":"w44:p3",...}}}}`.
+ */
+function parsePaneId(stdout: string): string {
+  const data = JSON.parse(stdout);
+  const paneId = data?.result?.pane?.pane_id;
+  if (typeof paneId !== "string" || paneId.length === 0) {
+    throw new Error(`Unexpected herdr pane split output: ${stdout}`);
+  }
+  return paneId;
+}
+
+// ── Pane layout ──
+
+/**
+ * Herdr has no named-layout rebalance command, so this is a no-op. Panes keep
+ * the ratio set at split time. Kept as a hook so index.ts / future Herdr
+ * layout support can plug in without changing call sites.
+ */
+function rebalanceSurfaces(_hintPane?: string): void {
+  // no-op: Herdr pane layout is not `select-layout`-style rebalanceable today.
+}
+
+// ── Surface primitives ──
+
+/**
+ * Create a new pane for a subagent: a right split off the parent pi's pane,
+ * so new panes follow the agent rather than the user's focus.
+ * Returns the new pane id (e.g. `w44:p3`).
+ */
+export function createSurface(name: string): string {
+  void name; // Herdr panes are not named; the pi process inside shows its own title.
+  return createSurfaceSplit(name, "right", process.env.HERDR_PANE_ID);
+}
+
+/**
+ * Create a new split in the given direction from an optional source pane.
+ * Returns the new pane id (e.g. `w44:p3`).
+ */
+export function createSurfaceSplit(
+  name: string,
+  direction: "left" | "right" | "up" | "down",
+  fromSurface?: string,
+): string {
+  void name;
+  requireHerdr();
+
+  // Herdr only exposes `right` and `down` split directions. Map the tmux-style
+  // four-way directions onto the two Herdr supports, choosing the closest
+  // non-overlapping direction for `left`/`up` (split the parent anyway).
+  const herdrDirection: "right" | "down" =
+    direction === "up" || direction === "down" ? "down" : "right";
+
+  const args = ["pane", "split"];
+  if (fromSurface) {
+    args.push(fromSurface);
+  }
+  args.push("--direction", herdrDirection, "--ratio", "0.5", "--no-focus");
+
+  const stdout = execFileSync("herdr", args, { encoding: "utf8" });
+  const pane = parsePaneId(stdout);
+  rebalanceSurfaces(pane);
+  return pane;
+}
+
+/**
+ * Send a command string to a pane and execute it.
+ * `herdr pane send-text` sends literal text (the tmux `send-keys -l` analogue),
+ * then `herdr pane send-keys Enter` submits it.
+ */
+export function sendCommand(surface: string, command: string): void {
+  requireHerdr();
+  execFileSync("herdr", ["pane", "send-text", surface, command], { encoding: "utf8" });
+  execFileSync("herdr", ["pane", "send-keys", surface, "Enter"], { encoding: "utf8" });
+}
+
+/**
+ * Send a long command to a pane by writing it to a script file first.
+ * This avoids terminal line-wrapping issues that break commands exceeding the
+ * pane's column width when sent character-by-character via sendCommand.
+ *
+ * By default the script is written to a temp directory, but callers can pass a
+ * stable path (for example under session artifacts) so the exact invocation is
+ * preserved for debugging.
+ *
+ * Returns the script path.
+ */
+export function sendLongCommand(
+  surface: string,
+  command: string,
+  options?: { scriptPath?: string; scriptPreamble?: string },
+): string {
+  const scriptPath =
+    options?.scriptPath ??
+    join(
+      tmpdir(),
+      "pi-subagent-scripts",
+      `cmd-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sh`,
+    );
+  mkdirSync(dirname(scriptPath), { recursive: true });
+
+  const scriptParts = ["#!/bin/bash"];
+  if (options?.scriptPreamble) {
+    scriptParts.push(options.scriptPreamble.trimEnd());
+  }
+  scriptParts.push(command);
+
+  writeFileSync(scriptPath, scriptParts.join("\n") + "\n", {
+    mode: 0o755,
+  });
+  sendCommand(surface, `bash ${shellEscape(scriptPath)}`);
+  return scriptPath;
+}
+
+/**
+ * Read the screen contents of a pane (sync).
+ * `herdr pane read --source recent` is the tmux `capture-pane -p` analogue.
+ */
+export function readScreen(surface: string, lines = 50): string {
+  requireHerdr();
+  return execFileSync(
+    "herdr",
+    ["pane", "read", surface, "--source", "recent", "--lines", String(Math.max(1, lines)), "--format", "text"],
+    { encoding: "utf8" },
+  );
+}
+
+/**
+ * Read the screen contents of a pane (async).
+ */
+export async function readScreenAsync(surface: string, lines = 50): Promise<string> {
+  requireHerdr();
+  const { stdout } = await execFileAsync(
+    "herdr",
+    ["pane", "read", surface, "--source", "recent", "--lines", String(Math.max(1, lines)), "--format", "text"],
+    { encoding: "utf8" },
+  );
+  return stdout;
+}
+
+/**
+ * Close a pane.
+ */
+export function closeSurface(surface: string): void {
+  requireHerdr();
+  execFileSync("herdr", ["pane", "close", surface], { encoding: "utf8" });
+  rebalanceSurfaces();
+}
+
+// ── Exit polling ──
+
+export interface PollResult {
+  /** How the subagent exited */
+  reason: "done" | "sentinel" | "error";
+  /** Shell exit code (from sentinel). 0 for file-based exits. */
+  exitCode: number;
+  /** Error message if reason is "error" (auto-retry exhausted, provider overload, etc.) */
+  errorMessage?: string;
+}
+
+/**
+ * Interpret an `.exit` sidecar payload (written by the error path in
+ * subagent-done.ts). Centralized so both the fast and slow paths in
+ * pollForExit decode the payload the same way. Clean completions write no
+ * sidecar and are detected via the terminal sentinel instead.
+ *
+ * Note: ask_question does NOT write a `.exit` sidecar — it keeps the session
+ * open and signals the parent via a separate `.ask` file.
+ */
+function interpretExitSidecar(data: any): PollResult {
+  if (data?.type === "error") {
+    const errorMessage =
+      typeof data.errorMessage === "string" && data.errorMessage.trim() !== ""
+        ? data.errorMessage
+        : "Subagent exited with stopReason=error (no errorMessage in sidecar).";
+    return { reason: "error", exitCode: 1, errorMessage };
+  }
+  return { reason: "done", exitCode: 0 };
+}
+
+export const __pollForExitTest__ = { interpretExitSidecar };
+
+/**
+ * Poll until the subagent exits. Checks for a `.exit` sidecar file first
+ * (written by the error path), falling back to the terminal sentinel for
+ * clean-completion and crash detection. Identical logic to ./tmux.ts; only
+ * the underlying readScreenAsync differs.
+ */
+export async function pollForExit(
+  surface: string,
+  signal: AbortSignal,
+  options: {
+    interval: number;
+    sessionFile?: string;
+    sentinelFile?: string;
+    onTick?: (elapsed: number) => void;
+  },
+): Promise<PollResult> {
+  const start = Date.now();
+
+  for (;;) {
+    if (signal.aborted) {
+      throw new Error("Aborted while waiting for subagent to finish");
+    }
+
+    // Fast path: check for .exit sidecar file (written by the error path)
+    if (options.sessionFile) {
+      try {
+        const exitFile = `${options.sessionFile}.exit`;
+        if (existsSync(exitFile)) {
+          const data = JSON.parse(readFileSync(exitFile, "utf-8"));
+          rmSync(exitFile, { force: true });
+          return interpretExitSidecar(data);
+        }
+      } catch {}
+    }
+
+    // Check Claude sentinel file (written by plugin Stop hook)
+    if (options.sentinelFile) {
+      try {
+        if (existsSync(options.sentinelFile)) {
+          return { reason: "sentinel", exitCode: 0 };
+        }
+      } catch {}
+    }
+
+    // Slow path: read terminal screen for sentinel (crash detection)
+    try {
+      const screen = await readScreenAsync(surface, 5);
+      const match = screen.match(/__SUBAGENT_DONE_(\d+)__/);
+      if (match) {
+        return { reason: "sentinel", exitCode: parseInt(match[1], 10) };
+      }
+    } catch {
+      // Surface may have been destroyed — check if .exit file appeared in the meantime
+      if (options.sessionFile) {
+        try {
+          const exitFile = `${options.sessionFile}.exit`;
+          if (existsSync(exitFile)) {
+            const data = JSON.parse(readFileSync(exitFile, "utf-8"));
+            rmSync(exitFile, { force: true });
+            return interpretExitSidecar(data);
+          }
+        } catch {}
+      }
+    }
+
+    const elapsed = Math.floor((Date.now() - start) / 1000);
+    options.onTick?.(elapsed);
+
+    await new Promise<void>((resolve, reject) => {
+      if (signal.aborted) return reject(new Error("Aborted"));
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, options.interval);
+      function onAbort() {
+        clearTimeout(timer);
+        reject(new Error("Aborted"));
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/index.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/index.ts
@@ -1,0 +1,2529 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { keyHint } from "@earendil-works/pi-coding-agent";
+import { Type, type Static } from "@earendil-works/pi-ai";
+import { Box, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  copyFileSync,
+  unlinkSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import {
+  isMuxAvailable,
+  muxSetupHint,
+  createSurface,
+  sendCommand,
+  sendLongCommand,
+  pollForExit,
+  closeSurface,
+  shellEscape,
+  readScreen,
+} from "./surface.ts";
+
+import {
+  countSessionEntryLines,
+  findLastAssistantMessage,
+  getNewEntries,
+  getSessionId,
+  readNameRegistry,
+  readSubagentLoadout,
+  registerName,
+  resolveNameInRegistry,
+  seedSubagentSessionFile,
+  summarizeSessionStats,
+  writeSubagentLoadout,
+  type SessionStats,
+  type SubagentLoadout,
+} from "./session.ts";
+import {
+  type StatusSnapshot,
+  type SubagentStatusState,
+  advanceStatusState,
+  capStatusLines,
+  classifyStatus,
+  createStatusState,
+  forceStatusAfterInterrupt,
+  formatStatusAggregate,
+  formatTransitionLine,
+  observeStatus,
+  loadStatusConfig,
+} from "./status.ts";
+import {
+  getSubagentActivityFile,
+  readSubagentActivityFile,
+  type ActivityReadResult,
+  type SubagentActivityState,
+} from "./activity.ts";
+
+/** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
+const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
+
+// Survive /reload: clear timers and abort poll loops from the previous module load.
+// /reload re-imports this file, giving fresh module-level state, but closures from
+// the old module keep running. See https://github.com/HazAT/pi-interactive-subagents/issues/5
+const WIDGET_INTERVAL_KEY = Symbol.for("pi-subagents/widget-interval");
+const STATUS_INTERVAL_KEY = Symbol.for("pi-subagents/status-interval");
+const POLL_ABORT_KEY = Symbol.for("pi-subagents/poll-abort-controller");
+
+{
+  const prevInterval = (globalThis as any)[WIDGET_INTERVAL_KEY];
+  if (prevInterval) {
+    clearInterval(prevInterval);
+    (globalThis as any)[WIDGET_INTERVAL_KEY] = null;
+  }
+  const prevStatusInterval = (globalThis as any)[STATUS_INTERVAL_KEY];
+  if (prevStatusInterval) {
+    clearInterval(prevStatusInterval);
+    (globalThis as any)[STATUS_INTERVAL_KEY] = null;
+  }
+  const prevAbort = (globalThis as any)[POLL_ABORT_KEY] as AbortController | undefined;
+  if (prevAbort) prevAbort.abort();
+  (globalThis as any)[POLL_ABORT_KEY] = new AbortController();
+}
+
+function getModuleAbortSignal(): AbortSignal {
+  return ((globalThis as any)[POLL_ABORT_KEY] as AbortController).signal;
+}
+
+const SubagentParams = Type.Object({
+  agent: Type.String({
+    description:
+      "Which agent to spawn (e.g. 'worker', 'scout', 'researcher'). This loads the agent's " +
+      "fixed profile — its model, tool loadout, and system prompt. Must be one of the available agents.",
+  }),
+  task: Type.String({ description: "Task/prompt for the sub-agent" }),
+  name: Type.Optional(
+    Type.String({
+      description:
+        "Optional cosmetic label for the subagent's pane and widget row. Defaults to the agent name. " +
+        "Has no effect on which agent runs — use `agent` for that.",
+    }),
+  ),
+  model: Type.Optional(Type.String({ description: "Model override (overrides agent default)" })),
+  cwd: Type.Optional(
+    Type.String({
+      description:
+        "Working directory for the sub-agent. The agent starts in this folder and picks up its local .pi/ config, CLAUDE.md, skills, and extensions. Use for role-specific subfolders.",
+    }),
+  ),
+});
+
+type SubagentSessionMode = "standalone" | "lineage-only" | "fork";
+
+interface AgentDefaults {
+  model?: string;
+  tools?: string;
+  skills?: string;
+  thinking?: string;
+  /**
+   * If set (non-empty), this agent is granted the full subagent spawning
+   * toolset and may only spawn the listed agents. Presence of this field —
+   * not the `tools` list — is what grants spawning. Enforced in the child via
+   * the PI_SUBAGENT_ALLOWED env var.
+   */
+  subagentAgents?: string[];
+  autoExit?: boolean;
+  interactive?: boolean;
+  systemPromptMode?: "append" | "replace";
+  sessionMode?: SubagentSessionMode;
+  cwd?: string;
+  cli?: string;
+  body?: string;
+  disableModelInvocation?: boolean;
+}
+
+type AgentSource = "package" | "global" | "project";
+
+interface AgentDefinition extends AgentDefaults {
+  name: string;
+  description?: string;
+  disableModelInvocation: boolean;
+}
+
+interface ListedAgentDefinition extends AgentDefinition {
+  source: AgentSource;
+}
+
+/**
+ * The full subagent lifecycle/spawning toolset registered by this extension.
+ * An agent is granted these (and this extension is loaded into its child
+ * process) only when its frontmatter declares a non-empty `subagent_agents`.
+ */
+const SPAWNING_TOOLS = [
+  "subagent",
+  "subagent_message",
+  "subagents_list",
+] as const;
+
+/** Built-in tools pi provides natively — no extension needs to be loaded. */
+const BUILTIN_TOOLS = new Set(["read", "write", "edit", "bash", "grep", "find", "ls"]);
+
+/** Resolve the global agent config directory, respecting PI_CODING_AGENT_DIR. */
+function getAgentConfigDir(): string {
+  return process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+}
+
+// ── Runtime tool-extension registration ─────────────────────────────────────
+// `getToolExtensionPath` otherwise only knows a closed set of tool names. Other
+// pi extensions that bundle a tool for subagents (e.g. a project-local
+// extension exposing a bespoke tool) register its name → extension-file path
+// here at load/session_start time so a child process can be launched with
+// `--no-extensions` + an explicit `-e <path>` for it. Mirrors the legacy
+// `subagents` extension's `registerToolExtension` hook.
+const EXTRA_TOOL_EXTENSIONS = new Map<string, string>();
+
+/** Register (or re-register) a custom tool's backing extension file. */
+export function registerToolExtension(name: string, extensionPath: string): void {
+  if (BUILTIN_TOOLS.has(name)) {
+    throw new Error(`Cannot register custom tool "${name}": shadows a built-in pi tool`);
+  }
+  if ((SPAWNING_TOOLS as readonly string[]).includes(name)) {
+    throw new Error(`Cannot register custom tool "${name}": shadows a spawning tool`);
+  }
+  const existing = EXTRA_TOOL_EXTENSIONS.get(name);
+  if (existing === extensionPath) return; // idempotent / reload-safe
+  if (existing !== undefined) {
+    throw new Error(
+      `Tool extension already registered for "${name}": ${existing} (refusing to overwrite with ${extensionPath})`,
+    );
+  }
+  EXTRA_TOOL_EXTENSIONS.set(name, extensionPath);
+}
+
+// Expose registration on a process-global so project-local extensions loaded
+// via jiti (separate module instances) can reach this shared map. Set at module
+// load so it's available before any `session_start` listener runs.
+(globalThis as any).__pi_interactive_subagents = {
+  registerToolExtension,
+};
+
+/**
+ * Map a custom (non-built-in) tool name to the pi-extension file that
+ * registers it. Used to build the child's `--extension` whitelist after
+ * `--no-extensions` disables global discovery. Returns undefined for built-in
+ * tools and for unknown names (which simply won't be granted).
+ */
+function getToolExtensionPath(tool: string): string | undefined {
+  if (BUILTIN_TOOLS.has(tool)) return undefined;
+  // The four spawning tools are registered by THIS extension.
+  if ((SPAWNING_TOOLS as readonly string[]).includes(tool)) {
+    return fileURLToPath(import.meta.url);
+  }
+  const extBase = join(getAgentConfigDir(), "extensions");
+  const map: Record<string, string> = {
+    web_search: join(extBase, "web-search", "index.ts"),
+    web_fetch: join(extBase, "web-fetch", "index.ts"),
+    video_extract: join(extBase, "video-extract", "index.ts"),
+    youtube_search: join(extBase, "youtube-search", "index.ts"),
+    google_image_search: join(extBase, "google-image-search", "index.ts"),
+    safe_bash: join(SUBAGENTS_DIR, "tools", "safe-bash.ts"),
+  };
+  // Prefer the built-in path, but fall back to a runtime-registered extension
+  // when that path no longer exists on disk (e.g. a built-in tool extension
+  // was disabled/removed but a project-local extension re-registered it).
+  const builtin = map[tool];
+  if (builtin && existsSync(builtin)) return builtin;
+  return EXTRA_TOOL_EXTENSIONS.get(tool);
+}
+
+/**
+ * When this process was spawned as a restricted subagent, the parent pins the
+ * set of agents it may itself spawn via PI_SUBAGENT_ALLOWED. `null` means no
+ * restriction (top-level session, or an unrestricted child).
+ */
+const SUBAGENT_ALLOWLIST: Set<string> | null = (() => {
+  const raw = process.env.PI_SUBAGENT_ALLOWED;
+  if (!raw) return null;
+  const list = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  return list.length > 0 ? new Set(list) : null;
+})();
+
+function getBundledAgentsDir(): string {
+  return join(SUBAGENTS_DIR, "../../agents");
+}
+
+function getFrontmatterValue(frontmatter: string, key: string): string | undefined {
+  const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  return match ? match[1].trim() : undefined;
+}
+
+function parseOptionalBoolean(value: string | undefined): boolean | undefined {
+  return value != null ? value === "true" : undefined;
+}
+
+/** Parse a comma-separated frontmatter value into a trimmed list (or undefined). */
+function parseCommaList(value: string | undefined): string[] | undefined {
+  if (value == null) return undefined;
+  const list = value.split(",").map((s) => s.trim()).filter(Boolean);
+  return list.length > 0 ? list : undefined;
+}
+
+function parseSessionMode(value: string | undefined): SubagentSessionMode | undefined {
+  if (value === "standalone" || value === "lineage-only" || value === "fork") {
+    return value;
+  }
+  return undefined;
+}
+
+function parseAgentDefinition(content: string, fallbackName: string): AgentDefinition | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const frontmatter = match[1];
+  const body = content.replace(/^---\n[\s\S]*?\n---\n*/, "").trim();
+  const systemPromptMode = getFrontmatterValue(frontmatter, "system-prompt");
+
+  return {
+    name: getFrontmatterValue(frontmatter, "name") ?? fallbackName,
+    description: getFrontmatterValue(frontmatter, "description"),
+    model: getFrontmatterValue(frontmatter, "model"),
+    tools: getFrontmatterValue(frontmatter, "tools"),
+    systemPromptMode:
+      systemPromptMode === "replace"
+        ? "replace"
+        : systemPromptMode === "append"
+          ? "append"
+          : undefined,
+    skills: getFrontmatterValue(frontmatter, "skill") ?? getFrontmatterValue(frontmatter, "skills"),
+    thinking: getFrontmatterValue(frontmatter, "thinking"),
+    subagentAgents: parseCommaList(getFrontmatterValue(frontmatter, "subagent_agents")),
+    autoExit: parseOptionalBoolean(getFrontmatterValue(frontmatter, "auto-exit")),
+    interactive: parseOptionalBoolean(getFrontmatterValue(frontmatter, "interactive")),
+    sessionMode: parseSessionMode(getFrontmatterValue(frontmatter, "session-mode")),
+    cwd: getFrontmatterValue(frontmatter, "cwd"),
+    cli: getFrontmatterValue(frontmatter, "cli"),
+    body: body || undefined,
+    disableModelInvocation:
+      getFrontmatterValue(frontmatter, "disable-model-invocation")?.toLowerCase() === "true",
+  };
+}
+
+function discoverAgentDefinitions(): ListedAgentDefinition[] {
+  const agents = new Map<string, ListedAgentDefinition>();
+  const dirs: Array<{ path: string; source: AgentSource }> = [
+    { path: getBundledAgentsDir(), source: "package" },
+    { path: join(getAgentConfigDir(), "agents"), source: "global" },
+    { path: join(process.cwd(), ".pi", "agents"), source: "project" },
+  ];
+
+  for (const { path: dir, source } of dirs) {
+    if (!existsSync(dir)) continue;
+    for (const file of readdirSync(dir).filter((entry) => entry.endsWith(".md"))) {
+      const parsed = parseAgentDefinition(
+        readFileSync(join(dir, file), "utf8"),
+        file.replace(/\.md$/, ""),
+      );
+      if (!parsed) continue;
+      agents.set(parsed.name, { ...parsed, source });
+    }
+  }
+
+  // When this process is itself a restricted subagent, only expose the agents
+  // it is permitted to spawn (PI_SUBAGENT_ALLOWED). Top-level sessions see all.
+  const all = [...agents.values()];
+  return SUBAGENT_ALLOWLIST ? all.filter((a) => SUBAGENT_ALLOWLIST.has(a.name)) : all;
+}
+
+function resolveSubagentPaths(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+): { effectiveCwd: string | null; localAgentDir: string | null; effectiveAgentDir: string } {
+  const rawCwd = params.cwd ?? agentDefs?.cwd ?? null;
+  const cwdIsFromAgent = !params.cwd && agentDefs?.cwd != null;
+  const cwdBase = cwdIsFromAgent ? getAgentConfigDir() : process.cwd();
+  const effectiveCwd = rawCwd
+    ? rawCwd.startsWith("/")
+      ? rawCwd
+      : join(cwdBase, rawCwd)
+    : null;
+  const localAgentDir = effectiveCwd ? join(effectiveCwd, ".pi", "agent") : null;
+  const effectiveAgentDir =
+    localAgentDir && existsSync(localAgentDir) ? localAgentDir : getAgentConfigDir();
+  return { effectiveCwd, localAgentDir, effectiveAgentDir };
+}
+
+function getDefaultSessionDirFor(cwd: string, agentDir: string): string {
+  const safePath = `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+  const sessionDir = join(agentDir, "sessions", safePath);
+  if (!existsSync(sessionDir)) {
+    mkdirSync(sessionDir, { recursive: true });
+  }
+  return sessionDir;
+}
+
+function resolveEffectiveSessionMode(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+): SubagentSessionMode {
+  return agentDefs?.sessionMode ?? "standalone";
+}
+
+function resolveLaunchBehavior(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+): {
+  sessionMode: SubagentSessionMode;
+  seededSessionMode: "lineage-only" | "fork" | null;
+  inheritsConversationContext: boolean;
+  taskDelivery: "direct" | "artifact";
+} {
+  const sessionMode = resolveEffectiveSessionMode(params, agentDefs);
+  const inheritsConversationContext = sessionMode === "fork";
+  return {
+    sessionMode,
+    seededSessionMode: sessionMode === "standalone" ? null : sessionMode,
+    inheritsConversationContext,
+    taskDelivery: inheritsConversationContext ? "direct" : "artifact",
+  };
+}
+
+/**
+ * Decide whether a subagent is interactive (user-driven, long-running).
+ *
+ * Resolution order:
+ *   1. Explicit `interactive` frontmatter field on the agent.
+ *   2. Default: the inverse of `auto-exit`. Agents that auto-exit are
+ *      autonomous (scout, researcher) and the parent session should be
+ *      woken on stall/recovery transitions. Agents that don't auto-exit are
+ *      driven by the user in their own pane (worker) and stall pings are noise.
+ */
+function resolveEffectiveInteractive(
+  _params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+): boolean {
+  if (agentDefs?.interactive != null) return agentDefs.interactive;
+  return !(agentDefs?.autoExit ?? false);
+}
+
+function loadAgentDefaults(agentName: string): AgentDefaults | null {
+  const configDir = getAgentConfigDir();
+  const paths = [
+    join(process.cwd(), ".pi", "agents", `${agentName}.md`),
+    join(configDir, "agents", `${agentName}.md`),
+    join(getBundledAgentsDir(), `${agentName}.md`),
+  ];
+
+  for (const p of paths) {
+    if (!existsSync(p)) continue;
+    const parsed = parseAgentDefinition(readFileSync(p, "utf8"), agentName);
+    if (parsed) return parsed;
+  }
+
+  return null;
+}
+
+function formatElapsed(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}m ${s}s`;
+}
+
+/** Compact token count: 850, 3.2k, 45k. */
+function formatTokens(n: number): string {
+  return n < 1000 ? String(n) : n < 10000 ? `${(n / 1000).toFixed(1)}k` : `${Math.round(n / 1000)}k`;
+}
+
+/**
+ * Known context-window sizes by model id substring, used for the context-usage
+ * gauge. Unknown models fall back to a window-less "Nk ctx" label.
+ */
+function contextWindowFor(model: string | null | undefined): number | undefined {
+  if (!model) return undefined;
+  const m = model.toLowerCase();
+  if (m.includes("claude")) return 200_000;
+  if (m.includes("gpt-4.1") || m.includes("gpt-4o")) return 128_000;
+  if (m.includes("gemini")) return 1_000_000;
+  return undefined;
+}
+
+/** Context-usage gauge: "18.0%/200k" when window known, else "37k ctx". */
+function formatContextUsage(tokens: number, contextWindow: number | undefined): string {
+  if (!contextWindow) return `${formatTokens(tokens)} ctx`;
+  const pct = (tokens / contextWindow) * 100;
+  const maxStr =
+    contextWindow >= 1_000_000
+      ? `${(contextWindow / 1_000_000).toFixed(1)}M`
+      : `${Math.round(contextWindow / 1000)}k`;
+  return `${pct.toFixed(1)}%/${maxStr}`;
+}
+
+/**
+ * Build the dim usage line for a completed subagent, mirroring the format of
+ * the in-process subagents extension: "↑in ↓out R… W… $cost · ctx".
+ * `theme.fg` is applied by the caller; this returns plain segments joined.
+ */
+function formatUsageSegments(stats: SessionStats): string[] {
+  const segs: string[] = [];
+  if (stats.inputTokens) segs.push(`↑${formatTokens(stats.inputTokens)}`);
+  if (stats.outputTokens) segs.push(`↓${formatTokens(stats.outputTokens)}`);
+  if (stats.cacheReadTokens) segs.push(`R${formatTokens(stats.cacheReadTokens)}`);
+  if (stats.cacheWriteTokens) segs.push(`W${formatTokens(stats.cacheWriteTokens)}`);
+  if (stats.cost) segs.push(`$${stats.cost.toFixed(3)}`);
+  return segs;
+}
+
+/** ANSI colors for widget status icons (raw, since the widget bypasses theme). */
+const ICON_GREEN = "\x1b[38;2;126;186;103m";
+const ICON_YELLOW = "\x1b[38;2;214;181;94m";
+const ICON_RED = "\x1b[38;2;224;108;117m";
+const ICON_DIM = "\x1b[38;2;128;128;128m";
+
+/** Map a live status kind to a colored single-char icon for the widget. */
+function widgetIcon(kind: StatusSnapshot["kind"]): string {
+  switch (kind) {
+    case "active":
+    case "running":
+      return `${ICON_YELLOW}⟳${RST}`;
+    case "stalled":
+      return `${ICON_RED}⟳${RST}`;
+    case "waiting":
+    case "starting":
+    default:
+      return `${ICON_DIM}○${RST}`;
+  }
+}
+
+/**
+ * Wait long enough for a freshly created pane to finish shell startup.
+ *
+ * Some environments do extra shell-init work before the prompt is ready
+ * (for example direnv/devenv), so the delay is configurable for users who hit
+ * dropped commands. Keep the historical default at 500ms.
+ */
+function getShellReadyDelayMs(): number {
+  const raw = process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS?.trim();
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 500;
+}
+
+function muxUnavailableResult() {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Subagents require a terminal multiplexer (Herdr or tmux). ${muxSetupHint()}`,
+      },
+    ],
+    details: { error: "no multiplexer surface available" },
+  };
+}
+
+/**
+ * Build the internal artifact directory path for the current session.
+ * Used by the subagents extension to stash task files, system prompts, and
+ * launch scripts for sub-agents. Path convention:
+ *   <sessionDir>/artifacts/<session-id>/
+ */
+function getArtifactDir(sessionDir: string, sessionId: string): string {
+  return join(sessionDir, "artifacts", sessionId);
+}
+
+const statusConfig = loadStatusConfig();
+
+function formatWidgetRightLabel(snapshot: StatusSnapshot): string {
+  if (snapshot.kind === "starting") return " starting… ";
+  if (snapshot.kind === "running") return ` running ${snapshot.elapsedText} `;
+  if (snapshot.kind === "active") {
+    const label = snapshot.activityLabel ?? snapshot.activeScope;
+    const duration = snapshot.activeDurationText ? ` ${snapshot.activeDurationText}` : "";
+    return label ? ` active · ${label}${duration} ` : " active ";
+  }
+  if (snapshot.kind === "waiting") {
+    const duration = snapshot.waitingDurationText ? ` ${snapshot.waitingDurationText}` : "";
+    const detail = snapshot.statusLabel ? ` · ${snapshot.statusLabel}` : "";
+    return ` waiting${duration}${detail} `;
+  }
+
+  const detail = snapshot.statusLabel ? ` · ${snapshot.statusLabel}` : "";
+  const duration = snapshot.snapshotProblemText ? ` ${snapshot.snapshotProblemText}` : "";
+  return ` stalled${detail}${duration} `;
+}
+
+function resolveResultPresentation(
+  result: Pick<
+    SubagentResult,
+    "exitCode" | "elapsed" | "summary" | "sessionFile" | "sessionId" | "errorMessage"
+  >,
+  name: string,
+): string {
+  // Name is the persistent handle: the same name steers a running subagent or
+  // resumes a finished one, so follow-ups always reference it.
+  const sessionRef = `\n\nFollow up with subagent_message({ name: "${name}", message: "…" })`;
+
+  if (result.errorMessage) {
+    // Auto-retry exhausted or other agent-loop error. The subagent did not
+    // produce a usable result — surface the underlying provider/network
+    // failure so the orchestrator can decide whether to retry, resume, or
+    // change approach instead of silently treating the run as completed.
+    return (
+      `Sub-agent "${name}" failed after ${formatElapsed(result.elapsed)} ` +
+      `(provider/agent error — auto-retry exhausted).\n\n` +
+      `Error: ${result.errorMessage}\n\n` +
+      `The subagent did not produce a result. You can retry by spawning a new ` +
+      `subagent or resume the session with subagent_message.${sessionRef}`
+    );
+  }
+
+  return result.exitCode !== 0
+    ? `Sub-agent "${name}" failed (exit code ${result.exitCode}).\n\n${result.summary}${sessionRef}`
+    : `Sub-agent "${name}" completed (${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`;
+}
+
+/**
+ * Result from running a single subagent.
+ */
+interface SubagentResult {
+  name: string;
+  task: string;
+  summary: string;
+  sessionFile?: string;
+  /** Canonical session header id, used for follow-ups via subagent_message. */
+  sessionId?: string;
+  claudeSessionId?: string;
+  exitCode: number;
+  elapsed: number;
+  error?: string;
+  /** Provider/agent error message when auto-retry exhausted (overload, rate limit, etc.). */
+  errorMessage?: string;
+  /** Aggregate usage/model/tool stats parsed from the completed session file. */
+  stats?: SessionStats;
+}
+
+/**
+ * State for a launched (but not yet completed) subagent.
+ */
+interface RunningSubagent {
+  id: string;
+  name: string;
+  task: string;
+  agent?: string;
+  surface: string;
+  startTime: number;
+  sessionFile: string;
+  launchScriptFile?: string;
+  activityFile?: string;
+  activity?: SubagentActivityState;
+  activityRead?: {
+    ok: boolean;
+    reason?: "missing" | "invalid" | "wrong-id";
+    error?: string;
+  };
+  abortController?: AbortController;
+  cli?: string;
+  sentinelFile?: string;
+  statusState: SubagentStatusState;
+  /**
+   * When true, status transitions (stalled/recovered) do not wake the parent
+   * session via a steer message. The widget still updates locally. Used for
+   * long-running agents where the user drives the conversation in the
+   * subagent's pane (e.g. planner).
+   */
+  interactive: boolean;
+}
+
+/** All currently running subagents, keyed by id. */
+const runningSubagents = new Map<string, RunningSubagent>();
+
+// When this extension is loaded inside a subagent that itself spawns children
+// (e.g. a worker delegating to scout/researcher), `subagent-done.ts` runs in the
+// same process and needs to know whether this session still has children in
+// flight — so it can suppress auto-exit and keep the session open until they all
+// report back. Expose a live count through a process-global symbol that both
+// modules share. (subagent-done.ts reads it; if absent it assumes zero.)
+const RUNNING_CHILDREN_COUNT_KEY = Symbol.for("pi-subagents/running-children-count");
+(globalThis as any)[RUNNING_CHILDREN_COUNT_KEY] = () => runningSubagents.size;
+
+// ── Widget management ──
+
+/** Latest ExtensionContext from session_start, used for widget updates. */
+let latestCtx: ExtensionContext | null = null;
+/** Latest ExtensionAPI, used to deliver ask_question notifications from the watcher. */
+let latestPi: ExtensionAPI | null = null;
+
+/** Interval timer for widget re-renders. */
+let widgetInterval: ReturnType<typeof setInterval> | null = null;
+
+/** Interval timer for status transition checks. */
+let statusInterval: ReturnType<typeof setInterval> | null = null;
+
+function formatElapsedMMSS(startTime: number): string {
+  const seconds = Math.floor((Date.now() - startTime) / 1000);
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+const ACCENT = "\x1b[38;2;77;163;255m";
+const RST = "\x1b[0m";
+
+/**
+ * Build a bordered content line: │left          right│
+ * Left content is truncated if needed, right is preserved, padded to fill width.
+ */
+function borderLine(left: string, right: string, width: number): string {
+  if (width <= 0) return "";
+  if (width === 1) return `${ACCENT}│${RST}`;
+
+  // width = total visible chars for the whole line including │ and │
+  const contentWidth = Math.max(0, width - 2); // space inside the two │ chars
+  const rightVis = visibleWidth(right);
+
+  // If the status chunk alone is too wide, prefer preserving it in compact form
+  // rather than overflowing the terminal.
+  if (rightVis >= contentWidth) {
+    const truncRight = truncateToWidth(right, contentWidth);
+    const rightPad = Math.max(0, contentWidth - visibleWidth(truncRight));
+    return `${ACCENT}│${RST}${truncRight}${" ".repeat(rightPad)}${ACCENT}│${RST}`;
+  }
+
+  const maxLeft = Math.max(0, contentWidth - rightVis);
+  const truncLeft = truncateToWidth(left, maxLeft);
+  const leftVis = visibleWidth(truncLeft);
+  const pad = Math.max(0, contentWidth - leftVis - rightVis);
+  return `${ACCENT}│${RST}${truncLeft}${" ".repeat(pad)}${right}${ACCENT}│${RST}`;
+}
+
+/**
+ * Build the bordered top line: ╭─ Title ──── info ─╮
+ * All chars are accounted for within `width`.
+ */
+function borderTop(title: string, info: string, width: number): string {
+  if (width <= 0) return "";
+  if (width === 1) return `${ACCENT}╭${RST}`;
+
+  // ╭─ Title ───...─── info ─╮
+  // overhead: ╭─ (2) + space around title (2) + space around info (2) + ─╮ (2) = but we simplify
+  const inner = Math.max(0, width - 2); // inside ╭ and ╮
+  const titlePart = `─ ${title} `;
+  const infoPart = ` ${info} ─`;
+  const fillLen = Math.max(0, inner - titlePart.length - infoPart.length);
+  const fill = "─".repeat(fillLen);
+  const content = `${titlePart}${fill}${infoPart}`.slice(0, inner).padEnd(inner, "─");
+  return `${ACCENT}╭${content}╮${RST}`;
+}
+
+/**
+ * Build the bordered bottom line: ╰──────────────────╯
+ */
+function borderBottom(width: number): string {
+  if (width <= 0) return "";
+  if (width === 1) return `${ACCENT}╰${RST}`;
+
+  const inner = Math.max(0, width - 2);
+  return `${ACCENT}╰${"─".repeat(inner)}╯${RST}`;
+}
+
+function renderSubagentWidgetLines(agents: RunningSubagent[], width: number): string[] {
+  const count = agents.length;
+  const title = "Subagents";
+  const info = `${count} running`;
+
+  const lines: string[] = [borderTop(title, info, width)];
+
+  for (const agent of agents) {
+    const elapsed = formatElapsedMMSS(agent.startTime);
+    const agentTag = agent.agent ? ` (${agent.agent})` : "";
+    const snapshot = classifyStatus(agent.statusState, Date.now());
+    const icon = widgetIcon(snapshot.kind);
+    const left = ` ${icon} ${elapsed}  ${agent.name}${agentTag} `;
+    const right = statusConfig.enabled
+      ? formatWidgetRightLabel(snapshot)
+      : agent.cli === "claude"
+        ? " running… "
+        : " starting… ";
+
+    lines.push(borderLine(left, right, width));
+  }
+
+  lines.push(borderBottom(width));
+  return lines;
+}
+
+function updateWidget() {
+  if (!latestCtx?.hasUI) return;
+
+  if (runningSubagents.size === 0) {
+    latestCtx.ui.setWidget("subagent-status", undefined);
+    if (widgetInterval) {
+      clearInterval(widgetInterval);
+      widgetInterval = null;
+      (globalThis as any)[WIDGET_INTERVAL_KEY] = null;
+    }
+    return;
+  }
+
+  latestCtx.ui.setWidget(
+    "subagent-status",
+    (_tui: any, _theme: any) => {
+      return {
+        invalidate() {},
+        render(width: number) {
+          return renderSubagentWidgetLines(Array.from(runningSubagents.values()), width);
+        },
+      };
+    },
+    { placement: "aboveEditor" },
+  );
+}
+
+/**
+ * Build the positional prompt args for a Pi CLI subagent launch.
+ *
+ * In artifact-backed launches (lineage-only, standalone), Pi's buildInitialMessage()
+ * concatenates @file content with messages[0] into one initial prompt. That breaks
+ * /skill: expansion because the message no longer starts with "/skill:". Only
+ * messages[1..] are sent as separate follow-up prompts where /skill: is recognized.
+ *
+ * When there are skill prompts AND artifact-backed delivery, we prepend an empty
+ * first positional message so that /skill: args land in messages[1..] and arrive
+ * as standalone prompts in the child session.
+ */
+const SUBAGENT_CONTROL_TOOLS = ["ask_question"] as const;
+
+/**
+ * Build the child --tools allowlist.
+ *
+ * Pi 0.70+ applies --tools to built-in, extension, and custom tools. If a
+ * subagent definition restricts tools to e.g. "read,bash,write", the child
+ * control tools from subagent-done.ts would otherwise be hidden, leaving a
+ * manually resumed or user-touched subagent unable to call ask_question.
+ */
+function buildSubagentToolAllowlist(
+  effectiveTools?: string,
+  opts?: { grantSpawning?: boolean },
+): string | null {
+  const requested = (effectiveTools ?? "")
+    .split(",")
+    .map((tool) => tool.trim())
+    .filter(Boolean);
+
+  const grantSpawning = opts?.grantSpawning ?? false;
+
+  // No explicit tool restriction and no spawning grant → don't pass --tools at
+  // all (the child keeps its default toolset).
+  if (requested.length === 0 && !grantSpawning) return null;
+
+  const allow = new Set(requested);
+  if (grantSpawning) {
+    for (const tool of SPAWNING_TOOLS) allow.add(tool);
+  }
+  for (const tool of SUBAGENT_CONTROL_TOOLS) {
+    allow.add(tool);
+  }
+
+  return [...allow].join(",");
+}
+
+/**
+ * Apply a loadout snapshot's sandbox to a pi command's `parts` array: model,
+ * identity (system prompt), and the default-deny tool/extension restriction
+ * (`--no-extensions` + `--tools` + one `-e` per tool-backing extension).
+ *
+ * This is the single source of truth for reconstructing a subagent's sandbox,
+ * used both by the initial `launchSubagent` and by the `subagent_message`
+ * resume path so the two can never drift. Env vars (PI_SUBAGENT_AGENT /
+ * PI_SUBAGENT_ALLOWED / PI_CODING_AGENT_DIR) and cwd are the caller's
+ * responsibility since they differ slightly between launch and resume.
+ */
+function applySandboxToParts(
+  parts: string[],
+  loadout: SubagentLoadout,
+  opts: { artifactDir: string; name: string },
+): void {
+  if (loadout.model) {
+    const model = loadout.thinking ? `${loadout.model}:${loadout.thinking}` : loadout.model;
+    parts.push("--model", shellEscape(model));
+  }
+
+  if (loadout.identity) {
+    const flag = loadout.systemPromptMode === "replace" ? "--system-prompt" : "--append-system-prompt";
+    const spTimestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const spSafeName = opts.name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+    const spPath = join(opts.artifactDir, `context/${spSafeName || "subagent"}-sysprompt-${spTimestamp}.md`);
+    mkdirSync(dirname(spPath), { recursive: true });
+    writeFileSync(spPath, loadout.identity, "utf8");
+    parts.push(flag, shellEscape(spPath));
+  }
+
+  // Default-deny: disable global extension discovery and re-enable only the
+  // extensions backing the whitelisted tools. A null allowlist means the spawn
+  // was intentionally unrestricted (e.g. a fork clone) and is replayed as-is.
+  if (loadout.toolAllowlist) {
+    parts.push("--no-extensions");
+    parts.push("--tools", shellEscape(loadout.toolAllowlist));
+
+    const extPaths = new Set<string>();
+    for (const tool of loadout.toolAllowlist.split(",")) {
+      const extPath = getToolExtensionPath(tool);
+      if (extPath && existsSync(extPath)) extPaths.add(extPath);
+    }
+    for (const extPath of extPaths) {
+      parts.push("-e", shellEscape(extPath));
+    }
+  }
+}
+
+function buildPiPromptArgs(params: {
+  effectiveSkills?: string;
+  taskDelivery: "direct" | "artifact";
+  taskArg: string;
+}): string[] {
+  const skillPrompts = (params.effectiveSkills ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((skill) => `/skill:${skill}`);
+
+  const needsSeparator = params.taskDelivery === "artifact" && skillPrompts.length > 0;
+
+  return [
+    ...(needsSeparator ? [""] : []),
+    ...skillPrompts,
+    params.taskArg,
+  ];
+}
+
+function activityLabel(activity: SubagentActivityState): string | undefined {
+  if (activity.phase !== "active") return undefined;
+  if (activity.activeScope === "tool") return activity.toolName ?? "tool";
+  if (activity.activeScope === "provider") return "provider";
+  if (activity.activeScope === "streaming") return "streaming";
+  return activity.activeScope;
+}
+
+function observeRunningSubagent(running: RunningSubagent, observedAt = Date.now()) {
+  if (running.cli === "claude") return;
+
+  const activityFile = running.activityFile;
+  const read: ActivityReadResult = activityFile
+    ? readSubagentActivityFile(activityFile, running.id)
+    : { ok: false, reason: "missing" };
+
+  running.activityRead = read.ok
+    ? { ok: true }
+    : { ok: false, reason: read.reason, error: read.error };
+
+  if (read.ok) {
+    running.activity = read.activity;
+    running.statusState = observeStatus(running.statusState, {
+      snapshot: "present",
+      updatedAt: read.activity.updatedAt,
+      sequence: read.activity.sequence,
+      phase: read.activity.phase,
+      active: read.activity.phase === "active",
+      activeScope: read.activity.activeScope,
+      activeSince: read.activity.activeSince,
+      waitingSince: read.activity.waitingSince,
+      latestEvent: read.activity.latestEvent,
+      activityLabel: activityLabel(read.activity),
+    }, observedAt);
+    return;
+  }
+
+  running.statusState = observeStatus(running.statusState, {
+    snapshot: read.reason,
+    snapshotError: read.error,
+  }, observedAt);
+}
+
+/**
+ * Names claimed by spawns that are mid-launch but not yet registered in
+ * `runningSubagents`. Parallel `subagent` tool calls run their synchronous
+ * prefix (name defaulting) before any of them finishes `launchSubagent` and
+ * registers, so without this they'd all see an empty map and pick the same
+ * name. Reserved synchronously when a default name is chosen and released once
+ * the subagent registers (or its launch fails).
+ */
+const reservedNames = new Set<string>();
+
+/**
+ * Return `base`, or `base-2`, `base-3`, … so the result is unique within this
+ * spawner session. Considers (a) currently-running subagents, (b) names
+ * reserved by parallel in-flight spawns, and (c) every name already recorded in
+ * the spawner's persistent registry — so a defaulted name never collides with a
+ * finished subagent either. This lets `subagent_message({ name })` address any
+ * subagent of this session unambiguously, running or finished.
+ *
+ * `registryNames` is the set of names already taken in the registry (empty when
+ * there is no session file / artifact dir yet).
+ */
+function uniqueRunningName(base: string, registryNames?: Set<string>): string {
+  const taken = new Set(Array.from(runningSubagents.values()).map((r) => r.name));
+  for (const reserved of reservedNames) taken.add(reserved);
+  if (registryNames) for (const n of registryNames) taken.add(n);
+  if (!taken.has(base)) return base;
+  let n = 2;
+  while (taken.has(`${base}-${n}`)) n++;
+  return `${base}-${n}`;
+}
+
+function resolveRunningByName(name: string):
+  | { running: RunningSubagent }
+  | { error: string } {
+  const requestedName = name.trim();
+  if (!requestedName) {
+    return { error: "Provide the exact display name of a running subagent." };
+  }
+
+  const matches = Array.from(runningSubagents.values()).filter((running) => running.name === requestedName);
+  if (matches.length === 1) return { running: matches[0] };
+  if (matches.length === 0) {
+    const names = Array.from(runningSubagents.values()).map((r) => r.name);
+    const hint = names.length
+      ? ` Currently running: ${[...new Set(names)].join(", ")}.`
+      : " No subagents are currently running.";
+    return { error: `No running subagent named "${requestedName}".${hint}` };
+  }
+
+  const candidates = matches.map((running) => `${running.name} [${running.id}]`).join(", ");
+  return { error: `Ambiguous subagent name "${requestedName}". Matches: ${candidates}` };
+}
+
+/**
+ * Type a follow-up message into a running subagent's live pane. Newlines are
+ * collapsed to spaces because each newline submits a turn in the child's TUI
+ * editor; a multi-line message would otherwise fire as several partial turns.
+ */
+function steerSubagent(
+  running: RunningSubagent,
+  message: string,
+  send: (surface: string, command: string) => void = sendCommand,
+): { ok: true } | { error: string } {
+  const flattened = message.replace(/\s*\n\s*/g, " ").trim();
+  try {
+    send(running.surface, flattened);
+    return { ok: true };
+  } catch (error: any) {
+    return {
+      error:
+        `Failed to deliver message to subagent "${running.name}" via tmux: ` +
+        `${error?.message ?? String(error)}`,
+    };
+  }
+}
+
+function handleSubagentSteer(
+  params: { name?: string; message?: string },
+  send: (surface: string, command: string) => void = sendCommand,
+) {
+  const message = params.message?.trim();
+  if (!message) {
+    const err = "`message` is required to steer a running subagent.";
+    return { content: [{ type: "text" as const, text: err }], details: { error: err } };
+  }
+
+  const resolved = resolveRunningByName(params.name ?? "");
+  if ("error" in resolved) {
+    return {
+      content: [{ type: "text" as const, text: resolved.error }],
+      details: { error: resolved.error },
+    };
+  }
+
+  const running = resolved.running;
+  const now = Date.now();
+  observeRunningSubagent(running, now);
+
+  const steer = steerSubagent(running, message, send);
+  if ("error" in steer) {
+    return {
+      content: [{ type: "text" as const, text: steer.error }],
+      details: { error: steer.error, id: running.id, name: running.name },
+    };
+  }
+
+  running.statusState = forceStatusAfterInterrupt(running.statusState, now);
+  updateWidget();
+
+  return {
+    content: [{
+      type: "text" as const,
+      text:
+        `Message delivered to running subagent "${running.name}". It picks this up at its next ` +
+        `turn boundary. If it exits, its result still arrives as a steer message.`,
+    }],
+    details: { id: running.id, name: running.name, status: "steered" },
+  };
+}
+
+function startStatusRefresh(pi: ExtensionAPI) {
+  if (!statusConfig.enabled || statusInterval) return;
+
+  statusInterval = setInterval(() => {
+    if (runningSubagents.size === 0) {
+      if (statusInterval) {
+        clearInterval(statusInterval);
+        statusInterval = null;
+        (globalThis as any)[STATUS_INTERVAL_KEY] = null;
+      }
+      return;
+    }
+
+    const transitionLines: string[] = [];
+    const now = Date.now();
+    let shouldRefreshWidget = false;
+
+    for (const running of runningSubagents.values()) {
+      observeRunningSubagent(running, now);
+      const { nextState, snapshot, transition } = advanceStatusState(running.statusState, now);
+      if (nextState.currentKind !== running.statusState.currentKind) {
+        shouldRefreshWidget = true;
+      }
+      running.statusState = nextState;
+
+      // Interactive subagents (long-running, user-driven) intentionally don't
+      // wake the parent session on stalled/recovered transitions — the user is
+      // working in the subagent's pane, and a steer message here would burn an
+      // orchestrator turn on a no-op "still waiting" ping. Widget still updates.
+      if (transition && !running.interactive) {
+        transitionLines.push(formatTransitionLine(running.name, snapshot, transition));
+      }
+    }
+
+    if (shouldRefreshWidget) updateWidget();
+
+    if (transitionLines.length > 0) {
+      const capped = capStatusLines(transitionLines, statusConfig.lineLimit);
+      pi.sendMessage(
+        {
+          customType: "subagent_status",
+          content: formatStatusAggregate(transitionLines, statusConfig.lineLimit),
+          display: true,
+          details: { lines: capped.visibleLines, overflow: capped.overflow },
+        },
+        { triggerTurn: true, deliverAs: "steer" },
+      );
+    }
+  }, 1000);
+
+  (globalThis as any)[STATUS_INTERVAL_KEY] = statusInterval;
+}
+
+// Resuming a finished session is always autonomous: the relaunched agent runs
+// its follow-up task to completion and the harness delivers the result as a
+// steer message (fire-and-forget). An interactive resume would park the pane
+// waiting for the user, contradicting that result-delivery model.
+function resolveResumeLaunchBehavior(): { autoExit: boolean; interactive: boolean } {
+  return { autoExit: true, interactive: false };
+}
+
+export const __test__ = {
+  borderLine,
+  getShellReadyDelayMs,
+  renderSubagentWidgetLines,
+  loadAgentDefaults,
+  discoverAgentDefinitions,
+  resolveEffectiveSessionMode,
+  resolveLaunchBehavior,
+  resolveEffectiveInteractive,
+  buildSubagentToolAllowlist,
+  applySandboxToParts,
+  buildPiPromptArgs,
+  formatWidgetRightLabel,
+  observeRunningSubagent,
+  getToolExtensionPath,
+  resolveRunningByName,
+  uniqueRunningName,
+  reservedNames,
+  steerSubagent,
+  handleSubagentSteer,
+  resolveResultPresentation,
+  resolveResumeLaunchBehavior,
+  runningSubagents,
+  formatElapsed,
+  formatTokens,
+  formatContextUsage,
+  contextWindowFor,
+  formatUsageSegments,
+  widgetIcon,
+};
+
+function startWidgetRefresh() {
+  if (widgetInterval) return;
+  updateWidget(); // immediate first render
+  widgetInterval = setInterval(() => {
+    updateWidget();
+  }, 1000);
+  (globalThis as any)[WIDGET_INTERVAL_KEY] = widgetInterval;
+}
+
+/**
+ * Launch a subagent: creates the multiplexer pane, builds the command, and
+ * sends it. Returns a RunningSubagent — does NOT poll.
+ *
+ * Call watchSubagent() on the returned object to observe completion.
+ */
+async function launchSubagent(
+  params: typeof SubagentParams.static,
+  ctx: { sessionManager: { getSessionFile(): string | null; getSessionId(): string; getSessionDir(): string }; cwd: string },
+  options?: { surface?: string },
+): Promise<RunningSubagent> {
+  const startTime = Date.now();
+  const id = Math.random().toString(16).slice(2, 10);
+
+  const agentDefs = params.agent ? loadAgentDefaults(params.agent) : null;
+  const effectiveModel = params.model ?? agentDefs?.model;
+  const effectiveTools = agentDefs?.tools;
+  const effectiveSkills = agentDefs?.skills;
+  const effectiveThinking = agentDefs?.thinking;
+  const effectiveInteractive = resolveEffectiveInteractive(params, agentDefs);
+
+  const sessionFile = ctx.sessionManager.getSessionFile();
+  if (!sessionFile) throw new Error("No session file");
+  const sessionId = ctx.sessionManager.getSessionId();
+  const artifactDir = getArtifactDir(ctx.sessionManager.getSessionDir(), sessionId);
+
+  const { effectiveCwd, localAgentDir, effectiveAgentDir } = resolveSubagentPaths(params, agentDefs);
+  const targetCwdForSession = effectiveCwd ?? ctx.cwd;
+  const sessionDir = getDefaultSessionDirFor(targetCwdForSession, effectiveAgentDir);
+
+  // Generate a deterministic session file path for this subagent.
+  // This eliminates race conditions when multiple agents launch simultaneously —
+  // each agent knows exactly which file is theirs.
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 23) + "Z";
+  const uuid = [
+    id,
+    Math.random().toString(16).slice(2, 10),
+    Math.random().toString(16).slice(2, 10),
+    Math.random().toString(16).slice(2, 6),
+  ].join("-");
+  const subagentSessionFile = join(sessionDir, `${timestamp}_${uuid}.jsonl`);
+
+  // Use pre-created surface (parallel mode) or create a new one.
+  // For new surfaces, pause briefly so the shell is ready before sending the command.
+  const surfacePreCreated = !!options?.surface;
+  const surface = options?.surface ?? createSurface(params.name);
+  if (!surfacePreCreated) {
+    await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
+  }
+
+  const launchBehavior = resolveLaunchBehavior(params, agentDefs);
+
+  if (launchBehavior.seededSessionMode) {
+    seedSubagentSessionFile({
+      mode: launchBehavior.seededSessionMode,
+      parentSessionFile: sessionFile,
+      childSessionFile: subagentSessionFile,
+      childCwd: targetCwdForSession,
+    });
+  }
+
+  const activityFile = getSubagentActivityFile(artifactDir, id);
+  mkdirSync(dirname(activityFile), { recursive: true });
+  const { inheritsConversationContext } = launchBehavior;
+
+  // Build the task message
+  // Only full-context fork mode inherits prior conversation state.
+  // Blank-session modes need the wrapper instructions and artifact-backed handoff.
+  const modeHint = agentDefs?.autoExit
+    ? "Complete your task autonomously. When you are finished, simply stop — your session ends automatically."
+    : "Complete your task. The user can interact with you at any time, and the session ends when the user exits the pane.";
+  const summaryInstruction = agentDefs?.autoExit
+    ? "Your FINAL assistant message should summarize what you accomplished."
+    : "Your FINAL assistant message (before the user exits) should summarize what you accomplished.";
+  // An agent with a non-empty subagent_agents list is granted the spawning
+  // toolset and may only spawn the listed agents (enforced via PI_SUBAGENT_ALLOWED).
+  const grantSpawning = !!(agentDefs?.subagentAgents && agentDefs.subagentAgents.length > 0);
+  const identity = agentDefs?.body ?? null;
+  const systemPromptMode = agentDefs?.systemPromptMode;
+  const identityInSystemPrompt = systemPromptMode && identity;
+  const roleBlock = identity && !identityInSystemPrompt ? `\n\n${identity}` : "";
+  const fullTask = inheritsConversationContext
+    ? params.task
+    : `${roleBlock}\n\n${modeHint}\n\n${params.task}\n\n${summaryInstruction}`;
+  // ── Claude Code CLI path ──
+  if (agentDefs?.cli === "claude") {
+    const sentinelFile = `/tmp/pi-claude-${id}-done`;
+    const pluginDir = join(SUBAGENTS_DIR, "plugin");
+
+    const cmdParts: string[] = [];
+    cmdParts.push(`PI_CLAUDE_SENTINEL=${shellEscape(sentinelFile)}`);
+    cmdParts.push("claude");
+    cmdParts.push("--dangerously-skip-permissions");
+
+    if (existsSync(pluginDir)) {
+      cmdParts.push("--plugin-dir", shellEscape(pluginDir));
+    }
+
+    if (effectiveModel) {
+      cmdParts.push("--model", shellEscape(effectiveModel));
+    }
+
+    const sp = agentDefs.body;
+    if (sp) {
+      cmdParts.push("--append-system-prompt", shellEscape(sp));
+    }
+
+    // Always pass the task as the prompt — even for resumed sessions,
+    // the caller's task is the follow-up instruction.
+    cmdParts.push(shellEscape(params.task));
+
+    const cdPrefix = effectiveCwd ? `cd ${shellEscape(effectiveCwd)} && ` : "";
+    const command = `${cdPrefix}${cmdParts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;
+
+    const launchScriptName = `${(params.name || "subagent")
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "subagent"}-${id}.sh`;
+    const launchScriptFile = join(artifactDir, "subagent-scripts", launchScriptName);
+
+    sendLongCommand(surface, command, {
+      scriptPath: launchScriptFile,
+      scriptPreamble: [
+        `# Claude Code subagent launch script for ${params.name}`,
+        `# Generated: ${new Date().toISOString()}`,
+        `# Surface: ${surface}`,
+      ].join("\n"),
+    });
+
+    const running: RunningSubagent = {
+      id,
+      name: params.name,
+      task: params.task,
+      agent: params.agent,
+      surface,
+      startTime,
+      sessionFile: subagentSessionFile,
+      launchScriptFile,
+      cli: "claude",
+      sentinelFile,
+      interactive: effectiveInteractive,
+      statusState: createStatusState({
+        source: "claude",
+        startTimeMs: startTime,
+      }),
+    };
+
+    runningSubagents.set(id, running);
+    return running;
+  }
+
+  // ── Pi CLI path ──
+
+  // Build pi command
+  const parts: string[] = ["pi"];
+  parts.push("--session", shellEscape(subagentSessionFile));
+
+  const subagentDonePath = join(SUBAGENTS_DIR, "subagent-done.ts");
+  parts.push("-e", shellEscape(subagentDonePath));
+
+  // Resolve the config dir the child sees: a target-local .pi/agent/ wins,
+  // else the propagated global dir. Captured once so the launch env and the
+  // resume snapshot agree.
+  const resolvedAgentDir =
+    localAgentDir && existsSync(localAgentDir)
+      ? localAgentDir
+      : process.env.PI_CODING_AGENT_DIR ?? null;
+
+  // Default-deny model: when an agent restricts its tools (or is granted the
+  // spawning toolset), we disable global extension discovery and re-enable only
+  // the extensions backing the whitelisted tools. Bare/fork spawns with no tool
+  // restriction keep their full default toolset and all global extensions.
+  const toolAllowlist = buildSubagentToolAllowlist(effectiveTools, { grantSpawning });
+
+  // Snapshot the fully-resolved sandbox beside the session file so a later
+  // `subagent_message({ name })` resume can replay the exact same
+  // restriction instead of relaunching pi with all global extensions + tools.
+  const loadout: SubagentLoadout = {
+    agent: params.agent ?? null,
+    toolAllowlist,
+    model: effectiveModel ?? null,
+    thinking: effectiveThinking ?? null,
+    systemPromptMode: systemPromptMode ?? null,
+    identity: identityInSystemPrompt ? identity : null,
+    spawnable: agentDefs?.subagentAgents ?? null,
+    autoExit: agentDefs?.autoExit ?? false,
+    cwd: effectiveCwd ?? null,
+    agentDir: resolvedAgentDir,
+  };
+  writeSubagentLoadout(subagentSessionFile, loadout);
+
+  // Apply model, identity, and the default-deny tool/extension restriction via
+  // the shared helper (same code path resume uses — they can't drift).
+  applySandboxToParts(parts, loadout, { artifactDir, name: params.name });
+
+  // Build env prefix: subagent identity + config dir propagation + spawn allowlist
+  const envParts: string[] = [];
+
+  if (resolvedAgentDir) {
+    envParts.push(`PI_CODING_AGENT_DIR=${shellEscape(resolvedAgentDir)}`);
+  }
+
+  if (grantSpawning && agentDefs?.subagentAgents) {
+    envParts.push(`PI_SUBAGENT_ALLOWED=${shellEscape(agentDefs.subagentAgents.join(","))}`);
+  }
+  envParts.push(`PI_SUBAGENT_NAME=${shellEscape(params.name)}`);
+  if (params.agent) {
+    envParts.push(`PI_SUBAGENT_AGENT=${shellEscape(params.agent)}`);
+  }
+  if (agentDefs?.autoExit) {
+    envParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+  }
+  envParts.push(`PI_SUBAGENT_SESSION=${shellEscape(subagentSessionFile)}`);
+  envParts.push(`PI_SUBAGENT_ID=${shellEscape(id)}`);
+  envParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellEscape(activityFile)}`);
+  envParts.push(`PI_SUBAGENT_SURFACE=${shellEscape(surface)}`);
+  const envPrefix = envParts.join(" ") + " ";
+
+  // Pass task and skill prompts to the sub-agent.
+  // Only full-context fork mode gets a direct task argument because it already
+  // inherits the parent conversation. Blank-session modes use artifact-backed
+  // handoff so the wrapper instructions arrive as the initial user message.
+  let taskArg: string;
+  if (launchBehavior.taskDelivery === "direct") {
+    taskArg = fullTask;
+  } else {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const safeName = params.name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "") // strip everything except alphanumeric, spaces, hyphens
+      .replace(/\s+/g, "-") // spaces to hyphens
+      .replace(/-+/g, "-") // collapse multiple hyphens
+      .replace(/^-|-$/g, ""); // trim leading/trailing hyphens
+    const artifactName = `context/${safeName || "subagent"}-${timestamp}.md`;
+    const artifactPath = join(artifactDir, artifactName);
+    mkdirSync(dirname(artifactPath), { recursive: true });
+    writeFileSync(artifactPath, fullTask, "utf8");
+    taskArg = `@${artifactPath}`;
+  }
+
+  for (const promptArg of buildPiPromptArgs({
+    effectiveSkills,
+    taskDelivery: launchBehavior.taskDelivery,
+    taskArg,
+  })) {
+    parts.push(shellEscape(promptArg));
+  }
+
+  // Resolve cwd — param overrides agent default, supports absolute and relative paths.
+  // This was already computed above so session placement, PI_CODING_AGENT_DIR, and cd agree.
+  const cdPrefix = effectiveCwd ? `cd ${shellEscape(effectiveCwd)} && ` : "";
+
+  const piCommand = cdPrefix + envPrefix + parts.join(" ");
+  const command = `${piCommand}; echo '__SUBAGENT_DONE_'$?'__'`;
+  const launchScriptName = `${(params.name || "subagent")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "") || "subagent"}-${id}.sh`;
+  const launchScriptFile = join(artifactDir, "subagent-scripts", launchScriptName);
+  sendLongCommand(surface, command, {
+    scriptPath: launchScriptFile,
+    scriptPreamble: [
+      `# Subagent launch script for ${params.name}`,
+      `# Generated: ${new Date().toISOString()}`,
+      `# Session: ${subagentSessionFile}`,
+      `# Surface: ${surface}`,
+    ].join("\n"),
+  });
+
+  const running: RunningSubagent = {
+    id,
+    name: params.name,
+    task: params.task,
+    agent: params.agent,
+    surface,
+    startTime,
+    sessionFile: subagentSessionFile,
+    launchScriptFile,
+    activityFile,
+    interactive: effectiveInteractive,
+    statusState: createStatusState({
+      source: "pi",
+      startTimeMs: startTime,
+    }),
+  };
+
+  runningSubagents.set(id, running);
+  return running;
+}
+
+/**
+ * Watch a launched subagent until it exits. Polls for completion, extracts
+ * the summary from the session file, cleans up the surface,
+ * and removes the entry from runningSubagents.
+ */
+const CLAUDE_SESSIONS_DIR = join(
+  process.env.HOME ?? "/tmp",
+  ".pi", "agent", "sessions", "claude-code",
+);
+
+function copyClaudeSession(sentinelFile: string): string | null {
+  try {
+    const transcriptFile = sentinelFile + ".transcript";
+    if (!existsSync(transcriptFile)) return null;
+    const transcriptPath = readFileSync(transcriptFile, "utf-8").trim();
+    if (!transcriptPath || !existsSync(transcriptPath)) return null;
+    mkdirSync(CLAUDE_SESSIONS_DIR, { recursive: true });
+    const filename = transcriptPath.split("/").pop() ?? `claude-${Date.now()}.jsonl`;
+    const dest = join(CLAUDE_SESSIONS_DIR, filename);
+    copyFileSync(transcriptPath, dest);
+    return filename;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect an `ask_question` signal from a still-running subagent and notify the
+ * orchestrator without ending the subagent. Each subagent has its own
+ * `${sessionFile}.ask` file and its own watcher, so parallel questions from
+ * multiple subagents are delivered independently. The file is deleted after
+ * delivery so it fires once per question (a subagent may ask again later).
+ */
+function deliverPendingQuestion(running: RunningSubagent): void {
+  const askFile = `${running.sessionFile}.ask`;
+  let payload: any = null;
+  try {
+    if (!existsSync(askFile)) return;
+    payload = JSON.parse(readFileSync(askFile, "utf-8"));
+  } catch {
+    // Malformed/partway-written file — drop it and move on.
+  }
+  try {
+    unlinkSync(askFile);
+  } catch {}
+  if (!payload?.question) return;
+
+  const name = running.name; // unique per session (deduped at spawn) — targets the reply
+  const sessionId = existsSync(running.sessionFile) ? getSessionId(running.sessionFile) : null;
+  const elapsed = Math.floor((Date.now() - running.startTime) / 1000);
+  const replyHint = `\n\nReply with subagent_message({ name: "${name}", message: "…" }) — the same name works whether it is still running or has since exited. It stays open until you reply.`;
+
+  latestPi?.sendMessage(
+    {
+      customType: "subagent_question",
+      content: `Sub-agent "${name}" asks (${formatElapsed(elapsed)}):\n\n${payload.question}${replyHint}`,
+      display: true,
+      details: {
+        name,
+        agent: running.agent,
+        question: payload.question,
+        ...(sessionId ? { sessionId } : {}),
+      },
+    },
+    { triggerTurn: true, deliverAs: "steer" },
+  );
+}
+
+async function watchSubagent(
+  running: RunningSubagent,
+  signal: AbortSignal,
+): Promise<SubagentResult> {
+  const { name, task, surface, startTime, sessionFile } = running;
+
+  try {
+    const result = await pollForExit(surface, AbortSignal.any([signal, getModuleAbortSignal()]), {
+      interval: 1000,
+      sessionFile,
+      sentinelFile: running.sentinelFile,
+      onTick() {
+        observeRunningSubagent(running);
+        deliverPendingQuestion(running);
+      },
+    });
+
+    const elapsed = Math.floor((Date.now() - startTime) / 1000);
+
+    if (running.cli === "claude") {
+      // Claude Code result extraction
+      let summary = "";
+
+      if (running.sentinelFile) {
+        try {
+          summary = readFileSync(running.sentinelFile, "utf-8").trim();
+        } catch {}
+      }
+
+      if (!summary) {
+        summary = readScreen(surface, 200)
+          .replace(/__SUBAGENT_DONE_\d+__/, "")
+          .trimEnd();
+      }
+
+      if (!summary) {
+        summary = result.exitCode !== 0
+          ? `Claude Code exited with code ${result.exitCode}`
+          : "Claude Code exited without output";
+      }
+
+      // Copy Claude session transcript
+      let sessionId: string | null = null;
+      if (running.sentinelFile) {
+        sessionId = copyClaudeSession(running.sentinelFile);
+        try { unlinkSync(running.sentinelFile); } catch {}
+        try { unlinkSync(running.sentinelFile + ".transcript"); } catch {}
+      }
+
+      closeSurface(surface);
+      runningSubagents.delete(running.id);
+
+      return { name, task, summary, exitCode: result.exitCode, elapsed, ...(sessionId ? { claudeSessionId: sessionId } : {}) };
+    }
+
+    // Pi subagent result extraction
+    let summary: string;
+    if (existsSync(sessionFile)) {
+      const allEntries = getNewEntries(sessionFile, 0);
+      summary =
+        findLastAssistantMessage(allEntries) ??
+        (result.errorMessage
+          ? `Subagent error: ${result.errorMessage}`
+          : result.exitCode !== 0
+            ? `Sub-agent exited with code ${result.exitCode}`
+            : "Sub-agent exited without output");
+    } else {
+      summary = result.errorMessage
+        ? `Subagent error: ${result.errorMessage}`
+        : result.exitCode !== 0
+          ? `Sub-agent exited with code ${result.exitCode}`
+          : "Sub-agent exited without output";
+    }
+
+    const stats = existsSync(sessionFile) ? summarizeSessionStats(sessionFile) : null;
+    const subagentSessionId = existsSync(sessionFile) ? getSessionId(sessionFile) : null;
+
+    closeSurface(surface);
+    runningSubagents.delete(running.id);
+
+    return {
+      name,
+      task,
+      summary,
+      sessionFile,
+      ...(subagentSessionId ? { sessionId: subagentSessionId } : {}),
+      exitCode: result.exitCode,
+      elapsed,
+      ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+      ...(stats ? { stats } : {}),
+    };
+  } catch (err: any) {
+    try {
+      closeSurface(surface);
+    } catch {}
+    runningSubagents.delete(running.id);
+
+    if (signal.aborted) {
+      return {
+        name,
+        task,
+        summary: "Subagent cancelled.",
+        exitCode: 1,
+        elapsed: Math.floor((Date.now() - startTime) / 1000),
+        error: "cancelled",
+        sessionFile,
+      };
+    }
+    return {
+      name,
+      task,
+      summary: `Subagent error: ${err?.message ?? String(err)}`,
+      exitCode: 1,
+      elapsed: Math.floor((Date.now() - startTime) / 1000),
+      error: err?.message ?? String(err),
+    };
+  }
+}
+
+export default function subagentsExtension(pi: ExtensionAPI) {
+  latestPi = pi;
+  // Capture the UI context for widget updates
+  pi.on("session_start", (_event, ctx) => {
+    latestCtx = ctx;
+    // pi runs multiple sessions in one process. A prior session's shutdown
+    // aborts the shared module poll-abort controller; install a fresh one so
+    // subagents spawned in this session aren't watched against a dead signal.
+    // See https://github.com/HazAT/pi-interactive-subagents/issues/5
+    const prevAbort = (globalThis as any)[POLL_ABORT_KEY] as AbortController | undefined;
+    if (!prevAbort || prevAbort.signal.aborted) {
+      (globalThis as any)[POLL_ABORT_KEY] = new AbortController();
+    }
+  });
+
+  // Clean up on session shutdown
+  pi.on("session_shutdown", (_event, _ctx) => {
+    if (widgetInterval) {
+      clearInterval(widgetInterval);
+      widgetInterval = null;
+      (globalThis as any)[WIDGET_INTERVAL_KEY] = null;
+    }
+    if (statusInterval) {
+      clearInterval(statusInterval);
+      statusInterval = null;
+      (globalThis as any)[STATUS_INTERVAL_KEY] = null;
+    }
+    const moduleAbort = (globalThis as any)[POLL_ABORT_KEY] as AbortController | undefined;
+    if (moduleAbort) moduleAbort.abort();
+    for (const [_id, agent] of runningSubagents) {
+      agent.abortController?.abort();
+    }
+    runningSubagents.clear();
+  });
+
+  // The spawning tools are always registered here. Whether a child process can
+  // actually see/use them is governed by the parent's `--tools` allowlist and
+  // by which extensions are loaded into the child (default-deny --no-extensions
+  // + explicit -e). See launchSubagent().
+
+  // ── subagent tool ──
+  pi.registerTool({
+      name: "subagent",
+      label: "Subagent",
+      description:
+        "Spawn a sub-agent in a dedicated terminal multiplexer pane. " +
+        "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
+        "When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
+        "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT call subagents_list or any other tool to 'check' status. All of that is wasted work — the harness handles delivery for you. " +
+        "DO NOT fabricate, assume, or summarize results after calling this tool. " +
+        "After spawning, either end your turn immediately, or work on other independent tasks (including spawning more subagents in parallel). The harness will wake you with the result when it is ready.",
+      promptSnippet:
+        "Spawn a sub-agent in a dedicated terminal multiplexer pane. " +
+        "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
+        "When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
+        "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT call subagents_list or any other tool to 'check' status. All of that is wasted work — the harness handles delivery for you. " +
+        "DO NOT fabricate, assume, or summarize results after calling this tool. " +
+        "After spawning, either end your turn immediately, or work on other independent tasks (including spawning more subagents in parallel). The harness will wake you with the result when it is ready.",
+      parameters: SubagentParams,
+
+      async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+        // Prevent self-spawning (e.g. planner spawning another planner)
+        const currentAgent = process.env.PI_SUBAGENT_AGENT;
+        if (params.agent && currentAgent && params.agent === currentAgent) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `You are the ${currentAgent} agent — do not start another ${currentAgent}. You were spawned to do this work yourself. Complete the task directly.`,
+              },
+            ],
+            details: { error: "self-spawn blocked" },
+          };
+        }
+
+        // Strict whitelist at every depth. The caller's permitted set is:
+        //   • a restricted subagent (PI_SUBAGENT_ALLOWED) → only its pinned agents;
+        //   • a top-level session → every discoverable agent, i.e. exactly what
+        //     `subagents_list` shows.
+        // Every spawn must name an agent in that set. The lone exception is a
+        // top-level `fork: true` clone, which has no role and inherits the
+        // caller's own already-trusted toolset. Without this guard a missing or
+        // unknown `agent` silently launches an unrestricted, full-toolset child.
+        const permittedAgents = SUBAGENT_ALLOWLIST
+          ? [...SUBAGENT_ALLOWLIST]
+          : discoverAgentDefinitions().map((a) => a.name);
+        const permittedSet = new Set(permittedAgents);
+        const permittedList = permittedAgents.join(", ") || "(none)";
+
+        if (!params.agent) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `You must specify which agent to spawn via the "agent" field. ` +
+                  `Available agents: ${permittedList}.`,
+              },
+            ],
+            details: { error: "agent required" },
+          };
+        } else if (!permittedSet.has(params.agent)) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `You may not spawn the "${params.agent}" agent — it is not ` +
+                  `${SUBAGENT_ALLOWLIST ? "in your allowlist" : "a known agent"}. ` +
+                  `Available agents: ${permittedList}.`,
+              },
+            ],
+            details: {
+              error: SUBAGENT_ALLOWLIST ? "agent not in allowlist" : "unknown agent",
+            },
+          };
+        }
+
+        // Validate prerequisites (need mux + a session file to derive the
+        // artifact dir that hosts this session's name registry).
+        if (!isMuxAvailable()) {
+          return muxUnavailableResult();
+        }
+
+        if (!ctx.sessionManager.getSessionFile()) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Error: no session file. Start pi with a persistent session to use subagents.",
+              },
+            ],
+            details: { error: "no session file" },
+          };
+        }
+
+        // This spawner session's artifact dir hosts its persistent name
+        // registry (artifacts/<parentSessionId>/subagent-registry.json).
+        const parentArtifactDir = getArtifactDir(
+          ctx.sessionManager.getSessionDir(),
+          ctx.sessionManager.getSessionId(),
+        );
+
+        // Default the cosmetic pane label to the agent name when omitted,
+        // disambiguating against running subagents, in-flight reservations, and
+        // every name already in the registry — so names stay unique across the
+        // whole session, running or finished. Reserve the chosen name
+        // synchronously (before any await) so parallel spawns don't collide.
+        let reservedName: string | null = null;
+        if (!params.name?.trim()) {
+          const registryNames = new Set(Object.keys(readNameRegistry(parentArtifactDir)));
+          params.name = uniqueRunningName(params.agent, registryNames);
+          reservedName = params.name;
+          reservedNames.add(reservedName);
+        }
+
+        // Launch the subagent (creates pane, sends command). Release the name
+        // reservation once it registers in runningSubagents (or launch fails) —
+        // from then on uniqueRunningName tracks it via the running map.
+        let running;
+        try {
+          running = await launchSubagent(params, ctx);
+        } finally {
+          if (reservedName) reservedNames.delete(reservedName);
+        }
+
+        // Persist name → session so subagent_message({ name }) can resume this
+        // subagent after it finishes (and after a pi restart). Done at launch,
+        // not completion, so the handle exists even if the parent dies mid-run.
+        registerName(parentArtifactDir, running.name, {
+          sessionFile: running.sessionFile,
+          sessionId: getSessionId(running.sessionFile),
+        });
+
+        // Create a separate AbortController for the watcher
+        // (the tool's signal completes when we return)
+        const watcherAbort = new AbortController();
+        running.abortController = watcherAbort;
+
+        // Start widget refresh and status supervision when the first agent launches
+        startWidgetRefresh();
+        startStatusRefresh(pi);
+
+        // Fire-and-forget: start watching in background
+        watchSubagent(running, watcherAbort.signal)
+          .then((result) => {
+            updateWidget(); // reflect removal from Map immediately
+
+            const presentation = resolveResultPresentation(result, running.name);
+
+            pi.sendMessage(
+              {
+                customType: "subagent_result",
+                content: presentation,
+                display: true,
+                details: {
+                  name: running.name,
+                  task: running.task,
+                  agent: running.agent,
+                  exitCode: result.exitCode,
+                  elapsed: result.elapsed,
+                  sessionFile: result.sessionFile,
+                  ...(result.sessionId ? { sessionId: result.sessionId } : {}),
+                  ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+                  ...(result.claudeSessionId ? { claudeSessionId: result.claudeSessionId } : {}),
+                  ...(result.stats ? { stats: result.stats } : {}),
+                },
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          })
+          .catch((err) => {
+            updateWidget();
+            pi.sendMessage(
+              {
+                customType: "subagent_result",
+                content: `Sub-agent "${running.name}" error: ${err?.message ?? String(err)}`,
+                display: true,
+                details: { name: running.name, task: running.task, error: err?.message },
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          });
+
+        // Return immediately
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Sub-agent "${params.name}" launched and is now running in the background. ` +
+                `Do NOT generate or assume any results — you have no idea what the sub-agent will do or produce. ` +
+                `The results will be delivered to you automatically as a steer message when the sub-agent finishes. ` +
+                `Until then, move on to other work or tell the user you're waiting.`,
+            },
+          ],
+          details: {
+            id: running.id,
+            name: params.name,
+            task: params.task,
+            agent: params.agent,
+            sessionFile: running.sessionFile,
+            launchScriptFile: running.launchScriptFile,
+            status: "started",
+          },
+        };
+      },
+
+      renderCall(args, theme) {
+        const partialArgs = args as Record<string, unknown>;
+        const agentName =
+          typeof partialArgs.agent === "string" && partialArgs.agent ? partialArgs.agent : "";
+        const name =
+          typeof partialArgs.name === "string" && partialArgs.name
+            ? partialArgs.name
+            : agentName || "(unnamed)";
+        const task = typeof partialArgs.task === "string" ? partialArgs.task : "";
+        // Only show the agent tag separately when a distinct cosmetic name was given.
+        const agent =
+          agentName && name !== agentName ? theme.fg("dim", ` (${agentName})`) : "";
+        const cwdHint = typeof partialArgs.cwd === "string" && partialArgs.cwd
+          ? theme.fg("dim", ` in ${partialArgs.cwd}`)
+          : "";
+        let text =
+          "○ " +
+          theme.fg("toolTitle", theme.bold(name)) +
+          agent +
+          cwdHint;
+
+        // Show a one-line task preview. renderCall is called repeatedly as the
+        // LLM generates tool arguments, so args.task grows token by token.
+        // We keep it compact here — Ctrl+O on renderResult expands the full content.
+        if (task) {
+          const firstLine = task.split("\n").find((l: string) => l.trim()) ?? "";
+          const preview = firstLine.length > 100 ? firstLine.slice(0, 100) + "…" : firstLine;
+          if (preview) {
+            text += "\n" + theme.fg("toolOutput", preview);
+          }
+          const totalLines = task.split("\n").length;
+          if (totalLines > 1) {
+            text += theme.fg("muted", ` (${totalLines} lines)`);
+          }
+        }
+
+        return new Text(text, 0, 0);
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+        const name = details?.name ?? "(unnamed)";
+
+        // "Started" result — tool returned immediately
+        if (details?.status === "started") {
+          return new Text(
+            theme.fg("accent", "⟳") +
+              " " +
+              theme.fg("toolTitle", theme.bold(name)) +
+              theme.fg("dim", " — started"),
+            0,
+            0,
+          );
+        }
+
+        // Fallback (shouldn't happen)
+        const text = typeof result.content[0]?.text === "string" ? result.content[0].text : "";
+        return new Text(theme.fg("dim", text), 0, 0);
+      },
+    });
+
+  // ── subagents_list tool ──
+  pi.registerTool({
+      name: "subagents_list",
+      label: "List Subagents",
+      description:
+        "List all available subagent definitions. " +
+        "Scans project-local .pi/agents/ and global ~/.pi/agent/agents/. " +
+        "Project-local agents override global ones with the same name.",
+      promptSnippet:
+        "List all available subagent definitions. " +
+        "Scans project-local .pi/agents/ and global ~/.pi/agent/agents/. " +
+        "Project-local agents override global ones with the same name.",
+      parameters: Type.Object({}),
+
+      async execute() {
+        const list = discoverAgentDefinitions().filter((agent) => !agent.disableModelInvocation);
+
+        if (list.length === 0) {
+          return {
+            content: [{ type: "text", text: "No subagent definitions found." }],
+            details: { agents: [] },
+          };
+        }
+
+        const lines = list.map((a) => {
+          const badge = a.source === "project" ? " (project)" : "";
+          const desc = a.description ? ` — ${a.description}` : "";
+          const model = a.model ? ` [${a.model}]` : "";
+          return `• ${a.name}${badge}${model}${desc}`;
+        });
+
+        return {
+          content: [{ type: "text", text: lines.join("\n") }],
+          details: { agents: list },
+        };
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+        const agents = details?.agents ?? [];
+        if (agents.length === 0) {
+          return new Text(theme.fg("dim", "No subagent definitions found."), 0, 0);
+        }
+        const lines = agents.map((a: any) => {
+          const badge = a.source === "project" ? theme.fg("accent", " (project)") : "";
+          const desc = a.description ? theme.fg("dim", ` — ${a.description}`) : "";
+          const model = a.model ? theme.fg("dim", ` [${a.model}]`) : "";
+          return `  ${theme.fg("toolTitle", theme.bold(a.name))}${badge}${model}${desc}`;
+        });
+        return new Text(lines.join("\n"), 0, 0);
+      },
+    });
+
+
+
+  // ── subagent_message tool ──
+  pi.registerTool({
+      name: "subagent_message",
+      label: "Message Subagent",
+      description:
+        "Send a message to a subagent by name. Names are unique within your session and persist after a subagent finishes, " +
+        "so the SAME name works whether the subagent is running or finished: if it is still running, your message steers its live session; " +
+        "if it has finished, your message resumes that session and continues it. " +
+        "`name` and `message` are both required. " +
+        "Steering a running subagent returns immediately with a local acknowledgement and does NOT, by itself, emit a new result. " +
+        "Resuming is a fire-and-forget async call: when the resumed sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up. " +
+        "DO NOT poll, sleep, tail logs, or read session files to detect completion — the harness handles delivery. " +
+        "DO NOT fabricate or assume results. After calling, either end your turn or work on other independent tasks.",
+      promptSnippet:
+        "Message a subagent by name: steers it if running, resumes it if finished (same name either way). " +
+        "`name` and `message` are required. Steering returns immediately; resuming delivers its result later as a steer message. " +
+        "Do not poll or fabricate results.",
+      parameters: Type.Object({
+        name: Type.String({
+          description:
+            "Exact display name of the subagent. Steers it if it is still running; resumes its session if it has finished.",
+        }),
+        message: Type.String({
+          description:
+            "The message to deliver: a follow-up instruction for a running subagent, or the next task for a resumed session.",
+        }),
+      }),
+
+      renderCall(args, theme) {
+        const target = args.name ?? "(unknown)";
+        return new Text(
+          "○ " + theme.fg("toolTitle", theme.bold(target)) + theme.fg("dim", " — message"),
+          0,
+          0,
+        );
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+
+        if (details?.status === "steered") {
+          return new Text(
+            theme.fg("success", "✓") +
+              " " +
+              theme.fg("toolTitle", theme.bold(details.name ?? "subagent")) +
+              theme.fg("dim", " — message delivered"),
+            0,
+            0,
+          );
+        }
+
+        if (details?.status === "started") {
+          return new Text(
+            theme.fg("accent", "⟳") +
+              " " +
+              theme.fg("toolTitle", theme.bold(details.name ?? "Resume")) +
+              theme.fg("dim", " — resumed"),
+            0,
+            0,
+          );
+        }
+
+        // Fallback / error
+        const text = typeof result.content[0]?.text === "string" ? result.content[0].text : "";
+        return new Text(theme.fg("dim", text), 0, 0);
+      },
+
+      async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+        const requestedName = params.name?.trim();
+        if (!requestedName) {
+          const err = "Provide the subagent's `name` to steer (if running) or resume (if finished).";
+          return { content: [{ type: "text" as const, text: err }], details: { error: err } };
+        }
+
+        if (!isMuxAvailable()) {
+          return muxUnavailableResult();
+        }
+
+        // ── Steer a running subagent ──
+        // A name that matches a currently-running subagent always steers it.
+        const runningMatch = Array.from(runningSubagents.values()).find((r) => r.name === requestedName);
+        if (runningMatch) {
+          return handleSubagentSteer({ name: requestedName, message: params.message });
+        }
+
+        // ── Resume a finished session by name ──
+        const message = params.message;
+        const name = requestedName; // identity preservation: the resumed run reclaims its name
+        const { autoExit, interactive } = resolveResumeLaunchBehavior();
+        const startTime = Date.now();
+        const id = Math.random().toString(16).slice(2, 10);
+
+        // Resolve the name to its session file via this session's registry.
+        const parentArtifactDir = getArtifactDir(
+          ctx.sessionManager.getSessionDir(),
+          ctx.sessionManager.getSessionId(),
+        );
+        const entry = resolveNameInRegistry(parentArtifactDir, requestedName);
+        if (!entry) {
+          const known = Object.keys(readNameRegistry(parentArtifactDir));
+          const err =
+            `No subagent named "${requestedName}" in this session. ` +
+            (known.length > 0
+              ? `Known subagents: ${known.join(", ")}.`
+              : "No subagents have been spawned in this session yet.");
+          return { content: [{ type: "text" as const, text: err }], details: { error: err } };
+        }
+
+        const sessionPath = entry.sessionFile;
+        if (!sessionPath || !existsSync(sessionPath)) {
+          const err =
+            `Subagent "${requestedName}" is registered but its session file is gone ` +
+            `(${sessionPath}). It cannot be resumed. Spawn a fresh subagent instead.`;
+          return { content: [{ type: "text" as const, text: err }], details: { error: err } };
+        }
+
+        // Guard: never resume a session that is still running — two processes
+        // mutating the same .jsonl corrupts it. Steer it by name instead.
+        for (const r of runningSubagents.values()) {
+          if (resolve(r.sessionFile) === resolve(sessionPath)) {
+            const err = `Subagent "${requestedName}" is still running as "${r.name}". Your message will steer it; resending as a steer.`;
+            return handleSubagentSteer({ name: r.name, message: params.message });
+          }
+        }
+
+        // Reconstruct the sandbox from the snapshot written at spawn time.
+        // Without it we cannot safely resume: relaunching bare would load every
+        // global extension + the full toolset. Refuse rather than escalate.
+        const loadout = readSubagentLoadout(sessionPath);
+        if (!loadout) {
+          const err =
+            `Cannot safely resume "${requestedName}": no sandbox snapshot found for this session ` +
+            `(it predates sandboxed resume, or its .loadout.json sidecar was removed). ` +
+            `Resuming would relaunch with all global extensions and the full toolset, so this is refused. ` +
+            `Re-run the task as a fresh subagent instead.`;
+          return { content: [{ type: "text" as const, text: err }], details: { error: err } };
+        }
+
+        const resumedSessionId = entry.sessionId ?? getSessionId(sessionPath) ?? requestedName;
+
+        // Record entry count before resuming so we can extract new messages.
+        // Count lines cheaply (no per-line JSON.parse) so resuming a large
+        // transcript doesn't block the UI.
+        const entryCountBefore = countSessionEntryLines(sessionPath);
+
+        const surface = createSurface(name);
+        await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
+
+        // Build pi resume command
+        const parts = ["pi", "--session", shellEscape(sessionPath)];
+
+        // Load subagent-done extension so the agent can self-terminate if needed
+        const subagentDonePath = join(SUBAGENTS_DIR, "subagent-done.ts");
+        parts.push("-e", shellEscape(subagentDonePath));
+
+        const sessionId = ctx.sessionManager.getSessionId();
+        const artifactDir = getArtifactDir(ctx.sessionManager.getSessionDir(), sessionId);
+        const activityFile = getSubagentActivityFile(artifactDir, id);
+        mkdirSync(dirname(activityFile), { recursive: true });
+
+        // Replay the model, identity, and default-deny tool/extension sandbox.
+        applySandboxToParts(parts, loadout, { artifactDir, name });
+
+        let resumeMsgFile: string | undefined;
+        if (params.message) {
+          const msgTimestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+          resumeMsgFile = join(
+            artifactDir,
+            "subagent-resume",
+            `${name
+              .toLowerCase()
+              .replace(/[^a-z0-9\s-]/g, "")
+              .replace(/\s+/g, "-")
+              .replace(/-+/g, "-")
+              .replace(/^-|-$/g, "") || "resume"}-${msgTimestamp}.md`,
+          );
+          mkdirSync(dirname(resumeMsgFile), { recursive: true });
+          writeFileSync(resumeMsgFile, message, "utf8");
+          parts.push(shellEscape(`@${resumeMsgFile}`));
+        }
+
+        // Build env prefix — replay the snapshot's config dir + spawn whitelist
+        // so the resumed process resolves the same agents/extensions and keeps
+        // the same nested-spawn restriction it originally ran with.
+        const resumeEnvParts: string[] = [];
+        const resumeAgentDir = loadout.agentDir ?? process.env.PI_CODING_AGENT_DIR ?? null;
+        if (resumeAgentDir) {
+          resumeEnvParts.push(`PI_CODING_AGENT_DIR=${shellEscape(resumeAgentDir)}`);
+        }
+        if (loadout.spawnable && loadout.spawnable.length > 0) {
+          resumeEnvParts.push(`PI_SUBAGENT_ALLOWED=${shellEscape(loadout.spawnable.join(","))}`);
+        }
+        if (loadout.agent) {
+          resumeEnvParts.push(`PI_SUBAGENT_AGENT=${shellEscape(loadout.agent)}`);
+        }
+        resumeEnvParts.push(`PI_SUBAGENT_NAME=${shellEscape(name)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_SESSION=${shellEscape(sessionPath)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_ID=${shellEscape(id)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellEscape(activityFile)}`);
+        if (autoExit) {
+          resumeEnvParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+        }
+        const resumeEnvPrefix = resumeEnvParts.join(" ") + " ";
+
+        // Resume in the subagent's original cwd so its tools (safe_bash, edits)
+        // operate where they did before.
+        const resumeCdPrefix = loadout.cwd ? `cd ${shellEscape(loadout.cwd)} && ` : "";
+
+        const command = `${resumeCdPrefix}${resumeEnvPrefix}${parts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;
+        const launchScriptFile = join(
+          artifactDir,
+          "subagent-scripts",
+          `${name
+            .toLowerCase()
+            .replace(/[^a-z0-9\s-]/g, "")
+            .replace(/\s+/g, "-")
+            .replace(/-+/g, "-")
+            .replace(/^-|-$/g, "") || "resume"}-resume-${Date.now()}.sh`,
+        );
+        sendLongCommand(surface, command, {
+          scriptPath: launchScriptFile,
+          scriptPreamble: [
+            `# Subagent resume script for ${name}`,
+            `# Generated: ${new Date().toISOString()}`,
+            `# Session: ${sessionPath}`,
+            `# Surface: ${surface}`,
+            ...(resumeMsgFile ? [`# Resume message file: ${resumeMsgFile}`] : []),
+          ].join("\n"),
+        });
+
+        // Register as a running subagent for widget tracking
+        const running: RunningSubagent = {
+          id,
+          name,
+          task: message,
+          surface,
+          startTime,
+          sessionFile: sessionPath,
+          launchScriptFile,
+          activityFile,
+          interactive,
+          statusState: createStatusState({
+            source: "pi",
+            startTimeMs: startTime,
+          }),
+        };
+        runningSubagents.set(id, running);
+        startWidgetRefresh();
+        startStatusRefresh(pi);
+
+        // Fire-and-forget watcher
+        const watcherAbort = new AbortController();
+        running.abortController = watcherAbort;
+
+        watchSubagent(running, watcherAbort.signal)
+          .then((result) => {
+            updateWidget();
+
+            const allEntries = getNewEntries(sessionPath, entryCountBefore);
+            const summary = findLastAssistantMessage(allEntries) ??
+              (result.errorMessage
+                ? `Subagent error: ${result.errorMessage}`
+                : result.exitCode !== 0
+                  ? `Resumed session exited with code ${result.exitCode}`
+                  : "Resumed session exited without new output");
+            const presentation = resolveResultPresentation(
+              { ...result, summary, sessionFile: sessionPath, sessionId: resumedSessionId },
+              name,
+            );
+
+            pi.sendMessage(
+              {
+                customType: "subagent_result",
+                content: presentation,
+                display: true,
+                details: {
+                  name,
+                  task: message,
+                  exitCode: result.exitCode,
+                  elapsed: result.elapsed,
+                  sessionFile: sessionPath,
+                  sessionId: resumedSessionId,
+                  ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+                },
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          })
+          .catch((err) => {
+            updateWidget();
+            pi.sendMessage(
+              {
+                customType: "subagent_result",
+                content: `Resume error: ${err?.message ?? String(err)}`,
+                display: true,
+                details: { name, error: err?.message },
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          });
+
+        return {
+          content: [{ type: "text", text: `Session "${name}" resumed.` }],
+          details: {
+            id,
+            name,
+            sessionId: resumedSessionId,
+            sessionFile: sessionPath,
+            launchScriptFile,
+            status: "started",
+          },
+        };
+      },
+    });
+
+  // /subagent command — spawn a subagent by name
+  pi.registerCommand("subagent", {
+    description: "Spawn a subagent: /subagent <agent> <task>",
+    handler: async (args, ctx) => {
+      const trimmed = args.trim();
+      if (!trimmed) {
+        ctx.ui.notify("Usage: /subagent <agent> [task]", "warning");
+        return;
+      }
+
+      const spaceIdx = trimmed.indexOf(" ");
+      const agentName = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+      const task = spaceIdx === -1 ? "" : trimmed.slice(spaceIdx + 1).trim();
+
+      const defs = loadAgentDefaults(agentName);
+      if (!defs) {
+        ctx.ui.notify(
+          `Agent "${agentName}" not found in ~/.pi/agent/agents/ or .pi/agents/`,
+          "error",
+        );
+        return;
+      }
+
+      const taskText = task || `You are the ${agentName} agent. Wait for instructions.`;
+      const displayName = agentName[0].toUpperCase() + agentName.slice(1);
+      const toolCall = `Use subagent with agent: "${agentName}", name: "${displayName}", task: ${JSON.stringify(taskText)}`;
+      pi.sendUserMessage(toolCall);
+    },
+  });
+
+  // ── subagent_result message renderer ──
+  pi.registerMessageRenderer("subagent_result", (message, options, theme) => {
+    const details = message.details as any;
+    if (!details) return undefined;
+
+    return {
+      render(width: number): string[] {
+        const name = details.name ?? "subagent";
+        const exitCode = details.exitCode ?? 0;
+        const errorMessage = typeof details.errorMessage === "string" ? details.errorMessage : "";
+        const failed = exitCode !== 0 || !!errorMessage;
+        const elapsed = details.elapsed != null ? formatElapsed(details.elapsed) : "?";
+        const bgFn = failed
+          ? (text: string) => theme.bg("toolErrorBg", text)
+          : (text: string) => theme.bg("toolSuccessBg", text);
+        const stats = (details.stats ?? null) as SessionStats | null;
+        const icon = failed
+          ? theme.fg("error", "✗")
+          : theme.fg("success", "✓");
+        const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
+        const modelTag = stats?.model ? theme.fg("dim", ` (${stats.model})`) : "";
+        const titleSegment = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag}${modelTag} ${theme.fg("dim", "—")} `;
+
+        // Success: icon already conveys "completed", so show "N tools · duration"
+        // like the in-process extension. Failure: surface the failure reason.
+        let header: string;
+        if (failed) {
+          const reason = errorMessage ? "failed (provider/agent error)" : `failed (exit ${exitCode})`;
+          header = `${titleSegment}${theme.fg("error", reason)} ${theme.fg("dim", `· ${elapsed}`)}`;
+        } else {
+          const toolPart = stats ? `${stats.toolCount} tools · ${elapsed}` : elapsed;
+          header = `${titleSegment}${theme.fg("dim", toolPart)}`;
+        }
+
+        // Usage line: ↑in ↓out R… W… $cost · context-gauge (color-coded by %).
+        let usageLine: string | null = null;
+        if (stats) {
+          const segs = formatUsageSegments(stats).map((s) => theme.fg("dim", s));
+          if (stats.contextTokens > 0) {
+            const window = contextWindowFor(stats.model);
+            const ctxStr = formatContextUsage(stats.contextTokens, window);
+            const pct = window ? (stats.contextTokens / window) * 100 : 0;
+            const coloredCtx =
+              pct > 90 ? theme.fg("error", ctxStr) : pct > 70 ? theme.fg("warning", ctxStr) : theme.fg("dim", ctxStr);
+            segs.push(coloredCtx);
+          }
+          if (segs.length > 0) usageLine = segs.join(theme.fg("dim", " "));
+        }
+
+        const rawContent = typeof message.content === "string" ? message.content : "";
+
+        // Clean summary (remove follow-up ref and leading label for display)
+        const summary = rawContent
+          .replace(/\n\nFollow up with subagent_message[\s\S]+$/, "")
+          .replace(`Sub-agent "${name}" completed (${elapsed}).\n\n`, "")
+          .replace(`Sub-agent "${name}" failed (exit code ${exitCode}).\n\n`, "")
+          .replace(
+            new RegExp(
+              `^Sub-agent "${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}" failed after ${elapsed} \\(provider/agent error — auto-retry exhausted\\)\\.\\n\\n`,
+            ),
+            "",
+          );
+
+        // Build content for the box
+        const contentLines = [header];
+        if (usageLine) contentLines.push(usageLine);
+
+        if (options.expanded) {
+          // Full view: complete summary + session info
+          if (summary) {
+            for (const line of summary.split("\n")) {
+              contentLines.push(line.slice(0, width - 6));
+            }
+          }
+          if (details.name || details.sessionFile) {
+            contentLines.push("");
+            if (details.name) {
+              contentLines.push(
+                theme.fg(
+                  "dim",
+                  `Follow up:  subagent_message({ name: "${details.name}", message: "…" })`,
+                ),
+              );
+            }
+            if (details.sessionFile) {
+              contentLines.push(theme.fg("muted", `Session file: ${details.sessionFile}`));
+            }
+          }
+        } else {
+          // Collapsed: preview + expand hint
+          if (summary) {
+            const previewLines = summary.split("\n").slice(0, 5);
+            for (const line of previewLines) {
+              contentLines.push(theme.fg("dim", line.slice(0, width - 6)));
+            }
+            const totalLines = summary.split("\n").length;
+            if (totalLines > 5) {
+              contentLines.push(theme.fg("muted", `… ${totalLines - 5} more lines`));
+            }
+          }
+          contentLines.push(theme.fg("muted", keyHint("app.tools.expand", "to expand")));
+        }
+
+        // Render via Box for background + padding, with blank line above for separation
+        const box = new Box(1, 1, bgFn);
+        box.addChild(new Text(contentLines.join("\n"), 0, 0));
+        return ["", ...box.render(width)];
+      },
+    };
+  });
+
+  // ── subagent_status message renderer ──
+  pi.registerMessageRenderer("subagent_status", (message, options, theme) => {
+    const details = message.details as any;
+    const lines = Array.isArray(details?.lines) ? details.lines : [];
+    const overflow = typeof details?.overflow === "number" ? details.overflow : 0;
+    if (lines.length === 0 && overflow === 0) return undefined;
+
+    return {
+      render(width: number): string[] {
+        const lineWidth = Math.max(0, width - 6);
+        const contentLines = [
+          `${theme.fg("accent", "•")} ${theme.fg("toolTitle", theme.bold("Subagent status"))}`,
+          ...lines.map((line: string) => theme.fg("dim", truncateToWidth(line, lineWidth))),
+        ];
+
+        if (overflow > 0) {
+          contentLines.push(theme.fg("muted", `+${overflow} more running.`));
+        }
+        if (!options.expanded) {
+          contentLines.push(theme.fg("muted", keyHint("app.tools.expand", "to expand")));
+        }
+
+        const box = new Box(1, 1, (text: string) => theme.bg("customMessageBg", text));
+        box.addChild(new Text(contentLines.join("\n"), 0, 0));
+        return ["", ...box.render(width)];
+      },
+    };
+  });
+
+  // ── subagent_question message renderer ──
+  pi.registerMessageRenderer("subagent_question", (message, options, theme) => {
+    const details = message.details as any;
+    if (!details) return undefined;
+
+    return {
+      render(width: number): string[] {
+        const name = details.name ?? "subagent";
+        const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
+        const bgFn = (text: string) => theme.bg("toolSuccessBg", text);
+
+        const icon = theme.fg("accent", "?");
+        const header = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag} ${theme.fg("dim", "— asks a question")}`;
+
+        const contentLines = [header];
+
+        if (options.expanded) {
+          contentLines.push("");
+          contentLines.push(details.question ?? "");
+          contentLines.push("");
+          contentLines.push(
+            theme.fg("dim", `Reply: subagent_message({ name: "${name}", message: "…" })`),
+          );
+        } else {
+          const preview = (details.question ?? "").split("\n")[0].slice(0, width - 10);
+          contentLines.push(theme.fg("dim", preview));
+          contentLines.push(theme.fg("muted", keyHint("app.tools.expand", "to expand")));
+        }
+
+        const box = new Box(1, 1, bgFn);
+        box.addChild(new Text(contentLines.join("\n"), 0, 0));
+        return ["", ...box.render(width)];
+      },
+    };
+  });
+
+}
+// test

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/plugin/.claude-plugin/plugin.json
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "pi-auto-exit",
+  "version": "1.0.0",
+  "description": "Auto-exit plugin for pi-spawned Claude sessions"
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/plugin/hooks/hooks.json
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/on-stop.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/plugin/hooks/on-stop.sh
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/plugin/hooks/on-stop.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Stop hook for pi-spawned Claude sessions.
+# Writes a sentinel file when Claude completes autonomously (no user interjection).
+
+set -euo pipefail
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Guard: if stop_hook_active is true, we're in a loop — bail out
+stop_hook_active=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('stop_hook_active', False))" 2>/dev/null || echo "False")
+if [ "$stop_hook_active" = "True" ]; then
+  exit 0
+fi
+
+# Guard: only act for pi-spawned sessions
+if [ -z "${PI_CLAUDE_SENTINEL:-}" ]; then
+  exit 0
+fi
+
+# Get transcript path
+transcript_path=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('transcript_path', ''))" 2>/dev/null || echo "")
+if [ -z "$transcript_path" ] || [ ! -f "$transcript_path" ]; then
+  exit 0
+fi
+
+# Count real human messages in transcript (not tool results)
+# Claude's transcript format:
+#   Human message: {"type": "user", "message": {"role": "user", "content": "..."}}
+#   Tool result:   {"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", ...}]}}
+# We only count entries where content is a string (real human input)
+user_msg_count=$(python3 - "$transcript_path" <<'EOF'
+import sys, json
+
+transcript_path = sys.argv[1]
+count = 0
+with open(transcript_path, 'r') as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            if entry.get('type') != 'user':
+                continue
+            content = entry.get('message', {}).get('content', '')
+            # Real human messages have string content
+            # Tool results have array content with tool_result blocks
+            if isinstance(content, str):
+                count += 1
+        except (json.JSONDecodeError, AttributeError):
+            pass
+print(count)
+EOF
+)
+
+# Always write transcript path so the watcher can copy the session file
+if [ -n "$transcript_path" ]; then
+  echo "$transcript_path" > "${PI_CLAUDE_SENTINEL}.transcript" 2>/dev/null || true
+fi
+
+# If exactly 1 user message (the initial prompt), this was autonomous — signal completion
+if [ "$user_msg_count" -eq 1 ]; then
+  # Write last_assistant_message to sentinel so the watcher gets a clean result
+  echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('last_assistant_message', ''))" > "$PI_CLAUDE_SENTINEL" 2>/dev/null || touch "$PI_CLAUDE_SENTINEL"
+fi
+
+exit 0

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/session.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/session.ts
@@ -1,0 +1,625 @@
+import {
+  appendFileSync,
+  closeSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { randomBytes, randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+
+export interface SessionEntry {
+  type: string;
+  id: string;
+  parentId?: string;
+  [key: string]: unknown;
+}
+
+export interface MessageEntry extends SessionEntry {
+  type: "message";
+  message: {
+    role: "user" | "assistant" | "toolResult";
+    content: Array<{ type: string; text?: string; [key: string]: unknown }>;
+  };
+}
+
+export type SeededSubagentSessionMode = "lineage-only" | "fork";
+
+function getForkContentLines(parentSessionFile: string): string[] {
+  const raw = readFileSync(parentSessionFile, "utf8");
+  const lines = raw.split("\n").filter((line) => line.trim());
+
+  let truncateAt = lines.length;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const entry = JSON.parse(lines[i]);
+      if (entry.type === "message" && entry.message?.role === "user") {
+        truncateAt = i;
+        break;
+      }
+    } catch {
+      // ignore malformed lines
+    }
+  }
+
+  return lines.slice(0, truncateAt).filter((line) => {
+    try {
+      return JSON.parse(line).type !== "session";
+    } catch {
+      return true;
+    }
+  });
+}
+
+export function seedSubagentSessionFile(params: {
+  mode: SeededSubagentSessionMode;
+  parentSessionFile: string;
+  childSessionFile: string;
+  childCwd: string;
+}): void {
+  const header = {
+    type: "session",
+    version: 3,
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    cwd: params.childCwd,
+    parentSession: params.parentSessionFile,
+  };
+  const contentLines =
+    params.mode === "fork" ? getForkContentLines(params.parentSessionFile) : [];
+  const lines = [JSON.stringify(header), ...contentLines];
+
+  mkdirSync(dirname(params.childSessionFile), { recursive: true });
+  writeFileSync(params.childSessionFile, lines.join("\n") + "\n", "utf8");
+}
+
+/**
+ * A snapshot of everything needed to reconstruct a subagent's sandbox when its
+ * session is later resumed via `subagent_message({ sessionId })`.
+ *
+ * Written next to the session file as `<sessionFile>.loadout.json` at spawn
+ * time. Resume replays this exact snapshot so the reincarnated process gets the
+ * same `--no-extensions` + `--tools` restriction, model, identity, spawn
+ * whitelist, cwd, and config dir it originally ran with — instead of falling
+ * back to pi's default (all global extensions + full toolset). Storing the
+ * resolved loadout (rather than re-deriving from the agent `.md` by name) keeps
+ * resume faithful even if the agent definition is later edited, moved, or
+ * deleted.
+ */
+export interface SubagentLoadout {
+  /** Agent profile name (for PI_SUBAGENT_AGENT); null for agentless spawns. */
+  agent: string | null;
+  /** The `--tools` allowlist string, or null when the spawn was unrestricted. */
+  toolAllowlist: string | null;
+  /** Model id (without thinking suffix), or null to use the session default. */
+  model: string | null;
+  /** Thinking level appended to the model as `model:level`, or null. */
+  thinking: string | null;
+  /** How the identity text was applied: append/replace, or null. */
+  systemPromptMode: "append" | "replace" | null;
+  /** The system-prompt/identity text, only when it lived in the system prompt. */
+  identity: string | null;
+  /** Agents this subagent was allowed to spawn (for PI_SUBAGENT_ALLOWED). */
+  spawnable: string[] | null;
+  /** Whether the agent auto-exits (informational; resume forces autonomous). */
+  autoExit: boolean;
+  /** Working directory the subagent ran in, or null. */
+  cwd: string | null;
+  /** PI_CODING_AGENT_DIR the subagent resolved config/extensions from, or null. */
+  agentDir: string | null;
+}
+
+/** Path of the loadout sidecar written next to a subagent session file. */
+export function loadoutSidecarPath(sessionFile: string): string {
+  return `${sessionFile}.loadout.json`;
+}
+
+/** Persist a subagent's resolved sandbox loadout beside its session file. */
+export function writeSubagentLoadout(sessionFile: string, loadout: SubagentLoadout): void {
+  try {
+    writeFileSync(loadoutSidecarPath(sessionFile), JSON.stringify(loadout), "utf8");
+  } catch {
+    // Best-effort: a missing snapshot only means resume will refuse, never that
+    // it launches unrestricted.
+  }
+}
+
+/** Read a subagent's loadout snapshot, or null if absent/unparseable. */
+export function readSubagentLoadout(sessionFile: string): SubagentLoadout | null {
+  try {
+    const p = loadoutSidecarPath(sessionFile);
+    if (!existsSync(p)) return null;
+    const parsed = JSON.parse(readFileSync(p, "utf8"));
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as SubagentLoadout;
+  } catch {
+    return null;
+  }
+}
+
+// ── Name registry ────────────────────────────────────────────────────────────
+// Each spawner session (the top-level pi session, or a worker that spawns its
+// own children) gets a registry mapping a subagent's display name to the
+// session file it ran in. Names are unique per spawner session and persist on
+// disk, so `subagent_message({ name })` can steer a running subagent or resume
+// a finished one by the same handle — even across a pi restart. The registry
+// lives in the spawner's own artifact dir, which is directly addressable from
+// the spawner's session id (no sessions-tree scan, so resume stays fast).
+
+export interface NameRegistryEntry {
+  /** Absolute path to the subagent's session .jsonl file. */
+  sessionFile: string;
+  /** Canonical session header id (kept for display/lineage). */
+  sessionId: string | null;
+}
+
+export type NameRegistry = Record<string, NameRegistryEntry>;
+
+/** Path of the name registry for a given spawner session's artifact dir. */
+export function nameRegistryPath(artifactDir: string): string {
+  return join(artifactDir, "subagent-registry.json");
+}
+
+/** Read a spawner session's name registry, or {} if absent/corrupt. */
+export function readNameRegistry(artifactDir: string): NameRegistry {
+  try {
+    const p = nameRegistryPath(artifactDir);
+    if (!existsSync(p)) return {};
+    const parsed = JSON.parse(readFileSync(p, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as NameRegistry;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Register (or overwrite) a name → session mapping for a spawner session.
+ * Writes atomically (temp file + rename) so a concurrent reader never sees a
+ * partial registry.
+ */
+export function registerName(
+  artifactDir: string,
+  name: string,
+  entry: NameRegistryEntry,
+): void {
+  try {
+    mkdirSync(artifactDir, { recursive: true });
+    const registry = readNameRegistry(artifactDir);
+    registry[name] = entry;
+    const p = nameRegistryPath(artifactDir);
+    const tmp = `${p}.tmp-${process.pid}-${Math.random().toString(16).slice(2, 8)}`;
+    writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf8");
+    renameSync(tmp, p);
+  } catch {
+    // Best-effort: a failed registration only means resume-by-name won't find
+    // this subagent later; it never breaks the spawn itself.
+  }
+}
+
+/** Resolve a name to its registry entry within a spawner session, or null. */
+export function resolveNameInRegistry(
+  artifactDir: string,
+  name: string,
+): NameRegistryEntry | null {
+  const entry = readNameRegistry(artifactDir)[name];
+  return entry && typeof entry.sessionFile === "string" ? entry : null;
+}
+
+function readEntries(sessionFile: string): SessionEntry[] {
+  const raw = readFileSync(sessionFile, "utf8");
+  return raw
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as SessionEntry);
+}
+
+/**
+ * Return the id of the last entry in the session file (current branch point / leaf).
+ */
+export function getLeafId(sessionFile: string): string | null {
+  const entries = readEntries(sessionFile);
+  return entries.length > 0 ? entries[entries.length - 1].id : null;
+}
+
+/**
+ * Read the canonical session id from a session file's header.
+ *
+ * pi's `--session <id>` flag resolves against this header `id` (exact match,
+ * then prefix), NOT the filename — so this is the value to hand back to the
+ * orchestrator for follow-ups.
+ */
+/**
+ * Read only the first line of a file without loading the whole thing into
+ * memory. Session files grow to many MB, but the header we need is always the
+ * first JSON line, so reading a small prefix keeps header lookups cheap — this
+ * is what makes scanning a large session tree fast enough to avoid blocking the
+ * event loop. Returns the first line (sans trailing newline), or null.
+ */
+function readFirstLine(path: string, maxBytes = 65536): string | null {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, "r");
+    const buf = Buffer.allocUnsafe(maxBytes);
+    const bytes = readSync(fd, buf, 0, maxBytes, 0);
+    if (bytes <= 0) return null;
+    const nl = buf.indexOf(0x0a); // '\n'
+    const end = nl === -1 || nl >= bytes ? bytes : nl;
+    return buf.toString("utf8", 0, end);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+export function getSessionId(sessionFile: string): string | null {
+  return readHeaderId(sessionFile);
+}
+
+function readHeaderId(sessionFile: string): string | null {
+  const firstLine = readFirstLine(sessionFile)?.trim();
+  if (!firstLine) return null;
+  try {
+    const entry = JSON.parse(firstLine) as { type?: string; id?: string };
+    return entry.type === "session" && typeof entry.id === "string" ? entry.id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a session id (or id prefix) to a session file path by scanning every
+ * `*.jsonl` under `sessionsRoot` and matching the header `id`. Mirrors pi's own
+ * resolution order: exact match first, then prefix match. Most recently
+ * modified file wins on ties. Returns null when nothing matches.
+ */
+/**
+ * In-process index of session id → session file, per sessions root.
+ *
+ * Resolving a session id naively walks every `.jsonl` under the sessions tree
+ * and reads each header. With a few thousand sessions that is thousands of
+ * synchronous open/read/stat syscalls — on the extension host's single thread
+ * that blocks the entire terminal UI for many seconds (measured ~67s on a
+ * 2010-file tree). To avoid that, we build the index once per root and cache
+ * it; subsequent lookups are O(1). The cache is validated cheaply (a directory
+ * listing plus statSync-only mtime checks) on every call, so new sessions are
+ * picked up without re-reading unchanged headers and without ever freezing the
+ * UI again.
+ */
+interface SessionIndex {
+  idToFile: Map<string, { path: string; mtime: number }>;
+  /** file path → mtime when indexed (staleness detection). */
+  files: Map<string, number>;
+  /** top-level dir signature used to detect newly added cwd dirs. */
+  topSig: string;
+}
+const sessionIndexCache = new Map<string, SessionIndex>();
+
+function topLevelSignature(root: string): string {
+  const parts: string[] = [];
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return "";
+  }
+  for (const e of entries) {
+    const full = join(root, e.name);
+    if (e.isDirectory()) {
+      let m = 0;
+      try {
+        m = statSync(full).mtimeMs;
+      } catch {
+        /* ignore */
+      }
+      parts.push(`d:${e.name}:${m}`);
+    } else if (e.isFile() && e.name.endsWith(".jsonl")) {
+      parts.push(`f:${e.name}`);
+    }
+  }
+  parts.sort();
+  return parts.join("|");
+}
+
+/** Recursively index new/changed .jsonl files under dir into idx. */
+function indexDir(dir: string, idx: SessionIndex): void {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      indexDir(full, idx);
+    } else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      let mtime = 0;
+      try {
+        mtime = statSync(full).mtimeMs;
+      } catch {
+        continue;
+      }
+      const known = idx.files.get(full);
+      if (known !== undefined && known === mtime) continue; // unchanged
+      const id = readHeaderId(full); // only read headers for new/changed files
+      idx.files.set(full, mtime);
+      if (!id) continue;
+      const prev = idx.idToFile.get(id);
+      if (!prev || mtime >= prev.mtime) {
+        idx.idToFile.set(id, { path: full, mtime });
+      }
+    }
+  }
+}
+
+function getSessionIndex(sessionsRoot: string): SessionIndex {
+  let idx = sessionIndexCache.get(sessionsRoot);
+  const sig = topLevelSignature(sessionsRoot);
+  if (!idx) {
+    idx = { idToFile: new Map(), files: new Map(), topSig: sig };
+    sessionIndexCache.set(sessionsRoot, idx);
+    indexDir(sessionsRoot, idx); // first build: full scan, once per process
+  } else if (idx.topSig !== sig) {
+    idx.topSig = sig;
+    indexDir(sessionsRoot, idx); // a cwd dir was added/changed: incremental rescan
+  } else {
+    indexDir(sessionsRoot, idx); // cheap: stats files, reads only new/changed headers
+  }
+  return idx;
+}
+
+export function resolveSessionFileById(sessionId: string, sessionsRoot: string): string | null {
+  if (!sessionId || !existsSync(sessionsRoot)) return null;
+  const idx = getSessionIndex(sessionsRoot);
+  return lookupSessionIndex(idx, sessionId);
+}
+
+function lookupSessionIndex(
+  idx: { idToFile: Map<string, { path: string; mtime: number }> },
+  sessionId: string,
+): string | null {
+  // Exact match first.
+  const exact = idx.idToFile.get(sessionId);
+  if (exact && existsSync(exact.path)) return exact.path;
+
+  // Prefix match: most recently modified wins (ids are unique in practice, so
+  // this is only a convenience for hand-typed short prefixes).
+  let best: { path: string; mtime: number } | null = null;
+  for (const [id, rec] of idx.idToFile) {
+    if (!id.startsWith(sessionId)) continue;
+    if (!existsSync(rec.path)) continue;
+    if (!best || rec.mtime > best.mtime) best = rec;
+  }
+  return best ? best.path : null;
+}
+
+/**
+ * Async variant used by the interactive resume path. Index building/refresh is
+ * synchronous I/O, which can take many seconds on a cold OS page cache with a
+ * few thousand sessions; running it synchronously would block the extension
+ * host's single thread and freeze the terminal UI. Deferring to a macrotask
+ * keeps the event loop responsive. The heavy work only happens on the first
+ * resolution per process (and incrementally thereafter); warm lookups are ~50ms.
+ */
+export async function resolveSessionFileByIdAsync(
+  sessionId: string,
+  sessionsRoot: string,
+): Promise<string | null> {
+  if (!sessionId || !existsSync(sessionsRoot)) return null;
+  // Let the event loop breathe (and the UI repaint) before the sync scan.
+  await new Promise<void>((r) => setImmediate(r));
+  const idx = getSessionIndex(sessionsRoot);
+  return lookupSessionIndex(idx, sessionId);
+}
+
+/** Test hook: drop the cached session index so tests start clean. */
+export function resetSessionIndexCache(): void {
+  sessionIndexCache.clear();
+}
+
+/**
+ * Return entries added after `afterLine` (1-indexed count of existing entries).
+ */
+/**
+ * Count the number of entry lines in a session file without parsing each line
+ * into an object. Used by the resume path, which only needs the *count* of
+ * pre-existing entries (so it can later slice out the new ones). Parsing every
+ * line of a large resumed transcript synchronously at resume time would block
+ * the UI; counting newlines is dramatically cheaper.
+ */
+export function countSessionEntryLines(sessionFile: string): number {
+  try {
+    const raw = readFileSync(sessionFile, "utf8");
+    // Count non-blank lines, mirroring getNewEntries' `.filter(line => line.trim())`
+    // but skipping the per-line JSON.parse that makes resume slow on big files.
+    let count = 0;
+    for (const line of raw.split("\n")) {
+      if (line.trim()) count++;
+    }
+    return count;
+  } catch {
+    return 0;
+  }
+}
+
+export function getNewEntries(sessionFile: string, afterLine: number): SessionEntry[] {
+  const raw = readFileSync(sessionFile, "utf8");
+  const lines = raw.split("\n").filter((line) => line.trim());
+  return lines.slice(afterLine).map((line) => JSON.parse(line) as SessionEntry);
+}
+
+/**
+ * Find the last assistant message text in a list of entries.
+ *
+ * Falls back to the `errorMessage` field when the last assistant message has
+ * `stopReason: "error"` and no usable text content — this happens when
+ * auto-retry exhausts on a provider overload / rate limit / server error, and
+ * without this fallback the parent would silently see a stale earlier message.
+ */
+export function findLastAssistantMessage(entries: SessionEntry[]): string | null {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.type !== "message") continue;
+    const msg = entry as MessageEntry;
+    if (msg.message.role !== "assistant") continue;
+
+    const texts = msg.message.content
+      .filter(
+        (block) =>
+          block.type === "text" && typeof block.text === "string" && block.text.trim() !== "",
+      )
+      .map((block) => block.text as string);
+
+    if (texts.length > 0 && texts.join("").trim()) return texts.join("\n");
+
+    const stopReason = (msg.message as { stopReason?: unknown }).stopReason;
+    const errorMessage = (msg.message as { errorMessage?: unknown }).errorMessage;
+    if (
+      stopReason === "error" &&
+      typeof errorMessage === "string" &&
+      errorMessage.trim() !== ""
+    ) {
+      return `Subagent error: ${errorMessage.trim()}`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Append a branch_summary entry to the session file.
+ * Returns the new entry's id.
+ */
+export function appendBranchSummary(
+  sessionFile: string,
+  branchPointId: string,
+  fromId: string | null,
+  summary: string,
+): string {
+  const id = randomBytes(4).toString("hex");
+  const entry = {
+    type: "branch_summary",
+    id,
+    parentId: branchPointId,
+    timestamp: new Date().toISOString(),
+    fromId: fromId ?? branchPointId,
+    summary,
+  };
+  appendFileSync(sessionFile, JSON.stringify(entry) + "\n", "utf8");
+  return id;
+}
+
+/**
+ * Copy the session file to destDir for parallel worker isolation.
+ * Returns the path of the copy.
+ */
+export function copySessionFile(sessionFile: string, destDir: string): string {
+  const id = randomBytes(4).toString("hex");
+  const dest = join(destDir, `subagent-${id}.jsonl`);
+  copyFileSync(sessionFile, dest);
+  return dest;
+}
+
+/**
+ * Read new entries from sourceFile (after afterLine), append them to targetFile.
+ * Returns the appended entries.
+ */
+export function mergeNewEntries(
+  sourceFile: string,
+  targetFile: string,
+  afterLine: number,
+): SessionEntry[] {
+  const entries = getNewEntries(sourceFile, afterLine);
+  for (const entry of entries) {
+    appendFileSync(targetFile, JSON.stringify(entry) + "\n", "utf8");
+  }
+  return entries;
+}
+
+export interface SessionStats {
+  model: string | null;
+  toolCount: number;
+  /** Cumulative token usage across all assistant turns. */
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  /** Current context size: the last assistant turn's totalTokens. */
+  contextTokens: number;
+  /** Cumulative cost in USD across all assistant turns. */
+  cost: number;
+}
+
+/**
+ * Parse a completed subagent session JSONL into aggregate stats for display:
+ * model, tool-call count, cumulative token usage + cost, and current context
+ * size. Cumulative usage fields are summed across every assistant turn; the
+ * context size is taken from the last assistant turn's `totalTokens` (the live
+ * context window occupancy). Returns null if the file can't be read.
+ */
+export function summarizeSessionStats(sessionFile: string): SessionStats | null {
+  let entries: SessionEntry[];
+  try {
+    entries = readEntries(sessionFile);
+  } catch {
+    return null;
+  }
+
+  const stats: SessionStats = {
+    model: null,
+    toolCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    contextTokens: 0,
+    cost: 0,
+  };
+
+  for (const entry of entries) {
+    if (entry.type === "model_change") {
+      const modelId = (entry as { modelId?: unknown }).modelId;
+      if (typeof modelId === "string" && modelId) stats.model = modelId;
+      continue;
+    }
+    if (entry.type !== "message") continue;
+    const msg = (entry as MessageEntry).message;
+    if (msg.role !== "assistant") continue;
+
+    const model = (msg as { model?: unknown }).model;
+    if (typeof model === "string" && model) stats.model = model;
+
+    for (const block of msg.content) {
+      if (block.type === "toolCall") stats.toolCount++;
+    }
+
+    const usage = (msg as { usage?: Record<string, unknown> }).usage;
+    if (usage && typeof usage === "object") {
+      const num = (v: unknown): number => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+      stats.inputTokens += num(usage.input);
+      stats.outputTokens += num(usage.output);
+      stats.cacheReadTokens += num(usage.cacheRead);
+      stats.cacheWriteTokens += num(usage.cacheWrite);
+      const total = num(usage.totalTokens);
+      if (total > 0) stats.contextTokens = total;
+      const cost = usage.cost;
+      if (cost && typeof cost === "object") stats.cost += num((cost as Record<string, unknown>).total);
+    }
+  }
+
+  return stats;
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/status.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/status.ts
@@ -1,0 +1,513 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SNAPSHOT_STALLED_AFTER_MS = 60_000;
+export const DEFAULT_STATUS_LINE_LIMIT = 4;
+export const MAX_STATUS_NAME_LENGTH = 72;
+export const MAX_STATUS_LINE_LENGTH = 120;
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_STATUS_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
+const STATUS_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
+
+export type SubagentStatusKind = "starting" | "active" | "waiting" | "stalled" | "running";
+export type SubagentStatusSource = "pi" | "claude";
+export type SubagentStatusTransition = "stalled" | "recovered" | null;
+export type StatusSnapshotState = "unseen" | "present" | "missing" | "invalid" | "wrong-id";
+export type StatusActivityPhase = "starting" | "active" | "waiting" | "done";
+
+export interface StatusConfig {
+  enabled: boolean;
+  lineLimit: number;
+}
+
+export type StatusObservation =
+  | {
+      snapshot: "present";
+      updatedAt: number;
+      sequence: number;
+      phase: StatusActivityPhase;
+      active?: boolean;
+      activeScope?: string;
+      activeSince?: number;
+      waitingSince?: number;
+      latestEvent?: string;
+      activityLabel?: string;
+    }
+  | {
+      snapshot: "missing" | "invalid" | "wrong-id";
+      snapshotError?: string;
+    };
+
+export interface SubagentStatusState {
+  source: SubagentStatusSource;
+  startTimeMs: number;
+  firstObservationAtMs: number | null;
+  lastActivityAtMs: number | null;
+  lastActivitySequence: number | null;
+  localOverrideAtMs: number | null;
+  localOverrideSequence: number | null;
+  activeNow: boolean;
+  activeSinceMs: number | null;
+  activeScope: string | null;
+  waitingSinceMs: number | null;
+  phase: StatusActivityPhase | null;
+  latestEvent: string | null;
+  activityLabel: string | null;
+  snapshotState: StatusSnapshotState;
+  snapshotProblemSinceMs: number | null;
+  snapshotError: string | null;
+  currentKind: SubagentStatusKind;
+}
+
+export interface StatusSnapshot {
+  kind: SubagentStatusKind;
+  elapsedMs: number;
+  elapsedText: string;
+  activeSinceMs: number | null;
+  activeDurationText: string | null;
+  activeScope: string | null;
+  waitingSinceMs: number | null;
+  waitingDurationText: string | null;
+  latestEvent: string | null;
+  activityLabel: string | null;
+  snapshotState: StatusSnapshotState;
+  snapshotError: string | null;
+  snapshotProblemText: string | null;
+  statusLabel: string | null;
+}
+
+export interface CappedStatusLines {
+  visibleLines: string[];
+  overflow: number;
+}
+
+function invalidStatusConfig(source: string, message: string): never {
+  throw new Error(`Invalid subagent status config in ${source}: ${message}`);
+}
+
+function requireObject(value: unknown, source: string, fieldName: string): Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    invalidStatusConfig(source, `${fieldName} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireBoolean(value: unknown, source: string, fieldName: string): boolean {
+  if (typeof value !== "boolean") {
+    invalidStatusConfig(source, `${fieldName} must be a boolean`);
+  }
+  return value;
+}
+
+function rejectUnsupportedKeys(
+  value: Record<string, unknown>,
+  allowedKeys: string[],
+  source: string,
+  fieldName: string,
+): void {
+  const unsupportedKeys = Object.keys(value).filter((key) => !allowedKeys.includes(key));
+  if (unsupportedKeys.length > 0) {
+    invalidStatusConfig(source, `${fieldName} has unsupported key(s): ${unsupportedKeys.join(", ")}`);
+  }
+}
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  if (maxLength <= 1) return text.slice(0, maxLength);
+  return `${text.slice(0, maxLength - 1)}…`;
+}
+
+export function normalizeStatusName(name: string): string {
+  const collapsed = name.replace(/\s+/g, " ").trim() || "subagent";
+  return truncateText(collapsed, MAX_STATUS_NAME_LENGTH);
+}
+
+function boundStatusLine(line: string): string {
+  return truncateText(line.replace(/\s+/g, " ").trim(), MAX_STATUS_LINE_LENGTH);
+}
+
+function snapshotProblemLabel(snapshotState: StatusSnapshotState): string | null {
+  if (snapshotState === "wrong-id") return "wrong activity id";
+  return null;
+}
+
+function activityLabel(snapshot: Pick<StatusSnapshot, "activityLabel" | "activeScope">): string | null {
+  return snapshot.activityLabel ?? snapshot.activeScope;
+}
+
+export function parseStatusConfig(rawConfig: unknown, source = "config.json"): StatusConfig {
+  const config = requireObject(rawConfig, source, "root");
+  const status = requireObject(config.status, source, "status");
+  rejectUnsupportedKeys(status, ["enabled"], source, "status");
+  const enabled = requireBoolean(status.enabled, source, "status.enabled");
+
+  return {
+    enabled,
+    lineLimit: DEFAULT_STATUS_LINE_LIMIT,
+  };
+}
+
+function readStatusConfigFile(configPath: string, examplePath: string): { sourcePath: string; rawConfig: string } {
+  try {
+    return { sourcePath: configPath, rawConfig: readFileSync(configPath, "utf8") };
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code !== "ENOENT") throw error;
+  }
+
+  try {
+    return { sourcePath: examplePath, rawConfig: readFileSync(examplePath, "utf8") };
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        `Missing subagent status config. Expected ${configPath} or ${examplePath}.`,
+      );
+    }
+    throw error;
+  }
+}
+
+export function loadStatusConfig(
+  configPath = DEFAULT_STATUS_CONFIG_PATH,
+  examplePath = STATUS_CONFIG_EXAMPLE_PATH,
+): StatusConfig {
+  const { sourcePath, rawConfig } = readStatusConfigFile(configPath, examplePath);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawConfig) as unknown;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON in subagent config ${sourcePath}: ${detail}`);
+  }
+
+  return parseStatusConfig(parsed, sourcePath);
+}
+
+export function formatElapsedDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (hours > 0) return `${hours}h ${minutes}m`;
+
+  return `${minutes}m`;
+}
+
+export function createStatusState(params: {
+  source: SubagentStatusSource;
+  startTimeMs: number;
+}): SubagentStatusState {
+  const initialKind = params.source === "claude" ? "running" : "starting";
+  return {
+    source: params.source,
+    startTimeMs: params.startTimeMs,
+    firstObservationAtMs: null,
+    lastActivityAtMs: null,
+    lastActivitySequence: null,
+    localOverrideAtMs: null,
+    localOverrideSequence: null,
+    activeNow: false,
+    activeSinceMs: null,
+    activeScope: null,
+    waitingSinceMs: null,
+    phase: null,
+    latestEvent: null,
+    activityLabel: null,
+    snapshotState: params.source === "claude" ? "unseen" : "unseen",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
+    currentKind: initialKind,
+  };
+}
+
+export function observeStatus(
+  state: SubagentStatusState,
+  observation: StatusObservation,
+  now: number,
+): SubagentStatusState {
+  if (state.source === "claude") return state;
+
+  if (observation.snapshot !== "present") {
+    return {
+      ...state,
+      firstObservationAtMs: state.firstObservationAtMs ?? now,
+      snapshotState: observation.snapshot,
+      snapshotProblemSinceMs: state.snapshotProblemSinceMs ?? now,
+      snapshotError: observation.snapshotError ?? null,
+    };
+  }
+
+  const updatedAt = observation.updatedAt;
+  const sequence = observation.sequence;
+  const lastActivityAtMs = state.lastActivityAtMs;
+  const lastActivitySequence = state.lastActivitySequence;
+  const olderThanLastActivity = lastActivityAtMs != null && (
+    updatedAt < lastActivityAtMs ||
+    (updatedAt === lastActivityAtMs && lastActivitySequence != null && sequence < lastActivitySequence)
+  );
+  if (olderThanLastActivity) return state;
+
+  const blockedByLocalOverride = state.localOverrideAtMs != null && (
+    updatedAt < state.localOverrideAtMs ||
+    (updatedAt === state.localOverrideAtMs && state.localOverrideSequence != null && sequence <= state.localOverrideSequence)
+  );
+  if (blockedByLocalOverride) return state;
+
+  const phase = observation.phase;
+  const activeNow = phase === "active" || observation.active === true;
+  const activeSinceMs = activeNow
+    ? observation.activeSince ?? state.activeSinceMs ?? updatedAt
+    : null;
+  const waitingSinceMs = phase === "waiting"
+    ? observation.waitingSince ?? state.waitingSinceMs ?? updatedAt
+    : null;
+
+  return {
+    ...state,
+    firstObservationAtMs: state.firstObservationAtMs ?? now,
+    lastActivityAtMs: updatedAt,
+    lastActivitySequence: sequence,
+    activeNow,
+    activeSinceMs,
+    activeScope: activeNow ? observation.activeScope ?? null : null,
+    waitingSinceMs,
+    phase,
+    latestEvent: observation.latestEvent ?? null,
+    activityLabel: observation.activityLabel ?? null,
+    snapshotState: "present",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
+    localOverrideAtMs: null,
+    localOverrideSequence: null,
+  };
+}
+
+export function forceStatusAfterInterrupt(state: SubagentStatusState, now: number): SubagentStatusState {
+  if (state.source === "claude") return state;
+
+  return {
+    ...state,
+    firstObservationAtMs: state.firstObservationAtMs ?? now,
+    lastActivityAtMs: now,
+    localOverrideAtMs: now,
+    localOverrideSequence: state.lastActivitySequence,
+    activeNow: false,
+    activeSinceMs: null,
+    activeScope: null,
+    waitingSinceMs: now,
+    phase: "waiting",
+    latestEvent: "interrupt_requested",
+    activityLabel: "interrupted",
+    snapshotState: "present",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
+    currentKind: "waiting",
+  };
+}
+
+function classifyProblemState(state: SubagentStatusState, now: number): Pick<StatusSnapshot, "kind" | "statusLabel"> {
+  const problemLabel = snapshotProblemLabel(state.snapshotState);
+  const hasValidSnapshot = state.lastActivityAtMs != null;
+
+  if (!hasValidSnapshot) {
+    const referenceMs = state.firstObservationAtMs ?? state.startTimeMs;
+    const elapsedMs = Math.max(0, now - referenceMs);
+    return elapsedMs >= SNAPSHOT_STALLED_AFTER_MS
+      ? { kind: "stalled", statusLabel: problemLabel }
+      : { kind: "starting", statusLabel: null };
+  }
+
+  const problemSinceMs = state.snapshotProblemSinceMs ?? now;
+  const problemMs = Math.max(0, now - problemSinceMs);
+  if (problemMs >= SNAPSHOT_STALLED_AFTER_MS) return { kind: "stalled", statusLabel: problemLabel };
+
+  const lastHealthyKind = state.activeNow
+    ? "active"
+    : state.waitingSinceMs != null || state.phase === "done"
+      ? "waiting"
+      : state.currentKind === "stalled"
+        ? "starting"
+        : state.currentKind;
+  return { kind: lastHealthyKind, statusLabel: problemLabel };
+}
+
+export function classifyStatus(state: SubagentStatusState, now: number): StatusSnapshot {
+  const elapsedMs = Math.max(0, now - state.startTimeMs);
+  const elapsedText = formatElapsedDuration(elapsedMs);
+
+  if (state.source === "claude") {
+    return {
+      kind: "running",
+      elapsedMs,
+      elapsedText,
+      activeSinceMs: null,
+      activeDurationText: null,
+      activeScope: null,
+      waitingSinceMs: null,
+      waitingDurationText: null,
+      latestEvent: null,
+      activityLabel: null,
+      snapshotState: state.snapshotState,
+      snapshotError: null,
+      snapshotProblemText: null,
+      statusLabel: null,
+    };
+  }
+
+  let kind: SubagentStatusKind;
+  let statusLabel: string | null = null;
+
+  if (state.snapshotState === "present") {
+    if (state.phase === "active" || state.activeNow) {
+      kind = "active";
+    } else if (state.phase === "waiting") {
+      kind = "waiting";
+    } else if (state.phase === "done") {
+      kind = "waiting";
+      statusLabel = "done";
+    } else {
+      const referenceMs = state.firstObservationAtMs ?? state.startTimeMs;
+      const elapsedSinceObservationMs = Math.max(0, now - referenceMs);
+      kind = elapsedSinceObservationMs >= SNAPSHOT_STALLED_AFTER_MS ? "stalled" : "starting";
+      statusLabel = null;
+    }
+  } else {
+    const classified = classifyProblemState(state, now);
+    kind = classified.kind;
+    statusLabel = classified.statusLabel;
+  }
+
+  const activeDurationText = state.activeSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.activeSinceMs);
+  const waitingDurationText = state.waitingSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.waitingSinceMs);
+  const snapshotProblemText = state.snapshotProblemSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.snapshotProblemSinceMs);
+
+  return {
+    kind,
+    elapsedMs,
+    elapsedText,
+    activeSinceMs: state.activeSinceMs,
+    activeDurationText,
+    activeScope: state.activeScope,
+    waitingSinceMs: state.waitingSinceMs,
+    waitingDurationText,
+    latestEvent: state.latestEvent,
+    activityLabel: state.activityLabel,
+    snapshotState: state.snapshotState,
+    snapshotError: state.snapshotError,
+    snapshotProblemText,
+    statusLabel,
+  };
+}
+
+export function advanceStatusState(
+  state: SubagentStatusState,
+  now: number,
+): {
+  nextState: SubagentStatusState;
+  snapshot: StatusSnapshot;
+  transition: SubagentStatusTransition;
+} {
+  const snapshot = classifyStatus(state, now);
+  const transition =
+    state.currentKind !== "stalled" && snapshot.kind === "stalled"
+      ? "stalled"
+      : state.currentKind === "stalled" && (snapshot.kind === "active" || snapshot.kind === "waiting")
+        ? "recovered"
+        : null;
+
+  return {
+    snapshot,
+    transition,
+    nextState: {
+      ...state,
+      currentKind: snapshot.kind,
+    },
+  };
+}
+
+function formatActiveDetail(snapshot: StatusSnapshot): string {
+  const label = activityLabel(snapshot);
+  if (!label) return "active";
+  const duration = snapshot.activeDurationText ? ` ${snapshot.activeDurationText}` : "";
+  return `active (${label}${duration})`;
+}
+
+function formatWaitingDetail(snapshot: StatusSnapshot): string {
+  const duration = snapshot.waitingDurationText ? ` ${snapshot.waitingDurationText}` : "";
+  return `waiting${duration}`;
+}
+
+function formatStalledDetail(snapshot: StatusSnapshot): string {
+  const detail = snapshot.statusLabel ? ` (${snapshot.statusLabel})` : "";
+  const duration = snapshot.snapshotProblemText ? ` ${snapshot.snapshotProblemText}` : "";
+  return `stalled${duration}${detail}`;
+}
+
+export function formatStatusLine(name: string, snapshot: StatusSnapshot): string {
+  const boundedName = normalizeStatusName(name);
+
+  if (snapshot.kind === "starting") {
+    const label = snapshot.statusLabel ? ` (${snapshot.statusLabel})` : "";
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, starting${label}.`);
+  }
+
+  if (snapshot.kind === "running") {
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}.`);
+  }
+
+  if (snapshot.kind === "active") {
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatActiveDetail(snapshot)}.`);
+  }
+
+  if (snapshot.kind === "waiting") {
+    const problem = snapshot.statusLabel && snapshot.statusLabel !== "done"
+      ? ` (${snapshot.statusLabel})`
+      : snapshot.statusLabel === "done"
+        ? " (done)"
+        : "";
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatWaitingDetail(snapshot)}${problem}.`);
+  }
+
+  return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatStalledDetail(snapshot)}.`);
+}
+
+export function formatTransitionLine(
+  name: string,
+  snapshot: StatusSnapshot,
+  transition: Exclude<SubagentStatusTransition, null>,
+): string {
+  const boundedName = normalizeStatusName(name);
+
+  if (transition === "recovered") {
+    const detail = snapshot.kind === "waiting" ? formatWaitingDetail(snapshot) : formatActiveDetail(snapshot);
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, recovered; ${detail}.`);
+  }
+
+  return formatStatusLine(boundedName, snapshot);
+}
+
+export function capStatusLines(lines: string[], lineLimit: number): CappedStatusLines {
+  const visibleLines = lines.slice(0, lineLimit);
+  return {
+    visibleLines,
+    overflow: Math.max(0, lines.length - visibleLines.length),
+  };
+}
+
+export function formatStatusAggregate(lines: string[], lineLimit: number): string {
+  const { visibleLines, overflow } = capStatusLines(lines, lineLimit);
+  const bulletLines = visibleLines.map((line) => `• ${line}`);
+  if (overflow > 0) bulletLines.push(`• +${overflow} more running.`);
+  return `Subagent status:\n${bulletLines.join("\n")}`;
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/subagent-done.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/subagent-done.ts
@@ -1,0 +1,399 @@
+/**
+ * Extension loaded into sub-agents.
+ * - Shows agent identity + available tools as a styled widget above the editor (toggle with Ctrl+Alt+O)
+ * - Provides an `ask_question` tool for asking the parent orchestrator a question
+ *
+ * Subagents do NOT self-terminate via a tool. Auto-exit agents shut down
+ * automatically when their agent loop ends (see the `agent_end` handler);
+ * interactive agents end when the human exits the pane.
+ *
+ * `ask_question` keeps the session OPEN: it writes a `${sessionFile}.ask`
+ * signal the parent's watcher picks up, parks the session in a "waiting" state
+ * (auto-exit is suppressed for that turn via `awaitingAnswer`), and the parent
+ * replies with subagent_message — which lands as the subagent's next turn.
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Box, Text } from "@earendil-works/pi-tui";
+import { Type } from "@earendil-works/pi-ai";
+import { writeFileSync } from "node:fs";
+import { createSubagentActivityRecorder } from "./activity.ts";
+
+export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
+  return agentStarted;
+}
+
+/**
+ * Number of child subagents this session itself still has in flight.
+ *
+ * When this extension is loaded inside a subagent that can spawn its own
+ * children (e.g. a worker delegating to scout/researcher), `index.ts` runs in
+ * the same process and publishes a live count through a shared process-global
+ * symbol. A subagent that spawns children and then writes a "waiting for
+ * results" message would otherwise auto-exit the instant that turn ends —
+ * killing the session before its children report back. Reading this count lets
+ * `agent_end` keep the session open until every child has finished and its
+ * result has been delivered.
+ *
+ * Returns 0 when the spawning tools aren't loaded (scout/researcher, or a
+ * standalone session), so those agents auto-exit exactly as before.
+ */
+export function runningChildrenCount(): number {
+  const fn = (globalThis as any)[Symbol.for("pi-subagents/running-children-count")];
+  if (typeof fn !== "function") return 0;
+  try {
+    const n = fn();
+    return typeof n === "number" && n > 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function shouldAutoExitOnAgentEnd(
+  _userTookOver: boolean,
+  messages: any[] | undefined,
+): boolean {
+  // Manual input should not strand an auto-exit subagent. If the latest agent
+  // turn completed normally, close the session. Escape/abort still leaves it
+  // open for inspection or another prompt.
+  //
+  // stopReason: "error" (e.g. exhausted retries on a provider overload) also
+  // returns true — we want to shut down so the parent is woken up — but we
+  // pair this with findLatestAssistantError() so the parent learns it was an
+  // error, not a clean completion.
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg?.role === "assistant") {
+        return msg.stopReason !== "aborted";
+      }
+    }
+  }
+
+  return true;
+}
+
+export interface SubagentErrorInfo {
+  errorMessage: string;
+  stopReason: "error";
+}
+
+/**
+ * If the last assistant message in the turn ended with `stopReason: "error"`
+ * (typically auto-retry exhausted on an overload / rate limit / server error),
+ * return its error info so the parent orchestrator can surface a clear
+ * failure instead of silently treating the run as completed.
+ *
+ * Returns `null` when the latest assistant turn completed normally or was
+ * aborted by the user (handled separately by shouldAutoExitOnAgentEnd).
+ */
+export function findLatestAssistantError(
+  messages: any[] | undefined,
+): SubagentErrorInfo | null {
+  if (!messages) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role !== "assistant") continue;
+    if (msg.stopReason !== "error") return null;
+    const raw = typeof msg.errorMessage === "string" ? msg.errorMessage.trim() : "";
+    return {
+      errorMessage: raw || "Subagent agent loop ended with stopReason=error (no errorMessage field).",
+      stopReason: "error",
+    };
+  }
+  return null;
+}
+
+export function parseDeniedTools(rawValue: string | undefined): string[] {
+  return (rawValue ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export default function (pi: ExtensionAPI) {
+  let toolNames: string[] = [];
+  let denied: string[] = [];
+  let expanded = false;
+
+  // Read subagent identity from env vars (set by parent orchestrator)
+  const subagentName = process.env.PI_SUBAGENT_NAME ?? "";
+  const subagentAgent = process.env.PI_SUBAGENT_AGENT ?? "";
+  const deniedToolsValue = process.env.PI_DENY_TOOLS;
+  const autoExit = process.env.PI_SUBAGENT_AUTO_EXIT === "1";
+  const recorder = createSubagentActivityRecorder({
+    runningChildId: process.env.PI_SUBAGENT_ID,
+    activityFile: process.env.PI_SUBAGENT_ACTIVITY_FILE,
+  });
+
+  function renderWidget(ctx: { ui: { setWidget: Function } }, _theme: any) {
+    ctx.ui.setWidget(
+      "subagent-tools",
+      (_tui: any, theme: any) => {
+        const box = new Box(1, 0, (text: string) => theme.bg("toolSuccessBg", text));
+
+        const label = subagentAgent || subagentName;
+        const agentTag = label ? theme.bold(theme.fg("accent", `[${label}]`)) : "";
+
+        if (expanded) {
+          // Expanded: full tool list + denied
+          const countInfo = theme.fg("dim", ` — ${toolNames.length} available`);
+          const hint = theme.fg("muted", "  (Ctrl+Alt+O to collapse)");
+
+          const toolList = toolNames
+            .map((name: string) => theme.fg("dim", name))
+            .join(theme.fg("muted", ", "));
+
+          let deniedLine = "";
+          if (denied.length > 0) {
+            const deniedList = denied
+              .map((name: string) => theme.fg("error", name))
+              .join(theme.fg("muted", ", "));
+            deniedLine = "\n" + theme.fg("muted", "denied: ") + deniedList;
+          }
+
+          const content = new Text(
+            `${agentTag}${countInfo}${hint}\n${toolList}${deniedLine}`,
+            0,
+            0,
+          );
+          box.addChild(content);
+        } else {
+          // Collapsed: one-line summary
+          const countInfo = theme.fg("dim", ` — ${toolNames.length} tools`);
+          const deniedInfo =
+            denied.length > 0
+              ? theme.fg("dim", " · ") + theme.fg("error", `${denied.length} denied`)
+              : "";
+          const hint = theme.fg("muted", "  (Ctrl+Alt+O to expand)");
+
+          const content = new Text(`${agentTag}${countInfo}${deniedInfo}${hint}`, 0, 0);
+          box.addChild(content);
+        }
+
+        return box;
+      },
+      { placement: "aboveEditor" },
+    );
+  }
+
+  let userTookOver = false;
+  let agentStarted = false;
+  // Set when ask_question is called; suppresses auto-exit so the session stays
+  // open while it waits for the orchestrator's reply. Cleared when the reply
+  // lands — on `input` (covers a reply steered into the current run) and on
+  // `agent_start` (covers a reply that starts a fresh turn after parking).
+  let awaitingAnswer = false;
+
+  // Show widget + status bar on session start
+  pi.on("session_start", (_event, ctx) => {
+    recorder.sessionStart();
+    const tools = pi.getAllTools();
+    toolNames = tools.map((t) => t.name).sort();
+    denied = parseDeniedTools(deniedToolsValue);
+
+    renderWidget(ctx, null);
+  });
+
+  pi.on("input", () => {
+    recorder.input();
+    // A submitted message is the orchestrator's (or a human's) reply — the
+    // pending ask_question has been answered, however it was delivered. Clear
+    // here, not only on agent_start, because a reply steered in *mid-run* is
+    // absorbed into the current run (pi's `steer` behavior injects it before
+    // the next LLM call): no new agent_start fires, so without this the flag
+    // would stay set and agent_end would park the session as `waiting` even
+    // though the answer already arrived and was consumed. (The `input` event
+    // fires for mid-run steers because prompt() emits it before queueing.)
+    awaitingAnswer = false;
+    // Ignore the initial task message that starts an autonomous subagent.
+    // Only inputs after the first agent run has started count as user takeover.
+    if (!shouldMarkUserTookOver(agentStarted)) return;
+    userTookOver = true;
+  });
+
+  pi.on("before_agent_start", () => {
+    recorder.beforeAgentStart();
+  });
+
+  pi.on("agent_start", () => {
+    agentStarted = true;
+    // A new turn is starting — any pending ask_question has now been answered
+    // (or superseded), so let auto-exit resume normally when this turn ends.
+    awaitingAnswer = false;
+    recorder.agentStart();
+  });
+
+  pi.on("agent_end", (event, ctx) => {
+    const messages = (event as any).messages as any[] | undefined;
+    // Never shut down while this session still has work in flight:
+    //  - awaitingAnswer: an ask_question is pending the orchestrator's reply.
+    //  - runningChildrenCount(): this subagent spawned its own children and is
+    //    waiting for their results (delivered as steered turns). Exiting now
+    //    would strand those children and drop their results.
+    // In both cases the session parks as `waiting` and resumes when the next
+    // turn lands.
+    const hasPendingChildren = runningChildrenCount() > 0;
+    const shouldExit =
+      !awaitingAnswer &&
+      !hasPendingChildren &&
+      autoExit &&
+      shouldAutoExitOnAgentEnd(userTookOver, messages);
+
+    if (shouldExit) {
+      // Surface stopReason: "error" turns (auto-retry exhausted, provider
+      // overload, etc.) to the parent via the .exit sidecar so the watcher
+      // can report a clear failure with the underlying error message.
+      // Without this the parent would only see exit code 0 and a stale
+      // assistant message, mistaking the crash for a successful completion.
+      const errorInfo = findLatestAssistantError(messages);
+      const sessionFile = process.env.PI_SUBAGENT_SESSION;
+      if (errorInfo && sessionFile) {
+        try {
+          writeFileSync(
+            `${sessionFile}.exit`,
+            JSON.stringify({
+              type: "error",
+              errorMessage: errorInfo.errorMessage,
+              stopReason: errorInfo.stopReason,
+            }),
+          );
+        } catch {
+          // Best effort — even without the sidecar, watcher's session-file
+          // fallback can still recover the errorMessage.
+        }
+      }
+
+      recorder.agentEndDone();
+      ctx.shutdown();
+      return;
+    }
+
+    recorder.agentEndWaiting();
+    if (autoExit) {
+      // Reset any recorded manual input marker. Auto-exit is decided by whether
+      // the latest agent turn completed normally, not by who initiated it.
+      userTookOver = false;
+    }
+  });
+
+  pi.on("turn_start", (event) => {
+    recorder.turnStart((event as any).turnIndex);
+  });
+
+  pi.on("turn_end", (event) => {
+    recorder.turnEnd((event as any).turnIndex);
+  });
+
+  pi.on("before_provider_request", () => {
+    recorder.beforeProviderRequest();
+  });
+
+  pi.on("after_provider_response", () => {
+    recorder.afterProviderResponse();
+  });
+
+  pi.on("message_update", (event) => {
+    recorder.messageUpdate((event as any).assistantMessageEvent?.type);
+  });
+
+  pi.on("tool_execution_start", (event) => {
+    recorder.toolExecutionStart((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_call", (event) => {
+    recorder.toolCall((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_execution_update", (event) => {
+    recorder.toolExecutionUpdate((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_result", (event) => {
+    recorder.toolResult((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_execution_end", (event) => {
+    recorder.toolExecutionEnd((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("session_shutdown", (event) => {
+    recorder.sessionShutdown((event as any).reason);
+  });
+
+  // Toggle expand/collapse with Ctrl+Alt+O
+  pi.registerShortcut("ctrl+alt+o", {
+    description: "Toggle subagent tools widget",
+    handler: (ctx) => {
+      expanded = !expanded;
+      renderWidget(ctx, null);
+    },
+  });
+
+  pi.registerTool({
+    name: "ask_question",
+    label: "ask_question",
+    description:
+      "Ask the orchestrator (the parent agent that spawned you) a single question and pause until they reply. " +
+      "Use this when requirements are ambiguous, a decision would materially affect your work, you're blocked, " +
+      "or you need information or confirmation only the orchestrator has. Prefer asking over guessing. " +
+      "Your session stays open while you wait — the answer arrives as your next message, then you continue. " +
+      "Ask exactly one question per call; make separate calls for unrelated questions.",
+    promptSnippet:
+      "Use this tool to ask the orchestrator one clarifying, missing-requirement, preference, or decision question before continuing — instead of guessing.",
+    promptGuidelines: [
+      "Ask exactly one question per tool call.",
+      "If you need answers to multiple things, make separate ask_question calls instead of bundling them.",
+      "Prefer this tool over guessing when requirements, preferences, or implementation choices are unclear.",
+      "Use it when multiple valid paths exist and the right one depends on the orchestrator's intent.",
+      "Give enough context in the question that the orchestrator can answer without re-reading your whole task.",
+      "After asking, stop and wait — the reply will arrive as your next message.",
+    ],
+    parameters: Type.Object({
+      question: Type.String({
+        description:
+          "The single freeform question to ask the orchestrator. Include enough context to answer it directly.",
+      }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      const sessionFile = process.env.PI_SUBAGENT_SESSION;
+      if (!sessionFile) {
+        throw new Error(
+          "ask_question is only available in subagent contexts. " +
+            "PI_SUBAGENT_SESSION environment variable is not set.",
+        );
+      }
+
+      // Keep the session open: suppress auto-exit for this turn and park in the
+      // "waiting" phase. The parent's watcher picks up the `.ask` signal and
+      // notifies the orchestrator, who replies via subagent_message.
+      awaitingAnswer = true;
+      recorder.askQuestion();
+      const askData = {
+        name: process.env.PI_SUBAGENT_NAME ?? "subagent",
+        agent: process.env.PI_SUBAGENT_AGENT ?? "",
+        question: params.question,
+      };
+      writeFileSync(`${sessionFile}.ask`, JSON.stringify(askData));
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              "Question sent to the orchestrator. Stop here and wait — do not continue working or " +
+              "assume an answer. Their reply will arrive as your next message.",
+          },
+        ],
+        details: { question: params.question },
+      };
+    },
+
+    renderCall(args, theme) {
+      const text =
+        theme.fg("toolTitle", theme.bold("ask_question ")) +
+        theme.fg("muted", String((args as any).question ?? ""));
+      return new Text(text, 0, 0);
+    },
+  });
+
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/surface.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/surface.ts
@@ -1,0 +1,52 @@
+/**
+ * Surface dispatcher — selects between the tmux and Herdr pane surfaces at
+ * module load time, so the rest of the extension (index.ts) stays
+ * multiplexer-agnostic and talks to a single surface contract.
+ *
+ * Selection order:
+ *   1. Herdr  — when `HERDR_ENV=1`, `HERDR_PANE_ID` is set, and `herdr` is on PATH.
+ *   2. tmux   — when `TMUX` is set and `tmux` is on PATH (the upstream surface).
+ *   3. neither — `isMuxAvailable()` returns false and `muxSetupHint()` tells
+ *                the caller how to start a supported multiplexer.
+ *
+ * index.ts imports this module instead of ./tmux.ts directly. Every symbol
+ * re-exported here matches the ./tmux.ts export contract one-for-one.
+ */
+import * as tmux from "./tmux.ts";
+import * as herdr from "./herdr.ts";
+
+export type PollResult = herdr.PollResult;
+
+const useHerdr = herdr.isHerdrAvailable();
+const useTmux = !useHerdr && tmux.isTmuxAvailable();
+const surface = useHerdr ? herdr : useTmux ? tmux : herdr; // default to herdr for hint when none available
+
+/** True when any supported multiplexer surface is available. */
+export const isMuxAvailable = (): boolean => useHerdr || useTmux;
+
+/** Human-readable hint for starting a supported multiplexer. */
+export function muxSetupHint(): string {
+  if (useHerdr) return herdr.muxSetupHint();
+  if (useTmux) return tmux.muxSetupHint();
+  // Neither available: prefer the Herdr hint (captain's primary surface), but
+  // mention tmux as the upstream alternative.
+  return `${herdr.muxSetupHint()} Alternatively start pi inside tmux (\`tmux new -A -s pi 'pi'\`).`;
+}
+
+export const createSurface = surface.createSurface;
+export const createSurfaceSplit = surface.createSurfaceSplit;
+export const sendCommand = surface.sendCommand;
+export const sendLongCommand = surface.sendLongCommand;
+export const readScreen = surface.readScreen;
+export const readScreenAsync = surface.readScreenAsync;
+export const closeSurface = surface.closeSurface;
+export const shellEscape = surface.shellEscape;
+export const pollForExit = surface.pollForExit;
+export const __pollForExitTest__ = surface.__pollForExitTest__;
+
+/** Which surface is active — exposed for diagnostics/tests. */
+export const activeSurface: "herdr" | "tmux" | "none" = useHerdr
+  ? "herdr"
+  : useTmux
+    ? "tmux"
+    : "none";

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/tmux.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/tmux.ts
@@ -1,0 +1,354 @@
+/**
+ * tmux surface layer — the only terminal multiplexer this extension supports.
+ *
+ * Everything the extension does to a pane goes through the small API in this
+ * file: create/split a pane, type a command into it, read its screen, close
+ * it, and poll for exit. Keeping the tmux calls isolated here means index.ts
+ * stays testable without a multiplexer running.
+ *
+ * Panes are identified by tmux pane ids (e.g. `%12`). Splits always target
+ * the parent pi's pane (`$TMUX_PANE`) so they follow the agent rather than
+ * the user's focus.
+ */
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+// ── Availability ──
+
+const commandAvailability = new Map<string, boolean>();
+
+function hasCommand(command: string): boolean {
+  if (commandAvailability.has(command)) {
+    return commandAvailability.get(command)!;
+  }
+
+  let available = false;
+  try {
+    execFileSync("sh", ["-c", `command -v ${command}`], { stdio: "ignore" });
+    available = true;
+  } catch {
+    available = false;
+  }
+
+  commandAvailability.set(command, available);
+  return available;
+}
+
+/**
+ * True when running inside tmux with the tmux binary on PATH.
+ * `TMUX` is set by tmux in every process it spawns (shell or pane).
+ */
+export function isTmuxAvailable(): boolean {
+  return !!process.env.TMUX && hasCommand("tmux");
+}
+
+export function isMuxAvailable(): boolean {
+  return isTmuxAvailable();
+}
+
+export function muxSetupHint(): string {
+  return "Start pi inside tmux (`tmux new -A -s pi 'pi'`).";
+}
+
+function requireTmux(): void {
+  if (!isTmuxAvailable()) {
+    throw new Error(`tmux is required for subagents. ${muxSetupHint()}`);
+  }
+}
+
+// ── Shell helpers ──
+
+export function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+// ── Pane layout ──
+
+/**
+ * tmux layout applied to the subagent window to keep panes evenly sized.
+ * Switchable: "even-horizontal" (equal columns, matches Ctrl+b Alt+1),
+ * "main-vertical" (big main pane + tiled column), "tiled" (grid).
+ */
+const SUBAGENT_TMUX_LAYOUT = "even-horizontal";
+
+let rebalanceTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Re-balance subagent panes so repeated splits don't leave them lopsided.
+ * tmux halves the target pane on every split and dumps freed space onto a
+ * neighbor on close, so without this panes drift to wildly uneven widths.
+ * Applies SUBAGENT_TMUX_LAYOUT to the parent pi window. Debounced so a burst
+ * of parallel spawns or staggered exits collapses into a single layout call,
+ * and non-fatal: a cosmetic resize must never break spawning or watching.
+ */
+function rebalanceSurfaces(hintPane?: string): void {
+  // Prefer the parent pi pane (stable; survives a closing subagent pane).
+  const target = process.env.TMUX_PANE ?? hintPane;
+  if (!target) return;
+  if (rebalanceTimer) clearTimeout(rebalanceTimer);
+  rebalanceTimer = setTimeout(() => {
+    rebalanceTimer = null;
+    try {
+      // -t <pane> resolves to that pane's window; does not change focus.
+      execFileSync("tmux", ["select-layout", "-t", target, SUBAGENT_TMUX_LAYOUT], {
+        encoding: "utf8",
+      });
+    } catch {
+      // Pane/window may be gone; balancing is best-effort.
+    }
+  }, 120);
+}
+
+// ── Surface primitives ──
+
+/**
+ * Create a new pane for a subagent: a right split off the parent pi's pane,
+ * so new panes follow the agent rather than the user's focus.
+ * See https://github.com/HazAT/pi-interactive-subagents/issues/12
+ *
+ * Returns the new pane id (e.g. `%12`).
+ */
+export function createSurface(name: string): string {
+  void name; // tmux panes are not named; the pi process inside shows its own title.
+  return createSurfaceSplit(name, "right", process.env.TMUX_PANE);
+}
+
+/**
+ * Create a new split in the given direction from an optional source pane.
+ * Returns the new pane id (e.g. `%12`).
+ */
+export function createSurfaceSplit(
+  name: string,
+  direction: "left" | "right" | "up" | "down",
+  fromSurface?: string,
+): string {
+  void name;
+  requireTmux();
+
+  const args = ["split-window", "-d"];
+  if (direction === "left" || direction === "right") {
+    args.push("-h");
+  } else {
+    args.push("-v");
+  }
+  if (direction === "left" || direction === "up") {
+    args.push("-b");
+  }
+  if (fromSurface) {
+    args.push("-t", fromSurface);
+  }
+  args.push("-P", "-F", "#{pane_id}");
+
+  const pane = execFileSync("tmux", args, { encoding: "utf8" }).trim();
+  if (!pane.startsWith("%")) {
+    throw new Error(`Unexpected tmux split-window output: ${pane}`);
+  }
+
+  rebalanceSurfaces(pane);
+  return pane;
+}
+
+/**
+ * Send a command string to a pane and execute it.
+ * Typed literally (`-l`) so special characters are not interpreted as keys,
+ * then submitted with Enter.
+ */
+export function sendCommand(surface: string, command: string): void {
+  requireTmux();
+  execFileSync("tmux", ["send-keys", "-t", surface, "-l", command], { encoding: "utf8" });
+  execFileSync("tmux", ["send-keys", "-t", surface, "Enter"], { encoding: "utf8" });
+}
+
+/**
+ * Send a long command to a pane by writing it to a script file first.
+ * This avoids terminal line-wrapping issues that break commands exceeding the
+ * pane's column width when sent character-by-character via sendCommand.
+ *
+ * By default the script is written to a temp directory, but callers can pass a
+ * stable path (for example under session artifacts) so the exact invocation is
+ * preserved for debugging.
+ *
+ * Returns the script path.
+ */
+export function sendLongCommand(
+  surface: string,
+  command: string,
+  options?: { scriptPath?: string; scriptPreamble?: string },
+): string {
+  const scriptPath =
+    options?.scriptPath ??
+    join(
+      tmpdir(),
+      "pi-subagent-scripts",
+      `cmd-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sh`,
+    );
+  mkdirSync(dirname(scriptPath), { recursive: true });
+
+  const scriptParts = ["#!/bin/bash"];
+  if (options?.scriptPreamble) {
+    scriptParts.push(options.scriptPreamble.trimEnd());
+  }
+  scriptParts.push(command);
+
+  writeFileSync(scriptPath, scriptParts.join("\n") + "\n", {
+    mode: 0o755,
+  });
+  sendCommand(surface, `bash ${shellEscape(scriptPath)}`);
+  return scriptPath;
+}
+
+/**
+ * Read the screen contents of a pane (sync).
+ */
+export function readScreen(surface: string, lines = 50): string {
+  requireTmux();
+  return execFileSync(
+    "tmux",
+    ["capture-pane", "-p", "-t", surface, "-S", `-${Math.max(1, lines)}`],
+    {
+      encoding: "utf8",
+    },
+  );
+}
+
+/**
+ * Read the screen contents of a pane (async).
+ */
+export async function readScreenAsync(surface: string, lines = 50): Promise<string> {
+  requireTmux();
+  const { stdout } = await execFileAsync(
+    "tmux",
+    ["capture-pane", "-p", "-t", surface, "-S", `-${Math.max(1, lines)}`],
+    { encoding: "utf8" },
+  );
+  return stdout;
+}
+
+/**
+ * Close a pane.
+ */
+export function closeSurface(surface: string): void {
+  requireTmux();
+  execFileSync("tmux", ["kill-pane", "-t", surface], { encoding: "utf8" });
+  rebalanceSurfaces();
+}
+
+// ── Exit polling ──
+
+export interface PollResult {
+  /** How the subagent exited */
+  reason: "done" | "sentinel" | "error";
+  /** Shell exit code (from sentinel). 0 for file-based exits. */
+  exitCode: number;
+  /** Error message if reason is "error" (auto-retry exhausted, provider overload, etc.) */
+  errorMessage?: string;
+}
+
+/**
+ * Interpret an `.exit` sidecar payload (written by the error path in
+ * subagent-done.ts). Centralized so both the fast and slow paths in
+ * pollForExit decode the payload the same way. Clean completions write no
+ * sidecar and are detected via the terminal sentinel instead.
+ *
+ * Note: ask_question does NOT write a `.exit` sidecar — it keeps the session
+ * open and signals the parent via a separate `.ask` file (see deliverPendingQuestion).
+ */
+function interpretExitSidecar(data: any): PollResult {
+  if (data?.type === "error") {
+    const errorMessage =
+      typeof data.errorMessage === "string" && data.errorMessage.trim() !== ""
+        ? data.errorMessage
+        : "Subagent exited with stopReason=error (no errorMessage in sidecar).";
+    return { reason: "error", exitCode: 1, errorMessage };
+  }
+  return { reason: "done", exitCode: 0 };
+}
+
+export const __pollForExitTest__ = { interpretExitSidecar };
+
+/**
+ * Poll until the subagent exits. Checks for a `.exit` sidecar file first
+ * (written by the error path), falling back to the terminal sentinel for
+ * clean-completion and crash detection.
+ */
+export async function pollForExit(
+  surface: string,
+  signal: AbortSignal,
+  options: {
+    interval: number;
+    sessionFile?: string;
+    sentinelFile?: string;
+    onTick?: (elapsed: number) => void;
+  },
+): Promise<PollResult> {
+  const start = Date.now();
+
+  for (;;) {
+    if (signal.aborted) {
+      throw new Error("Aborted while waiting for subagent to finish");
+    }
+
+    // Fast path: check for .exit sidecar file (written by the error path)
+    if (options.sessionFile) {
+      try {
+        const exitFile = `${options.sessionFile}.exit`;
+        if (existsSync(exitFile)) {
+          const data = JSON.parse(readFileSync(exitFile, "utf-8"));
+          rmSync(exitFile, { force: true });
+          return interpretExitSidecar(data);
+        }
+      } catch {}
+    }
+
+    // Check Claude sentinel file (written by plugin Stop hook)
+    if (options.sentinelFile) {
+      try {
+        if (existsSync(options.sentinelFile)) {
+          return { reason: "sentinel", exitCode: 0 };
+        }
+      } catch {}
+    }
+
+    // Slow path: read terminal screen for sentinel (crash detection)
+    try {
+      const screen = await readScreenAsync(surface, 5);
+      const match = screen.match(/__SUBAGENT_DONE_(\d+)__/);
+      if (match) {
+        return { reason: "sentinel", exitCode: parseInt(match[1], 10) };
+      }
+    } catch {
+      // Surface may have been destroyed — check if .exit file appeared in the meantime
+      if (options.sessionFile) {
+        try {
+          const exitFile = `${options.sessionFile}.exit`;
+          if (existsSync(exitFile)) {
+            const data = JSON.parse(readFileSync(exitFile, "utf-8"));
+            rmSync(exitFile, { force: true });
+            return interpretExitSidecar(data);
+          }
+        } catch {}
+      }
+    }
+
+    const elapsed = Math.floor((Date.now() - start) / 1000);
+    options.onTick?.(elapsed);
+
+    await new Promise<void>((resolve, reject) => {
+      if (signal.aborted) return reject(new Error("Aborted"));
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, options.interval);
+      function onAbort() {
+        clearTimeout(timer);
+        reject(new Error("Aborted"));
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+}

--- a/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/tools/safe-bash.ts
+++ b/pi/.pi/agent/extensions/interactive-subagents/pi-extension/subagents/tools/safe-bash.ts
@@ -1,0 +1,63 @@
+/**
+ * Safe bash extension for the worker subagent.
+ * Wraps the built-in bash tool with dangerous command blocking.
+ *
+ * Loaded into a child pi process via `--extension` when an agent's `tools`
+ * frontmatter lists `safe_bash`. See CUSTOM_TOOL_EXTENSIONS in ../index.ts.
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createBashTool } from "@earendil-works/pi-coding-agent";
+import { Type } from "@earendil-works/pi-ai";
+
+const DANGEROUS_PATTERNS = [
+	/\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?(-[a-zA-Z]*r[a-zA-Z]*\s+)?(\/|~\/?\s|~\/?\b)/,
+	/\brm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+)?(-[a-zA-Z]*f[a-zA-Z]*\s+)?(\/|~\/?\s|~\/?\b)/,
+	/\bsudo\b/,
+	/\bmkfs\b/,
+	/\bdd\s+if=/,
+	/:\(\)\s*\{\s*:\|:&\s*\}\s*;:/,
+	/>\s*\/dev\/[sh]d[a-z]/,
+	/\bchmod\s+(-[a-zA-Z]+\s+)?777\s+\//,
+	/\bchown\s+(-[a-zA-Z]+\s+)?root/,
+	/\bcurl\s.*\|\s*(ba)?sh/,
+	/\bwget\s.*\|\s*(ba)?sh/,
+	/\bshutdown\b/,
+	/\breboot\b/,
+	/\binit\s+0\b/,
+	/\bkill\s+-9\s+1\b/,
+	/\bkillall\b/,
+];
+
+function isDangerous(command: string): string | null {
+	const normalized = command.replace(/\\\n/g, " ");
+	for (const pattern of DANGEROUS_PATTERNS) {
+		if (pattern.test(normalized)) {
+			return `Command blocked by safe_bash: matches dangerous pattern ${pattern}`;
+		}
+	}
+	return null;
+}
+
+export default function (pi: ExtensionAPI) {
+	const bashTool = createBashTool(process.cwd());
+
+	pi.registerTool({
+		name: "safe_bash",
+		label: "Safe Bash",
+		description:
+			"Execute a bash command. Blocks dangerous commands (rm -rf /, sudo, mkfs, etc.).",
+		parameters: Type.Object({
+			command: Type.String({ description: "Bash command to execute" }),
+			timeout: Type.Optional(
+				Type.Number({ description: "Timeout in seconds (optional)" }),
+			),
+		}),
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const danger = isDangerous(params.command);
+			if (danger) {
+				throw new Error(danger);
+			}
+			return bashTool.execute(toolCallId, params, signal, onUpdate);
+		},
+	});
+}


### PR DESCRIPTION
## Summary

Vendors [amosblomqvist/pi-interactive-subagents](https://github.com/amosblomqvist/pi-interactive-subagents) (MIT) into `pi/.pi/agent/extensions/interactive-subagents/` and adds a **Herdr surface layer** so it works under the captain's live Herdr-managed pi (the upstream is tmux-only).

Tools added to pi: `subagent`, `subagent_message`, `subagents_list`, and sub-agent-only `ask_question`. Bundled agents: `scout`, `researcher`, `worker`.

## The critical compatibility question — answered

**Upstream is tmux-only and incompatible with Herdr as-is.** Every surface primitive in `pi-extension/subagents/tmux.ts` calls `requireTmux()`, which throws `tmux is required for subagents` unless `process.env.TMUX` is set *and* the `tmux` binary is on PATH. `isTmuxAvailable()` is `!!process.env.TMUX && hasCommand("tmux")`.

The captain's pi runs under **Herdr**, not tmux. Evidence gathered on the live host:

- Live Herdr-managed pi processes (`/proc/<pid>/environ`) carry `HERDR_ENV=1`, `HERDR_PANE_ID=w43:p1C`, `HERDR_SOCKET_PATH=/home/avirus/.config/herdr/herdr.sock` — Herdr's socket+pane protocol — and **no** `TMUX` / `TMUX_PANE`.
- `tmux ls` → `error connecting to /tmp/tmux-1000/default (No such file or directory)`; `/tmp/tmux-1000/` is empty; no `tmux` process in the tree. A `tmux split-window` has no server to connect to even if `TMUX` were faked.
- This fork (amosblomqvist) is explicitly "tmux-only"; no Herdr/zellij/cmux surface adapter exists.

So the tools would register but every `subagent` spawn would throw at the first `tmux split-window`.

## What this PR does — prototype Herdr support

Instead of abandoning, this ports the surface layer to Herdr (option (b) from the investigation):

1. **`pi-extension/subagents/herdr.ts`** (new) — a Herdr pane surface that mirrors `tmux.ts`'s exact export contract (`isMuxAvailable`, `muxSetupHint`, `createSurface`, `createSurfaceSplit`, `sendCommand`, `sendLongCommand`, `readScreen`, `readScreenAsync`, `closeSurface`, `shellEscape`, `pollForExit`, `__pollForExitTest__`). It drives panes through the `herdr` CLI, which maps cleanly onto tmux's primitives:

   | tmux.ts | herdr.ts |
   | --- | --- |
   | `tmux split-window -d -h -t $TMUX_PANE` | `herdr pane split <HERDR_PANE_ID> --direction right --ratio 0.5 --no-focus` |
   | `tmux send-keys -t %p -l <cmd>` + `Enter` | `herdr pane send-text <pane> <cmd>` + `herdr pane send-keys <pane> Enter` |
   | `tmux capture-pane -p -t %p -S -N` | `herdr pane read <pane> --source recent --lines N --format text` |
   | `tmux kill-pane -t %p` | `herdr pane close <pane>` |

   The parent pane id comes from `HERDR_PANE_ID` (the tmux `$TMUX_PANE` analogue). Availability is `HERDR_ENV === "1" && HERDR_PANE_ID && hasCommand("herdr")`.

2. **`pi-extension/subagents/surface.ts`** (new) — auto-detect dispatcher. Selects Herdr when `HERDR_ENV=1` + `HERDR_PANE_ID` are set, else tmux when `TMUX` is set, else reports unavailable. Re-exports the active surface's API so the rest of the extension stays multiplexer-agnostic.

3. **`index.ts`** — one import changed: `from "./tmux.ts"` → `from "./surface.ts"`. `tmux.ts` is kept intact as the fallback surface (upstream fidelity preserved). The "Subagents require tmux" error message is generalized to "Subagents require a terminal multiplexer (Herdr or tmux)".

4. **Import remap** — `@mariozechner/pi-coding-agent` → `@earendil-works/pi-coding-agent`, `@mariozechner/pi-tui` → `@earendil-works/pi-tui`, `@sinclair/typebox` → `@earendil-works/pi-ai` (which re-exports `Type`/`Static`). The upstream imports the `@mariozechner/*` publish names, which do **not** resolve under the captain's `@earendil-works/*` pi install. Applied to `index.ts`, `subagent-done.ts`, `tools/safe-bash.ts`.

5. **`package.json`** — fork metadata (`pi-interactive-subagents-herdr`, `3.7.2-herdr.1`), `@earendil-works/*` peer deps, and a `forkNotes` block recording every change for future upstream syncs.

### Known gap (documented, non-blocking)

Herdr has no `select-layout even-horizontal` equivalent, so pane rebalancing (`rebalanceSurfaces`) is a **no-op** on the Herdr surface. Panes keep the 0.5 split ratio set at creation. This is cosmetic — it does not affect spawning, watching, or result steering. Kept as a hook so future Herdr layout support can plug in without changing call sites.

### Verification (static — see note on runtime check)

- `interactive-subagents.test.mjs` (matches the repo's `*.test.mjs` jiti pattern) jiti-loads `surface.ts`, asserts the full index.ts export contract is present, exercises `shellEscape`, and asserts Herdr detection under `HERDR_ENV=1` + `HERDR_PANE_ID`. **Passes.**
- `surface.ts` loads cleanly under Node 22 type-stripping: `activeSurface = "herdr"`, `isMuxAvailable() = true`, all 11 exports present.
- Full round-trip proven on the live host (read-only, on my own pane): `herdr pane split` → `send-text` → `send-keys Enter` → `read` → sentinel regex `__SUBAGENT_DONE_42__` matched → `close`. The Herdr pane API behaves exactly as the port expects.
- All 9 vendored `.ts` files type-strip parse-check clean (no SyntaxErrors).

**Runtime "tools register" check:** could not start a fresh pi to confirm tool registration — the captain's pi runs in the shared Herdr server and must not be restarted by a worker. The static checks above are the strongest verification possible without driving pi's runtime. After merge, the captain can confirm by reloading pi and invoking `subagents_list`.

## Install path chosen: vendoring (not `pi install`)

Vendored rather than `pi install git:github.com/amosblomqvist/pi-interactive-subagents` because:

- `pi install` would land the upstream tree in a location **not** covered by the dotfiles stow symlink (`~/.pi/agent/extensions` symlinks per-entry into `~/dotfiles/pi/.pi/agent/extensions/`), so it would not be tracked in this repo and would not survive a re-stow.
- Vendoring into `pi/.pi/agent/extensions/interactive-subagents/` makes it tracked, reviewable, and auto-surfaced by the existing `stow pi` step (GNU Stow symlinks the new dir into `~/.pi/agent/extensions/` on re-stow).
- The Herdr surface layer and `@earendil-works/*` remap are fork-specific changes that a stock `pi install` couldn't carry.

## Dependencies

No global npm installs. The extension has **no runtime npm dependencies** — only pi-runtime peer packages (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, `@earendil-works/pi-ai`) provided by pi at load time. No `npm install` is needed in the extension directory. `.gitignore` excludes `node_modules/`, `config.json`, `.DS_Store`.

## Goes live after merge

The extension is staged under the stowed `pi` package. After merge + `stow -R pi` (re-stow), GNU Stow creates `~/.pi/agent/extensions/interactive-subagents -> ../../../dotfiles/pi/.pi/agent/extensions/interactive-subagents` and the extension loads on the next pi start/reload. No `install.sh` change needed — the existing `stow pi` step handles it.

## Scope

Dotfiles-only. The `projects/pi-config` stub is untouched (different repo, out of scope).

## Suggested follow-up questions
- Want a `subagent` smoke spawn (e.g. `scout` on a small dir) to be run by the captain post-merge to confirm tool registration end-to-end?
- Should I upstream the Herdr surface layer + dispatcher to `amosblomqvist/pi-interactive-subagents` so future `pi install` updates don't clobber the fork?
- Want a `herdr pane resize`-based rebalance heuristic to close the `even-horizontal` gap?
