### PR TITLE
fix(pi): focus output after copying command

### DIFF
--- a/agents/.agents/skills/professor/SKILL.md
+++ b/agents/.agents/skills/professor/SKILL.md
@@ -283,12 +283,13 @@ precision.
 
 Hands-on verification — delivered through the **`run-command` extension tool**
 (`pi/.pi/agent/extensions/run-command.ts`). A floating panel above the prompt
-supports two user-driven paths: `y` copies the command for manual execution and
-pasted output; `r` runs it in a visible Neovim `:term dm` pane and automatically
-captures output plus exit status. You receive the command and observed output
-**together** — grading = output vs. your grounded prediction (see Grounding
-predictions). Prefer `y` when typing the command is part of the lesson; use `r`
-when observing and interpreting its result is the learning target.
+supports two user-driven paths: `y` copies the command and focuses the output
+field for manual execution and pasting; `r` runs it in a visible Neovim
+`:term dm` pane and automatically captures output plus exit status. You receive
+the command and observed output **together** — grading = output vs. your grounded
+prediction (see Grounding predictions). Prefer `y` when typing the command is
+part of the lesson; use `r` when observing and interpreting its result is the
+learning target.
 
 If his output differs from the prediction, that mismatch is diagnostic gold:
 either host state drifted or your model was wrong — find out which. A submission

--- a/pi/.pi/agent/extensions/run-command.test.mjs
+++ b/pi/.pi/agent/extensions/run-command.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createRequire } from "node:module";
@@ -120,4 +120,114 @@ for (const shell of ["sh", "bash", "zsh", "dash"]) {
 // No END marker yet → not complete.
 assert.deepEqual(extractMarkedOutput("only partial", token), { complete: false });
 
-console.log("run-command helper tests passed");
+// Exercise the registered tool through its public execute/UI boundary. The
+// lightweight dependency stub keeps this deterministic and prevents an
+// automated test from changing the machine clipboard; the extension's real
+// panel event handler and renderer still process every key below.
+const stubDir = mkdtempSync(join(tmpdir(), "run-command-ui-test-"));
+const stubPath = join(stubDir, "deps.cjs");
+writeFileSync(
+	stubPath,
+	String.raw`
+class Editor {
+  constructor() { this.focused = false; this.disableSubmit = false; this.text = ""; }
+  getText() { return this.text; }
+  handleInput(data) { if (this.focused) this.text += data; }
+  invalidate() {}
+  render() { return [this.focused ? this.text + "▌" : this.text]; }
+}
+class Text { constructor(text) { this.text = text; } }
+const Key = { enter: "\r", tab: "\t", escape: "\x1b" };
+const Type = { Object: x => x, String: x => x, Optional: x => x };
+function wrapTextWithAnsi(text, width) {
+  const lines = [];
+  for (let rest = text; rest.length > width; rest = rest.slice(width)) lines.push(rest.slice(0, width));
+  lines.push(text.slice(lines.length * width));
+  return lines;
+}
+module.exports = {
+  Editor, Text, Key, Type,
+  copyToClipboard: async text => { globalThis.__runCommandClipboardCalls.push(text); },
+  matchesKey: (data, key) => data === key,
+  truncateToWidth: (text, width) => text.slice(0, width),
+  visibleWidth: text => text.length,
+  wrapTextWithAnsi,
+};
+`,
+);
+
+try {
+	globalThis.__runCommandClipboardCalls = [];
+	const uiJiti = createJiti(import.meta.url, {
+		alias: {
+			"@earendil-works/pi-coding-agent": stubPath,
+			"@earendil-works/pi-tui": stubPath,
+			typebox: stubPath,
+		},
+		moduleCache: false,
+	});
+	const runCommandExtension = uiJiti("./run-command.ts").default;
+	let tool;
+	runCommandExtension({ registerTool(value) { tool = value; } });
+	assert.ok(tool, "extension must register run-command");
+
+	async function drive(keys) {
+		let panel;
+		const renders = [];
+		const theme = { fg: (_color, text) => text, bold: text => text };
+		const tui = { requestRender: () => renders.push(panel.render(80).join("\n")) };
+		const ctx = {
+			hasUI: true,
+			cwd: process.cwd(),
+			ui: {
+				custom(factory) {
+					return new Promise(resolve => {
+						panel = factory(tui, theme, {}, resolve);
+						renders.push(panel.render(80).join("\n"));
+						for (const key of keys) {
+							panel.handleInput(key);
+							renders.push(panel.render(80).join("\n"));
+						}
+					});
+			},
+		},
+		};
+		const result = await tool.execute(
+			"test-call",
+			{ command: "printf ready", prediction: "ready" },
+			undefined,
+			undefined,
+			ctx,
+		);
+		return { result, renders };
+	}
+
+	const yanked = await drive(["y", "received through leader-at", "\r"]);
+	assert.deepEqual(globalThis.__runCommandClipboardCalls, ["printf ready"]);
+	assert.equal(yanked.result.details.output, "received through leader-at");
+	assert.equal(yanked.result.details.copied, true);
+	assert.match(yanked.renders[1], /Output \(paste what you saw below\):/);
+	assert.match(yanked.renders[1], /Enter — submit · Tab — unfocus/);
+	assert.doesNotMatch(yanked.renders[1], /Tab to focus/);
+	if (process.env.RUN_COMMAND_SHOW_PANEL === "1") {
+		console.log([
+			"INITIAL PANEL",
+			yanked.renders[0],
+			"",
+			"AFTER PRESSING Y (NO TAB)",
+			yanked.renders[1],
+			"",
+			"OUTPUT RECEIVED DIRECTLY",
+			yanked.renders[2],
+		].join("\n"));
+	}
+
+	const tabbed = await drive(["\t", "manual paste", "\r"]);
+	assert.equal(tabbed.result.details.output, "manual paste");
+	assert.equal(tabbed.result.details.copied, false);
+} finally {
+	delete globalThis.__runCommandClipboardCalls;
+	rmSync(stubDir, { recursive: true, force: true });
+}
+
+console.log("run-command helper and UI workflow tests passed");

--- a/pi/.pi/agent/extensions/run-command.ts
+++ b/pi/.pi/agent/extensions/run-command.ts
@@ -23,9 +23,9 @@ import { Type } from "typebox";
 // Where quiz verifies the HEAD (concepts, terminology), run-command verifies
 // the HANDS: the agent presents ONE command with a grounded prediction and the
 // user runs it. Two capture paths share the panel:
-//   - Manual: `y` yanks the command to the clipboard; the user runs it in their
-//     own terminal, returns, types/pastes output into the response field (Tab
-//     to focus), and submits. The agent never executes the command — the user
+//   - Manual: `y` yanks the command to the clipboard and focuses the response
+//     field; the user runs it in their own terminal, returns, types/pastes
+//     output, and submits. The agent never executes the command — the user
 //     types everything, which is the point.
 //   - Auto: `r` opens a Neovim `:term dm` pane, runs the command there, and
 //     captures output + exit status back into the grading flow (see
@@ -586,7 +586,7 @@ async function askRunCommand(
 					top.push("");
 					addWrapped(
 						top,
-						theme.fg("dim", "y — copy · r — run in Neovim :term dm and auto-capture · paste output below"),
+						theme.fg("dim", "y — copy and focus output · r — run in Neovim :term dm and auto-capture"),
 						tw,
 						" ",
 					);
@@ -641,8 +641,10 @@ async function askRunCommand(
 						return;
 					}
 
-					// Unfocused: y yanks the command as-is, r runs it via Neovim, Tab focuses the field.
+					// Unfocused: y yanks and focuses output, r runs via Neovim, Tab only focuses.
 					if (data === "y") {
+						focus = "editor";
+						editor.focused = true;
 						copyToClipboard(command)
 							.then(() => {
 								copied = true;


### PR DESCRIPTION
## Intent

Modify run-command so pressing the yank shortcut copies the displayed command and immediately switches the panel to accepting output, exactly as if Tab had been pressed, allowing Neovim <leader>at output to be received without an extra Tab. Keep the existing manual and Neovim auto-run workflows intact. Commit the change and push it safely. The user explicitly chose to exclude the unrelated local-main Ghostty font-size commit from this feature branch.

## What Changed

- Make the `y` shortcut copy the displayed command and immediately focus the output field.
- Preserve the existing Tab-based manual entry path and Neovim auto-capture workflow.
- Add UI workflow coverage and update guidance for the yank-to-output behavior.

## Risk Assessment

✅ Low: The focused-state transition exactly matches the existing Tab path, preserves both manual and auto-run workflows, and the branch contains only the intended run-command change.

## Testing

After resolving the local Jiti path, the pre-fix failure was reproduced and the target passed focused helper and public UI tests covering y-to-output focus, direct output receipt without Tab, the existing Tab workflow, and Neovim capture helpers; rendered transcript and screenshot evidence confirm the user-visible behavior, and branch inspection confirmed the unrelated Ghostty change is absent.

- Evidence: Rendered run-command panel before y, immediately after y, and after direct output receipt (local file: <code>~/.no-mistakes/evidence/01M1MT0FCNT1F1XRVR2SC7MQ06/run-command-yank-focus.png</code>)

<details>
<summary>Evidence: Browser-renderable run-command yank-focus evidence</summary>

```text
<!doctype html><meta charset="utf-8"><title>run-command yank focus evidence</title><style>html{background:#1d2021;color:#ebdbb2}body{margin:32px}h1{font:600 20px system-ui;color:#fabd2f}pre{display:inline-block;margin:0;padding:24px;border:1px solid #665c54;border-radius:10px;background:#282828;color:#ebdbb2;font:16px/1.35 "DejaVu Sans Mono",monospace;white-space:pre}</style><h1>run-command: yank immediately focuses output</h1><pre>INITIAL PANEL
  ╭──────────────────────────────────────────────────────────────────────────╮
  │  run this command                                                        │
  │                                                                          │
  │  printf ready                                                            │
  │                                                                          │
  │  y — copy and focus output · r — run in Neovim :term dm and auto-capture │
  │  Output (paste what you saw below) — Tab to focus:                       │
  │  Tab — focus output · Esc — cancel                                       │
╭─┴──────────────────────────────────────────────────────────────────────────┴─╮
│  output — Tab to paste                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯

AFTER PRESSING Y (NO TAB)
  ╭──────────────────────────────────────────────────────────────────────────╮
  │  run this command                                                        │
  │                                                                          │
  │  printf ready                                                            │
  │                                                                          │
  │  y — copy and focus output · r — run in Neovim :term dm and auto-capture │
  │  Output (paste what you saw below):                                      │
  │  Enter — submit · Tab — unfocus · Esc — cancel                           │
╭─┴──────────────────────────────────────────────────────────────────────────┴─╮
│ ▌                                                                            │
╰──────────────────────────────────────────────────────────────────────────────╯

OUTPUT RECEIVED DIRECTLY
  ╭──────────────────────────────────────────────────────────────────────────╮
  │  run this command                                                        │
  │                                                                          │
  │  printf ready                                                            │
  │                                                                          │
  │  y — copy and focus output · r — run in Neovim :term dm and auto-capture │
  │  Output (paste what you saw below):                                      │
  │  Enter — submit · Tab — unfocus · Esc — cancel                           │
╭─┴──────────────────────────────────────────────────────────────────────────┴─╮
│ received through leader-at▌                                                  │
╰──────────────────────────────────────────────────────────────────────────────╯
run-command helper and UI workflow tests passed
</pre>
```
</details>
<details>
<summary>Evidence: Exact rendered TUI transcript from the behavioral test</summary>

```text
INITIAL PANEL
  ╭──────────────────────────────────────────────────────────────────────────╮
  │  run this command                                                        │
  │                                                                          │
  │  printf ready                                                            │
  │                                                                          │
  │  y — copy and focus output · r — run in Neovim :term dm and auto-capture │
  │  Output (paste what you saw below) — Tab to focus:                       │
  │  Tab — focus output · Esc — cancel                                       │
╭─┴──────────────────────────────────────────────────────────────────────────┴─╮
│  output — Tab to paste                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯

AFTER PRESSING Y (NO TAB)
  ╭──────────────────────────────────────────────────────────────────────────╮
  │  run this command                                                        │
  │                                                                          │
  │  printf ready                                                            │
  │                                                                          │
  │  y — copy and focus output · r — run in Neovim :term dm and auto-capture │
  │  Output (paste what you saw below):                                      │
  │  Enter — submit · Tab — unfocus · Esc — cancel                           │
╭─┴──────────────────────────────────────────────────────────────────────────┴─╮
│ ▌                                                                            │
╰──────────────────────────────────────────────────────────────────────────────╯

OUTPUT RECEIVED DIRECTLY
  ╭──────────────────────────────────────────────────────────────────────────╮
  │  run this command                                                        │
  │                                                                          │
  │  printf ready                                                            │
  │                                                                          │
  │  y — copy and focus output · r — run in Neovim :term dm and auto-capture │
  │  Output (paste what you saw below):                                      │
  │  Enter — submit · Tab — unfocus · Esc — cancel                           │
╭─┴──────────────────────────────────────────────────────────────────────────┴─╮
│ received through leader-at▌                                                  │
╰──────────────────────────────────────────────────────────────────────────────╯
run-command helper and UI workflow tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1d23fb45d74de5a07a92cf55901701ee490b1f65","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --stat` and `git diff --name-only a14c6de..e641e35`; only run-command changed, with no Ghostty commit.</code>
- <code>Ran `node pi/.pi/agent/extensions/run-command.test.mjs`; initial setup failed because its macOS Jiti fallback was unavailable.</code>
- <code>Re-ran the focused test with the host `JITI_PATH`; helper, yank-focus, manual Tab, and shell capture workflows passed.</code>
- `Temporarily executed the new behavioral test against the base revision; it exited 13 because y left output unfocused, reproducing the regression, then restored the target source.`
- <code>Ran with `RUN_COMMAND_SHOW_PANEL=1` to capture initial, post-y, and direct-output panel renders.</code>
- `Rendered and visually inspected the captured panel as a Chromium screenshot.`
- <code>Ran `git diff --check` and confirmed only the intentional test modification remains in the worktree.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
