### PR TITLE
feat(gh-dash): add gh-dash stow package with tuicr diff keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For manual installation:
 
 ```sh
 brew bundle
-stow nvim tmux zsh ghostty git starship agents pi herdr launchd
+stow nvim tmux zsh ghostty git starship agents pi herdr launchd gh-dash
 ```
 
 On Linux (systemd) systems, deploy the user services with:

--- a/gh-dash/.config/gh-dash/config.yml
+++ b/gh-dash/.config/gh-dash/config.yml
@@ -1,0 +1,101 @@
+prSections:
+    - title: My Pull Requests
+      filters: is:open author:@me
+    - title: Needs My Review
+      filters: is:open review-requested:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+issuesSections:
+    - title: My Issues
+      filters: is:open author:@me
+    - title: Assigned
+      filters: is:open assignee:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+notificationsSections:
+    - title: All
+      filters: ""
+    - title: Created
+      filters: reason:author
+    - title: Participating
+      filters: reason:participating
+    - title: Mentioned
+      filters: reason:mention
+    - title: Review Requested
+      filters: reason:review-requested
+    - title: Assigned
+      filters: reason:assign
+    - title: Subscribed
+      filters: reason:subscribed
+    - title: Team Mentioned
+      filters: reason:team-mention
+repo:
+    branchesRefetchIntervalSeconds: 30
+    prsRefetchIntervalSeconds: 60
+defaults:
+    preview:
+        open: true
+        width: 0.45
+        height: 0.6
+        position: auto
+    prsLimit: 20
+    prApproveComment: LGTM
+    issuesLimit: 20
+    notificationsLimit: 20
+    view: prs
+    layout:
+        prs:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 20
+            author:
+                width: 15
+            authorIcon:
+                hidden: false
+            labels:
+                width: 22
+                hidden: true
+            assignees:
+                width: 20
+                hidden: true
+            base:
+                width: 15
+                hidden: true
+            lines:
+                width: 15
+        issues:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 15
+            creator:
+                width: 10
+            creatorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+    refetchIntervalMinutes: 30
+keybindings:
+    prs:
+        - key: C
+          name: tuicr review
+          command: tuicr pr "{{.RepoName}}#{{.PrNumber}}" --no-update-check
+repoPaths: {}
+theme:
+    ui:
+        sectionsShowCount: true
+        table:
+            showSeparator: true
+            compact: false
+pager:
+    diff: ""
+confirmQuit: false
+showAuthorIcons: true
+smartFilteringAtLaunch: true
+includeReadNotifications: true


### PR DESCRIPTION
## What

Add a new `gh-dash` stow package managing `~/.config/gh-dash/config.yml`, and wire the currently-selected PR's diff into [tuicr](https://github.com/aviral-atreya/tuicr) (vim-keybinding code review TUI, `~/.cargo/bin/tuicr`) via a custom PR keybinding.

## Why

The captain uses `gh dash` (dlvhdr/gh-dash v4.25.2) as his GitHub PR browser and `tuicr` as his preferred diff/code-review viewer. This pops the selected PR's diff into tuicr without leaving the dashboard.

## The keybinding

```yaml
keybindings:
  prs:
    - key: C
      name: tuicr review
      command: tuicr pr "{{.RepoName}}#{{.PrNumber}}" --no-update-check
```

- **`C`** (shift-c) — free key, avoids all default gh-dash PR bindings (`c` comment, `d` diff, `o`/`O` checkout, `m` merge).
- **`{{.RepoName}}#{{.PrNumber}}`** — gh-dash v4.25.2 exposes `RepoName` (`owner/repo`) and `PrNumber` to custom PR commands but **no `{{.Url}}` field**; tuicr accepts `owner/repo#N` natively (`tuicr pr --help`).
- **Execution** — gh-dash runs the command via `$SHELL -c` through `tea.ExecProcess`, which suspends the dashboard, runs tuicr fullscreen, and resumes gh-dash on `q`. No tmux wrapper needed.
- **`--no-update-check`** — suppress tuicr's startup update check for instant launch.

## Scope

The rest of `config.yml` mirrors the captain's existing live config verbatim; the only change is `keybindings: {}` → the `prs` block above. README stow list updated to include `gh-dash`.

Full investigation: `data/ghdash-tuicr-config-scout/report.md` (config surface map, source citations, tuicr consumption test).

## Apply (post-merge)

The live `~/.config/gh-dash/config.yml` is currently a plain file, not a symlink. After merging, stow with:

```sh
cd ~/path/to/dotfiles
# adopt the existing file so stow symlinks it in place
stow --adopt gh-dash
# then restore the tracked version (in case --adopt pulled in the old copy)
git checkout -- gh-dash
```

Or, if you prefer a clean stow: `rm ~/.config/gh-dash/config.yml && stow gh-dash`.