### PR TITLE
herdr 0.8.2 update + keep visual mode after yank

### DIFF
--- a/nvim/.config/nvim/lua/plugins/yanky.lua
+++ b/nvim/.config/nvim/lua/plugins/yanky.lua
@@ -1,0 +1,18 @@
+-- Keep visual mode active after yanking so the selection stays usable for
+-- further operations. The LazyVim `coding.yanky` extra maps `y` to
+-- `<Plug>(YankyYank)` (recording every yank in its ring) in both normal and
+-- visual mode; appending `gv` reselects the same visual region after the yank.
+--
+-- The override must run after yanky loads: lazy.nvim applies the extra's own
+-- `keys` spec (which maps `x y` to `<Plug>(YankyYank)`) on load, which would
+-- clobber a plain config/keymaps.lua entry. Setting the visual-mode map inside
+-- the plugin's `config` runs after those keymaps and wins. yanky's merged
+-- `opts` from the extra are forwarded unchanged, so yank history, paste
+-- cycling ([y/]y, p/P, <leader>p), and the ring are untouched.
+return {
+  "gbprod/yanky.nvim",
+  config = function(_, opts)
+    require("yanky").setup(opts)
+    vim.keymap.set("x", "y", "<Plug>(YankyYank)gv", { desc = "Yank Text (keep selection)" })
+  end,
+}


### PR DESCRIPTION
## What

Two bundled dotfiles changes on one branch:

### Part 1 — herdr updated to latest (0.8.2)
- herdr CLI and server are on **0.8.2** (latest stable, protocol 20), upgraded from 0.8.0 via the repo's install path (`install.sh` curls `https://herdr.dev/install.sh`, which fetches latest with no version pin).
- Reviewed the 0.8.0 → 0.8.2 changelog. No config-schema keys were removed or renamed that affect the tracked `herdr/.config/herdr/config.toml`. 0.8.2 additions (`ui.pane_outer_borders`, `keys.resize_pane_*`, `ui.window_title`, tab-bar status, etc.) are all opt-in.
- `herdr config check` → `config: ok` (zero errors) on 0.8.2.
- `ui.pane_scrollbars` (added in 0.8.0, restored by the prior `herdr-update-config-fix` task) is still a valid key in the 0.8.2 schema — no regression.
- No repo edit required for Part 1; the binary is upgraded in place and the install path is already reproducible from `install.sh`.

### Part 2 — Keep visual mode after yank (Neovim)
- Default Vim drops to normal mode after a visual yank. This keeps visual mode active so the selection stays usable.
- The LazyVim `coding.yanky` extra maps `y` → `<Plug>(YankyYank)` (records into the yank ring). The new `lua/plugins/yanky.lua` overrides the **visual-mode** `y` to `<Plug>(YankyYank)gv`, so the same yanky yank runs and `gv` reselects the region.
- The override is a yanky plugin-spec `config` function, not a `config/keymaps.lua` entry, because lazy.nvim applies the extra's own `keys` spec on plugin load and would clobber a plain keymap. Running `vim.keymap.set` inside `config` executes *after* those keymaps and wins.
- Verified: `x y` → `<Plug>(YankyYank)gv`; normal-mode `y` and all cycle/paste bindings (`[y`/`]y`, `p`/`P`, `<leader>p`) unchanged. `scripts/verify-nvim.lua` → `PASS verify-nvim agent-keymaps`.

## Acceptance
- [x] herdr on latest (0.8.2); tracked config loads with zero errors.
- [x] Visual mode persists (reselection via `gv`) after yank.
- [x] No regression to `pane_scrollbars` or yanky's yank history.
- [x] Both changes on `fm/herdr-update-yank-visual`, shipped as one PR against the fork.
