### PR TITLE
fix(pi): locate interactive components across install layouts

### DIFF
--- a/pi/.pi/agent/extensions/tool-call-renderer.ts
+++ b/pi/.pi/agent/extensions/tool-call-renderer.ts
@@ -1,5 +1,5 @@
 import { keyHint, type ExtensionAPI, type Theme } from "@earendil-works/pi-coding-agent";
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { hostname } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -1721,7 +1721,19 @@ async function loadPiInternals(): Promise<{
   theme: Theme;
 }> {
   const cliPath = realpathSync(process.argv[1] ?? "");
-  const interactivePath = join(dirname(cliPath), "modes/interactive");
+  const cliDir = dirname(cliPath);
+  const interactivePath = [
+    join(cliDir, "modes/interactive"),
+    join(dirname(cliDir), "modes/interactive"),
+  ].find((candidate) =>
+    existsSync(join(candidate, "components/assistant-message.js")),
+  );
+  if (!interactivePath) {
+    throw new Error(
+      "tool-call-renderer: could not locate pi interactive components relative to " +
+        cliPath,
+    );
+  }
   const [assistantModule, toolModule, themeModule] = await Promise.all([
     import(
       pathToFileURL(join(interactivePath, "components/assistant-message.js"))


### PR DESCRIPTION
## Summary

Fixes the `tool-call-renderer` pi extension failing to load with `Cannot find module .../assistant-message.js`.

The installed pi layout puts `modes/interactive` under `dist/` (the parent of the `dist/bundle/` CLI dir), but the extension assumed it was a sibling of the CLI. `loadPiInternals` now searches both the CLI dir and its parent, and verifies `components/assistant-message.js` exists before using a candidate.

This unblocks pi as a no-mistakes gate-review agent on this machine (and fixes the live pi extension load).

## Test plan

- [x] Verified `dist/modes/interactive/components/assistant-message.js` exists (candidate 2)
- [x] Verified `dist/bundle/modes/interactive` does NOT exist (old broken candidate 1)
- [ ] pi loads the extension without error after merge
