### PR TITLE
fix(agents): load nvimr skill in Pi

### DIFF
--- a/agents/.agents/skills/nvimr/SKILL.md
+++ b/agents/.agents/skills/nvimr/SKILL.md
@@ -22,6 +22,7 @@ directory. nvim serves a default RPC socket at
 `nvim` skill's launcher also opens a socket for nvimr to find.
 
 Override knobs (env):
+
 - `NVIM_BIN=` — nvim binary path if `nvim` is not on `PATH`.
 - `NVIM_LISTEN_ADDRESS=` — force a specific socket path (wins over all auto-discovery).
 - `HERDR_TIMEOUT=` — seconds for herdr CLI calls (default 5).
@@ -29,6 +30,7 @@ Override knobs (env):
 ## Discovery and targeting
 
 `nvimr` resolves a socket in this order:
+
 1. `NVIM_LISTEN_ADDRESS` (explicit env).
 2. The **focused Herdr pane's** nvim, if that pane is running nvim.
 3. Any Herdr pane running nvim (first live).
@@ -57,12 +59,14 @@ A pane→socket link is made by reading the nvim process's `--listen <path>` fro
 All commands run as `./nvimr <command> [args]` from this skill directory.
 
 ### Sessions and targeting
+
 ```bash
 ./nvimr sessions            # List nvim sessions in herdr panes
 ./nvimr --pane <id> <cmd>   # Run <cmd> against a specific pane's nvim
 ```
 
 ### Inspect editor state
+
 ```bash
 ./nvimr socket              # Print the resolved socket path
 ./nvimr state               # Current buf, cursor, mode, cwd, window list
@@ -72,6 +76,7 @@ All commands run as `./nvimr <command> [args]` from this skill directory.
 ```
 
 ### Take actions
+
 ```bash
 ./nvimr open <path> [line]  # Open file in an editable window, goto line
 ./nvimr goto <line> [col]   # Move cursor in current editable window

--- a/agents/.agents/skills/nvimr/SKILL.md
+++ b/agents/.agents/skills/nvimr/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: nvimr
-description: Drive a running neovim session over its RPC socket — list nvim sessions in Herdr panes, open files, jump to lines, read buffers, get diagnostics, run ex commands. Use when the user asks to do something in their editor, open/navigate files, check diagnostics, or says "in my editor" / "in neovim". Herdr-aware: discovers nvim by pane and lets you target a specific pane.
+description: >-
+  Drive a running Neovim session over its RPC socket: list sessions in Herdr
+  panes, open files, jump to lines, read buffers, get diagnostics, and run Ex
+  commands. Use when the user asks to inspect or control an existing editor,
+  check editor diagnostics, or says "in my editor" or "in Neovim".
 ---
 
 # nvimr — neovim remote control


### PR DESCRIPTION
## Intent

Fix the nvimr skill conflict for Pi Agent by making its YAML frontmatter parse correctly, update the skill description if needed, commit the fix, merge it, and push that commit to origin. Preserve all unrelated working-tree changes.

## What Changed

- Convert the nvimr skill description to a folded YAML scalar so its frontmatter parses correctly.
- Clarify the skill’s editor-control triggers and normalize Markdown spacing.

## Risk Assessment

✅ Low: The change is narrowly scoped and uses a valid folded YAML scalar that prevents the prior colon from being interpreted as mapping syntax while preserving the skill description's meaning.

## Testing

Inspected the one-file change, reproduced the baseline YAML parse failure with Pi's real loader, and confirmed the target skill is discovered and advertised end-to-end with no nvimr diagnostics; the worktree remained clean.

<details>
<summary>Evidence: Pi nvimr baseline-versus-fixed package discovery transcript</summary>

```text
=== Pi 0.84.4 baseline package discovery ===
{
  "label": "baseline",
  "nvimrLoaded": false,
  "discoveredPath": null,
  "description": null,
  "advertisedToAgent": false,
  "nvimrDiagnostics": [
    {
      "type": "warning",
      "message": "Nested mappings are not allowed in compact mappings at line 2, column 14:\n\ndescription: Drive a running neovim session over its RPC socket — list nvim ses…\n             ^\n",
      "path": "~/.no-mistakes/evidence/01M1MYS52M869JS8GNGP7AP444/baseline-package/.agents/skills/nvimr/SKILL.md"
    }
  ]
}
=== Pi 0.84.4 fixed package discovery ===
{
  "label": "fixed",
  "nvimrLoaded": true,
  "discoveredPath": "~/.no-mistakes/worktrees/e5cce92fbf21/01M1MYS52M869JS8GNGP7AP444/agents/.agents/skills/nvimr/SKILL.md",
  "description": "Drive a running Neovim session over its RPC socket: list sessions in Herdr panes, open files, jump to lines, read buffers, get diagnostics, and run Ex commands. Use when the user asks to inspect or control an existing editor, check editor diagnostics, or says \"in my editor\" or \"in Neovim\".",
  "advertisedToAgent": true,
  "nvimrDiagnostics": []
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3cd4eaf44ad43c2125e7835dc2f6e841bb4cdf27","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 2d739847..952ea7f -- agents/.agents/skills/nvimr/SKILL.md`.</code>
- <code>Ran exploratory direct-path probes with `verify-nvimr-skill.mjs` against baseline and fixed files.</code>
- <code>Ran Pi 0.84.4 `DefaultResourceLoader` package discovery against the baseline; it reproduced the YAML warning and omitted nvimr.</code>
- `Ran the same package discovery against the target; nvimr loaded once, had no diagnostics, retained its updated description, and appeared in the agent prompt.`
- <code>Verified `git status --porcelain=v1` remained empty at HEAD `952ea7f`.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
