### PR TITLE
fix(pi): patch the runtime's bundled chunk, not dead modes/interactive copy

### DIFF
--- a/pi/.pi/agent/extensions/tool-call-renderer.test.mjs
+++ b/pi/.pi/agent/extensions/tool-call-renderer.test.mjs
@@ -1,0 +1,198 @@
+// Regression test for the tool-call-renderer "dual-instance no-op" bug.
+//
+// The published pi runtime ships a BUNDLED CLI: dist/bundle/cli.js boots from
+// dist/bundle/chunks/*.js, which inline their OWN copies of
+// AssistantMessageComponent / ToolExecutionComponent. The separate
+// dist/modes/interactive/components/*.js tree is a dead-at-runtime build
+// output. ESM caches modules by URL, so the chunk classes and the
+// modes/interactive classes are DIFFERENT instances. Patching the
+// modes/interactive prototypes (the pre-fix behavior) therefore never affects
+// the classes the runtime instantiates — a silent no-op that leaves the live
+// TUI with zero `▸/▹/◆/◇` tree rows.
+//
+// This test activates the renderer the way pi does (with process.argv[1]
+// pointing at the real pi CLI so the extension's loadPiInternals path
+// resolution matches production) and asserts:
+//   1. the renderer resolves its classes from the bundled chunk, not
+//      modes/interactive (the stderr diagnostic names the source);
+//   2. the bundled chunk's AssistantMessageComponent / ToolExecutionComponent
+//      prototypes ARE patched (the runtime's classes — the fix);
+//   3. the dead modes/interactive copies are NOT patched (they are a
+//      different instance — the precondition that made the pre-fix code a
+//      no-op).
+//
+// On the pre-fix code (8e243c2, which only imports modes/interactive) the
+// chunk-prototype assertions fail and the diagnostic names modes/interactive,
+// which is exactly the regression this guards against.
+
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+// Make the globally-installed pi package tree resolvable from this test
+// (mirrors usage.test.mjs).
+process.env.NODE_PATH = [
+	"/opt/homebrew/lib/node_modules",
+	"/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules",
+	process.env.NODE_PATH || "",
+].filter(Boolean).join(":");
+require("node:module").Module._initPaths();
+
+// --- Locate the installed pi package (the runtime the renderer must patch) ---
+// The package `exports` map only defines an `import` condition, so CJS
+// require.resolve cannot resolve it; resolve the install by known path (same
+// candidate style as the other extension tests).
+const piPackageCandidates = [
+	process.env.PI_PACKAGE_DIR,
+	"/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent",
+	"/home/avirus/.nvm/versions/node/v22.22.3/lib/node_modules/@earendil-works/pi-coding-agent",
+].filter(Boolean);
+const piPackageDir = piPackageCandidates.find((p) =>
+	existsSync(join(p, "dist", "bundle", "cli.js")),
+);
+if (!piPackageDir) {
+	console.error("pi install not found. Set PI_PACKAGE_DIR to the pi-coding-agent package dir.");
+	process.exit(1);
+}
+const piCliPath = realpathSync(join(piPackageDir, "dist", "bundle", "cli.js"));
+const cliDir = dirname(piCliPath);
+const chunksDir = join(cliDir, "chunks");
+const interactiveDir = join(dirname(cliDir), "modes", "interactive");
+assert.ok(existsSync(chunksDir), "test expects a bundled pi install with dist/bundle/chunks");
+assert.ok(
+	existsSync(join(interactiveDir, "components", "assistant-message.js")),
+	"test expects dist/modes/interactive present as the dead-at-runtime copy",
+);
+
+// --- Locate jiti (same resolution as the other extension tests) ---
+const jitiCandidates = [
+	process.env.JITI_PATH,
+	"/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs",
+	"/home/avirus/.nvm/versions/node/v22.22.3/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/jiti/lib/jiti.cjs",
+].filter(Boolean);
+const jitiPath = jitiCandidates.find((p) => p && existsSync(p));
+if (!jitiPath) {
+	console.error("jiti not found. Set JITI_PATH to jiti.cjs for your pi install.");
+	process.exit(1);
+}
+const { createJiti } = require(jitiPath);
+// Replicate pi's getAliases() so the renderer's `@earendil-works/*` imports
+// resolve the same way they do when pi loads the extension (the package
+// `exports` map has no `require` condition, so plain CJS resolution fails).
+const piTuiEntry = require.resolve("@earendil-works/pi-tui", { paths: [piPackageDir] });
+const jiti = createJiti(import.meta.url, {
+	alias: {
+		"@earendil-works/pi-coding-agent": join(piPackageDir, "dist", "index.js"),
+		"@earendil-works/pi-tui": piTuiEntry,
+		"@mariozechner/pi-coding-agent": join(piPackageDir, "dist", "index.js"),
+		"@mariozechner/pi-tui": piTuiEntry,
+	},
+});
+
+// --- The patched-prototype symbols the renderer sets (must match the .ts) ---
+const ASSISTANT_PATCHED = Symbol.for("aviral.pi.work-step-renderer.assistant");
+const TOOL_PATCHED = Symbol.for("aviral.pi.work-step-renderer.tool");
+
+// --- Find the bundled chunk that actually exports the runtime classes ---
+// Mirrors the renderer's own scan in loadPiInternals.
+let chunkFile;
+for (const file of readdirSync(chunksDir).filter((f) => f.endsWith(".js"))) {
+	const src = readFileSync(join(chunksDir, file), "utf8");
+	if (src.includes("AssistantMessageComponent") && src.includes("ToolExecutionComponent")) {
+		const mod = await import(pathToFileURL(join(chunksDir, file)).href).catch(() => undefined);
+		if (mod?.AssistantMessageComponent && mod?.ToolExecutionComponent) {
+			chunkFile = file;
+			break;
+		}
+	}
+}
+assert.ok(chunkFile, "could not find a bundled chunk exporting the components");
+const chunkUrl = pathToFileURL(join(chunksDir, chunkFile)).href;
+const chunkModule = await import(chunkUrl);
+const ChunkAssistant = chunkModule.AssistantMessageComponent;
+const ChunkTool = chunkModule.ToolExecutionComponent;
+
+// The dead-at-runtime modes/interactive copy (separate class instance).
+const interactiveAssistant = (
+	await import(pathToFileURL(join(interactiveDir, "components", "assistant-message.js")).href)
+).AssistantMessageComponent;
+const interactiveTool = (
+	await import(pathToFileURL(join(interactiveDir, "components", "tool-execution.js")).href)
+).ToolExecutionComponent;
+
+// Sanity: the two trees really are different instances (the precondition for
+// the original no-op bug). If these ever become reference-equal, the bug
+// disappears on its own and this regression test is no longer meaningful.
+assert.notEqual(
+	ChunkAssistant,
+	interactiveAssistant,
+	"bundled chunk and modes/interactive must be distinct AssistantMessageComponent instances",
+);
+assert.notEqual(
+	ChunkTool,
+	interactiveTool,
+	"bundled chunk and modes/interactive must be distinct ToolExecutionComponent instances",
+);
+
+// --- Activate the renderer as pi would ---
+// loadPiInternals reads process.argv[1] to find the CLI, so point it at the
+// real installed pi CLI for the duration of the activation.
+const savedArgv1 = process.argv[1];
+process.argv[1] = piCliPath;
+
+const renderer = jiti.import("./tool-call-renderer.ts", { default: true });
+const activate = await renderer;
+assert.equal(typeof activate, "function", "renderer must export an activate function");
+
+const stderrLines = [];
+const savedError = console.error;
+console.error = (...args) => stderrLines.push(args.join(" "));
+try {
+	const stubPi = { on() {}, events: { on() {} } };
+	await activate(stubPi);
+} finally {
+	console.error = savedError;
+	process.argv[1] = savedArgv1;
+}
+
+const diagnostic = stderrLines.join("\n");
+
+// --- Assertions ---
+
+// 1. The renderer patched the BUNDLED CHUNK classes (the runtime's classes),
+//    not the dead modes/interactive copy. This is the fix.
+assert.equal(
+	ChunkAssistant.prototype[ASSISTANT_PATCHED],
+	true,
+	"bundled chunk AssistantMessageComponent.prototype must be patched (the runtime class)",
+);
+assert.equal(
+	ChunkTool.prototype[TOOL_PATCHED],
+	true,
+	"bundled chunk ToolExecutionComponent.prototype must be patched (the runtime class)",
+);
+
+// 2. The dead modes/interactive copy is NOT patched — proving it is a separate
+//    instance and that patching it (the pre-fix behavior) was a no-op.
+assert.notEqual(
+	interactiveAssistant.prototype[ASSISTANT_PATCHED],
+	true,
+	"modes/interactive AssistantMessageComponent must NOT be patched (dead-at-runtime copy)",
+);
+assert.notEqual(
+	interactiveTool.prototype[TOOL_PATCHED],
+	true,
+	"modes/interactive ToolExecutionComponent must NOT be patched (dead-at-runtime copy)",
+);
+
+// 3. The renderer's own diagnostic confirms it took the chunk path.
+assert.ok(
+	diagnostic.includes("bundled chunk"),
+	`renderer diagnostic must name the bundled chunk source; got: ${diagnostic}`,
+);
+
+console.log("tool-call-renderer.test.mjs: PASS — runtime bundled-chunk classes patched, dead modes/interactive copy not patched");

--- a/pi/.pi/agent/extensions/tool-call-renderer.ts
+++ b/pi/.pi/agent/extensions/tool-call-renderer.ts
@@ -1,5 +1,10 @@
 import { keyHint, type ExtensionAPI, type Theme } from "@earendil-works/pi-coding-agent";
-import { existsSync, realpathSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
 import { hostname } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -1719,35 +1724,107 @@ async function loadPiInternals(): Promise<{
   AssistantMessageComponent: any;
   ToolExecutionComponent: any;
   theme: Theme;
+  source: string;
 }> {
   const cliPath = realpathSync(process.argv[1] ?? "");
   const cliDir = dirname(cliPath);
+
+  // `dist/modes/interactive/...` is kept as the theme-singleton source and as
+  // a fallback for non-bundled dev runs.
   const interactivePath = [
     join(cliDir, "modes/interactive"),
     join(dirname(cliDir), "modes/interactive"),
   ].find((candidate) =>
     existsSync(join(candidate, "components/assistant-message.js")),
   );
-  if (!interactivePath) {
+
+  // Published pi ships a BUNDLED CLI: `dist/bundle/cli.js` imports everything
+  // from `dist/bundle/chunks/*.js` (hashed names). Those chunks inline their
+  // OWN copies of AssistantMessageComponent / ToolExecutionComponent and do NOT
+  // import from `dist/modes/interactive/...` — that tree is a separate,
+  // dead-at-runtime build output. Patching the classes imported from
+  // `modes/interactive` therefore patches prototypes the runtime never
+  // instantiates: a silent no-op (the bug this fixes). Instead, import the
+  // components from the bundled chunk the runtime actually uses. ESM caches
+  // modules by URL, so importing the chunk's file URL returns the SAME class
+  // instances the runtime renders with — prototype patching then takes effect.
+  const chunksDir = join(cliDir, "chunks");
+  let AssistantMessageComponent: any;
+  let ToolExecutionComponent: any;
+  let source: string | undefined;
+  if (existsSync(chunksDir)) {
+    const chunkFiles = readdirSync(chunksDir).filter((file) =>
+      file.endsWith(".js"),
+    );
+    for (const file of chunkFiles) {
+      // Cheap pre-filter so we only dynamic-import chunks that can match.
+      // NB: name this local `chunkSource`, not `source` — the outer `let source`
+      // records the resolved origin for the diagnostic, and reusing the name
+      // here would shadow it and make the `source = ` assignment below a
+      // runtime `Assignment to constant variable` TypeError under jiti, which
+      // silently disables the renderer.
+      const chunkSource = readFileSync(join(chunksDir, file), "utf8");
+      if (
+        !chunkSource.includes("AssistantMessageComponent") &&
+        !chunkSource.includes("ToolExecutionComponent")
+      )
+        continue;
+      const module = await import(
+        pathToFileURL(join(chunksDir, file)).href
+      ).catch(() => undefined);
+      if (!AssistantMessageComponent && module?.AssistantMessageComponent) {
+        AssistantMessageComponent = module.AssistantMessageComponent;
+        source = `bundled chunk ${file}`;
+      }
+      if (!ToolExecutionComponent && module?.ToolExecutionComponent)
+        ToolExecutionComponent = module.ToolExecutionComponent;
+      if (AssistantMessageComponent && ToolExecutionComponent) break;
+    }
+  }
+
+  // Fallback for non-bundled layouts: import the classes from modes/interactive.
+  if (
+    (!AssistantMessageComponent || !ToolExecutionComponent) &&
+    interactivePath
+  ) {
+    const [assistantModule, toolModule] = await Promise.all([
+      import(
+        pathToFileURL(join(interactivePath, "components/assistant-message.js"))
+          .href
+      ),
+      import(
+        pathToFileURL(join(interactivePath, "components/tool-execution.js"))
+          .href
+      ),
+    ]);
+    AssistantMessageComponent ??= assistantModule.AssistantMessageComponent;
+    ToolExecutionComponent ??= toolModule.ToolExecutionComponent;
+    if (!source) source = "modes/interactive (fallback)";
+  }
+
+  // The lowercase `theme` singleton is not exported from the chunk; pull it from
+  // the modes/interactive theme module. Any valid Theme instance colors
+  // correctly, so the source need not match the runtime's.
+  let theme: Theme | undefined;
+  if (interactivePath) {
+    const themeModule = await import(
+      pathToFileURL(join(interactivePath, "theme/theme.js")).href
+    );
+    theme = themeModule.theme as Theme | undefined;
+  }
+
+  if (!AssistantMessageComponent || !ToolExecutionComponent || !theme) {
     throw new Error(
-      "tool-call-renderer: could not locate pi interactive components relative to " +
-        cliPath,
+      "tool-call-renderer: could not locate pi interactive components (bundled chunks or modes/interactive) relative to " +
+        cliPath +
+        (source ? ` (last tried ${source})` : ""),
     );
   }
-  const [assistantModule, toolModule, themeModule] = await Promise.all([
-    import(
-      pathToFileURL(join(interactivePath, "components/assistant-message.js"))
-        .href
-    ),
-    import(
-      pathToFileURL(join(interactivePath, "components/tool-execution.js")).href
-    ),
-    import(pathToFileURL(join(interactivePath, "theme/theme.js")).href),
-  ]);
   return {
-    AssistantMessageComponent: assistantModule.AssistantMessageComponent,
-    ToolExecutionComponent: toolModule.ToolExecutionComponent,
-    theme: themeModule.theme as Theme,
+    AssistantMessageComponent,
+    ToolExecutionComponent,
+    theme,
+    source: source ?? "unknown",
   };
 }
 
@@ -1824,9 +1901,57 @@ function patchComponents(
   }
 }
 
+// Fail-soft wrapper around loadPiInternals + patchComponents. A future pi update
+// that moves the internal component modules would make discovery throw; this
+// catches that, logs once to stderr, and leaves pi's built-in renderer in place
+// instead of failing the whole extension load. Idempotent: `patchApplied` plus
+// the prototype guard symbols make repeated calls (e.g. on session_start) a
+// no-op once patching has succeeded, so re-discovery only runs when the initial
+// load-time attempt failed.
+let patchApplied = false;
+let patchAnnounced = false;
+
+async function applyRendererPatch(
+  state: RendererState,
+  controller: RendererController,
+  onTheme: (theme: Theme) => void,
+): Promise<boolean> {
+  if (patchApplied) return true;
+  try {
+    const {
+      AssistantMessageComponent,
+      ToolExecutionComponent,
+      theme,
+      source,
+    } = await loadPiInternals();
+    patchComponents(
+      AssistantMessageComponent,
+      ToolExecutionComponent,
+      controller,
+    );
+    onTheme(theme);
+    patchApplied = true;
+    if (!patchAnnounced) {
+      patchAnnounced = true;
+      console.error(
+        `tool-call-renderer: custom rendering active (patched ${source}).`,
+      );
+    }
+    return true;
+  } catch (error) {
+    if (!patchAnnounced) {
+      patchAnnounced = true;
+      console.error(
+        "tool-call-renderer: custom rendering disabled — could not patch pi interactive components; falling back to built-in rendering. " +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    }
+    return false;
+  }
+}
+
 export default async function (pi: ExtensionAPI) {
-  const { AssistantMessageComponent, ToolExecutionComponent, theme } =
-    await loadPiInternals();
+  let theme: Theme;
   const state: RendererState = {
     pending: new Map(),
     persisted: new WeakMap(),
@@ -1918,17 +2043,20 @@ export default async function (pi: ExtensionAPI) {
       return renderToolComponent(component, width, state, theme);
     },
   };
-  patchComponents(
-    AssistantMessageComponent,
-    ToolExecutionComponent,
-    controller,
-  );
+  await applyRendererPatch(state, controller, (resolved) => {
+    theme = resolved;
+  });
 
-  pi.on("session_start", (_event, ctx) => {
+  pi.on("session_start", async (_event, ctx) => {
     const sessionId = ctx.sessionManager.getSessionId();
     if (state.sessionId && state.sessionId !== sessionId) disposeState(state);
     state.sessionId = sessionId;
     scanPersistedSession(state, ctx.sessionManager.getEntries());
+    // Re-attempt patching if the load-time attempt failed (e.g. pi internals
+    // were not resolvable when the extension first loaded). No-op once applied.
+    await applyRendererPatch(state, controller, (resolved) => {
+      theme = resolved;
+    });
   });
 
   pi.on("agent_start", () => {


### PR DESCRIPTION
> **pi-agent session cost:** $5.0005 (131 provider calls; 350,329 input / 122,571 output / 16,456,299 cacheRead tokens)
>
> **no-mistakes cost:** not run — this task shipped direct-PR (no `/no-mistakes`).

## Root cause

The `tool-call-renderer` extension patches the wrong class instances on the
**published (bundled) pi install**.

`dist/bundle/cli.js` boots from `dist/bundle/chunks/*.js` (hashed, inlined
copies of `AssistantMessageComponent` / `ToolExecutionComponent`). The separate
`dist/modes/interactive/components/*.js` tree is a **dead-at-runtime build
output** — `cli.js` never references it. ESM caches modules by URL, so the
chunk classes and the `modes/interactive` classes are **different instances**.

The pre-existing renderer imported the classes from `modes/interactive` and
patched those prototypes. The runtime instantiates the chunk classes, which
were never patched → no `render` / `updateContent` override takes effect → pi
falls back to flat native rendering: **zero `▸/▹/◆/◇` tree rows, including zero
tool rows.** Headless `pi -p` hid this because it never draws the TUI — the
extension module loads cleanly, it just patches the wrong classes (PR #195's
candidate-path search located `modes/interactive` correctly; locating it was
never the right target on a bundled install).

## Fix

`loadPiInternals` now scans `dist/bundle/chunks/*.js` and imports the
components from the bundled chunk the runtime actually uses (ESM returns the
same class instances by URL → prototype patching takes effect). It keeps
`modes/interactive` as a fallback for non-bundled/dev runs and pulls the
lowercase `theme` singleton from `modes/interactive` (the chunk doesn't export
it). Patching is idempotent (`patchApplied` + existing prototype-guard
symbols), so `session_start` re-attempts and recovers if the load-time attempt
failed. A one-time stderr diagnostic names the patched source so the next
silent breakage is visible.

### Shadowing bug also fixed

The chunk scan originally declared an inner `const source` that shadowed the
outer `let source` recording the resolved origin, so the
`source = \`bundled chunk <file>\`` label assignment threw
`Assignment to constant variable` under jiti. `applyRendererPatch` caught it,
printed `custom rendering disabled`, and fell back to built-in rendering — i.e.
the fix itself silently no-op'd under the very loader pi uses for `.ts`
extensions. Renamed the inner binding to `chunkSource`.

## Live proof (herdr lab, same model/prompt/settings/cwd, only renderer differs)

| condition | renderer | live-TUI tree glyphs |
|---|---|---|
| B | `8e243c2` (patches `modes/interactive`) | **0** — flat native text + native tool box |
| C′ | this fix (patches bundled chunk) | **full tree** `│ └─ ├─ ▸ ◆` |

Both sessions verified to emit `thinking` + `toolCall bash` blocks. Condition
C′ also printed the diagnostic:
`tool-call-renderer: custom rendering active (patched bundled chunk chunk-OMWWHBTG.js).`
The `◆` tool-row signal is config-independent (`hideThinkingBlock` never
suppresses tool rows), so B=0 `◆` vs C′=1 `◆` alone proves the no-op and the
fix.

## Regression test

`tool-call-renderer.test.mjs` jiti-activates the renderer with
`process.argv[1]` pointed at the real pi CLI (so `loadPiInternals` path
resolution matches production), then asserts:

1. the bundled chunk's `AssistantMessageComponent` / `ToolExecutionComponent`
   prototypes **are** patched (the runtime's classes — the fix);
2. the dead `modes/interactive` copies are **not** patched (separate instance —
   the precondition that made the pre-fix code a no-op);
3. the diagnostic names the bundled chunk source.

Fails on the pre-fix code and on the shadowed version; passes with this change.
Run: `node pi/.pi/agent/extensions/tool-call-renderer.test.mjs` (needs the pi
install + jiti; `JITI_PATH` / `PI_PACKAGE_DIR` overrides for non-default
installs).

## Notes

- Backward-compatible: keeps the `modes/interactive` fallback for non-bundled
  dev runs.
- The 18:59Z firstmate session predates this fix and cannot pick it up
  mid-session (pi doesn't reload extensions on a plain settings change without
  a session reload); it needs a restart to get the tree.
- `hideThinkingBlock: false` is a separate config choice for `▸ Thinking` rows;
  it does not affect tool rows.
