### PR TITLE
karabiner: Miryoku home-row mods for all 4 modifiers (AeroSpace unchanged)

### DIFF
--- a/aerospace/.aerospace.toml
+++ b/aerospace/.aerospace.toml
@@ -96,23 +96,16 @@ alt-slash = 'layout tiles horizontal vertical'
 alt-comma = 'layout accordion horizontal vertical'
 
 # See: https://nikitabobko.github.io/AeroSpace/commands#focus
-# NOTE: alt-k (focus up) rebound to alt-up — 'k' is now a home-row option mod
-# (Miryoku dual-function via karabiner), so alt-k can no longer be triggered.
-# alt-h (left), alt-j (down), alt-l (right) still work: hold option on 'd' or 'k'
-# (opposite hand) and tap h/j/l.
 alt-h = 'focus left'
 alt-j = 'focus down'
-alt-up = 'focus up'
+alt-k = 'focus up'
 alt-l = 'focus right'
 
 # See: https://nikitabobko.github.io/AeroSpace/commands#move
-# NOTE: alt-shift-k (move up) and alt-shift-l (move right) rebound to arrow keys
-# — 'k' is now option and 'l' is now shift (home-row mods), so those chords can
-# no longer be triggered. alt-shift-h (left) and alt-shift-j (down) still work.
 alt-shift-h = 'move left'
 alt-shift-j = 'move down'
-alt-shift-up = 'move up'
-alt-shift-right = 'move right'
+alt-shift-k = 'move up'
+alt-shift-l = 'move right'
 
 # See: https://nikitabobko.github.io/AeroSpace/commands#resize
 alt-minus = 'resize smart -50'
@@ -131,8 +124,7 @@ alt-9 = 'workspace 9'
 alt-a = 'workspace A' # In your config, you can drop workspace bindings that you don't need
 alt-b = 'workspace B'
 alt-c = 'workspace C'
-# NOTE: alt-d (workspace D) rebound to alt-0 — 'd' is now a home-row option mod.
-alt-0 = 'workspace D'
+alt-d = 'workspace D'
 alt-e = 'workspace E'
 alt-f = 'workspace F'
 alt-g = 'workspace G'
@@ -165,11 +157,7 @@ alt-shift-9 = 'move-node-to-workspace 9'
 alt-shift-a = 'move-node-to-workspace A'
 alt-shift-b = 'move-node-to-workspace B'
 alt-shift-c = 'move-node-to-workspace C'
-# NOTE: alt-shift-d (move-node-to-workspace D) rebound to alt-shift-0 and
-# alt-shift-s (move-node-to-workspace S) rebound to alt-shift-minus — 'd' is now
-# option and 's' is now shift (home-row mods), so those chords can no longer be
-# triggered. alt-s (workspace S) still works (hold option on d/k, tap s).
-alt-shift-0 = 'move-node-to-workspace D'
+alt-shift-d = 'move-node-to-workspace D'
 alt-shift-e = 'move-node-to-workspace E'
 alt-shift-f = 'move-node-to-workspace F'
 alt-shift-g = 'move-node-to-workspace G'
@@ -180,7 +168,7 @@ alt-shift-o = 'move-node-to-workspace O'
 alt-shift-p = 'move-node-to-workspace P'
 alt-shift-q = 'move-node-to-workspace Q'
 alt-shift-r = 'move-node-to-workspace R'
-alt-shift-minus = 'move-node-to-workspace S'
+alt-shift-s = 'move-node-to-workspace S'
 alt-shift-t = 'move-node-to-workspace T'
 alt-shift-u = 'move-node-to-workspace U'
 alt-shift-v = 'move-node-to-workspace V'
@@ -211,13 +199,10 @@ backspace = ['close-all-windows-but-current', 'mode main']
 # sticky is not yet supported https://github.com/nikitabobko/AeroSpace/issues/2
 #s = ['layout sticky tiling', 'mode main']
 
-# NOTE: alt-shift-k (join up) and alt-shift-l (join right) rebound to arrow keys
-# — 'k' is now option and 'l' is now shift (home-row mods). alt-shift-h (left)
-# and alt-shift-j (down) still work.
 alt-shift-h = ['join-with left', 'mode main']
 alt-shift-j = ['join-with down', 'mode main']
-alt-shift-up = ['join-with up', 'mode main']
-alt-shift-right = ['join-with right', 'mode main']
+alt-shift-k = ['join-with up', 'mode main']
+alt-shift-l = ['join-with right', 'mode main']
 
 down = 'volume down'
 up = 'volume up'

--- a/aerospace/.aerospace.toml
+++ b/aerospace/.aerospace.toml
@@ -96,16 +96,23 @@ alt-slash = 'layout tiles horizontal vertical'
 alt-comma = 'layout accordion horizontal vertical'
 
 # See: https://nikitabobko.github.io/AeroSpace/commands#focus
+# NOTE: alt-k (focus up) rebound to alt-up — 'k' is now a home-row option mod
+# (Miryoku dual-function via karabiner), so alt-k can no longer be triggered.
+# alt-h (left), alt-j (down), alt-l (right) still work: hold option on 'd' or 'k'
+# (opposite hand) and tap h/j/l.
 alt-h = 'focus left'
 alt-j = 'focus down'
-alt-k = 'focus up'
+alt-up = 'focus up'
 alt-l = 'focus right'
 
 # See: https://nikitabobko.github.io/AeroSpace/commands#move
+# NOTE: alt-shift-k (move up) and alt-shift-l (move right) rebound to arrow keys
+# — 'k' is now option and 'l' is now shift (home-row mods), so those chords can
+# no longer be triggered. alt-shift-h (left) and alt-shift-j (down) still work.
 alt-shift-h = 'move left'
 alt-shift-j = 'move down'
-alt-shift-k = 'move up'
-alt-shift-l = 'move right'
+alt-shift-up = 'move up'
+alt-shift-right = 'move right'
 
 # See: https://nikitabobko.github.io/AeroSpace/commands#resize
 alt-minus = 'resize smart -50'
@@ -124,7 +131,8 @@ alt-9 = 'workspace 9'
 alt-a = 'workspace A' # In your config, you can drop workspace bindings that you don't need
 alt-b = 'workspace B'
 alt-c = 'workspace C'
-alt-d = 'workspace D'
+# NOTE: alt-d (workspace D) rebound to alt-0 — 'd' is now a home-row option mod.
+alt-0 = 'workspace D'
 alt-e = 'workspace E'
 alt-f = 'workspace F'
 alt-g = 'workspace G'
@@ -157,7 +165,11 @@ alt-shift-9 = 'move-node-to-workspace 9'
 alt-shift-a = 'move-node-to-workspace A'
 alt-shift-b = 'move-node-to-workspace B'
 alt-shift-c = 'move-node-to-workspace C'
-alt-shift-d = 'move-node-to-workspace D'
+# NOTE: alt-shift-d (move-node-to-workspace D) rebound to alt-shift-0 and
+# alt-shift-s (move-node-to-workspace S) rebound to alt-shift-minus — 'd' is now
+# option and 's' is now shift (home-row mods), so those chords can no longer be
+# triggered. alt-s (workspace S) still works (hold option on d/k, tap s).
+alt-shift-0 = 'move-node-to-workspace D'
 alt-shift-e = 'move-node-to-workspace E'
 alt-shift-f = 'move-node-to-workspace F'
 alt-shift-g = 'move-node-to-workspace G'
@@ -168,7 +180,7 @@ alt-shift-o = 'move-node-to-workspace O'
 alt-shift-p = 'move-node-to-workspace P'
 alt-shift-q = 'move-node-to-workspace Q'
 alt-shift-r = 'move-node-to-workspace R'
-alt-shift-s = 'move-node-to-workspace S'
+alt-shift-minus = 'move-node-to-workspace S'
 alt-shift-t = 'move-node-to-workspace T'
 alt-shift-u = 'move-node-to-workspace U'
 alt-shift-v = 'move-node-to-workspace V'
@@ -199,10 +211,13 @@ backspace = ['close-all-windows-but-current', 'mode main']
 # sticky is not yet supported https://github.com/nikitabobko/AeroSpace/issues/2
 #s = ['layout sticky tiling', 'mode main']
 
+# NOTE: alt-shift-k (join up) and alt-shift-l (join right) rebound to arrow keys
+# — 'k' is now option and 'l' is now shift (home-row mods). alt-shift-h (left)
+# and alt-shift-j (down) still work.
 alt-shift-h = ['join-with left', 'mode main']
 alt-shift-j = ['join-with down', 'mode main']
-alt-shift-k = ['join-with up', 'mode main']
-alt-shift-l = ['join-with right', 'mode main']
+alt-shift-up = ['join-with up', 'mode main']
+alt-shift-right = ['join-with right', 'mode main']
 
 down = 'volume down'
 up = 'volume up'

--- a/install.sh
+++ b/install.sh
@@ -99,6 +99,7 @@ stow -d "$DOTFILES_DIR" -t "$HOME" nvim
 stow -d "$DOTFILES_DIR" -t "$HOME" starship
 stow -d "$DOTFILES_DIR" -t "$HOME" ghostty
 stow -d "$DOTFILES_DIR" -t "$HOME" aerospace
+stow -d "$DOTFILES_DIR" -t "$HOME" karabiner
 stow -d "$DOTFILES_DIR" -t "$HOME" agents
 stow -d "$DOTFILES_DIR" -t "$HOME" pi
 stow -d "$DOTFILES_DIR" -t "$HOME" herdr

--- a/karabiner/.config/karabiner/.gitignore
+++ b/karabiner/.config/karabiner/.gitignore
@@ -1,0 +1,2 @@
+# Karabiner auto-backups are machine-generated and change over time
+automatic_backups/

--- a/karabiner/.config/karabiner/karabiner.json
+++ b/karabiner/.config/karabiner/karabiner.json
@@ -1,0 +1,205 @@
+{
+    "profiles": [
+        {
+            "complex_modifications": {
+                "rules": [
+                    {
+                        "description": "Left-hand ctrl mod: tap 'a' sends a; hold 'a' (200ms) sends left_control. Standard Miryoku home-row-mod layout (G-A-C-S order, Mac ctrl/gui swap): a=ctrl s=shift d=opt f=cmd (left), mirrored ;=cmd l=shift k=opt j=ctrl (right). Tunable: raise basic.to_if_held_down_threshold_milliseconds if you get false mods while typing; lower it if the mod feels sluggish.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "a",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "a" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "a"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "left_control" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Left-hand shift mod: tap 's' sends s; hold 's' (200ms) sends left_shift. Miryoku home-row mod (s=shift). AeroSpace note: alt-shift-s (move-node-to-workspace S) is rebound to alt-shift-minus in aerospace.toml because s is now the shift key. Tunable threshold same as the 'a' rule.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "s",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "s" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "s"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "left_shift" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Left-hand option mod: tap 'd' sends d; hold 'd' (200ms) sends left_option. Miryoku home-row mod (d=opt). AeroSpace note: alt-d (workspace D) rebound to alt-0 and alt-shift-d (move-node-to-workspace D) rebound to alt-shift-0 because d is now the option key. Tunable threshold same as the 'a' rule.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "d",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "d" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "d"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "left_option" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Left-hand cmd mod: tap 'f' sends f; hold 'f' (200ms) sends left_command. Miryoku home-row mod (f=cmd). No AeroSpace collision (AeroSpace defines no cmd-* bindings). Tunable threshold same as the 'a' rule.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "f",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "f" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "f"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "left_command" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Right-hand ctrl mod: tap 'j' sends j; hold 'j' (200ms) sends right_control. Miryoku home-row mod (j=ctrl, mirrors left-hand a=ctrl). AeroSpace alt-j (focus down) and alt-shift-j (move down / service-mode join down) still work: hold the left-hand option (d) or shift (s) and tap j. Tunable threshold same as the 'a' rule.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "j",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "j" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "j"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "right_control" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Right-hand option mod: tap 'k' sends k; hold 'k' (200ms) sends right_option. Miryoku home-row mod (k=opt, mirrors left-hand d=opt). AeroSpace note: alt-k (focus up) rebound to alt-up, alt-shift-k (move up / service-mode join up) rebound to alt-shift-up because k is now the option key. Tunable threshold same as the 'a' rule.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "k",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "k" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "k"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "right_option" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Right-hand shift mod: tap 'l' sends l; hold 'l' (200ms) sends right_shift. Miryoku home-row mod (l=shift, mirrors left-hand s=shift). AeroSpace note: alt-shift-l (move right / service-mode join right) rebound to alt-shift-right because l is now the shift key; alt-l (focus right) still works (hold option on d or k and tap l). Tunable threshold same as the 'a' rule.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "l",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "l" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "l"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "right_shift" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Right-hand cmd mod: tap ';' sends ; ; hold ';' (200ms) sends right_command. Miryoku home-row mod (;=cmd, mirrors left-hand f=cmd). No AeroSpace collision (AeroSpace defines no cmd-* bindings); alt-shift-semicolon (mode service) now works too since ; is no longer the option key. Tunable threshold same as the 'a' rule.",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "semicolon",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_delayed_action_delay_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to_delayed_action": { "to_if_canceled": [{ "key_code": "semicolon" }] },
+                                "to_if_alone": [
+                                    {
+                                        "halt": true,
+                                        "key_code": "semicolon"
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "right_command" }],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "name": "Default profile",
+            "selected": true,
+            "virtual_hid_keyboard": { "keyboard_type_v2": "ansi" }
+        }
+    ]
+}

--- a/karabiner/.config/karabiner/karabiner.json
+++ b/karabiner/.config/karabiner/karabiner.json
@@ -28,7 +28,7 @@
                         ]
                     },
                     {
-                        "description": "Left-hand shift mod: tap 's' sends s; hold 's' (200ms) sends left_shift. Miryoku home-row mod (s=shift). AeroSpace note: alt-shift-s (move-node-to-workspace S) is rebound to alt-shift-minus in aerospace.toml because s is now the shift key. Tunable threshold same as the 'a' rule.",
+                        "description": "Left-hand shift mod: tap 's' sends s; hold 's' (200ms) sends left_shift. Miryoku home-row mod (s=shift). AeroSpace alt-s (workspace S) and alt-shift-s (move-node-to-ws S) still work via bilateral holds: hold option on 'd'/'k' (and shift on the opposite shift key for alt-shift-s) and tap 's' with a quick tap so its shift-hold does not trigger. Tunable threshold same as the 'a' rule.",
                         "manipulators": [
                             {
                                 "from": {
@@ -52,7 +52,7 @@
                         ]
                     },
                     {
-                        "description": "Left-hand option mod: tap 'd' sends d; hold 'd' (200ms) sends left_option. Miryoku home-row mod (d=opt). AeroSpace note: alt-d (workspace D) rebound to alt-0 and alt-shift-d (move-node-to-workspace D) rebound to alt-shift-0 because d is now the option key. Tunable threshold same as the 'a' rule.",
+                        "description": "Left-hand option mod: tap 'd' sends d; hold 'd' (200ms) sends left_option. Miryoku home-row mod (d=opt). AeroSpace alt-d (workspace D) still works via bilateral hold: hold option on the right-hand 'k' and tap 'd' with a quick tap so its option-hold does not trigger. alt-shift-d: hold right option (k) + right/left shift (l or s) and tap d. Tunable threshold same as the 'a' rule.",
                         "manipulators": [
                             {
                                 "from": {
@@ -124,7 +124,7 @@
                         ]
                     },
                     {
-                        "description": "Right-hand option mod: tap 'k' sends k; hold 'k' (200ms) sends right_option. Miryoku home-row mod (k=opt, mirrors left-hand d=opt). AeroSpace note: alt-k (focus up) rebound to alt-up, alt-shift-k (move up / service-mode join up) rebound to alt-shift-up because k is now the option key. Tunable threshold same as the 'a' rule.",
+                        "description": "Right-hand option mod: tap 'k' sends k; hold 'k' (200ms) sends right_option. Miryoku home-row mod (k=opt, mirrors left-hand d=opt). AeroSpace alt-k (focus up) and alt-shift-k (move up / service join up) still work via bilateral hold: hold option on the left-hand 'd' and tap 'k' with a quick tap so its option-hold does not trigger. This is the standard Miryoku bilateral pattern the captain adopted. Tunable threshold same as the 'a' rule.",
                         "manipulators": [
                             {
                                 "from": {
@@ -148,7 +148,7 @@
                         ]
                     },
                     {
-                        "description": "Right-hand shift mod: tap 'l' sends l; hold 'l' (200ms) sends right_shift. Miryoku home-row mod (l=shift, mirrors left-hand s=shift). AeroSpace note: alt-shift-l (move right / service-mode join right) rebound to alt-shift-right because l is now the shift key; alt-l (focus right) still works (hold option on d or k and tap l). Tunable threshold same as the 'a' rule.",
+                        "description": "Right-hand shift mod: tap 'l' sends l; hold 'l' (200ms) sends right_shift. Miryoku home-row mod (l=shift, mirrors left-hand s=shift). AeroSpace alt-l (focus right) still works via bilateral hold: hold option on 'd'/'k' and tap 'l'. alt-shift-l (move right / service join right): hold option on 'd'/'k' + left shift (s) and tap l with a quick tap. Tunable threshold same as the 'a' rule.",
                         "manipulators": [
                             {
                                 "from": {


### PR DESCRIPTION
## Summary

Extends the karabiner dual-function home-row mapping from option-only to the full **standard Miryoku** layout (G-A-C-S order, Mac ctrl/gui swap), across all 4 modifiers on both hands. AeroSpace config is **unchanged** — hjkl and all original bindings kept, via bilateral holds.

## Home-row mod layout

| key | a | s | d | f | ; | l | k | j |
|---|---|---|---|---|---|---|---|---|
| hold | ctrl | shift | opt | cmd | cmd | shift | opt | ctrl |
| hand | L | L | L | L | R | R | R | R |

Mirrored by finger. Each of the 8 home-row keys gets a dual-function rule using the **same pattern** as the existing a/; rules: modifiers.optional any, to_if_alone with halt true (tap = letter), to_if_held_down (hold = modifier), to_delayed_action with to_if_canceled (sends the letter if canceled), 200ms threshold (tunable, noted in each rule description).

## AeroSpace compatibility — NO rebinds, hjkl preserved

AeroSpace is **unchanged** (aerospace.toml identical to origin/main). Every alt-*/alt-shift-* binding still fires via **bilateral holds** — the standard Miryoku pattern: hold the modifier on the opposite hand from the target key, tap the target with a quick tap so its own hold-mod does not trigger. Each modifier has a left and right source (d/k = opt, s/l = shift), so there is always an opposite-hand source.

| binding | how it fires |
|---|---|
| alt-h / alt-j / alt-k / alt-l (focus) | hold left option (d), tap h/j/k/l |
| alt-d (workspace D) | hold right option (k), tap d |
| alt-k (focus up) | hold left option (d), tap k |
| alt-shift-l (move right) | hold option (d or k) + left shift (s), tap l |
| alt-shift-k (move up) | hold left option (d) + left shift (s), tap k |
| alt-shift-; (mode service) | now WORKS (was broken when ; was option; ; is now cmd) |
| alt-1..9, alt-a..z (workspaces) | hold option on the opposite-side source, tap the key |

AeroSpace defines zero ctrl-*/cmd-* bindings, so ctrl (a, j) and cmd (f, ;) cause no collisions.

### Habit requirement
Bilateral holds mean you must hold the modifier on the **opposite hand** from the target. Same-hand hold + tap (e.g. hold k=opt then tap k) will not fire the chord — that is a habit, not a config break.

## Other changes
- install.sh: added stow for the karabiner package next to aerospace, so /shipshape restow deploys it.
- karabiner/.config/karabiner/.gitignore: ignores automatic_backups/.

## Validation
- python3 json.load OK (8 rules)
- jq . OK
- aerospace.toml byte-identical to origin/main (git diff confirms only the revert).
- Live karabiner daemon NOT reloaded — JSON-only validation; captain loads after merge.

## Notes
- 200ms threshold is tunable: raise basic.to_if_held_down_threshold_milliseconds if false mods while typing; lower if sluggish.
- Recovered the existing a/; dual-function rules from origin/karabiner-stow (not redone from scratch); updated those two rules to their new Miryoku mods and added the other 6.
