### PR TITLE
Add karabiner stow package: AeroSpace home-row option mods

### DIFF
--- a/karabiner/.config/karabiner/.gitignore
+++ b/karabiner/.config/karabiner/.gitignore
@@ -1,0 +1,2 @@
+# Karabiner auto-backups are machine-generated and change over time
+automatic_backups/

--- a/karabiner/.config/karabiner/karabiner.json
+++ b/karabiner/.config/karabiner/karabiner.json
@@ -1,0 +1,61 @@
+{
+    "profiles": [
+        {
+            "complex_modifications": {
+                "rules": [
+                    {
+                        "description": "Left-hand option mod: tap 'a' sends a; hold 'a' (200ms) sends left_option. Reuses existing AeroSpace alt-* bindings (alt-h/j/k/l focus, alt-1..9 workspaces, etc.) with no aerospace.toml change. Tunable: raise basic.to_if_held_down_threshold_milliseconds if you get false mods while typing; lower it if the mod feels sluggish.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "a",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "a" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "a"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "left_option" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Right-hand option mod: tap ';' sends ; ; hold ';' (200ms) sends right_option. Mirrors the left-hand 'a' mod so you can hold right-hand option + tap left-hand keys (1..9, q, tab) for the AeroSpace bindings whose keys sit on the left. One collision: alt-shift-semicolon (mode service) can't be triggered via the dual-function key — use the real Option key for that rare binding. Tunable threshold same as the 'a' rule.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "semicolon",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "semicolon" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "semicolon"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "right_option" }],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "name": "Default profile",
+            "selected": true,
+            "virtual_hid_keyboard": { "keyboard_type_v2": "ansi" }
+        }
+    ]
+}


### PR DESCRIPTION
## What
Version the Karabiner-Elements config as a stow package so it is file-driven (no GUI) and checked into dotfiles, alongside the existing `aerospace` package.

## Why
Wanted AeroSpace window bindings reachable from home-row keys on the Nuphy without touching the Karabiner UI. Karabiner live-reloads `karabiner.json`, so the file is the source of truth.

## Changes
- New `karabiner/.config/karabiner/karabiner.json` with two dual-function rules inlined into `complex_modifications.rules`:
  - `a` (left): tap = `a`, hold (200ms) = `left_option`
  - `;` (right): tap = `;`, hold (200ms) = `right_option`
  - Both reuse the existing `alt-*` AeroSpace bindings in `~/.aerospace.toml` — no aerospace.toml change.
- `karabiner/.config/karabiner/.gitignore` ignores `automatic_backups/` (machine-generated).
- Installed live: `~/.config/karabiner` is now a dir-level symlink into this package.

## How to use
- Hold `a` + tap `h/j/k/l` → focus left/down/up/right
- Hold `a` + tap `1..9` → switch workspace
- Hold `;` + tap a left-hand key for left-side bindings
- Tune hold threshold via `basic.to_if_held_down_threshold_milliseconds` in `karabiner.json`

## Notes
- One collision: `alt-shift-semicolon` (AeroSpace service mode) cannot fire via the dual-function `;` — use the real Option key for that.
- No `aerospace.toml` changes.